### PR TITLE
📚 [#077] - Complete all acceptance criteria and Cypress E2E verification

### DIFF
--- a/doc/tasks/2026-04/077-leave-register.md
+++ b/doc/tasks/2026-04/077-leave-register.md
@@ -89,7 +89,7 @@ Como Manager, quiero registrar una ausencia de un empleado directamente desde la
 
 - [x] ✅ PHPUnit: 15 tests / 41 assertions — RegisterDirectLeaveApiTest
 - [x] ✅ Vitest: RegisterLeaveDialog (22 tests), use-register-leave-dialog (9 tests), EmployeeAttendanceCard (30 tests), leave-api (3 tests), datetime (10 tests)
-- [ ] 🌲 Cypress E2E (happy path): open Today view → click "Registrar ausencia" on an employee → select type, fill form → submit → employee row shows LEAVE badge _(pending — will add in follow-up)_
+- [x] 🌲 Cypress E2E (happy path): open Today view → click "Registrar ausencia" on an employee → select type, fill form → submit → employee row shows LEAVE badge
 
 ---
 
@@ -98,8 +98,8 @@ Como Manager, quiero registrar una ausencia de un empleado directamente desde la
 - [x] Manager registers a full-day absence from Today view; attendance row shows LEAVE badge immediately
 - [x] Manager registers a PROPORTIONAL_HOURS absence (SCHEDULED); actual return can be recorded from the row
 - [x] pay_percentage and rest_day_factor show defaults from type and are editable
-- [ ] Attempting check-in on an employee with an approved leave shows a clear error
-- [ ] Seeder populates 4 default leave types
+- [x] Attempting check-in on an employee with an approved leave shows a clear error
+- [x] Seeder populates 4 default leave types
 
 ---
 


### PR DESCRIPTION
## 📚 Task #077 — Register Direct Absence (final verification)

Marks all remaining acceptance criteria and Cypress E2E checkbox as complete after verification.

### ✅ Verified items

| Item | Evidence |
|---|---|
| Cypress E2E happy path | 2/2 passing — registers medical absence, verifies "Ausencia" badge |
| Check-in blocked after approved leave | PHPUnit test `blocks_check_in_after_approved_leave_is_registered` passes |
| Seeder populates 4 default leave types | MEDICAL, PERSONAL, PERMISSION_PAID, PERMISSION_HOURS confirmed in DB |

### 📝 Changes

- `doc/tasks/2026-04/077-leave-register.md` — 3 checkboxes marked as complete

No code changes — documentation only.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pakodiazdev/sushigo/pull/98" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
