### PR TITLE
[#035] Add retroactive check-in time with timezone-safe attendance calculations and E2E coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help e2e-ui cypress-ui cypress-run cypress-spec cypress-debug cypress-build chrome-clear-hsts ssl-info hosts-setup db-seed e2e-up e2e-down e2e-logs e2e-restart
+.PHONY: help e2e-ui cypress-ui cypress-run cypress-run-headed cypress-spec cypress-debug cypress-build chrome-clear-hsts ssl-info hosts-setup db-seed e2e-up e2e-down e2e-logs e2e-restart
 
 # Colores para output
 GREEN  := \033[0;32m
@@ -66,6 +66,10 @@ cypress-debug: ## Abrir spec en modo interactivo (navegador queda abierto): make
 cypress-run: ## Ejecutar tests de Cypress en modo headless
 	@echo "$(GREEN)Ejecutando tests de Cypress...$(NC)"
 	@docker compose -f docker-compose.yml -f docker-compose.e2e.yml run --rm cypress
+
+cypress-run-headed: cypress-up ## Ejecutar TODOS los tests con navegador visible (ver en VNC http://localhost:6080)
+	@echo "$(GREEN)Ejecutando todos los tests en modo headed (VNC: http://localhost:6080)...$(NC)"
+	@docker exec -it cypress-ui npx cypress run --headed --browser chrome
 
 cypress-build: ## Reconstruir imagen de Cypress UI
 	@echo "$(GREEN)Reconstruyendo imagen de Cypress UI...$(NC)"

--- a/code/api/app/Actions/Attendances/RegisterCheckInAction.php
+++ b/code/api/app/Actions/Attendances/RegisterCheckInAction.php
@@ -42,6 +42,10 @@ class RegisterCheckInAction
         // and late-seconds calculation.  This prevents cross-midnight UTC bugs
         // where a late-night local check-in falls on the next UTC day.
         $checkInLocal = Carbon::parse($data['check_in']);
+
+        // Reject future check-ins (allow up to 5 minutes of clock skew)
+        $this->guardNotInFuture($checkInLocal);
+
         $date = $checkInLocal->toDateString();
         $dayOfWeekIso = $checkInLocal->dayOfWeekIso;
         $checkIn = $checkInLocal->clone()->utc();
@@ -83,8 +87,23 @@ class RegisterCheckInAction
         }
     }
 
-    /**
-     * Return the active employment period for the employee on the given date.
+    /**     * Reject check-in times in the future (allow up to 5 minutes of clock skew).
+     *
+     * @throws ValidationException
+     */
+    private function guardNotInFuture(Carbon $checkInLocal): void
+    {
+        $nowLocal = Carbon::now($checkInLocal->timezone);
+        $toleranceMinutes = 5;
+
+        if ($checkInLocal->isAfter($nowLocal->copy()->addMinutes($toleranceMinutes))) {
+            throw ValidationException::withMessages([
+                'check_in' => 'La hora de entrada no puede ser en el futuro.',
+            ]);
+        }
+    }
+
+    /**     * Return the active employment period for the employee on the given date.
      *
      * @throws ValidationException
      */

--- a/code/api/app/Actions/Attendances/RegisterCheckInAction.php
+++ b/code/api/app/Actions/Attendances/RegisterCheckInAction.php
@@ -52,7 +52,7 @@ class RegisterCheckInAction
         $schedule = $this->resolveActiveSchedule($period->id, $date);
         $scheduleDay = $this->resolveScheduleDay($schedule, $dayOfWeekIso);
 
