### PR TITLE
✨ [#032] - Implement lunch-start frontend (salida a comida) 🍽️

### DIFF
--- a/code/webapp/cypress/e2e/attendance-lunch-start.cy.ts
+++ b/code/webapp/cypress/e2e/attendance-lunch-start.cy.ts
@@ -1,0 +1,144 @@
+/**
+ * Attendance Lunch-Start (Salida a Comida) — E2E tests
+ *
+ * Covers the employee meal break start flow.
+ * Pre-requisite: employee must be checked-in before starting lunch.
+ *
+ * Shift schedule (seeded for all employees):
+ *   expected_start = 13:00 local (America/Mexico_City)
+ *   expected_end   = 22:00 local
+ *
+ * DB reset strategy
+ * ─────────────────
+ * • before()     → cy.task('db:reset') ONCE por archivo (~90s).
+ * • beforeEach() → login vía UI + navega a /attendance/today.
+ * • Cada it() usa un EMPLEADO DISTINTO — no se reutiliza ningún slot.
+ *
+ * Employees used (EMP-001..EMP-002 seeded via config/seeders.php):
+ *   EMP-001  Mendoza, Carlos   → check-in 13:00, lunch 14:00 (a tiempo)
+ *   EMP-002  García, María     → check-in 13:00, lunch 13:45 (anticipado)
+ *
+ * Para correr solo este archivo:
+ *   make cypress-spec SPEC=attendance-lunch-start
+ *   make cypress-debug SPEC=attendance-lunch-start
+ */
+
+import users from "../fixtures/users.json";
+
+const { email: adminEmail, password: adminPassword } = users.admin;
+
+// ── Suite setup ─────────────────────────────────────────────────────────────
+
+before(() => {
+  cy.task("db:reset", null, { timeout: 90_000 });
+});
+
+beforeEach(() => {
+  cy.login(adminEmail, adminPassword);
+  cy.url().should("not.include", "/login", { timeout: 10_000 });
+  cy.visit("/attendance/today");
+  cy.url().should("include", "/attendance/today", { timeout: 10_000 });
+  cy.closeDevDebugger();
+});
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Opens the check-in dialog for the given employee card and submits with time.
+ */
+function openCheckInDialog(lastName: string, firstName: string, time: string) {
+  cy.contains("p", `${lastName}, ${firstName}`)
+    .closest("div.rounded-xl")
+    .contains("button", "Registrar entrada")
+    .scrollIntoView()
+    .click({ force: true });
+
+  cy.get("#checkin-time").clear({ force: true }).type(time, { force: true });
+
+  cy.contains("button", "Confirmar entrada")
+    .should("not.be.disabled")
+    .click();
+}
+
+/**
+ * Opens the lunch-start dialog for the given employee card and submits with time.
+ * Pre-requisite: employee must be in "En trabajo" (checked-in) phase.
+ */
+function openLunchStartDialog(lastName: string, firstName: string, time: string) {
+  cy.contains("p", `${lastName}, ${firstName}`)
+    .closest("div.rounded-xl")
+    .contains("button", "Salir a comer")
+    .scrollIntoView()
+    .click({ force: true });
+
+  cy.get("#lunch-time").clear({ force: true }).type(time, { force: true });
+
+  cy.contains("button", "Confirmar salida")
+    .should("not.be.disabled")
+    .click();
+}
+
+/**
+ * Returns a Cypress chain scoped to the employee's card.
+ * scrollIntoView ensures the card is in the viewport before asserting visibility.
+ */
+function getCard(lastName: string, firstName: string) {
+  return cy
+    .contains("p", `${lastName}, ${firstName}`, { timeout: 10_000 })
+    .closest("div.rounded-xl")
+    .scrollIntoView();
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// 1. Salida a comida — 14:00 (a tiempo)
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe("Lunch-start — A tiempo (14:00)", () => {
+  it("registra la salida a comida de Carlos a las 14:00", () => {
+    // Step 1: First check in the employee
+    openCheckInDialog("Mendoza", "Carlos", "13:00");
+
+    // Wait for check-in to complete and card to update
+    getCard("Mendoza", "Carlos").within(() => {
+      cy.contains("En trabajo", { timeout: 10_000 }).should("be.visible");
+    });
+
+    // Step 2: Register lunch-start
+    openLunchStartDialog("Mendoza", "Carlos", "14:00");
+
+    // Step 3: Verify lunch-start is visible in the card
+    getCard("Mendoza", "Carlos").within(() => {
+      cy.contains("Comida", { timeout: 10_000 }).should("be.visible");
+      cy.contains("Salida comida").should("be.visible");
+      // Verify the time is displayed (14:00 in some format)
+      cy.contains(/2:00\s*PM|14:00/).should("be.visible");
+    });
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════════
+// 2. Salida a comida anticipada — 13:45
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe("Lunch-start — Anticipada (13:45)", () => {
+  it("registra la salida a comida de María a las 13:45 (antes del horario programado)", () => {
+    // Step 1: First check in the employee
+    openCheckInDialog("García", "María", "13:00");
+
+    // Wait for check-in to complete and card to update
+    getCard("García", "María").within(() => {
+      cy.contains("En trabajo", { timeout: 10_000 }).should("be.visible");
+    });
+
+    // Step 2: Register lunch-start (earlier than scheduled)
+    openLunchStartDialog("García", "María", "13:45");
+
+    // Step 3: Verify lunch-start is visible in the card
+    getCard("García", "María").within(() => {
+      cy.contains("Comida", { timeout: 10_000 }).should("be.visible");
+      cy.contains("Salida comida").should("be.visible");
+      // Verify the time is displayed (13:45 in some format)
+      cy.contains(/1:45\s*PM|13:45/).should("be.visible");
+    });
+  });
+});

--- a/code/webapp/src/pages/attendance/-use-today-attendance-page.ts
+++ b/code/webapp/src/pages/attendance/-use-today-attendance-page.ts
@@ -17,7 +17,8 @@ export interface AttendanceSummary {
   withOvertime: number
 }
 
-function computeSummary(rows: TodayAttendanceRow[]): AttendanceSummary {
+/** Computes attendance summary from rows (exported for testing) */
+export function computeSummary(rows: TodayAttendanceRow[]): AttendanceSummary {
   let pending = 0, checkedIn = 0, done = 0, withOvertime = 0
 
   for (const row of rows) {
@@ -32,13 +33,13 @@ function computeSummary(rows: TodayAttendanceRow[]): AttendanceSummary {
   return { total: rows.length, pending, checkedIn, done, withOvertime }
 }
 
-/** Format current time as "HH:mm" for display in the confirm dialog */
-function currentTimeLabel(): string {
+/** Format current time as "HH:mm" for display in the confirm dialog (exported for testing) */
+export function currentTimeLabel(): string {
   return new Date().toTimeString().slice(0, 5)
 }
 
-/** ISO 8601 / RFC 3339 from a "HH:mm" string using today's date and local timezone offset */
-function timeToIso(hhmm: string): string {
+/** ISO 8601 / RFC 3339 from a "HH:mm" string using today's date and local timezone offset (exported for testing) */
+export function timeToIso(hhmm: string): string {
   if (!hhmm?.includes(':')) {
     throw new TypeError(`Invalid time value: "${hhmm}"`)
   }

--- a/code/webapp/src/pages/attendance/-use-today-attendance-page.ts
+++ b/code/webapp/src/pages/attendance/-use-today-attendance-page.ts
@@ -1,8 +1,13 @@
 import { useState } from 'react'
 import { useAuthStore } from '@/stores/auth.store'
-import { useTodayAttendance, useCheckIn } from '@/services/attendance-hooks'
+import { useTodayAttendance, useCheckIn, useLunchStart } from '@/services/attendance-hooks'
 import { getAttendancePhase } from '@/types/attendance'
 import type { TodayAttendanceRow, AttendancePhase, TodayAttendanceEmployee } from '@/types/attendance'
+
+interface PendingLunchStartData {
+  employee: TodayAttendanceEmployee
+  attendanceId: string
+}
 
 export interface AttendanceSummary {
   total: number
@@ -69,6 +74,14 @@ export interface UseTodayAttendancePageResult {
   openCheckIn: (employee: TodayAttendanceEmployee) => void
   closeCheckIn: () => void
   confirmCheckIn: () => void
+  // Lunch-start action
+  pendingLunchStart: PendingLunchStartData | null
+  isRegisteringLunch: boolean
+  selectedLunchTime: string
+  onLunchTimeChange: (time: string) => void
+  openLunchStart: (employee: TodayAttendanceEmployee, attendanceId: string) => void
+  closeLunchStart: () => void
+  confirmLunchStart: () => void
 }
 
 export function useTodayAttendancePage(): UseTodayAttendancePageResult {
@@ -77,9 +90,11 @@ export function useTodayAttendancePage(): UseTodayAttendancePageResult {
 
   const { data = [], isLoading, isError } = useTodayAttendance(branchId)
   const checkInMutation = useCheckIn()
+  const lunchStartMutation = useLunchStart()
 
   const summary = computeSummary(data)
 
+  // Check-in state
   const [pendingCheckInEmployee, setPendingCheckInEmployee] =
     useState<TodayAttendanceEmployee | null>(null)
   const [selectedTime, setSelectedTime] = useState('')
@@ -99,6 +114,26 @@ export function useTodayAttendancePage(): UseTodayAttendancePageResult {
     )
   }
 
+  // Lunch-start state
+  const [pendingLunchStart, setPendingLunchStart] =
+    useState<PendingLunchStartData | null>(null)
+  const [selectedLunchTime, setSelectedLunchTime] = useState('')
+
+  const openLunchStart = (employee: TodayAttendanceEmployee, attendanceId: string) => {
+    setSelectedLunchTime(currentTimeLabel())
+    setPendingLunchStart({ employee, attendanceId })
+  }
+
+  const closeLunchStart = () => setPendingLunchStart(null)
+
+  const confirmLunchStart = () => {
+    if (!pendingLunchStart || !selectedLunchTime) return
+    lunchStartMutation.mutate(
+      { attendance_id: pendingLunchStart.attendanceId, lunch_start: timeToIso(selectedLunchTime) },
+      { onSettled: closeLunchStart }
+    )
+  }
+
   return {
     rows: data,
     summary,
@@ -107,6 +142,7 @@ export function useTodayAttendancePage(): UseTodayAttendancePageResult {
     branchName: currentBranch?.name ?? null,
     hasBranch: !!branchId,
     getPhase: (row) => getAttendancePhase(row.attendance),
+    // Check-in
     pendingCheckInEmployee,
     isCheckingIn: checkInMutation.isPending,
     selectedTime,
@@ -114,5 +150,13 @@ export function useTodayAttendancePage(): UseTodayAttendancePageResult {
     openCheckIn,
     closeCheckIn,
     confirmCheckIn,
+    // Lunch-start
+    pendingLunchStart,
+    isRegisteringLunch: lunchStartMutation.isPending,
+    selectedLunchTime,
+    onLunchTimeChange: setSelectedLunchTime,
+    openLunchStart,
+    closeLunchStart,
+    confirmLunchStart,
   }
 }

--- a/code/webapp/src/pages/attendance/__tests__/use-today-attendance-page.test.ts
+++ b/code/webapp/src/pages/attendance/__tests__/use-today-attendance-page.test.ts
@@ -1,0 +1,518 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import React from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  useTodayAttendancePage,
+  computeSummary,
+  currentTimeLabel,
+  timeToIso,
+} from '@/pages/attendance/-use-today-attendance-page'
+import type { TodayAttendanceRow } from '@/types/attendance'
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockShowSuccess = vi.fn()
+const mockShowError = vi.fn()
+
+vi.mock('@/components/ui/toast-provider', () => ({
+  useToast: () => ({ showSuccess: mockShowSuccess, showError: mockShowError }),
+}))
+
+vi.mock('@/stores/auth.store', () => ({
+  useAuthStore: vi.fn((selector: (state: unknown) => unknown) =>
+    selector({ currentBranch: { id: 1, name: 'Main Branch' } })
+  ),
+}))
+
+vi.mock('@/services/attendance-api', () => ({
+  attendanceApi: {
+    today: vi.fn(),
+    checkIn: vi.fn(),
+    lunchStart: vi.fn(),
+  },
+}))
+
+import { attendanceApi } from '@/services/attendance-api'
+import { useAuthStore } from '@/stores/auth.store'
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children)
+  return { queryClient, wrapper }
+}
+
+/** Creates a test employee with all required fields */
+function makeEmployee(overrides: Partial<{ id: string; code: string; first_name: string; last_name: string; roles: string[] }> = {}) {
+  return {
+    id: 'emp-001',
+    code: 'EMP-001',
+    first_name: 'Test',
+    last_name: 'User',
+    roles: [] as string[],
+    ...overrides,
+  }
+}
+
+// Sample attendance rows for testing
+function makeRow(overrides: Partial<TodayAttendanceRow> = {}): TodayAttendanceRow {
+  return {
+    employee: {
+      id: 'emp-001',
+      code: 'EMP-001',
+      first_name: 'Carlos',
+      last_name: 'Mendoza',
+      roles: [],
+    },
+    attendance: null,
+    ...overrides,
+  }
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// computeSummary
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('computeSummary', () => {
+  it('returns all zeros for empty array', () => {
+    const result = computeSummary([])
+    expect(result).toEqual({
+      total: 0,
+      pending: 0,
+      checkedIn: 0,
+      done: 0,
+      withOvertime: 0,
+    })
+  })
+
+  it('counts pending employees (no attendance)', () => {
+    const rows = [makeRow(), makeRow({ employee: { id: 'emp-002', code: 'EMP-002', first_name: 'María', last_name: 'García', roles: [] } })]
+    const result = computeSummary(rows)
+    expect(result.total).toBe(2)
+    expect(result.pending).toBe(2)
+    expect(result.checkedIn).toBe(0)
+    expect(result.done).toBe(0)
+  })
+
+  it('counts checked-in employees (has check_in, no check_out)', () => {
+    const rows = [
+      makeRow({ attendance: { id: 'att-1', check_in: '2026-04-01T13:00:00Z' } as TodayAttendanceRow['attendance'] }),
+    ]
+    const result = computeSummary(rows)
+    expect(result.checkedIn).toBe(1)
+    expect(result.pending).toBe(0)
+  })
+
+  it('counts done employees (has check_out)', () => {
+    const rows = [
+      makeRow({
+        attendance: {
+          id: 'att-1',
+          check_in: '2026-04-01T13:00:00Z',
+          check_out: '2026-04-01T22:00:00Z',
+        } as TodayAttendanceRow['attendance'],
+      }),
+    ]
+    const result = computeSummary(rows)
+    expect(result.done).toBe(1)
+    expect(result.checkedIn).toBe(0)
+  })
+
+  it('counts employees with overtime', () => {
+    const rows = [
+      makeRow({
+        attendance: {
+          id: 'att-1',
+          check_in: '2026-04-01T13:00:00Z',
+          overtime_minutes: 30,
+        } as TodayAttendanceRow['attendance'],
+      }),
+      makeRow({
+        employee: { id: 'emp-002', code: 'EMP-002', first_name: 'María', last_name: 'García', roles: [] },
+        attendance: {
+          id: 'att-2',
+          check_in: '2026-04-01T13:00:00Z',
+          overtime_minutes: 0,
+        } as TodayAttendanceRow['attendance'],
+      }),
+    ]
+    const result = computeSummary(rows)
+    expect(result.withOvertime).toBe(1)
+  })
+
+  it('counts at-lunch phase as checkedIn', () => {
+    const rows = [
+      makeRow({
+        attendance: {
+          id: 'att-1',
+          check_in: '2026-04-01T13:00:00Z',
+          lunch_start: '2026-04-01T14:00:00Z',
+        } as TodayAttendanceRow['attendance'],
+      }),
+    ]
+    const result = computeSummary(rows)
+    expect(result.checkedIn).toBe(1)
+    expect(result.done).toBe(0)
+  })
+
+  it('counts returned phase as checkedIn', () => {
+    const rows = [
+      makeRow({
+        attendance: {
+          id: 'att-1',
+          check_in: '2026-04-01T13:00:00Z',
+          lunch_start: '2026-04-01T14:00:00Z',
+          lunch_end: '2026-04-01T15:00:00Z',
+        } as TodayAttendanceRow['attendance'],
+      }),
+    ]
+    const result = computeSummary(rows)
+    expect(result.checkedIn).toBe(1)
+    expect(result.done).toBe(0)
+  })
+})
+
+// ══════════════════════════════════════════════════════════════════════════════
+// currentTimeLabel
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('currentTimeLabel', () => {
+  it('returns time in HH:mm format', () => {
+    const result = currentTimeLabel()
+    expect(result).toMatch(/^\d{2}:\d{2}$/)
+  })
+
+  it('returns 5 character string', () => {
+    expect(currentTimeLabel().length).toBe(5)
+  })
+})
+
+// ══════════════════════════════════════════════════════════════════════════════
+// timeToIso
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('timeToIso', () => {
+  it('converts HH:mm to ISO 8601 format', () => {
+    const result = timeToIso('13:00')
+    // Should match ISO format with timezone offset
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T13:00:00[+-]\d{2}:\d{2}$/)
+  })
+
+  it('preserves hours and minutes in the output', () => {
+    const result = timeToIso('14:30')
+    expect(result).toContain('T14:30:00')
+  })
+
+  it('throws TypeError for invalid time without colon', () => {
+    expect(() => timeToIso('1300')).toThrow(TypeError)
+    expect(() => timeToIso('1300')).toThrow('Invalid time value')
+  })
+
+  it('throws TypeError for empty string', () => {
+    expect(() => timeToIso('')).toThrow(TypeError)
+  })
+
+  it('throws TypeError for NaN values', () => {
+    expect(() => timeToIso('ab:cd')).toThrow(TypeError)
+    expect(() => timeToIso('ab:cd')).toThrow('Invalid time value')
+  })
+
+  it('handles midnight correctly', () => {
+    const result = timeToIso('00:00')
+    expect(result).toContain('T00:00:00')
+  })
+
+  it('handles end of day correctly', () => {
+    const result = timeToIso('23:59')
+    expect(result).toContain('T23:59:00')
+  })
+
+  it('includes timezone offset in output', () => {
+    const result = timeToIso('12:00')
+    // Should end with timezone offset like +06:00 or -06:00
+    expect(result).toMatch(/[+-]\d{2}:\d{2}$/)
+  })
+})
+
+// ══════════════════════════════════════════════════════════════════════════════
+// useTodayAttendancePage hook
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('useTodayAttendancePage', () => {
+  const mockTodayResponse = {
+    data: {
+      data: [makeRow()],
+    },
+  }
+
+  beforeEach(() => {
+    vi.mocked(attendanceApi.today).mockResolvedValue(mockTodayResponse as never)
+    vi.mocked(attendanceApi.checkIn).mockResolvedValue({ data: { status: 200, data: {} } } as never)
+    vi.mocked(attendanceApi.lunchStart).mockResolvedValue({ data: { status: 200, data: {} } } as never)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns initial state correctly', async () => {
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+    expect(result.current.branchName).toBe('Main Branch')
+    expect(result.current.hasBranch).toBe(true)
+    expect(result.current.pendingCheckInEmployee).toBeNull()
+    expect(result.current.pendingLunchStart).toBeNull()
+    expect(result.current.selectedTime).toBe('')
+    expect(result.current.selectedLunchTime).toBe('')
+  })
+
+  it('fetches attendance data on mount', async () => {
+    const { wrapper } = makeWrapper()
+    renderHook(() => useTodayAttendancePage(), { wrapper })
+
+    await waitFor(() => {
+      expect(attendanceApi.today).toHaveBeenCalledWith(1)
+    })
+  })
+
+  // Check-in flow tests
+  describe('check-in flow', () => {
+    it('openCheckIn sets pending employee and current time', async () => {
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      const employee = makeEmployee()
+
+      act(() => {
+        result.current.openCheckIn(employee)
+      })
+
+      expect(result.current.pendingCheckInEmployee).toEqual(employee)
+      expect(result.current.selectedTime).toMatch(/^\d{2}:\d{2}$/)
+    })
+
+    it('closeCheckIn clears pending employee', async () => {
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      const employee = makeEmployee()
+
+      act(() => {
+        result.current.openCheckIn(employee)
+      })
+
+      act(() => {
+        result.current.closeCheckIn()
+      })
+
+      expect(result.current.pendingCheckInEmployee).toBeNull()
+    })
+
+    it('onTimeChange updates selected time', async () => {
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      act(() => {
+        result.current.onTimeChange('14:30')
+      })
+
+      expect(result.current.selectedTime).toBe('14:30')
+    })
+
+    it('confirmCheckIn does nothing if no pending employee', async () => {
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      act(() => {
+        result.current.confirmCheckIn()
+      })
+
+      expect(attendanceApi.checkIn).not.toHaveBeenCalled()
+    })
+
+    it('confirmCheckIn does nothing if no selected time', async () => {
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      const employee = makeEmployee()
+
+      act(() => {
+        result.current.openCheckIn(employee)
+      })
+
+      // Clear the time that was set by openCheckIn
+      act(() => {
+        result.current.onTimeChange('')
+      })
+
+      act(() => {
+        result.current.confirmCheckIn()
+      })
+
+      expect(attendanceApi.checkIn).not.toHaveBeenCalled()
+    })
+  })
+
+  // Lunch-start flow tests
+  describe('lunch-start flow', () => {
+    it('openLunchStart sets pending data and current time', async () => {
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      const employee = makeEmployee()
+
+      act(() => {
+        result.current.openLunchStart(employee, 'att-123')
+      })
+
+      expect(result.current.pendingLunchStart).toEqual({
+        employee,
+        attendanceId: 'att-123',
+      })
+      expect(result.current.selectedLunchTime).toMatch(/^\d{2}:\d{2}$/)
+    })
+
+    it('closeLunchStart clears pending data', async () => {
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      const employee = makeEmployee()
+
+      act(() => {
+        result.current.openLunchStart(employee, 'att-123')
+      })
+
+      act(() => {
+        result.current.closeLunchStart()
+      })
+
+      expect(result.current.pendingLunchStart).toBeNull()
+    })
+
+    it('onLunchTimeChange updates selected lunch time', async () => {
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      act(() => {
+        result.current.onLunchTimeChange('14:00')
+      })
+
+      expect(result.current.selectedLunchTime).toBe('14:00')
+    })
+
+    it('confirmLunchStart does nothing if no pending data', async () => {
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      act(() => {
+        result.current.confirmLunchStart()
+      })
+
+      expect(attendanceApi.lunchStart).not.toHaveBeenCalled()
+    })
+
+    it('confirmLunchStart does nothing if no selected time', async () => {
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      const employee = makeEmployee()
+
+      act(() => {
+        result.current.openLunchStart(employee, 'att-123')
+      })
+
+      // Clear the time that was set by openLunchStart
+      act(() => {
+        result.current.onLunchTimeChange('')
+      })
+
+      act(() => {
+        result.current.confirmLunchStart()
+      })
+
+      expect(attendanceApi.lunchStart).not.toHaveBeenCalled()
+    })
+
+    it('confirmLunchStart calls API with correct data', async () => {
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+      const employee = makeEmployee()
+
+      act(() => {
+        result.current.openLunchStart(employee, 'att-123')
+      })
+
+      await act(async () => {
+        result.current.confirmLunchStart()
+      })
+
+      await waitFor(() => {
+        expect(attendanceApi.lunchStart).toHaveBeenCalledWith(
+          'att-123',
+          expect.objectContaining({ lunch_start: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/) })
+        )
+      })
+    })
+  })
+
+  // Summary and phase tests
+  describe('summary and phase', () => {
+    it('computes summary from rows', async () => {
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+      expect(result.current.summary).toEqual({
+        total: 1,
+        pending: 1,
+        checkedIn: 0,
+        done: 0,
+        withOvertime: 0,
+      })
+    })
+
+    it('getPhase returns correct phase for row', async () => {
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+      const pendingRow = makeRow()
+      expect(result.current.getPhase(pendingRow)).toBe('pending')
+
+      const checkedInRow = makeRow({
+        attendance: { id: 'att-1', check_in: '2026-04-01T13:00:00Z' } as TodayAttendanceRow['attendance'],
+      })
+      expect(result.current.getPhase(checkedInRow)).toBe('checked-in')
+    })
+  })
+
+  // No branch scenario
+  describe('no branch selected', () => {
+    it('returns hasBranch false when no branch', async () => {
+      vi.mocked(useAuthStore).mockImplementation((selector) =>
+        selector({ currentBranch: null } as unknown as Parameters<typeof selector>[0])
+      )
+
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      expect(result.current.hasBranch).toBe(false)
+      expect(result.current.branchName).toBeNull()
+    })
+  })
+})

--- a/code/webapp/src/pages/attendance/today.tsx
+++ b/code/webapp/src/pages/attendance/today.tsx
@@ -270,7 +270,7 @@ interface EmployeeAttendanceCardProps {
   onLunchStart: (employee: TodayAttendanceEmployee, attendanceId: string) => void
 }
 
-function EmployeeAttendanceCard({ row, onCheckIn, onLunchStart }: EmployeeAttendanceCardProps) {
+function EmployeeAttendanceCard({ row, onCheckIn, onLunchStart }: Readonly<EmployeeAttendanceCardProps>) {
   const phase = getAttendancePhase(row.attendance)
   const att = row.attendance
 

--- a/code/webapp/src/pages/attendance/today.tsx
+++ b/code/webapp/src/pages/attendance/today.tsx
@@ -40,6 +40,14 @@ export function TodayAttendancePage() {
     openCheckIn,
     closeCheckIn,
     confirmCheckIn,
+    // Lunch-start
+    pendingLunchStart,
+    isRegisteringLunch,
+    selectedLunchTime,
+    onLunchTimeChange,
+    openLunchStart,
+    closeLunchStart,
+    confirmLunchStart,
   } = useTodayAttendancePage()
 
   if (!hasBranch) {
@@ -93,6 +101,7 @@ export function TodayAttendancePage() {
               key={row.employee.id}
               row={row}
               onCheckIn={openCheckIn}
+              onLunchStart={openLunchStart}
             />
           ))}
         </div>
@@ -133,6 +142,43 @@ export function TodayAttendancePage() {
         variant="info"
         isLoading={isCheckingIn}
         confirmDisabled={!selectedTime}
+      />
+
+      {/* Lunch-start confirmation dialog — single instance for the whole list */}
+      <ConfirmDialog
+        isOpen={!!pendingLunchStart}
+        onClose={closeLunchStart}
+        onConfirm={confirmLunchStart}
+        title="Salir a comer"
+        description={
+          pendingLunchStart ? (
+            <span className="flex flex-col gap-3">
+              <span>
+                {`¿Confirmas la salida a comida de ${pendingLunchStart.employee.first_name} ${pendingLunchStart.employee.last_name}?`}
+              </span>
+              <span className="flex items-center gap-2">
+                <label
+                  htmlFor="lunch-time"
+                  className="text-sm font-medium text-foreground whitespace-nowrap"
+                >
+                  Hora de salida:
+                </label>
+                <input
+                  id="lunch-time"
+                  type="time"
+                  value={selectedLunchTime}
+                  max={new Date().toTimeString().slice(0, 5)}
+                  onChange={e => onLunchTimeChange(e.target.value)}
+                  className="rounded border border-input bg-background px-2 py-1 text-sm text-foreground"
+                />
+              </span>
+            </span>
+          ) : undefined
+        }
+        confirmLabel="Confirmar salida"
+        variant="info"
+        isLoading={isRegisteringLunch}
+        confirmDisabled={!selectedLunchTime}
       />
     </PageContainer>
   )
@@ -221,9 +267,10 @@ function SummaryStat({
 interface EmployeeAttendanceCardProps {
   row: TodayAttendanceRow
   onCheckIn: (employee: TodayAttendanceEmployee) => void
+  onLunchStart: (employee: TodayAttendanceEmployee, attendanceId: string) => void
 }
 
-function EmployeeAttendanceCard({ row, onCheckIn }: EmployeeAttendanceCardProps) {
+function EmployeeAttendanceCard({ row, onCheckIn, onLunchStart }: EmployeeAttendanceCardProps) {
   const phase = getAttendancePhase(row.attendance)
   const att = row.attendance
 
@@ -286,6 +333,19 @@ function EmployeeAttendanceCard({ row, onCheckIn }: EmployeeAttendanceCardProps)
         >
           <LogIn className="h-3.5 w-3.5 mr-1.5" />
           Registrar entrada
+        </Button>
+      )}
+
+      {/* Lunch-start action — only for checked-in employees (no lunch_start yet) */}
+      {phase === 'checked-in' && att && (
+        <Button
+          size="sm"
+          variant="outline"
+          className="w-full mt-auto"
+          onClick={() => onLunchStart(row.employee, att.id)}
+        >
+          <UtensilsCrossed className="h-3.5 w-3.5 mr-1.5" />
+          Salir a comer
         </Button>
       )}
 

--- a/code/webapp/src/services/__tests__/attendance-api.test.ts
+++ b/code/webapp/src/services/__tests__/attendance-api.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { attendanceApi } from '@/services/attendance-api'
+
+vi.mock('@/lib/api-client', () => ({
+  apiClient: {
+    get: vi.fn().mockResolvedValue({ data: {} }),
+    post: vi.fn().mockResolvedValue({ data: {} }),
+    patch: vi.fn().mockResolvedValue({ data: {} }),
+  },
+}))
+
+import { apiClient } from '@/lib/api-client'
+
+// ── attendanceApi.today ────────────────────────────────────────────────────────
+
+describe('attendanceApi.today', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('calls GET /attendances/today with branch_id param', async () => {
+    const mockResponse = {
+      data: {
+        data: [
+          { employee: { id: '1', first_name: 'Carlos', last_name: 'Mendoza' }, attendance: null },
+        ],
+      },
+    }
+    vi.mocked(apiClient.get).mockResolvedValueOnce(mockResponse as never)
+
+    const result = await attendanceApi.today(5)
+
+    expect(apiClient.get).toHaveBeenCalledWith('/attendances/today', {
+      params: { branch_id: 5 },
+    })
+    expect(result).toEqual(mockResponse)
+  })
+
+  it('passes different branch_id values correctly', async () => {
+    await attendanceApi.today(10)
+    expect(apiClient.get).toHaveBeenCalledWith('/attendances/today', {
+      params: { branch_id: 10 },
+    })
+
+    await attendanceApi.today(1)
+    expect(apiClient.get).toHaveBeenCalledWith('/attendances/today', {
+      params: { branch_id: 1 },
+    })
+  })
+})
+
+// ── attendanceApi.checkIn ──────────────────────────────────────────────────────
+
+describe('attendanceApi.checkIn', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('calls POST /attendances/check-in with employee_id and check_in', async () => {
+    const mockResponse = {
+      data: {
+        status: 201,
+        data: {
+          id: 'att-123',
+          employee_id: 'emp-001',
+          check_in: '2026-04-01T13:00:00-06:00',
+        },
+      },
+    }
+    vi.mocked(apiClient.post).mockResolvedValueOnce(mockResponse as never)
+
+    const payload = {
+      employee_id: 'emp-001',
+      check_in: '2026-04-01T13:00:00-06:00',
+    }
+    const result = await attendanceApi.checkIn(payload)
+
+    expect(apiClient.post).toHaveBeenCalledWith('/attendances/check-in', payload)
+    expect(result).toEqual(mockResponse)
+  })
+
+  it('sends the exact datetime string provided', async () => {
+    const isoTime = '2026-04-01T14:30:00+00:00'
+    await attendanceApi.checkIn({ employee_id: 'xyz', check_in: isoTime })
+
+    expect(apiClient.post).toHaveBeenCalledWith('/attendances/check-in', {
+      employee_id: 'xyz',
+      check_in: isoTime,
+    })
+  })
+})
+
+// ── attendanceApi.lunchStart ───────────────────────────────────────────────────
+
+describe('attendanceApi.lunchStart', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('calls PATCH /attendances/{id}/lunch-start with lunch_start', async () => {
+    const mockResponse = {
+      data: {
+        status: 200,
+        data: {
+          id: 'att-123',
+          lunch_start: '2026-04-01T14:00:00-06:00',
+        },
+      },
+    }
+    vi.mocked(apiClient.patch).mockResolvedValueOnce(mockResponse as never)
+
+    const result = await attendanceApi.lunchStart('att-123', {
+      lunch_start: '2026-04-01T14:00:00-06:00',
+    })
+
+    expect(apiClient.patch).toHaveBeenCalledWith('/attendances/att-123/lunch-start', {
+      lunch_start: '2026-04-01T14:00:00-06:00',
+    })
+    expect(result).toEqual(mockResponse)
+  })
+
+  it('interpolates the attendanceId into the URL', async () => {
+    await attendanceApi.lunchStart('my-attendance-id', { lunch_start: '2026-04-01T15:00:00-06:00' })
+
+    expect(apiClient.patch).toHaveBeenCalledWith(
+      '/attendances/my-attendance-id/lunch-start',
+      { lunch_start: '2026-04-01T15:00:00-06:00' }
+    )
+  })
+
+  it('handles different attendance IDs correctly', async () => {
+    await attendanceApi.lunchStart('abc', { lunch_start: '2026-04-01T12:00:00Z' })
+    expect(apiClient.patch).toHaveBeenCalledWith('/attendances/abc/lunch-start', expect.any(Object))
+
+    await attendanceApi.lunchStart('def-456', { lunch_start: '2026-04-01T13:00:00Z' })
+    expect(apiClient.patch).toHaveBeenCalledWith('/attendances/def-456/lunch-start', expect.any(Object))
+  })
+})

--- a/code/webapp/src/services/__tests__/attendance-hooks.test.ts
+++ b/code/webapp/src/services/__tests__/attendance-hooks.test.ts
@@ -1,0 +1,303 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import React from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useTodayAttendance, useCheckIn, useLunchStart } from '@/services/attendance-hooks'
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockShowSuccess = vi.fn()
+const mockShowError = vi.fn()
+
+vi.mock('@/components/ui/toast-provider', () => ({
+  useToast: () => ({ showSuccess: mockShowSuccess, showError: mockShowError }),
+}))
+
+vi.mock('@/services/attendance-api', () => ({
+  attendanceApi: {
+    today: vi.fn(),
+    checkIn: vi.fn(),
+    lunchStart: vi.fn(),
+  },
+}))
+
+import { attendanceApi } from '@/services/attendance-api'
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children)
+  return { queryClient, wrapper }
+}
+
+const mockTodayResponse = {
+  data: {
+    data: [
+      {
+        employee: { id: 'emp-001', first_name: 'Carlos', last_name: 'Mendoza', code: 'EMP-001' },
+        attendance: null,
+        schedule_day: null,
+      },
+      {
+        employee: { id: 'emp-002', first_name: 'María', last_name: 'García', code: 'EMP-002' },
+        attendance: { id: 'att-001', check_in: '2026-04-01T13:00:00Z' },
+        schedule_day: null,
+      },
+    ],
+  },
+}
+
+const mockAttendanceRecord = {
+  data: {
+    status: 200,
+    data: {
+      id: 'att-123',
+      employee_id: 'emp-001',
+      check_in: '2026-04-01T13:00:00-06:00',
+    },
+  },
+}
+
+// ── useTodayAttendance ─────────────────────────────────────────────────────────
+
+describe('useTodayAttendance', () => {
+  beforeEach(() => {
+    vi.mocked(attendanceApi.today).mockResolvedValue(mockTodayResponse as never)
+  })
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns undefined data when branchId is null (query disabled)', async () => {
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useTodayAttendance(null), { wrapper })
+
+    // When disabled (null branchId), the query doesn't run and data is undefined
+    expect(result.current.data).toBeUndefined()
+    expect(attendanceApi.today).not.toHaveBeenCalled()
+  })
+
+  it('fetches attendance data when branchId is provided', async () => {
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useTodayAttendance(5), { wrapper })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(attendanceApi.today).toHaveBeenCalledWith(5)
+    expect(result.current.data).toEqual(mockTodayResponse.data.data)
+  })
+
+  it('is disabled when branchId is null', () => {
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useTodayAttendance(null), { wrapper })
+
+    // Query should still succeed but with empty data (not in loading state)
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('passes different branchId values correctly', async () => {
+    const { wrapper } = makeWrapper()
+    renderHook(() => useTodayAttendance(10), { wrapper })
+
+    await waitFor(() => expect(attendanceApi.today).toHaveBeenCalledWith(10))
+  })
+})
+
+// ── useCheckIn ─────────────────────────────────────────────────────────────────
+
+describe('useCheckIn', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('calls attendanceApi.checkIn with correct data', async () => {
+    vi.mocked(attendanceApi.checkIn).mockResolvedValueOnce(mockAttendanceRecord as never)
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useCheckIn(), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        employee_id: 'emp-001',
+        check_in: '2026-04-01T13:00:00-06:00',
+      })
+    })
+
+    expect(attendanceApi.checkIn).toHaveBeenCalledWith({
+      employee_id: 'emp-001',
+      check_in: '2026-04-01T13:00:00-06:00',
+    })
+  })
+
+  it('shows success toast on successful check-in', async () => {
+    vi.mocked(attendanceApi.checkIn).mockResolvedValueOnce(mockAttendanceRecord as never)
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useCheckIn(), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        employee_id: 'emp-001',
+        check_in: '2026-04-01T13:00:00-06:00',
+      })
+    })
+
+    expect(mockShowSuccess).toHaveBeenCalledWith(
+      'Entrada registrada correctamente.',
+      'Check-in'
+    )
+  })
+
+  it('shows error toast on failure', async () => {
+    vi.mocked(attendanceApi.checkIn).mockRejectedValueOnce(new Error('Network error'))
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useCheckIn(), { wrapper })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({
+          employee_id: 'emp-001',
+          check_in: '2026-04-01T13:00:00-06:00',
+        })
+      } catch {
+        /* expected */
+      }
+    })
+
+    expect(mockShowError).toHaveBeenCalledWith(
+      expect.any(String),
+      'Error al registrar'
+    )
+  })
+
+  it('invalidates today attendance queries on success', async () => {
+    vi.mocked(attendanceApi.checkIn).mockResolvedValueOnce(mockAttendanceRecord as never)
+    const { wrapper, queryClient } = makeWrapper()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useCheckIn(), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        employee_id: 'emp-001',
+        check_in: '2026-04-01T13:00:00-06:00',
+      })
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['attendances', 'today'] })
+  })
+})
+
+// ── useLunchStart ──────────────────────────────────────────────────────────────
+
+describe('useLunchStart', () => {
+  const mockLunchResponse = {
+    data: {
+      status: 200,
+      data: {
+        id: 'att-123',
+        lunch_start: '2026-04-01T14:00:00-06:00',
+      },
+    },
+  }
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('calls attendanceApi.lunchStart with correct data', async () => {
+    vi.mocked(attendanceApi.lunchStart).mockResolvedValueOnce(mockLunchResponse as never)
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useLunchStart(), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        attendance_id: 'att-123',
+        lunch_start: '2026-04-01T14:00:00-06:00',
+      })
+    })
+
+    expect(attendanceApi.lunchStart).toHaveBeenCalledWith('att-123', {
+      lunch_start: '2026-04-01T14:00:00-06:00',
+    })
+  })
+
+  it('shows success toast on successful lunch-start', async () => {
+    vi.mocked(attendanceApi.lunchStart).mockResolvedValueOnce(mockLunchResponse as never)
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useLunchStart(), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        attendance_id: 'att-123',
+        lunch_start: '2026-04-01T14:00:00-06:00',
+      })
+    })
+
+    expect(mockShowSuccess).toHaveBeenCalledWith(
+      'Salida a comida registrada correctamente.',
+      'Lunch Start'
+    )
+  })
+
+  it('shows error toast on failure', async () => {
+    vi.mocked(attendanceApi.lunchStart).mockRejectedValueOnce(new Error('Network error'))
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useLunchStart(), { wrapper })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({
+          attendance_id: 'att-123',
+          lunch_start: '2026-04-01T14:00:00-06:00',
+        })
+      } catch {
+        /* expected */
+      }
+    })
+
+    expect(mockShowError).toHaveBeenCalledWith(
+      expect.any(String),
+      'Error al registrar'
+    )
+  })
+
+  it('invalidates today attendance queries on success', async () => {
+    vi.mocked(attendanceApi.lunchStart).mockResolvedValueOnce(mockLunchResponse as never)
+    const { wrapper, queryClient } = makeWrapper()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useLunchStart(), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        attendance_id: 'att-123',
+        lunch_start: '2026-04-01T14:00:00-06:00',
+      })
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['attendances', 'today'] })
+  })
+
+  it('passes attendance_id and lunch_start separately', async () => {
+    vi.mocked(attendanceApi.lunchStart).mockResolvedValueOnce(mockLunchResponse as never)
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useLunchStart(), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        attendance_id: 'different-id',
+        lunch_start: '2026-04-01T15:30:00-06:00',
+      })
+    })
+
+    expect(attendanceApi.lunchStart).toHaveBeenCalledWith('different-id', {
+      lunch_start: '2026-04-01T15:30:00-06:00',
+    })
+  })
+})