-        $lateSeconds = $this->calculateLateSeconds($checkIn, $scheduleDay->expected_start);
+        $lateSeconds = $this->calculateLateSeconds($checkInLocal, $scheduleDay->expected_start);
 
         $attendance = Attendance::create([
             'employee_id' => $employee->id,
@@ -155,21 +155,24 @@ class RegisterCheckInAction
     /**
      * Calculate seconds late = max(0, checkIn − expectedStart).
      *
-     * The expected_start stored in ScheduleDay is a time-only value; we combine
-     * it with the check-in date to get a comparable Carbon timestamp.
+     * expected_start is a time-only value stored in local time (e.g. "09:00:00").
+     * We anchor it to the check-in's local date and timezone to get a correct
+     * comparable timestamp, avoiding UTC-offset errors.
      *
      * If the employee arrives before the expected time, returns 0 (no tardiness).
      */
-    private function calculateLateSeconds(Carbon $checkIn, mixed $expectedStart): int
+    private function calculateLateSeconds(Carbon $checkInLocal, mixed $expectedStart): int
     {
-        $expected = Carbon::parse($expectedStart)->setDateFrom($checkIn);
+        $date = $checkInLocal->toDateString();
+        $timeStr = Carbon::parse($expectedStart)->format('H:i:s');
+        $expected = Carbon::parse("{$date} {$timeStr}", $checkInLocal->timezone);
 
         // Night-shift guard: if the expected time lands more than 12 h after
-        // check-in it was anchored to the wrong UTC day — step back one day.
-        if ($expected->timestamp - $checkIn->timestamp > 12 * 3600) {
+        // check-in it was anchored to the wrong local day — step back one day.
+        if ($expected->timestamp - $checkInLocal->timestamp > 12 * 3600) {
             $expected->subDay();
         }
 
-        return (int) max(0, $checkIn->timestamp - $expected->timestamp);
+        return (int) max(0, $checkInLocal->timestamp - $expected->timestamp);
     }
 }

--- a/code/api/app/Actions/Attendances/RegisterCheckOutAction.php
+++ b/code/api/app/Actions/Attendances/RegisterCheckOutAction.php
@@ -39,10 +39,11 @@ class RegisterCheckOutAction
         $this->guardCheckInExists($attendance);
         $this->guardNoDuplicateCheckOut($attendance);
 
-        $checkOut = Carbon::parse($data['check_out'])->utc();
+        $checkOutLocal = Carbon::parse($data['check_out']);
+        $checkOut = $checkOutLocal->clone()->utc();
 
         $netWorkedMinutes = $this->calculateNetWorkedMinutes($attendance, $checkOut);
-        $overtimeMinutes = $this->calculateOvertimeMinutes($attendance, $checkOut);
+        $overtimeMinutes = $this->calculateOvertimeMinutes($attendance, $checkOut, $checkOutLocal);
 
         $attendance->update([
             'check_out' => $checkOut,
@@ -108,11 +109,15 @@ class RegisterCheckOutAction
      * Calculate overtime in whole minutes:
      *   overtime = max(0, check_out − expected_end) in minutes (floor)
      *
+     * expected_end is stored as a local time-only value (e.g. "22:00:00").
+     * We anchor it to the attendance START date using the check-out's timezone
+     * offset to get the correct UTC timestamp for comparison.
+     *
      * Returns 0 when:
      *   - The schedule cannot be resolved (non-blocking)
      *   - The employee left before or exactly at expected_end
      */
-    private function calculateOvertimeMinutes(Attendance $attendance, Carbon $checkOut): int
+    private function calculateOvertimeMinutes(Attendance $attendance, Carbon $checkOut, Carbon $checkOutLocal): int
     {
         $scheduleDay = $this->resolveScheduleDay($attendance);
 
@@ -120,14 +125,14 @@ class RegisterCheckOutAction
             return 0;
         }
 
-        // expected_end is a UTC time-only value — anchor it to the check-in's
-        // UTC date (NOT attendance->date, which stores the employee's local date
-        // and may differ from the UTC date for cross-midnight shifts).
-        // Cross-midnight shift: when expected_end < expected_start (e.g. 19:00→04:00 UTC),
-        // the end falls on the next calendar day.
-        $expectedEnd = Carbon::parse($scheduleDay->expected_end)
-            ->setDateFrom($attendance->check_in);
+        // Anchor expected_end to the attendance START date (local) using the
+        // checkout's timezone offset, so the comparison is timezone-correct.
+        $startDate = $attendance->date->toDateString();
+        $timeStr = Carbon::parse($scheduleDay->expected_end)->format('H:i:s');
+        $expectedEnd = Carbon::parse("{$startDate} {$timeStr}", $checkOutLocal->timezone);
 
+        // Cross-midnight shift: expected_end (local) < expected_start (local)
+        // means the shift ends on the next local calendar day.
         if ($scheduleDay->expected_start
             && $scheduleDay->expected_end < $scheduleDay->expected_start) {
             $expectedEnd->addDay();

--- a/code/api/app/Actions/Attendances/RegisterCheckOutAction.php
+++ b/code/api/app/Actions/Attendances/RegisterCheckOutAction.php
@@ -133,8 +133,10 @@ class RegisterCheckOutAction
 
         // Cross-midnight shift: expected_end (local) < expected_start (local)
         // means the shift ends on the next local calendar day.
-        if ($scheduleDay->expected_start
-            && $scheduleDay->expected_end < $scheduleDay->expected_start) {
+        if (
+            $scheduleDay->expected_start
+            && $scheduleDay->expected_end < $scheduleDay->expected_start
+        ) {
             $expectedEnd->addDay();
         }
 

--- a/code/api/config/seeders.php
+++ b/code/api/config/seeders.php
@@ -122,6 +122,33 @@ return [
             'password' => 'employee123456',
             'meta' => ['notes' => 'Part-time employee'],
         ],
+        [
+            'code' => 'EMP-006',
+            'first_name' => 'Laura',
+            'last_name' => 'Torres',
+            'roles' => ['cook'],
+            'email' => 'laura.torres@sushigo.com',
+            'phone' => '5512340006',
+            'password' => 'employee123456',
+        ],
+        [
+            'code' => 'EMP-007',
+            'first_name' => 'Miguel',
+            'last_name' => 'Flores',
+            'roles' => ['kitchen-assistant'],
+            'email' => 'miguel.flores@sushigo.com',
+            'phone' => '5512340007',
+            'password' => 'employee123456',
+        ],
+        [
+            'code' => 'EMP-008',
+            'first_name' => 'Sofia',
+            'last_name' => 'Vargas',
+            'roles' => ['delivery-driver'],
+            'email' => 'sofia.vargas@sushigo.com',
+            'phone' => '5512340008',
+            'password' => 'employee123456',
+        ],
     ],
 
     /*

--- a/code/api/tests/Feature/AttendancePayroll/CheckInApiTest.php
+++ b/code/api/tests/Feature/AttendancePayroll/CheckInApiTest.php
@@ -288,11 +288,11 @@ class CheckInApiTest extends TestCase
     {
         // Monday Feb 23 at 23:00 CST (UTC-6) = Tuesday Feb 24 at 05:00 UTC.
         // The attendance date must be the LOCAL date (Feb 23), not UTC (Feb 24).
-        // Schedule: expected_start = 05:00 UTC (the UTC equivalent of 23:00 CST).
+        // Schedule: expected_start = 23:00 local (CST), i.e. the night shift.
         ['employee' => $employee] = $this->makeEmployeeWithSchedule(
             date: self::DATE,                   // 2026-02-23 (Monday)
-            expectedStart: '05:00:00',          // UTC schedule start
-            expectedEnd: '12:00:00',            // UTC schedule end
+            expectedStart: '23:00:00',          // local schedule start (CST)
+            expectedEnd: '06:00:00',            // local schedule end next day (CST)
         );
 
         $response = $this->postJson('/api/v1/attendances/check-in', [
@@ -310,11 +310,11 @@ class CheckInApiTest extends TestCase
     public function calculates_late_seconds_with_offset_across_utc_midnight(): void
     {
         // Monday Feb 23 at 23:10 CST = Tuesday Feb 24 at 05:10 UTC.
-        // Schedule expected_start = 05:00 UTC → employee is 10 minutes (600 s) late.
+        // Schedule expected_start = 23:00 local (CST) → employee is 10 minutes (600 s) late.
         ['employee' => $employee] = $this->makeEmployeeWithSchedule(
             date: self::DATE,
-            expectedStart: '05:00:00',
-            expectedEnd: '12:00:00',
+            expectedStart: '23:00:00',
+            expectedEnd: '06:00:00',
         );
 
         $response = $this->postJson('/api/v1/attendances/check-in', [
@@ -337,8 +337,8 @@ class CheckInApiTest extends TestCase
         $date = '2026-02-24'; // Tuesday
         ['employee' => $employee] = $this->makeEmployeeWithSchedule(
             date: $date,
-            expectedStart: '16:00:00',          // UTC equivalent of 01:00 JST
-            expectedEnd: '22:00:00',
+            expectedStart: '01:00:00',          // local schedule start (JST)
+            expectedEnd: '09:00:00',            // local schedule end (JST)
         );
 
         $response = $this->postJson('/api/v1/attendances/check-in', [

--- a/code/api/tests/Feature/AttendancePayroll/CheckOutApiTest.php
+++ b/code/api/tests/Feature/AttendancePayroll/CheckOutApiTest.php
@@ -239,8 +239,7 @@ class CheckOutApiTest extends TestCase
     public function calculates_overtime_with_offset_across_utc_midnight(): void
     {
         // Night shift: Mon Feb 23 at 23:00 CST → Tue Feb 24 at 06:35 CST (check-out)
-        // UTC equivalent: 05:00 → 12:35
-        // Schedule: expected_start=05:00, expected_end=12:00 (UTC)
+        // Local schedule: expected_start=23:00 CST, expected_end=06:00 CST (next day)
         // Overtime = 35 minutes
         ['attendance' => $attendance] = $this->makeNightShiftAttendance();
 
@@ -363,7 +362,7 @@ class CheckOutApiTest extends TestCase
      * Night shift scenario: check-in crosses UTC midnight.
      *
      * Local: Mon Feb 23 at 23:00 CST (UTC-6) = Tue Feb 24 at 05:00 UTC.
-     * Schedule: expected_start=05:00 UTC, expected_end=12:00 UTC, no lunch.
+     * Schedule: expected_start=23:00 local (CST), expected_end=06:00 local (CST, next day).
      * Attendance: date='2026-02-23' (local Monday), check_in='2026-02-24T05:00:00' (UTC).
      */
     private function makeNightShiftAttendance(): array
@@ -380,11 +379,11 @@ class CheckOutApiTest extends TestCase
             'effective_from' => '2026-01-01',
         ]);
 
-        // Monday (dow=1) — night shift 05:00→12:00 UTC, no lunch
+        // Monday (dow=1) — night shift 23:00→06:00 local (CST), no lunch
         ScheduleDay::factory()
             ->workDay()
             ->monday()
-            ->withTimes(start: '05:00:00', end: '12:00:00')
+            ->withTimes(start: '23:00:00', end: '06:00:00')
             ->withLunchDuration(null)
             ->create(['employee_schedule_id' => $schedule->id]);
 

--- a/code/webapp/cypress/e2e/attendance-checkin.cy.ts
+++ b/code/webapp/cypress/e2e/attendance-checkin.cy.ts
@@ -1,0 +1,211 @@
+/**
+ * Attendance Check-In — E2E tests
+ *
+ * Covers the retroactive time picker on the check-in confirmation dialog.
+ * 8 scenarios: a tiempo, anticipado y tardanzas de 15m a 1h.
+ *
+ * Shift schedule (seeded for all employees):
+ *   expected_start = 13:00 local (America/Mexico_City)
+ *   expected_end   = 22:00 local
+ *
+ * DB reset strategy
+ * ─────────────────
+ * • before()     → cy.task('db:reset') ONCE por archivo (~90s).
+ * • beforeEach() → login vía UI + navega a /attendance/today.
+ * • Cada it() usa un EMPLEADO DISTINTO — no se reutiliza ningún slot.
+ *
+ * Employees used (EMP-001..EMP-008 seeded via config/seeders.php):
+ *   EMP-001  Mendoza, Carlos   → 13:00  (a tiempo,   0m tardanza)
+ *   EMP-002  García, María     → 12:45  (anticipado, 0m tardanza)
+ *   EMP-003  López, Pedro      → 13:15  (+15m)
+ *   EMP-004  Ramírez, Ana      → 13:20  (+20m)
+ *   EMP-005  Sánchez, Roberto  → 13:25  (+25m)
+ *   EMP-006  Torres, Laura     → 13:30  (+30m)
+ *   EMP-007  Flores, Miguel    → 13:31  (+31m)
+ *   EMP-008  Vargas, Sofia     → 14:00  (+60m → "1h")
+ *
+ * Para correr solo este archivo:
+ *   make cypress-spec SPEC=attendance-checkin
+ *   make cypress-debug SPEC=attendance-checkin
+ *
+ * Para filtrar por describe:
+ *   make cypress-spec SPEC=attendance-checkin GREP="a tiempo"
+ */
+
+import users from '../fixtures/users.json'
+
+const { email: adminEmail, password: adminPassword } = users.admin
+
+// ── Suite setup ─────────────────────────────────────────────────────────────
+
+before(() => {
+    cy.task('db:reset', null, { timeout: 90_000 })
+})
+
+beforeEach(() => {
+    cy.login(adminEmail, adminPassword)
+    cy.url().should('not.include', '/login', { timeout: 10_000 })
+    cy.visit('/attendance/today')
+    cy.url().should('include', '/attendance/today', { timeout: 10_000 })
+    cy.closeDevDebugger()
+})
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Opens the check-in dialog for the given employee card and submits with time.
+ */
+function openCheckInDialog(lastName: string, firstName: string, time: string) {
+    cy.contains('p', `${lastName}, ${firstName}`)
+        .closest('div.rounded-xl')
+        .contains('button', 'Registrar entrada')
+        .scrollIntoView()
+        .click({ force: true })
+
+    cy.get('#checkin-time')
+        .clear({ force: true })
+        .type(time, { force: true })
+
+    cy.contains('button', 'Confirmar entrada').click()
+}
+
+/**
+ * Returns a Cypress chain scoped to the employee's card (after check-in).
+ * scrollIntoView ensures the card is in the viewport before asserting visibility
+ * (required when other employees' cards push this one below the fold).
+ */
+function getCard(lastName: string, firstName: string) {
+    return cy
+        .contains('p', `${lastName}, ${firstName}`, { timeout: 10_000 })
+        .closest('div.rounded-xl')
+        .scrollIntoView()
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// 1. A tiempo — 13:00 (sin tardanza)
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('Check-in — A tiempo (13:00)', () => {
+    it('registra la entrada de Carlos a las 13:00 sin tardanza', () => {
+        openCheckInDialog('Mendoza', 'Carlos', '13:00')
+
+        getCard('Mendoza', 'Carlos').within(() => {
+            cy.contains('En trabajo', { timeout: 10_000 }).should('be.visible')
+            cy.contains('Entrada').should('be.visible')
+            cy.contains('Tardanza entrada').should('not.exist')
+        })
+    })
+})
+
+// ══════════════════════════════════════════════════════════════════════════════
+// 2. Anticipado — 12:45 (sin tardanza)
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('Check-in — Anticipado (12:45)', () => {
+    it('registra la entrada de María a las 12:45 sin tardanza', () => {
+        openCheckInDialog('García', 'María', '12:45')
+
+        getCard('García', 'María').within(() => {
+            cy.contains('En trabajo', { timeout: 10_000 }).should('be.visible')
+            cy.contains('Entrada').should('be.visible')
+            cy.contains('Tardanza entrada').should('not.exist')
+        })
+    })
+})
+
+// ══════════════════════════════════════════════════════════════════════════════
+// 3. Tardanza 15m — 13:15
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('Check-in — Tardanza 15m (13:15)', () => {
+    it('registra la entrada de Pedro a las 13:15 con 15m de tardanza', () => {
+        openCheckInDialog('López', 'Pedro', '13:15')
+
+        getCard('López', 'Pedro').within(() => {
+            cy.contains('En trabajo', { timeout: 10_000 }).should('be.visible')
+            cy.contains('Tardanza entrada').should('be.visible')
+            cy.contains('15m').should('be.visible')
+        })
+    })
+})
+
+// ══════════════════════════════════════════════════════════════════════════════
+// 4. Tardanza 20m — 13:20
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('Check-in — Tardanza 20m (13:20)', () => {
+    it('registra la entrada de Ana a las 13:20 con 20m de tardanza', () => {
+        openCheckInDialog('Ramírez', 'Ana', '13:20')
+
+        getCard('Ramírez', 'Ana').within(() => {
+            cy.contains('En trabajo', { timeout: 10_000 }).should('be.visible')
+            cy.contains('Tardanza entrada').should('be.visible')
+            cy.contains('20m').should('be.visible')
+        })
+    })
+})
+
+// ══════════════════════════════════════════════════════════════════════════════
+// 5. Tardanza 25m — 13:25
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('Check-in — Tardanza 25m (13:25)', () => {
+    it('registra la entrada de Roberto a las 13:25 con 25m de tardanza', () => {
+        openCheckInDialog('Sánchez', 'Roberto', '13:25')
+
+        getCard('Sánchez', 'Roberto').within(() => {
+            cy.contains('En trabajo', { timeout: 10_000 }).should('be.visible')
+            cy.contains('Tardanza entrada').should('be.visible')
+            cy.contains('25m').should('be.visible')
+        })
+    })
+})
+
+// ══════════════════════════════════════════════════════════════════════════════
+// 6. Tardanza 30m — 13:30
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('Check-in — Tardanza 30m (13:30)', () => {
+    it('registra la entrada de Laura a las 13:30 con 30m de tardanza', () => {
+        openCheckInDialog('Torres', 'Laura', '13:30')
+
+        getCard('Torres', 'Laura').within(() => {
+            cy.contains('En trabajo', { timeout: 10_000 }).should('be.visible')
+            cy.contains('Tardanza entrada').should('be.visible')
+            cy.contains('30m').should('be.visible')
+        })
+    })
+})
+
+// ══════════════════════════════════════════════════════════════════════════════
+// 7. Tardanza 31m — 13:31
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('Check-in — Tardanza 31m (13:31)', () => {
+    it('registra la entrada de Miguel a las 13:31 con 31m de tardanza', () => {
+        openCheckInDialog('Flores', 'Miguel', '13:31')
+
+        getCard('Flores', 'Miguel').within(() => {
+            cy.contains('En trabajo', { timeout: 10_000 }).should('be.visible')
+            cy.contains('Tardanza entrada').should('be.visible')
+            cy.contains('31m').should('be.visible')
+        })
+    })
+})
+
+// ══════════════════════════════════════════════════════════════════════════════
+// 8. Tardanza 1h — 14:00
+//    60 min → formatSeconds(3600) → "1h"
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('Check-in — Tardanza 1h (14:00)', () => {
+    it('registra la entrada de Sofia a las 14:00 con 1h de tardanza', () => {
+        openCheckInDialog('Vargas', 'Sofia', '14:00')
+
+        getCard('Vargas', 'Sofia').within(() => {
+            cy.contains('En trabajo', { timeout: 10_000 }).should('be.visible')
+            cy.contains('Tardanza entrada').should('be.visible')
+            cy.contains('1h').should('be.visible')
+        })
+    })
+})

--- a/code/webapp/cypress/e2e/attendance-checkin.cy.ts
+++ b/code/webapp/cypress/e2e/attendance-checkin.cy.ts
@@ -32,23 +32,23 @@
  *   make cypress-spec SPEC=attendance-checkin GREP="a tiempo"
  */
 
-import users from '../fixtures/users.json'
+import users from "../fixtures/users.json";
 
-const { email: adminEmail, password: adminPassword } = users.admin
+const { email: adminEmail, password: adminPassword } = users.admin;
 
 // ── Suite setup ─────────────────────────────────────────────────────────────
 
 before(() => {
-    cy.task('db:reset', null, { timeout: 90_000 })
-})
+  cy.task("db:reset", null, { timeout: 90_000 });
+});
 
 beforeEach(() => {
-    cy.login(adminEmail, adminPassword)
-    cy.url().should('not.include', '/login', { timeout: 10_000 })
-    cy.visit('/attendance/today')
-    cy.url().should('include', '/attendance/today', { timeout: 10_000 })
-    cy.closeDevDebugger()
-})
+  cy.login(adminEmail, adminPassword);
+  cy.url().should("not.include", "/login", { timeout: 10_000 });
+  cy.visit("/attendance/today");
+  cy.url().should("include", "/attendance/today", { timeout: 10_000 });
+  cy.closeDevDebugger();
+});
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -56,17 +56,17 @@ beforeEach(() => {
  * Opens the check-in dialog for the given employee card and submits with time.
  */
 function openCheckInDialog(lastName: string, firstName: string, time: string) {
-    cy.contains('p', `${lastName}, ${firstName}`)
-        .closest('div.rounded-xl')
-        .contains('button', 'Registrar entrada')
-        .scrollIntoView()
-        .click({ force: true })
+  cy.contains("p", `${lastName}, ${firstName}`)
+    .closest("div.rounded-xl")
+    .contains("button", "Registrar entrada")
+    .scrollIntoView()
+    .click({ force: true });
 
-    cy.get('#checkin-time')
-        .clear({ force: true })
-        .type(time, { force: true })
+  cy.get("#checkin-time").clear({ force: true }).type(time, { force: true });
 
-    cy.contains('button', 'Confirmar entrada').click()
+  cy.contains("button", "Confirmar entrada")
+    .should("not.be.disabled")
+    .click();
 }
 
 /**
@@ -75,137 +75,137 @@ function openCheckInDialog(lastName: string, firstName: string, time: string) {
  * (required when other employees' cards push this one below the fold).
  */
 function getCard(lastName: string, firstName: string) {
-    return cy
-        .contains('p', `${lastName}, ${firstName}`, { timeout: 10_000 })
-        .closest('div.rounded-xl')
-        .scrollIntoView()
+  return cy
+    .contains("p", `${lastName}, ${firstName}`, { timeout: 10_000 })
+    .closest("div.rounded-xl")
+    .scrollIntoView();
 }
 
 // ══════════════════════════════════════════════════════════════════════════════
 // 1. A tiempo — 13:00 (sin tardanza)
 // ══════════════════════════════════════════════════════════════════════════════
 
-describe('Check-in — A tiempo (13:00)', () => {
-    it('registra la entrada de Carlos a las 13:00 sin tardanza', () => {
-        openCheckInDialog('Mendoza', 'Carlos', '13:00')
+describe("Check-in — A tiempo (13:00)", () => {
+  it("registra la entrada de Carlos a las 13:00 sin tardanza", () => {
+    openCheckInDialog("Mendoza", "Carlos", "13:00");
 
-        getCard('Mendoza', 'Carlos').within(() => {
-            cy.contains('En trabajo', { timeout: 10_000 }).should('be.visible')
-            cy.contains('Entrada').should('be.visible')
-            cy.contains('Tardanza entrada').should('not.exist')
-        })
-    })
-})
+    getCard("Mendoza", "Carlos").within(() => {
+      cy.contains("En trabajo", { timeout: 10_000 }).should("be.visible");
+      cy.contains("Entrada").should("be.visible");
+      cy.contains("Tardanza entrada").should("not.exist");
+    });
+  });
+});
 
 // ══════════════════════════════════════════════════════════════════════════════
 // 2. Anticipado — 12:45 (sin tardanza)
 // ══════════════════════════════════════════════════════════════════════════════
 
-describe('Check-in — Anticipado (12:45)', () => {
-    it('registra la entrada de María a las 12:45 sin tardanza', () => {
-        openCheckInDialog('García', 'María', '12:45')
+describe("Check-in — Anticipado (12:45)", () => {
+  it("registra la entrada de María a las 12:45 sin tardanza", () => {
+    openCheckInDialog("García", "María", "12:45");
 
-        getCard('García', 'María').within(() => {
-            cy.contains('En trabajo', { timeout: 10_000 }).should('be.visible')
-            cy.contains('Entrada').should('be.visible')
-            cy.contains('Tardanza entrada').should('not.exist')
-        })
-    })
-})
+    getCard("García", "María").within(() => {
+      cy.contains("En trabajo", { timeout: 10_000 }).should("be.visible");
+      cy.contains("Entrada").should("be.visible");
+      cy.contains("Tardanza entrada").should("not.exist");
+    });
+  });
+});
 
 // ══════════════════════════════════════════════════════════════════════════════
 // 3. Tardanza 15m — 13:15
 // ══════════════════════════════════════════════════════════════════════════════
 
-describe('Check-in — Tardanza 15m (13:15)', () => {
-    it('registra la entrada de Pedro a las 13:15 con 15m de tardanza', () => {
-        openCheckInDialog('López', 'Pedro', '13:15')
+describe("Check-in — Tardanza 15m (13:15)", () => {
+  it("registra la entrada de Pedro a las 13:15 con 15m de tardanza", () => {
+    openCheckInDialog("López", "Pedro", "13:15");
 
-        getCard('López', 'Pedro').within(() => {
-            cy.contains('En trabajo', { timeout: 10_000 }).should('be.visible')
-            cy.contains('Tardanza entrada').should('be.visible')
-            cy.contains('15m').should('be.visible')
-        })
-    })
-})
+    getCard("López", "Pedro").within(() => {
+      cy.contains("En trabajo", { timeout: 10_000 }).should("be.visible");
+      cy.contains("Tardanza entrada").should("be.visible");
+      cy.contains("15m").should("be.visible");
+    });
+  });
+});
 
 // ══════════════════════════════════════════════════════════════════════════════
 // 4. Tardanza 20m — 13:20
 // ══════════════════════════════════════════════════════════════════════════════
 
-describe('Check-in — Tardanza 20m (13:20)', () => {
-    it('registra la entrada de Ana a las 13:20 con 20m de tardanza', () => {
-        openCheckInDialog('Ramírez', 'Ana', '13:20')
+describe("Check-in — Tardanza 20m (13:20)", () => {
+  it("registra la entrada de Ana a las 13:20 con 20m de tardanza", () => {
+    openCheckInDialog("Ramírez", "Ana", "13:20");
 
-        getCard('Ramírez', 'Ana').within(() => {
-            cy.contains('En trabajo', { timeout: 10_000 }).should('be.visible')
-            cy.contains('Tardanza entrada').should('be.visible')
-            cy.contains('20m').should('be.visible')
-        })
-    })
-})
+    getCard("Ramírez", "Ana").within(() => {
+      cy.contains("En trabajo", { timeout: 10_000 }).should("be.visible");
+      cy.contains("Tardanza entrada").should("be.visible");
+      cy.contains("20m").should("be.visible");
+    });
+  });
+});
 
 // ══════════════════════════════════════════════════════════════════════════════
 // 5. Tardanza 25m — 13:25
 // ══════════════════════════════════════════════════════════════════════════════
 
-describe('Check-in — Tardanza 25m (13:25)', () => {
-    it('registra la entrada de Roberto a las 13:25 con 25m de tardanza', () => {
-        openCheckInDialog('Sánchez', 'Roberto', '13:25')
+describe("Check-in — Tardanza 25m (13:25)", () => {
+  it("registra la entrada de Roberto a las 13:25 con 25m de tardanza", () => {
+    openCheckInDialog("Sánchez", "Roberto", "13:25");
 
-        getCard('Sánchez', 'Roberto').within(() => {
-            cy.contains('En trabajo', { timeout: 10_000 }).should('be.visible')
-            cy.contains('Tardanza entrada').should('be.visible')
-            cy.contains('25m').should('be.visible')
-        })
-    })
-})
+    getCard("Sánchez", "Roberto").within(() => {
+      cy.contains("En trabajo", { timeout: 10_000 }).should("be.visible");
+      cy.contains("Tardanza entrada").should("be.visible");
+      cy.contains("25m").should("be.visible");
+    });
+  });
+});
 
 // ══════════════════════════════════════════════════════════════════════════════
 // 6. Tardanza 30m — 13:30
 // ══════════════════════════════════════════════════════════════════════════════
 
-describe('Check-in — Tardanza 30m (13:30)', () => {
-    it('registra la entrada de Laura a las 13:30 con 30m de tardanza', () => {
-        openCheckInDialog('Torres', 'Laura', '13:30')
+describe("Check-in — Tardanza 30m (13:30)", () => {
+  it("registra la entrada de Laura a las 13:30 con 30m de tardanza", () => {
+    openCheckInDialog("Torres", "Laura", "13:30");
 
-        getCard('Torres', 'Laura').within(() => {
-            cy.contains('En trabajo', { timeout: 10_000 }).should('be.visible')
-            cy.contains('Tardanza entrada').should('be.visible')
-            cy.contains('30m').should('be.visible')
-        })
-    })
-})
+    getCard("Torres", "Laura").within(() => {
+      cy.contains("En trabajo", { timeout: 10_000 }).should("be.visible");
+      cy.contains("Tardanza entrada").should("be.visible");
+      cy.contains("30m").should("be.visible");
+    });
+  });
+});
 
 // ══════════════════════════════════════════════════════════════════════════════
 // 7. Tardanza 31m — 13:31
 // ══════════════════════════════════════════════════════════════════════════════
 
-describe('Check-in — Tardanza 31m (13:31)', () => {
-    it('registra la entrada de Miguel a las 13:31 con 31m de tardanza', () => {
-        openCheckInDialog('Flores', 'Miguel', '13:31')
+describe("Check-in — Tardanza 31m (13:31)", () => {
+  it("registra la entrada de Miguel a las 13:31 con 31m de tardanza", () => {
+    openCheckInDialog("Flores", "Miguel", "13:31");
 
-        getCard('Flores', 'Miguel').within(() => {
-            cy.contains('En trabajo', { timeout: 10_000 }).should('be.visible')
-            cy.contains('Tardanza entrada').should('be.visible')
-            cy.contains('31m').should('be.visible')
-        })
-    })
-})
+    getCard("Flores", "Miguel").within(() => {
+      cy.contains("En trabajo", { timeout: 10_000 }).should("be.visible");
+      cy.contains("Tardanza entrada").should("be.visible");
+      cy.contains("31m").should("be.visible");
+    });
+  });
+});
 
 // ══════════════════════════════════════════════════════════════════════════════
 // 8. Tardanza 1h — 14:00
 //    60 min → formatSeconds(3600) → "1h"
 // ══════════════════════════════════════════════════════════════════════════════
 
-describe('Check-in — Tardanza 1h (14:00)', () => {
-    it('registra la entrada de Sofia a las 14:00 con 1h de tardanza', () => {
-        openCheckInDialog('Vargas', 'Sofia', '14:00')
+describe("Check-in — Tardanza 1h (14:00)", () => {
+  it("registra la entrada de Sofia a las 14:00 con 1h de tardanza", () => {
+    openCheckInDialog("Vargas", "Sofia", "14:00");
 
-        getCard('Vargas', 'Sofia').within(() => {
-            cy.contains('En trabajo', { timeout: 10_000 }).should('be.visible')
-            cy.contains('Tardanza entrada').should('be.visible')
-            cy.contains('1h').should('be.visible')
-        })
-    })
-})
+    getCard("Vargas", "Sofia").within(() => {
+      cy.contains("En trabajo", { timeout: 10_000 }).should("be.visible");
+      cy.contains("Tardanza entrada").should("be.visible");
+      cy.contains("1h").should("be.visible");
+    });
+  });
+});

--- a/code/webapp/cypress/e2e/employees.cy.ts
+++ b/code/webapp/cypress/e2e/employees.cy.ts
@@ -59,7 +59,7 @@ describe('Crear empleado', () => {
     cy.contains('button', 'Crear').click()
 
     // Esperar a que aparezca la vista de detalle
-    cy.contains('Empleado Cypress', { timeout: 10_000 }).should('be.visible')
+    cy.contains('Empleado Cypress', { timeout: 10_000 }).scrollIntoView().should('be.visible')
 
     // ── 4. Crear horario: Martes-Domingo, 13:00-22:00, descansa Lunes ────────
     //

--- a/code/webapp/src/components/ui/confirm-dialog.tsx
+++ b/code/webapp/src/components/ui/confirm-dialog.tsx
@@ -9,7 +9,7 @@ export interface ConfirmDialogProps {
   onClose: () => void
   onConfirm: () => void | Promise<void>
   title: string
-  description?: string
+  description?: React.ReactNode
   confirmLabel?: string
   cancelLabel?: string
   variant?: 'danger' | 'warning' | 'info'
@@ -163,12 +163,12 @@ export function ConfirmDialog({
                 {title}
               </h3>
               {description && (
-                <p
+                <div
                   id="confirm-dialog-desc"
                   className="mt-2 text-sm text-muted-foreground"
                 >
                   {description}
-                </p>
+                </div>
               )}
             </div>
           </div>

--- a/code/webapp/src/components/ui/confirm-dialog.tsx
+++ b/code/webapp/src/components/ui/confirm-dialog.tsx
@@ -14,6 +14,8 @@ export interface ConfirmDialogProps {
   cancelLabel?: string
   variant?: 'danger' | 'warning' | 'info'
   isLoading?: boolean
+  /** Disable the confirm button (e.g. when required input is empty). */
+  confirmDisabled?: boolean
   /** Where to render the dialog overlay.
    *  - undefined (default): renders inline with absolute positioning,
    *    covering the nearest positioned ancestor (e.g. a SlidePanel).
@@ -54,6 +56,7 @@ export function ConfirmDialog({
   cancelLabel = 'Cancelar',
   variant = 'warning',
   isLoading = false,
+  confirmDisabled = false,
   container,
 }: ConfirmDialogProps) {
   const [visible, setVisible] = useState(false)
@@ -187,7 +190,7 @@ export function ConfirmDialog({
           <Button
             type="button"
             onClick={onConfirm}
-            disabled={isLoading}
+            disabled={isLoading || confirmDisabled}
             className={styles.confirmBtn}
           >
             {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}

--- a/code/webapp/src/pages/attendance/-use-today-attendance-page.ts
+++ b/code/webapp/src/pages/attendance/-use-today-attendance-page.ts
@@ -32,16 +32,18 @@ function currentTimeLabel(): string {
   return new Date().toTimeString().slice(0, 5)
 }
 
-/** ISO 8601 / RFC 3339 datetime with timezone offset: "2026-02-24T09:05:30-06:00" */
-function nowIso(): string {
+/** ISO 8601 / RFC 3339 from a "HH:mm" string using today's date and local timezone offset */
+function timeToIso(hhmm: string): string {
+  const [hours = 0, minutes = 0] = hhmm.split(':').map(Number)
   const d = new Date()
+  d.setHours(hours, minutes, 0, 0)
   const pad = (n: number) => String(n).padStart(2, '0')
   const offset = -d.getTimezoneOffset()
   const sign = offset >= 0 ? '+' : '-'
   const absOff = Math.abs(offset)
   const oh = pad(Math.floor(absOff / 60))
   const om = pad(absOff % 60)
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}${sign}${oh}:${om}`
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}:00${sign}${oh}:${om}`
 }
 
 export interface UseTodayAttendancePageResult {
@@ -56,7 +58,8 @@ export interface UseTodayAttendancePageResult {
   // Check-in action
   pendingCheckInEmployee: TodayAttendanceEmployee | null
   isCheckingIn: boolean
-  confirmTimeLabel: string
+  selectedTime: string
+  onTimeChange: (time: string) => void
   openCheckIn: (employee: TodayAttendanceEmployee) => void
   closeCheckIn: () => void
   confirmCheckIn: () => void
@@ -73,10 +76,10 @@ export function useTodayAttendancePage(): UseTodayAttendancePageResult {
 
   const [pendingCheckInEmployee, setPendingCheckInEmployee] =
     useState<TodayAttendanceEmployee | null>(null)
-  const [confirmTimeLabel, setConfirmTimeLabel] = useState('')
+  const [selectedTime, setSelectedTime] = useState('')
 
   const openCheckIn = (employee: TodayAttendanceEmployee) => {
-    setConfirmTimeLabel(currentTimeLabel())
+    setSelectedTime(currentTimeLabel())
     setPendingCheckInEmployee(employee)
   }
 
@@ -85,7 +88,7 @@ export function useTodayAttendancePage(): UseTodayAttendancePageResult {
   const confirmCheckIn = () => {
     if (!pendingCheckInEmployee) return
     checkInMutation.mutate(
-      { employee_id: pendingCheckInEmployee.id, check_in: nowIso() },
+      { employee_id: pendingCheckInEmployee.id, check_in: timeToIso(selectedTime) },
       { onSettled: closeCheckIn }
     )
   }
@@ -100,7 +103,8 @@ export function useTodayAttendancePage(): UseTodayAttendancePageResult {
     getPhase: (row) => getAttendancePhase(row.attendance),
     pendingCheckInEmployee,
     isCheckingIn: checkInMutation.isPending,
-    confirmTimeLabel,
+    selectedTime,
+    onTimeChange: setSelectedTime,
     openCheckIn,
     closeCheckIn,
     confirmCheckIn,

--- a/code/webapp/src/pages/attendance/-use-today-attendance-page.ts
+++ b/code/webapp/src/pages/attendance/-use-today-attendance-page.ts
@@ -34,7 +34,13 @@ function currentTimeLabel(): string {
 
 /** ISO 8601 / RFC 3339 from a "HH:mm" string using today's date and local timezone offset */
 function timeToIso(hhmm: string): string {
+  if (!hhmm?.includes(':')) {
+    throw new TypeError(`Invalid time value: "${hhmm}"`)
+  }
   const [hours = 0, minutes = 0] = hhmm.split(':').map(Number)
+  if (Number.isNaN(hours) || Number.isNaN(minutes)) {
+    throw new TypeError(`Invalid time value: "${hhmm}"`)
+  }
   const d = new Date()
   d.setHours(hours, minutes, 0, 0)
   const pad = (n: number) => String(n).padStart(2, '0')
@@ -86,7 +92,7 @@ export function useTodayAttendancePage(): UseTodayAttendancePageResult {
   const closeCheckIn = () => setPendingCheckInEmployee(null)
 
   const confirmCheckIn = () => {
-    if (!pendingCheckInEmployee) return
+    if (!pendingCheckInEmployee || !selectedTime) return
     checkInMutation.mutate(
       { employee_id: pendingCheckInEmployee.id, check_in: timeToIso(selectedTime) },
       { onSettled: closeCheckIn }

--- a/code/webapp/src/pages/attendance/today.tsx
+++ b/code/webapp/src/pages/attendance/today.tsx
@@ -35,7 +35,8 @@ export function TodayAttendancePage() {
     hasBranch,
     pendingCheckInEmployee,
     isCheckingIn,
-    confirmTimeLabel,
+    selectedTime,
+    onTimeChange,
     openCheckIn,
     closeCheckIn,
     confirmCheckIn,
@@ -104,9 +105,28 @@ export function TodayAttendancePage() {
         onConfirm={confirmCheckIn}
         title="Registrar entrada"
         description={
-          pendingCheckInEmployee
-            ? `¿Confirmas el check-in de ${pendingCheckInEmployee.first_name} ${pendingCheckInEmployee.last_name} a las ${confirmTimeLabel}?`
-            : ''
+          pendingCheckInEmployee ? (
+            <span className="flex flex-col gap-3">
+              <span>
+                {`¿Confirmas el check-in de ${pendingCheckInEmployee.first_name} ${pendingCheckInEmployee.last_name}?`}
+              </span>
+              <span className="flex items-center gap-2">
+                <label
+                  htmlFor="checkin-time"
+                  className="text-sm font-medium text-foreground whitespace-nowrap"
+                >
+                  Hora de entrada:
+                </label>
+                <input
+                  id="checkin-time"
+                  type="time"
+                  value={selectedTime}
+                  onChange={e => onTimeChange(e.target.value)}
+                  className="rounded border border-input bg-background px-2 py-1 text-sm text-foreground"
+                />
+              </span>
+            </span>
+          ) : undefined
         }
         confirmLabel="Confirmar entrada"
         variant="info"

--- a/code/webapp/src/pages/attendance/today.tsx
+++ b/code/webapp/src/pages/attendance/today.tsx
@@ -306,11 +306,11 @@ function EmployeeAttendanceCard({ row, onCheckIn }: EmployeeAttendanceCardProps)
 
 function phaseCardClass(phase: AttendancePhase): string {
   switch (phase) {
-    case 'pending':    return 'border-muted/60 opacity-70'
+    case 'pending': return 'border-muted/60 opacity-70'
     case 'checked-in': return 'border-blue-200 dark:border-blue-800'
-    case 'at-lunch':   return 'border-orange-200 dark:border-orange-800'
-    case 'returned':   return 'border-teal-200 dark:border-teal-800'
-    case 'done':       return 'border-green-200 dark:border-green-800'
+    case 'at-lunch': return 'border-orange-200 dark:border-orange-800'
+    case 'returned': return 'border-teal-200 dark:border-teal-800'
+    case 'done': return 'border-green-200 dark:border-green-800'
   }
 }
 

--- a/code/webapp/src/pages/attendance/today.tsx
+++ b/code/webapp/src/pages/attendance/today.tsx
@@ -121,6 +121,7 @@ export function TodayAttendancePage() {
                   id="checkin-time"
                   type="time"
                   value={selectedTime}
+                  max={new Date().toTimeString().slice(0, 5)}
                   onChange={e => onTimeChange(e.target.value)}
                   className="rounded border border-input bg-background px-2 py-1 text-sm text-foreground"
                 />
@@ -131,6 +132,7 @@ export function TodayAttendancePage() {
         confirmLabel="Confirmar entrada"
         variant="info"
         isLoading={isCheckingIn}
+        confirmDisabled={!selectedTime}
       />
     </PageContainer>
   )


### PR DESCRIPTION
### Summary
This PR enables retroactive check-in time selection from the attendance page and fixes late/overtime calculations for cross-date shifts and timezone offsets. It also adds focused E2E coverage for the check-in flow and improves Cypress execution in headed mode.

### Main Changes
1. **Frontend (Today Attendance)**
   - Adds a time picker to the check-in confirmation dialog.
   - Sends the selected check-in time as ISO 8601 with local timezone offset.
   - Updates the page hook to manage `selectedTime` and its change handler.

2. **Backend (Attendance)**
   - Fixes late-seconds calculation by anchoring expected start time to the correct local date/time context.
   - Fixes checkout overtime calculation for overnight shifts and local-date boundary crossings.

3. **Testing and E2E Support**
   - Adds a new check-in E2E spec with 8 scenarios (on-time, early, and lateness from 15m to 1h).
   - Updates employees E2E test with `scrollIntoView` to avoid visibility flakiness.
   - Extends seed data with additional employees to support E2E scenarios.
   - Adds `cypress-run-headed` to `Makefile` to run all tests with a visible browser (VNC).

### Expected Impact
- More accurate late and overtime calculations across timezone and overnight-shift scenarios.
- Better operations UX by allowing users to register the actual check-in time.
- Higher confidence in the attendance flow through expanded E2E coverage.

### Recommended Validation
- Run API tests for check-in/check-out.
- Run `attendance-checkin` E2E tests in both headless and headed modes.
- Manually verify one overnight-shift scenario crossing a date boundary.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pakodiazdev/sushigo/pull/89" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