--- a/code/webapp/src/services/attendance-api.ts
+++ b/code/webapp/src/services/attendance-api.ts
@@ -18,4 +18,15 @@ export const attendanceApi = {
    */
   checkIn: (data: { employee_id: string; check_in: string }) =>
     apiClient.post<{ status: number; data: AttendanceRecord }>('/attendances/check-in', data),
+
+  /**
+   * PATCH /attendances/{id}/lunch-start
+   * Registers the employee's lunch start (salida a comida) at the given datetime.
+   * Body: { lunch_start: "YYYY-MM-DDTHH:mm:ss+offset" }
+   */
+  lunchStart: (attendanceId: string, data: { lunch_start: string }) =>
+    apiClient.patch<{ status: number; data: AttendanceRecord }>(
+      `/attendances/${attendanceId}/lunch-start`,
+      data,
+    ),
 }

--- a/code/webapp/src/services/attendance-hooks.ts
+++ b/code/webapp/src/services/attendance-hooks.ts
@@ -48,3 +48,27 @@ export function useCheckIn() {
     },
   })
 }
+
+/**
+ * Mutation: register lunch-start (salida a comida) for an employee.
+ * On success: invalidates the today attendance query and shows a toast.
+ */
+export function useLunchStart() {
+  const queryClient = useQueryClient()
+  const { showSuccess, showError } = useToast()
+
+  return useMutation({
+    mutationFn: (data: { attendance_id: string; lunch_start: string }) =>
+      attendanceApi.lunchStart(data.attendance_id, { lunch_start: data.lunch_start }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['attendances', 'today'] })
+      showSuccess('Salida a comida registrada correctamente.', 'Lunch Start')
+    },
+    onError: (error: unknown) => {
+      showError(
+        getApiErrorMessage(error, 'No se pudo registrar la salida a comida.'),
+        'Error al registrar'
+      )
+    },
+  })
+}


### PR DESCRIPTION
- 🌐 Added `lunchStart()` method to attendance-api.ts
- 🪝 Created `useLunchStart()` mutation hook with toast notifications
- 🎛️ Added lunch-start state & handlers to useTodayAttendancePage hook
- 🖼️ Added "Salir a comer" button and confirmation dialog in today.tsx
- 🧪 Added Cypress E2E test for lunch-start flow (2 scenarios)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pakodiazdev/sushigo/pull/90" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
