### PR TITLE
✨ [#096] - Implement leave request with approve/reject workflow 📋

### DIFF
--- a/code/api/app/Actions/Leaves/ApproveLeaveAction.php
+++ b/code/api/app/Actions/Leaves/ApproveLeaveAction.php
@@ -59,16 +59,4 @@ class ApproveLeaveAction
 
         return $leave->load(['employee', 'leaveType', 'requestedBy', 'approvedBy']);
     }
-
-    /**
-     * @throws ValidationException
-     */
-    private function guardIsPending(Leave $leave): void
-    {
-        if ($leave->status !== LeaveStatus::PENDING) {
-            throw ValidationException::withMessages([
-                'status' => 'Solo se pueden aprobar solicitudes con estado PENDING.',
-            ]);
-        }
-    }
 }

--- a/code/api/app/Actions/Leaves/ApproveLeaveAction.php
+++ b/code/api/app/Actions/Leaves/ApproveLeaveAction.php
@@ -2,11 +2,9 @@
 
 namespace App\Actions\Leaves;
 
-use App\Enums\DayStatus;
+use App\Actions\Leaves\Concerns\LeaveGuards;
 use App\Enums\LeaveStatus;
-use App\Models\Attendance;
 use App\Models\Leave;
-use Carbon\CarbonPeriod;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 
@@ -21,6 +19,8 @@ use Illuminate\Validation\ValidationException;
  */
 class ApproveLeaveAction
 {
+    use LeaveGuards;
+
     /**
      * @throws ValidationException
      */
@@ -69,62 +69,6 @@ class ApproveLeaveAction
             throw ValidationException::withMessages([
                 'status' => 'Solo se pueden aprobar solicitudes con estado PENDING.',
             ]);
-        }
-    }
-
-    /**
-     * @throws ValidationException
-     */
-    private function guardNoExistingWorkedAttendance(int $employeeId, string $startDate, string $endDate): void
-    {
-        $exists = Attendance::where('employee_id', $employeeId)
-            ->where('day_status', DayStatus::WORKED)
-            ->where('date', '>=', $startDate)
-            ->where('date', '<=', $endDate)
-            ->lockForUpdate()
-            ->exists();
-
-        if ($exists) {
-            throw ValidationException::withMessages([
-                'start_date' => 'El empleado ya tiene asistencia trabajada registrada para alguno de los días indicados.',
-            ]);
-        }
-    }
-
-    /**
-     * @throws ValidationException
-     */
-    private function guardNoOverlappingApprovedLeave(int $employeeId, string $startDate, string $endDate, int $excludeLeaveId): void
-    {
-        $overlaps = Leave::where('employee_id', $employeeId)
-            ->where('status', LeaveStatus::APPROVED)
-            ->where('id', '!=', $excludeLeaveId)
-            ->where('start_date', '<=', $endDate)
-            ->where('end_date', '>=', $startDate)
-            ->lockForUpdate()
-            ->exists();
-
-        if ($overlaps) {
-            throw ValidationException::withMessages([
-                'start_date' => 'El empleado ya tiene una ausencia aprobada que se traslapa con las fechas indicadas.',
-            ]);
-        }
-    }
-
-    private function createAttendanceRecords(int $employeeId, string $startDate, string $endDate): void
-    {
-        $period = CarbonPeriod::create($startDate, $endDate);
-
-        foreach ($period as $day) {
-            Attendance::updateOrCreate(
-                [
-                    'employee_id' => $employeeId,
-                    'date' => $day->toDateString(),
-                ],
-                [
-                    'day_status' => DayStatus::LEAVE,
-                ]
-            );
         }
     }
 }

--- a/code/api/app/Actions/Leaves/ApproveLeaveAction.php
+++ b/code/api/app/Actions/Leaves/ApproveLeaveAction.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace App\Actions\Leaves;
+
+use App\Enums\DayStatus;
+use App\Enums\LeaveStatus;
+use App\Models\Attendance;
+use App\Models\Leave;
+use Carbon\CarbonPeriod;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * Approve a PENDING leave request.
+ *
+ * - Sets status = APPROVED, approved_by, approved_at.
+ * - Creates/updates Attendance records for each date in range with day_status = LEAVE.
+ * - Guards: only PENDING leaves may be approved; no worked attendance overlap.
+ *
+ * @see RF-25, RF-28
+ */
+class ApproveLeaveAction
+{
+    /**
+     * @throws ValidationException
+     */
+    public function __invoke(Leave $leave, int $approvedById): Leave
+    {
+        $leave = DB::transaction(function () use ($leave, $approvedById) {
+            $leave = Leave::lockForUpdate()->findOrFail($leave->id);
+
+            $this->guardIsPending($leave);
+            $this->guardNoExistingWorkedAttendance(
+                $leave->employee_id,
+                $leave->start_date->toDateString(),
+                $leave->end_date->toDateString()
+            );
+            $this->guardNoOverlappingApprovedLeave(
+                $leave->employee_id,
+                $leave->start_date->toDateString(),
+                $leave->end_date->toDateString(),
+                $leave->id
+            );
+
+            $leave->update([
+                'status' => LeaveStatus::APPROVED,
+                'approved_by' => $approvedById,
+                'approved_at' => now(),
+            ]);
+
+            $this->createAttendanceRecords(
+                $leave->employee_id,
+                $leave->start_date->toDateString(),
+                $leave->end_date->toDateString()
+            );
+
+            return $leave;
+        });
+
+        return $leave->load(['employee', 'leaveType', 'requestedBy', 'approvedBy']);
+    }
+
+    /**
+     * @throws ValidationException
+     */
+    private function guardIsPending(Leave $leave): void
+    {
+        if ($leave->status !== LeaveStatus::PENDING) {
+            throw ValidationException::withMessages([
+                'status' => 'Solo se pueden aprobar solicitudes con estado PENDING.',
+            ]);
+        }
+    }
+
+    /**
+     * @throws ValidationException
+     */
+    private function guardNoExistingWorkedAttendance(int $employeeId, string $startDate, string $endDate): void
+    {
+        $exists = Attendance::where('employee_id', $employeeId)
+            ->where('day_status', DayStatus::WORKED)
+            ->where('date', '>=', $startDate)
+            ->where('date', '<=', $endDate)
+            ->lockForUpdate()
+            ->exists();
+
+        if ($exists) {
+            throw ValidationException::withMessages([
+                'start_date' => 'El empleado ya tiene asistencia trabajada registrada para alguno de los días indicados.',
+            ]);
+        }
+    }
+
+    /**
+     * @throws ValidationException
+     */
+    private function guardNoOverlappingApprovedLeave(int $employeeId, string $startDate, string $endDate, int $excludeLeaveId): void
+    {
+        $overlaps = Leave::where('employee_id', $employeeId)
+            ->where('status', LeaveStatus::APPROVED)
+            ->where('id', '!=', $excludeLeaveId)
+            ->where('start_date', '<=', $endDate)
+            ->where('end_date', '>=', $startDate)
+            ->lockForUpdate()
+            ->exists();
+
+        if ($overlaps) {
+            throw ValidationException::withMessages([
+                'start_date' => 'El empleado ya tiene una ausencia aprobada que se traslapa con las fechas indicadas.',
+            ]);
+        }
+    }
+
+    private function createAttendanceRecords(int $employeeId, string $startDate, string $endDate): void
+    {
+        $period = CarbonPeriod::create($startDate, $endDate);
+
+        foreach ($period as $day) {
+            Attendance::updateOrCreate(
+                [
+                    'employee_id' => $employeeId,
+                    'date' => $day->toDateString(),
+                ],
+                [
+                    'day_status' => DayStatus::LEAVE,
+                ]
+            );
+        }
+    }
+}

--- a/code/api/app/Actions/Leaves/Concerns/LeaveGuards.php
+++ b/code/api/app/Actions/Leaves/Concerns/LeaveGuards.php
@@ -4,14 +4,32 @@ namespace App\Actions\Leaves\Concerns;
 
 use App\Enums\DayStatus;
 use App\Enums\LeaveStatus;
+use App\Enums\LeaveTimeMode;
+use App\Enums\RestDayFactor;
 use App\Models\Attendance;
+use App\Models\Employee;
 use App\Models\Leave;
+use App\Models\LeaveType;
 use Carbon\Carbon;
 use Carbon\CarbonPeriod;
 use Illuminate\Validation\ValidationException;
 
 trait LeaveGuards
 {
+    /**
+     * Throw 422 if the leave is not in PENDING status.
+     *
+     * @throws ValidationException
+     */
+    private function guardIsPending(Leave $leave): void
+    {
+        if ($leave->status !== LeaveStatus::PENDING) {
+            throw ValidationException::withMessages([
+                'status' => 'Solo se pueden procesar solicitudes con estado PENDING.',
+            ]);
+        }
+    }
+
     /**
      * Throw 422 if an approved leave already covers any day in the given range.
      *
@@ -93,5 +111,61 @@ trait LeaveGuards
         $end = Carbon::parse($endTime);
 
         return (int) $start->diffInMinutes($end, absolute: true);
+    }
+
+    /**
+     * Build the common Leave attributes array from validated request data.
+     *
+     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>  $overrides  Fields that differ per action (status, approved_by, approved_at)
+     * @return array<string, mixed>
+     */
+    private function buildLeaveAttributes(
+        array $data,
+        Employee $employee,
+        LeaveType $leaveType,
+        ?int $actualDurationMinutes,
+        int $requestedById,
+        array $overrides
+    ): array {
+        return array_merge([
+            'employee_id' => $employee->id,
+            'leave_type_id' => $leaveType->id,
+            'start_date' => $data['start_date'],
+            'end_date' => $data['end_date'],
+            'pay_percentage' => $data['pay_percentage'] ?? null,
+            'rest_day_factor' => isset($data['rest_day_factor'])
+                ? RestDayFactor::from($data['rest_day_factor'])
+                : null,
+            'time_mode' => isset($data['time_mode'])
+                ? LeaveTimeMode::from($data['time_mode'])
+                : null,
+            'scheduled_start_time' => $data['scheduled_start_time'] ?? null,
+            'scheduled_end_time' => $data['scheduled_end_time'] ?? null,
+            'actual_start_time' => $data['actual_start_time'] ?? null,
+            'actual_end_time' => $data['actual_end_time'] ?? null,
+            'actual_duration_minutes' => $actualDurationMinutes,
+            'requested_by' => $requestedById,
+            'notes' => $data['notes'] ?? null,
+        ], $overrides);
+    }
+
+    /**
+     * Resolve Employee and LeaveType from validated request data.
+     *
+     * @param  array<string, mixed>  $data
+     * @return array{Employee, LeaveType, int|null}
+     */
+    private function resolveLeaveContext(array $data): array
+    {
+        $employee = Employee::where('public_id', $data['employee_id'])->firstOrFail();
+        $leaveType = LeaveType::findOrFail($data['leave_type_id']);
+
+        $actualDurationMinutes = $this->computeActualDuration(
+            $data['actual_start_time'] ?? null,
+            $data['actual_end_time'] ?? null
+        );
+
+        return [$employee, $leaveType, $actualDurationMinutes];
     }
 }

--- a/code/api/app/Actions/Leaves/Concerns/LeaveGuards.php
+++ b/code/api/app/Actions/Leaves/Concerns/LeaveGuards.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Actions\Leaves\Concerns;
+
+use App\Enums\DayStatus;
+use App\Enums\LeaveStatus;
+use App\Models\Attendance;
+use App\Models\Leave;
+use Carbon\Carbon;
+use Carbon\CarbonPeriod;
+use Illuminate\Validation\ValidationException;
+
+trait LeaveGuards
+{
+    /**
+     * Throw 422 if an approved leave already covers any day in the given range.
+     *
+     * @throws ValidationException
+     */
+    private function guardNoOverlappingApprovedLeave(
+        int $employeeId,
+        string $startDate,
+        string $endDate,
+        ?int $excludeLeaveId = null
+    ): void {
+        $query = Leave::where('employee_id', $employeeId)
+            ->where('status', LeaveStatus::APPROVED)
+            ->where('start_date', '<=', $endDate)
+            ->where('end_date', '>=', $startDate);
+
+        if ($excludeLeaveId !== null) {
+            $query->where('id', '!=', $excludeLeaveId);
+        }
+
+        if ($query->lockForUpdate()->exists()) {
+            throw ValidationException::withMessages([
+                'start_date' => 'El empleado ya tiene una ausencia aprobada que se traslapa con las fechas indicadas.',
+            ]);
+        }
+    }
+
+    /**
+     * Throw 422 if any date in the range already has a WORKED attendance record.
+     *
+     * @throws ValidationException
+     */
+    private function guardNoExistingWorkedAttendance(int $employeeId, string $startDate, string $endDate): void
+    {
+        $exists = Attendance::where('employee_id', $employeeId)
+            ->where('day_status', DayStatus::WORKED)
+            ->where('date', '>=', $startDate)
+            ->where('date', '<=', $endDate)
+            ->lockForUpdate()
+            ->exists();
+
+        if ($exists) {
+            throw ValidationException::withMessages([
+                'start_date' => 'El empleado ya tiene asistencia trabajada registrada para alguno de los días indicados.',
+            ]);
+        }
+    }
+
+    /**
+     * Create Attendance records for each day in the range with day_status = LEAVE.
+     */
+    private function createAttendanceRecords(int $employeeId, string $startDate, string $endDate): void
+    {
+        $period = CarbonPeriod::create($startDate, $endDate);
+
+        foreach ($period as $day) {
+            Attendance::updateOrCreate(
+                [
+                    'employee_id' => $employeeId,
+                    'date' => $day->toDateString(),
+                ],
+                [
+                    'day_status' => DayStatus::LEAVE,
+                ]
+            );
+        }
+    }
+
+    /**
+     * Compute actual duration in minutes from start and end time strings (H:i format).
+     */
+    private function computeActualDuration(?string $startTime, ?string $endTime): ?int
+    {
+        if (! $startTime || ! $endTime) {
+            return null;
+        }
+
+        $start = Carbon::parse($startTime);
+        $end = Carbon::parse($endTime);
+
+        return (int) $start->diffInMinutes($end, absolute: true);
+    }
+}

--- a/code/api/app/Actions/Leaves/RegisterDirectLeaveAction.php
+++ b/code/api/app/Actions/Leaves/RegisterDirectLeaveAction.php
@@ -32,13 +32,13 @@ class RegisterDirectLeaveAction
         $attributes = $this->buildLeaveAttributes($data, $employee, $leaveType, $actualDurationMinutes, $requestedById, [
             'status' => LeaveStatus::APPROVED,
             'approved_by' => $requestedById,
-            'approved_at' => now(),
         ]);
 
         $leave = DB::transaction(function () use ($data, $employee, $attributes) {
             $this->guardNoOverlappingApprovedLeave($employee->id, $data['start_date'], $data['end_date']);
             $this->guardNoExistingWorkedAttendance($employee->id, $data['start_date'], $data['end_date']);
 
+            $attributes['approved_at'] = now();
             $leave = Leave::create($attributes);
 
             $this->createAttendanceRecords($employee->id, $data['start_date'], $data['end_date']);

--- a/code/api/app/Actions/Leaves/RegisterDirectLeaveAction.php
+++ b/code/api/app/Actions/Leaves/RegisterDirectLeaveAction.php
@@ -4,11 +4,7 @@ namespace App\Actions\Leaves;
 
 use App\Actions\Leaves\Concerns\LeaveGuards;
 use App\Enums\LeaveStatus;
-use App\Enums\LeaveTimeMode;
-use App\Enums\RestDayFactor;
-use App\Models\Employee;
 use App\Models\Leave;
-use App\Models\LeaveType;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -31,40 +27,19 @@ class RegisterDirectLeaveAction
      */
     public function __invoke(array $data, int $requestedById): Leave
     {
-        $employee = Employee::where('public_id', $data['employee_id'])->firstOrFail();
-        $leaveType = LeaveType::findOrFail($data['leave_type_id']);
+        [$employee, $leaveType, $actualDurationMinutes] = $this->resolveLeaveContext($data);
 
-        $actualDurationMinutes = $this->computeActualDuration(
-            $data['actual_start_time'] ?? null,
-            $data['actual_end_time'] ?? null
-        );
+        $attributes = $this->buildLeaveAttributes($data, $employee, $leaveType, $actualDurationMinutes, $requestedById, [
+            'status' => LeaveStatus::APPROVED,
+            'approved_by' => $requestedById,
+            'approved_at' => now(),
+        ]);
 
-        $leave = DB::transaction(function () use ($data, $employee, $leaveType, $actualDurationMinutes, $requestedById) {
+        $leave = DB::transaction(function () use ($data, $employee, $attributes) {
             $this->guardNoOverlappingApprovedLeave($employee->id, $data['start_date'], $data['end_date']);
             $this->guardNoExistingWorkedAttendance($employee->id, $data['start_date'], $data['end_date']);
-            $leave = Leave::create([
-                'employee_id' => $employee->id,
-                'leave_type_id' => $leaveType->id,
-                'start_date' => $data['start_date'],
-                'end_date' => $data['end_date'],
-                'pay_percentage' => $data['pay_percentage'] ?? null,
-                'rest_day_factor' => isset($data['rest_day_factor'])
-                    ? RestDayFactor::from($data['rest_day_factor'])
-                    : null,
-                'time_mode' => isset($data['time_mode'])
-                    ? LeaveTimeMode::from($data['time_mode'])
-                    : null,
-                'scheduled_start_time' => $data['scheduled_start_time'] ?? null,
-                'scheduled_end_time' => $data['scheduled_end_time'] ?? null,
-                'actual_start_time' => $data['actual_start_time'] ?? null,
-                'actual_end_time' => $data['actual_end_time'] ?? null,
-                'actual_duration_minutes' => $actualDurationMinutes,
-                'status' => LeaveStatus::APPROVED,
-                'requested_by' => $requestedById,
-                'approved_by' => $requestedById,
-                'approved_at' => now(),
-                'notes' => $data['notes'] ?? null,
-            ]);
+
+            $leave = Leave::create($attributes);
 
             $this->createAttendanceRecords($employee->id, $data['start_date'], $data['end_date']);
 

--- a/code/api/app/Actions/Leaves/RegisterDirectLeaveAction.php
+++ b/code/api/app/Actions/Leaves/RegisterDirectLeaveAction.php
@@ -2,18 +2,14 @@
 
 namespace App\Actions\Leaves;
 
-use App\Enums\DayStatus;
+use App\Actions\Leaves\Concerns\LeaveGuards;
 use App\Enums\LeaveStatus;
 use App\Enums\LeaveTimeMode;
 use App\Enums\RestDayFactor;
-use App\Models\Attendance;
 use App\Models\Employee;
 use App\Models\Leave;
 use App\Models\LeaveType;
-use Carbon\Carbon;
-use Carbon\CarbonPeriod;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Validation\ValidationException;
 
 /**
  * Register a direct (immediately approved) leave for an employee.
@@ -28,6 +24,8 @@ use Illuminate\Validation\ValidationException;
  */
 class RegisterDirectLeaveAction
 {
+    use LeaveGuards;
+
     /**
      * @param  array<string, mixed>  $data
      */
@@ -74,82 +72,5 @@ class RegisterDirectLeaveAction
         });
 
         return $leave->load(['employee', 'leaveType', 'requestedBy', 'approvedBy']);
-    }
-
-    /**
-     * Throw 422 if an approved leave already covers any day in the given range.
-     *
-     * @throws ValidationException
-     */
-    private function guardNoOverlappingApprovedLeave(int $employeeId, string $startDate, string $endDate): void
-    {
-        $overlaps = Leave::where('employee_id', $employeeId)
-            ->where('status', LeaveStatus::APPROVED)
-            ->where('start_date', '<=', $endDate)
-            ->where('end_date', '>=', $startDate)
-            ->lockForUpdate()
-            ->exists();
-
-        if ($overlaps) {
-            throw ValidationException::withMessages([
-                'start_date' => 'El empleado ya tiene una ausencia aprobada que se traslapa con las fechas indicadas.',
-            ]);
-        }
-    }
-
-    /**
-     * Throw 422 if any date in the range already has a WORKED attendance record.
-     *
-     * @throws ValidationException
-     */
-    private function guardNoExistingWorkedAttendance(int $employeeId, string $startDate, string $endDate): void
-    {
-        $exists = Attendance::where('employee_id', $employeeId)
-            ->where('day_status', DayStatus::WORKED)
-            ->where('date', '>=', $startDate)
-            ->where('date', '<=', $endDate)
-            ->lockForUpdate()
-            ->exists();
-
-        if ($exists) {
-            throw ValidationException::withMessages([
-                'start_date' => 'El empleado ya tiene asistencia trabajada registrada para alguno de los días indicados.',
-            ]);
-        }
-    }
-
-    /**
-     * Create Attendance records for each day in the range with day_status = LEAVE.
-     */
-    private function createAttendanceRecords(int $employeeId, string $startDate, string $endDate): void
-    {
-        $period = CarbonPeriod::create($startDate, $endDate);
-
-        foreach ($period as $day) {
-            Attendance::updateOrCreate(
-                [
-                    'employee_id' => $employeeId,
-                    'date' => $day->toDateString(),
-                ],
-                [
-                    'day_status' => DayStatus::LEAVE,
-                ]
-            );
-        }
-    }
-
-    /**
-     * Compute actual duration in minutes from start and end time strings (H:i format).
-     */
-    private function computeActualDuration(?string $startTime, ?string $endTime): ?int
-    {
-        if (! $startTime || ! $endTime) {
-            return null;
-        }
-
-        $start = Carbon::parse($startTime);
-        $end = Carbon::parse($endTime);
-
-        return (int) $start->diffInMinutes($end, absolute: true);
     }
 }

--- a/code/api/app/Actions/Leaves/RegisterLeaveRequestAction.php
+++ b/code/api/app/Actions/Leaves/RegisterLeaveRequestAction.php
@@ -2,15 +2,14 @@
 
 namespace App\Actions\Leaves;
 
+use App\Actions\Leaves\Concerns\LeaveGuards;
 use App\Enums\LeaveStatus;
 use App\Enums\LeaveTimeMode;
 use App\Enums\RestDayFactor;
 use App\Models\Employee;
 use App\Models\Leave;
 use App\Models\LeaveType;
-use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Validation\ValidationException;
 
 /**
  * Register a leave REQUEST (status = PENDING).
@@ -22,6 +21,8 @@ use Illuminate\Validation\ValidationException;
  */
 class RegisterLeaveRequestAction
 {
+    use LeaveGuards;
+
     /**
      * @param  array<string, mixed>  $data
      */
@@ -64,41 +65,5 @@ class RegisterLeaveRequestAction
         });
 
         return $leave->load(['employee', 'leaveType', 'requestedBy', 'approvedBy']);
-    }
-
-    /**
-     * Throw 422 if an approved leave already covers any day in the given range.
-     *
-     * @throws ValidationException
-     */
-    private function guardNoOverlappingApprovedLeave(int $employeeId, string $startDate, string $endDate): void
-    {
-        $overlaps = Leave::where('employee_id', $employeeId)
-            ->where('status', LeaveStatus::APPROVED)
-            ->where('start_date', '<=', $endDate)
-            ->where('end_date', '>=', $startDate)
-            ->lockForUpdate()
-            ->exists();
-
-        if ($overlaps) {
-            throw ValidationException::withMessages([
-                'start_date' => 'El empleado ya tiene una ausencia aprobada que se traslapa con las fechas indicadas.',
-            ]);
-        }
-    }
-
-    /**
-     * Compute actual duration in minutes from start and end time strings (H:i format).
-     */
-    private function computeActualDuration(?string $startTime, ?string $endTime): ?int
-    {
-        if (! $startTime || ! $endTime) {
-            return null;
-        }
-
-        $start = Carbon::parse($startTime);
-        $end = Carbon::parse($endTime);
-
-        return (int) $start->diffInMinutes($end, absolute: true);
     }
 }

--- a/code/api/app/Actions/Leaves/RegisterLeaveRequestAction.php
+++ b/code/api/app/Actions/Leaves/RegisterLeaveRequestAction.php
@@ -4,11 +4,7 @@ namespace App\Actions\Leaves;
 
 use App\Actions\Leaves\Concerns\LeaveGuards;
 use App\Enums\LeaveStatus;
-use App\Enums\LeaveTimeMode;
-use App\Enums\RestDayFactor;
-use App\Models\Employee;
 use App\Models\Leave;
-use App\Models\LeaveType;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -28,40 +24,18 @@ class RegisterLeaveRequestAction
      */
     public function __invoke(array $data, int $requestedById): Leave
     {
-        $employee = Employee::where('public_id', $data['employee_id'])->firstOrFail();
-        $leaveType = LeaveType::findOrFail($data['leave_type_id']);
+        [$employee, $leaveType, $actualDurationMinutes] = $this->resolveLeaveContext($data);
 
-        $actualDurationMinutes = $this->computeActualDuration(
-            $data['actual_start_time'] ?? null,
-            $data['actual_end_time'] ?? null
-        );
+        $attributes = $this->buildLeaveAttributes($data, $employee, $leaveType, $actualDurationMinutes, $requestedById, [
+            'status' => LeaveStatus::PENDING,
+            'approved_by' => null,
+            'approved_at' => null,
+        ]);
 
-        $leave = DB::transaction(function () use ($data, $employee, $leaveType, $actualDurationMinutes, $requestedById) {
+        $leave = DB::transaction(function () use ($data, $employee, $attributes) {
             $this->guardNoOverlappingApprovedLeave($employee->id, $data['start_date'], $data['end_date']);
 
-            return Leave::create([
-                'employee_id' => $employee->id,
-                'leave_type_id' => $leaveType->id,
-                'start_date' => $data['start_date'],
-                'end_date' => $data['end_date'],
-                'pay_percentage' => $data['pay_percentage'] ?? null,
-                'rest_day_factor' => isset($data['rest_day_factor'])
-                    ? RestDayFactor::from($data['rest_day_factor'])
-                    : null,
-                'time_mode' => isset($data['time_mode'])
-                    ? LeaveTimeMode::from($data['time_mode'])
-                    : null,
-                'scheduled_start_time' => $data['scheduled_start_time'] ?? null,
-                'scheduled_end_time' => $data['scheduled_end_time'] ?? null,
-                'actual_start_time' => $data['actual_start_time'] ?? null,
-                'actual_end_time' => $data['actual_end_time'] ?? null,
-                'actual_duration_minutes' => $actualDurationMinutes,
-                'status' => LeaveStatus::PENDING,
-                'requested_by' => $requestedById,
-                'approved_by' => null,
-                'approved_at' => null,
-                'notes' => $data['notes'] ?? null,
-            ]);
+            return Leave::create($attributes);
         });
 
         return $leave->load(['employee', 'leaveType', 'requestedBy', 'approvedBy']);

--- a/code/api/app/Actions/Leaves/RegisterLeaveRequestAction.php
+++ b/code/api/app/Actions/Leaves/RegisterLeaveRequestAction.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Actions\Leaves;
+
+use App\Enums\LeaveStatus;
+use App\Enums\LeaveTimeMode;
+use App\Enums\RestDayFactor;
+use App\Models\Employee;
+use App\Models\Leave;
+use App\Models\LeaveType;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * Register a leave REQUEST (status = PENDING).
+ *
+ * Unlike RegisterDirectLeaveAction, this does NOT create Attendance
+ * records — those are created only when the request is approved.
+ *
+ * @see RF-25, RF-28
+ */
+class RegisterLeaveRequestAction
+{
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function __invoke(array $data, int $requestedById): Leave
+    {
+        $employee = Employee::where('public_id', $data['employee_id'])->firstOrFail();
+        $leaveType = LeaveType::findOrFail($data['leave_type_id']);
+
+        $actualDurationMinutes = $this->computeActualDuration(
+            $data['actual_start_time'] ?? null,
+            $data['actual_end_time'] ?? null
+        );
+
+        $leave = DB::transaction(function () use ($data, $employee, $leaveType, $actualDurationMinutes, $requestedById) {
+            $this->guardNoOverlappingApprovedLeave($employee->id, $data['start_date'], $data['end_date']);
+
+            return Leave::create([
+                'employee_id' => $employee->id,
+                'leave_type_id' => $leaveType->id,
+                'start_date' => $data['start_date'],
+                'end_date' => $data['end_date'],
+                'pay_percentage' => $data['pay_percentage'] ?? null,
+                'rest_day_factor' => isset($data['rest_day_factor'])
+                    ? RestDayFactor::from($data['rest_day_factor'])
+                    : null,
+                'time_mode' => isset($data['time_mode'])
+                    ? LeaveTimeMode::from($data['time_mode'])
+                    : null,
+                'scheduled_start_time' => $data['scheduled_start_time'] ?? null,
+                'scheduled_end_time' => $data['scheduled_end_time'] ?? null,
+                'actual_start_time' => $data['actual_start_time'] ?? null,
+                'actual_end_time' => $data['actual_end_time'] ?? null,
+                'actual_duration_minutes' => $actualDurationMinutes,
+                'status' => LeaveStatus::PENDING,
+                'requested_by' => $requestedById,
+                'approved_by' => null,
+                'approved_at' => null,
+                'notes' => $data['notes'] ?? null,
+            ]);
+        });
+
+        return $leave->load(['employee', 'leaveType', 'requestedBy', 'approvedBy']);
+    }
+
+    /**
+     * Throw 422 if an approved leave already covers any day in the given range.
+     *
+     * @throws ValidationException
+     */
+    private function guardNoOverlappingApprovedLeave(int $employeeId, string $startDate, string $endDate): void
+    {
+        $overlaps = Leave::where('employee_id', $employeeId)
+            ->where('status', LeaveStatus::APPROVED)
+            ->where('start_date', '<=', $endDate)
+            ->where('end_date', '>=', $startDate)
+            ->lockForUpdate()
+            ->exists();
+
+        if ($overlaps) {
+            throw ValidationException::withMessages([
+                'start_date' => 'El empleado ya tiene una ausencia aprobada que se traslapa con las fechas indicadas.',
+            ]);
+        }
+    }
+
+    /**
+     * Compute actual duration in minutes from start and end time strings (H:i format).
+     */
+    private function computeActualDuration(?string $startTime, ?string $endTime): ?int
+    {
+        if (! $startTime || ! $endTime) {
+            return null;
+        }
+
+        $start = Carbon::parse($startTime);
+        $end = Carbon::parse($endTime);
+
+        return (int) $start->diffInMinutes($end, absolute: true);
+    }
+}

--- a/code/api/app/Actions/Leaves/RejectLeaveAction.php
+++ b/code/api/app/Actions/Leaves/RejectLeaveAction.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Leaves;
 
+use App\Actions\Leaves\Concerns\LeaveGuards;
 use App\Enums\LeaveStatus;
 use App\Models\Leave;
 use Illuminate\Support\Facades\DB;
@@ -17,6 +18,8 @@ use Illuminate\Validation\ValidationException;
  */
 class RejectLeaveAction
 {
+    use LeaveGuards;
+
     /**
      * @throws ValidationException
      */
@@ -37,17 +40,5 @@ class RejectLeaveAction
         });
 
         return $leave->load(['employee', 'leaveType', 'requestedBy', 'approvedBy']);
-    }
-
-    /**
-     * @throws ValidationException
-     */
-    private function guardIsPending(Leave $leave): void
-    {
-        if ($leave->status !== LeaveStatus::PENDING) {
-            throw ValidationException::withMessages([
-                'status' => 'Solo se pueden rechazar solicitudes con estado PENDING.',
-            ]);
-        }
     }
 }

--- a/code/api/app/Actions/Leaves/RejectLeaveAction.php
+++ b/code/api/app/Actions/Leaves/RejectLeaveAction.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Actions\Leaves;
+
+use App\Enums\LeaveStatus;
+use App\Models\Leave;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * Reject a PENDING leave request.
+ *
+ * - Sets status = REJECTED, approved_by, approved_at.
+ * - No attendance records are created or modified.
+ *
+ * @see RF-25, RF-28
+ */
+class RejectLeaveAction
+{
+    /**
+     * @throws ValidationException
+     */
+    public function __invoke(Leave $leave, int $rejectedById): Leave
+    {
+        $leave = DB::transaction(function () use ($leave, $rejectedById) {
+            $leave = Leave::lockForUpdate()->findOrFail($leave->id);
+
+            $this->guardIsPending($leave);
+
+            $leave->update([
+                'status' => LeaveStatus::REJECTED,
+                'approved_by' => $rejectedById,
+                'approved_at' => now(),
+            ]);
+
+            return $leave;
+        });
+
+        return $leave->load(['employee', 'leaveType', 'requestedBy', 'approvedBy']);
+    }
+
+    /**
+     * @throws ValidationException
+     */
+    private function guardIsPending(Leave $leave): void
+    {
+        if ($leave->status !== LeaveStatus::PENDING) {
+            throw ValidationException::withMessages([
+                'status' => 'Solo se pueden rechazar solicitudes con estado PENDING.',
+            ]);
+        }
+    }
+}

--- a/code/api/app/Http/Controllers/Api/V1/Employees/ListEmployeeLeavesController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Employees/ListEmployeeLeavesController.php
@@ -10,6 +10,40 @@ use App\Models\Employee;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
 
+/**
+ * @OA\Get(
+ *   path="/api/v1/employees/{employee}/leaves",
+ *   summary="List Employee Leaves",
+ *   description="Returns a paginated list of leaves for a specific employee. Supports filtering by status, date range, overlap range, and leave type.",
+ *   tags={"Employees"},
+ *   security={{"passport": {}}},
+ *
+ *   @OA\Parameter(name="employee", in="path", required=true, @OA\Schema(type="string"), description="Employee public_id (ULID)"),
+ *   @OA\Parameter(name="status", in="query", @OA\Schema(type="string", enum={"APPROVED", "PENDING", "REJECTED", "CANCELLED"}), description="Filter by leave status"),
+ *   @OA\Parameter(name="date_from", in="query", @OA\Schema(type="string", format="date"), description="Filter leaves with start_date >= this date"),
+ *   @OA\Parameter(name="date_to", in="query", @OA\Schema(type="string", format="date"), description="Filter leaves with end_date <= this date"),
+ *   @OA\Parameter(name="overlap_from", in="query", @OA\Schema(type="string", format="date"), description="Filter leaves that overlap with this start date"),
+ *   @OA\Parameter(name="overlap_to", in="query", @OA\Schema(type="string", format="date"), description="Filter leaves that overlap with this end date"),
+ *   @OA\Parameter(name="leave_type_id", in="query", @OA\Schema(type="integer"), description="Filter by leave type ID"),
+ *   @OA\Parameter(name="per_page", in="query", @OA\Schema(type="integer", default=15), description="Items per page (1-100)"),
+ *
+ *   @OA\Response(
+ *       response=200,
+ *       description="Employee leaves retrieved successfully",
+ *
+ *       @OA\JsonContent(
+ *           allOf={
+ *
+ *              @OA\Schema(ref="#/components/schemas/ResponsePaginated"),
+ *              @OA\Schema(@OA\Property(property="data", type="array", @OA\Items(ref="#/components/schemas/LeaveResponse")))
+ *           }
+ *       )
+ *   ),
+ *
+ *   @OA\Response(response=401, description="Unauthenticated"),
+ *   @OA\Response(response=404, description="Employee not found", @OA\JsonContent(ref="#/components/schemas/ResponseError"))
+ * )
+ */
 class ListEmployeeLeavesController extends Controller
 {
     public function __invoke(Request $request, Employee $employee): ResponsePaginated

--- a/code/api/app/Http/Controllers/Api/V1/Leaves/ApproveLeaveController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Leaves/ApproveLeaveController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Leaves;
+
+use App\Actions\Leaves\ApproveLeaveAction;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Leave\LeaveResource;
+use App\Models\Leave;
+
+class ApproveLeaveController extends Controller
+{
+    public function __invoke(
+        string $id,
+        ApproveLeaveAction $action
+    ): LeaveResource {
+        $leave = Leave::where('public_id', $id)->firstOrFail();
+
+        $leave = $action($leave, auth()->id());
+
+        return new LeaveResource($leave);
+    }
+}

--- a/code/api/app/Http/Controllers/Api/V1/Leaves/ApproveLeaveController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Leaves/ApproveLeaveController.php
@@ -7,6 +7,34 @@ use App\Http\Controllers\Controller;
 use App\Http\Resources\Leave\LeaveResource;
 use App\Models\Leave;
 
+/**
+ * @OA\Patch(
+ *   path="/api/v1/leaves/{id}/approve",
+ *   summary="Approve Leave Request",
+ *   description="Approves a PENDING leave request. Requires leaves.approve permission.",
+ *   tags={"Leaves"},
+ *   security={{"passport": {}}},
+ *
+ *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="string"), description="Leave public_id (ULID)"),
+ *
+ *   @OA\Response(
+ *       response=200,
+ *       description="Leave approved successfully",
+ *
+ *       @OA\JsonContent(
+ *           allOf={
+ *
+ *              @OA\Schema(ref="#/components/schemas/ResponseEntity"),
+ *              @OA\Schema(@OA\Property(property="data", ref="#/components/schemas/LeaveResponse"))
+ *           }
+ *       )
+ *   ),
+ *
+ *   @OA\Response(response=401, description="Unauthenticated"),
+ *   @OA\Response(response=404, description="Leave not found", @OA\JsonContent(ref="#/components/schemas/ResponseError")),
+ *   @OA\Response(response=422, description="Leave is not in PENDING status", @OA\JsonContent(ref="#/components/schemas/ResponseError"))
+ * )
+ */
 class ApproveLeaveController extends Controller
 {
     public function __invoke(

--- a/code/api/app/Http/Controllers/Api/V1/Leaves/ListLeaveTypesController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Leaves/ListLeaveTypesController.php
@@ -7,6 +7,30 @@ use App\Http\Resources\Leave\LeaveTypeResource;
 use App\Http\Responses\Common\ResponseEntity;
 use App\Models\LeaveType;
 
+/**
+ * @OA\Get(
+ *   path="/api/v1/leave-types",
+ *   summary="List Leave Types",
+ *   description="Returns all active leave types ordered by name.",
+ *   tags={"Leaves"},
+ *   security={{"passport": {}}},
+ *
+ *   @OA\Response(
+ *       response=200,
+ *       description="Leave types retrieved successfully",
+ *
+ *       @OA\JsonContent(
+ *           allOf={
+ *
+ *              @OA\Schema(ref="#/components/schemas/ResponseEntity"),
+ *              @OA\Schema(@OA\Property(property="data", type="array", @OA\Items(ref="#/components/schemas/LeaveTypeResponse")))
+ *           }
+ *       )
+ *   ),
+ *
+ *   @OA\Response(response=401, description="Unauthenticated")
+ * )
+ */
 class ListLeaveTypesController extends Controller
 {
     public function __invoke(): ResponseEntity

--- a/code/api/app/Http/Controllers/Api/V1/Leaves/RegisterDirectLeaveController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Leaves/RegisterDirectLeaveController.php
@@ -7,6 +7,33 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Leaves\RegisterDirectLeaveRequest;
 use App\Http\Resources\Leave\LeaveResource;
 
+/**
+ * @OA\Post(
+ *   path="/api/v1/leaves",
+ *   summary="Register Direct Leave",
+ *   description="Creates a leave record with APPROVED status directly. Requires leaves.register-direct permission.",
+ *   tags={"Leaves"},
+ *   security={{"passport": {}}},
+ *
+ *   @OA\RequestBody(required=true, @OA\JsonContent(ref="#/components/schemas/RegisterDirectLeaveRequest")),
+ *
+ *   @OA\Response(
+ *       response=201,
+ *       description="Leave registered successfully",
+ *
+ *       @OA\JsonContent(
+ *           allOf={
+ *
+ *              @OA\Schema(ref="#/components/schemas/ResponseEntity"),
+ *              @OA\Schema(@OA\Property(property="data", ref="#/components/schemas/LeaveResponse"))
+ *           }
+ *       )
+ *   ),
+ *
+ *   @OA\Response(response=401, description="Unauthenticated"),
+ *   @OA\Response(response=422, description="Validation Error", @OA\JsonContent(ref="#/components/schemas/ResponseError"))
+ * )
+ */
 class RegisterDirectLeaveController extends Controller
 {
     public function __invoke(

--- a/code/api/app/Http/Controllers/Api/V1/Leaves/RegisterLeaveRequestController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Leaves/RegisterLeaveRequestController.php
@@ -7,6 +7,33 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Leaves\RegisterLeaveRequestRequest;
 use App\Http\Resources\Leave\LeaveResource;
 
+/**
+ * @OA\Post(
+ *   path="/api/v1/leaves/requests",
+ *   summary="Register Leave Request",
+ *   description="Creates a leave record with PENDING status that requires approval. Requires leaves.request permission.",
+ *   tags={"Leaves"},
+ *   security={{"passport": {}}},
+ *
+ *   @OA\RequestBody(required=true, @OA\JsonContent(ref="#/components/schemas/RegisterDirectLeaveRequest")),
+ *
+ *   @OA\Response(
+ *       response=201,
+ *       description="Leave request created successfully",
+ *
+ *       @OA\JsonContent(
+ *           allOf={
+ *
+ *              @OA\Schema(ref="#/components/schemas/ResponseEntity"),
+ *              @OA\Schema(@OA\Property(property="data", ref="#/components/schemas/LeaveResponse"))
+ *           }
+ *       )
+ *   ),
+ *
+ *   @OA\Response(response=401, description="Unauthenticated"),
+ *   @OA\Response(response=422, description="Validation Error", @OA\JsonContent(ref="#/components/schemas/ResponseError"))
+ * )
+ */
 class RegisterLeaveRequestController extends Controller
 {
     public function __invoke(

--- a/code/api/app/Http/Controllers/Api/V1/Leaves/RegisterLeaveRequestController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Leaves/RegisterLeaveRequestController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Leaves;
+
+use App\Actions\Leaves\RegisterLeaveRequestAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Leaves\RegisterLeaveRequestRequest;
+use App\Http\Resources\Leave\LeaveResource;
+
+class RegisterLeaveRequestController extends Controller
+{
+    public function __invoke(
+        RegisterLeaveRequestRequest $request,
+        RegisterLeaveRequestAction $action
+    ): LeaveResource {
+        $leave = $action($request->validated(), auth()->id());
+
+        return (new LeaveResource($leave))->setStatusCode(201);
+    }
+}

--- a/code/api/app/Http/Controllers/Api/V1/Leaves/RejectLeaveController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Leaves/RejectLeaveController.php
@@ -7,6 +7,34 @@ use App\Http\Controllers\Controller;
 use App\Http\Resources\Leave\LeaveResource;
 use App\Models\Leave;
 
+/**
+ * @OA\Patch(
+ *   path="/api/v1/leaves/{id}/reject",
+ *   summary="Reject Leave Request",
+ *   description="Rejects a PENDING leave request. Requires leaves.reject permission.",
+ *   tags={"Leaves"},
+ *   security={{"passport": {}}},
+ *
+ *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="string"), description="Leave public_id (ULID)"),
+ *
+ *   @OA\Response(
+ *       response=200,
+ *       description="Leave rejected successfully",
+ *
+ *       @OA\JsonContent(
+ *           allOf={
+ *
+ *              @OA\Schema(ref="#/components/schemas/ResponseEntity"),
+ *              @OA\Schema(@OA\Property(property="data", ref="#/components/schemas/LeaveResponse"))
+ *           }
+ *       )
+ *   ),
+ *
+ *   @OA\Response(response=401, description="Unauthenticated"),
+ *   @OA\Response(response=404, description="Leave not found", @OA\JsonContent(ref="#/components/schemas/ResponseError")),
+ *   @OA\Response(response=422, description="Leave is not in PENDING status", @OA\JsonContent(ref="#/components/schemas/ResponseError"))
+ * )
+ */
 class RejectLeaveController extends Controller
 {
     public function __invoke(

--- a/code/api/app/Http/Controllers/Api/V1/Leaves/RejectLeaveController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Leaves/RejectLeaveController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Leaves;
+
+use App\Actions\Leaves\RejectLeaveAction;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Leave\LeaveResource;
+use App\Models\Leave;
+
+class RejectLeaveController extends Controller
+{
+    public function __invoke(
+        string $id,
+        RejectLeaveAction $action
+    ): LeaveResource {
+        $leave = Leave::where('public_id', $id)->firstOrFail();
+
+        $leave = $action($leave, auth()->id());
+
+        return new LeaveResource($leave);
+    }
+}

--- a/code/api/app/Http/Requests/Leaves/RegisterDirectLeaveRequest.php
+++ b/code/api/app/Http/Requests/Leaves/RegisterDirectLeaveRequest.php
@@ -46,7 +46,7 @@ class RegisterDirectLeaveRequest extends FormRequest
             ],
             'leave_type_id' => ['required', 'integer', Rule::exists('leave_types', 'id')->where('is_active', true)],
             'start_date' => ['required', 'date'],
-            'end_date' => ['required', 'date', 'gte:start_date'],
+            'end_date' => ['required', 'date', 'after_or_equal:start_date'],
             'pay_percentage' => ['nullable', 'numeric', 'min:0', 'max:100'],
             'rest_day_factor' => ['nullable', Rule::in(['FULL', 'PROPORTIONAL', 'NONE'])],
             'time_mode' => ['nullable', Rule::in([LeaveTimeMode::SCHEDULED->value, LeaveTimeMode::OPEN_ENDED->value])],

--- a/code/api/app/Http/Requests/Leaves/RegisterDirectLeaveRequest.php
+++ b/code/api/app/Http/Requests/Leaves/RegisterDirectLeaveRequest.php
@@ -10,6 +10,25 @@ use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Validator;
 
+/**
+ * @OA\Schema(
+ *   schema="RegisterDirectLeaveRequest",
+ *   required={"employee_id", "leave_type_id", "start_date", "end_date"},
+ *
+ *   @OA\Property(property="employee_id", type="string", example="01JKABC0987654321ZYXWVUTS", description="Employee public_id (ULID)"),
+ *   @OA\Property(property="leave_type_id", type="integer", example=1, description="Active leave type ID"),
+ *   @OA\Property(property="start_date", type="string", format="date", example="2026-03-01"),
+ *   @OA\Property(property="end_date", type="string", format="date", example="2026-03-03", description="Must be >= start_date"),
+ *   @OA\Property(property="pay_percentage", type="number", nullable=true, example=100, description="Override pay percentage (0-100)"),
+ *   @OA\Property(property="rest_day_factor", type="string", nullable=true, enum={"FULL", "PROPORTIONAL", "NONE"}, description="Override rest day factor"),
+ *   @OA\Property(property="time_mode", type="string", nullable=true, enum={"SCHEDULED", "OPEN_ENDED"}, description="Required for PROPORTIONAL_HOURS leave types"),
+ *   @OA\Property(property="scheduled_start_time", type="string", nullable=true, example="09:00", description="Format H:i, required with time_mode"),
+ *   @OA\Property(property="scheduled_end_time", type="string", nullable=true, example="13:00", description="Format H:i, required when time_mode is SCHEDULED"),
+ *   @OA\Property(property="actual_start_time", type="string", nullable=true, example="09:05", description="Format H:i"),
+ *   @OA\Property(property="actual_end_time", type="string", nullable=true, example="12:55", description="Format H:i"),
+ *   @OA\Property(property="notes", type="string", nullable=true, maxLength=1000, example="Cita médica", description="Optional notes")
+ * )
+ */
 class RegisterDirectLeaveRequest extends FormRequest
 {
     public function authorize(): bool

--- a/code/api/app/Http/Requests/Leaves/RegisterLeaveRequestRequest.php
+++ b/code/api/app/Http/Requests/Leaves/RegisterLeaveRequestRequest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Http\Requests\Leaves;
+
+use App\Enums\LeaveCalculationMode;
+use App\Enums\LeaveTimeMode;
+use App\Models\Employee;
+use App\Models\LeaveType;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
+
+class RegisterLeaveRequestRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'employee_id' => [
+                'required',
+                'string',
+                Rule::exists('employees', 'public_id')->whereNull('deleted_at'),
+            ],
+            'leave_type_id' => ['required', 'integer', Rule::exists('leave_types', 'id')->where('is_active', true)],
+            'start_date' => ['required', 'date'],
+            'end_date' => ['required', 'date', 'gte:start_date'],
+            'pay_percentage' => ['nullable', 'numeric', 'min:0', 'max:100'],
+            'rest_day_factor' => ['nullable', Rule::in(['FULL', 'PROPORTIONAL', 'NONE'])],
+            'time_mode' => ['nullable', Rule::in([LeaveTimeMode::SCHEDULED->value, LeaveTimeMode::OPEN_ENDED->value])],
+            'scheduled_start_time' => ['nullable', 'date_format:H:i', 'required_with:time_mode'],
+            'scheduled_end_time' => ['nullable', 'date_format:H:i', 'after:scheduled_start_time'],
+            'actual_start_time' => ['nullable', 'date_format:H:i'],
+            'actual_end_time' => ['nullable', 'date_format:H:i', 'after:actual_start_time'],
+            'notes' => ['nullable', 'string', 'max:1000'],
+        ];
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $v) {
+            $leaveType = LeaveType::find($this->input('leave_type_id'));
+
+            if (! $leaveType) {
+                return;
+            }
+
+            if ($leaveType->calculation_mode === LeaveCalculationMode::PROPORTIONAL_HOURS) {
+                if (! $this->input('time_mode')) {
+                    $v->errors()->add('time_mode', 'El modo de horario es requerido para permisos por horas.');
+                }
+
+                if (
+                    $this->input('start_date') && $this->input('end_date')
+                    && $this->input('start_date') !== $this->input('end_date')
+                ) {
+                    $v->errors()->add('end_date', 'Los permisos por horas deben ser de un solo día.');
+                }
+            }
+
+            if (
+                $this->input('time_mode') === LeaveTimeMode::SCHEDULED->value
+                && ! $this->input('scheduled_end_time')
+            ) {
+                $v->errors()->add('scheduled_end_time', 'La hora de fin es requerida cuando el horario es definido.');
+            }
+        });
+    }
+
+    public function employee(): Employee
+    {
+        return Employee::where('public_id', $this->input('employee_id'))->firstOrFail();
+    }
+}

--- a/code/api/app/Http/Requests/Leaves/RegisterLeaveRequestRequest.php
+++ b/code/api/app/Http/Requests/Leaves/RegisterLeaveRequestRequest.php
@@ -2,76 +2,12 @@
 
 namespace App\Http\Requests\Leaves;
 
-use App\Enums\LeaveCalculationMode;
-use App\Enums\LeaveTimeMode;
-use App\Models\Employee;
-use App\Models\LeaveType;
-use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Validation\Rule;
-use Illuminate\Validation\Validator;
-
-class RegisterLeaveRequestRequest extends FormRequest
+/**
+ * Validation for leave requests (PENDING).
+ *
+ * Shares the same rules as RegisterDirectLeaveRequest.
+ */
+class RegisterLeaveRequestRequest extends RegisterDirectLeaveRequest
 {
-    public function authorize(): bool
-    {
-        return true;
-    }
-
-    public function rules(): array
-    {
-        return [
-            'employee_id' => [
-                'required',
-                'string',
-                Rule::exists('employees', 'public_id')->whereNull('deleted_at'),
-            ],
-            'leave_type_id' => ['required', 'integer', Rule::exists('leave_types', 'id')->where('is_active', true)],
-            'start_date' => ['required', 'date'],
-            'end_date' => ['required', 'date', 'gte:start_date'],
-            'pay_percentage' => ['nullable', 'numeric', 'min:0', 'max:100'],
-            'rest_day_factor' => ['nullable', Rule::in(['FULL', 'PROPORTIONAL', 'NONE'])],
-            'time_mode' => ['nullable', Rule::in([LeaveTimeMode::SCHEDULED->value, LeaveTimeMode::OPEN_ENDED->value])],
-            'scheduled_start_time' => ['nullable', 'date_format:H:i', 'required_with:time_mode'],
-            'scheduled_end_time' => ['nullable', 'date_format:H:i', 'after:scheduled_start_time'],
-            'actual_start_time' => ['nullable', 'date_format:H:i'],
-            'actual_end_time' => ['nullable', 'date_format:H:i', 'after:actual_start_time'],
-            'notes' => ['nullable', 'string', 'max:1000'],
-        ];
-    }
-
-    public function withValidator(Validator $validator): void
-    {
-        $validator->after(function (Validator $v) {
-            $leaveType = LeaveType::find($this->input('leave_type_id'));
-
-            if (! $leaveType) {
-                return;
-            }
-
-            if ($leaveType->calculation_mode === LeaveCalculationMode::PROPORTIONAL_HOURS) {
-                if (! $this->input('time_mode')) {
-                    $v->errors()->add('time_mode', 'El modo de horario es requerido para permisos por horas.');
-                }
-
-                if (
-                    $this->input('start_date') && $this->input('end_date')
-                    && $this->input('start_date') !== $this->input('end_date')
-                ) {
-                    $v->errors()->add('end_date', 'Los permisos por horas deben ser de un solo día.');
-                }
-            }
-
-            if (
-                $this->input('time_mode') === LeaveTimeMode::SCHEDULED->value
-                && ! $this->input('scheduled_end_time')
-            ) {
-                $v->errors()->add('scheduled_end_time', 'La hora de fin es requerida cuando el horario es definido.');
-            }
-        });
-    }
-
-    public function employee(): Employee
-    {
-        return Employee::where('public_id', $this->input('employee_id'))->firstOrFail();
-    }
+    //
 }

--- a/code/api/app/Http/Resources/Leave/LeaveResource.php
+++ b/code/api/app/Http/Resources/Leave/LeaveResource.php
@@ -7,6 +7,37 @@ use App\Models\Leave;
 
 /**
  * @mixin Leave
+ *
+ * @OA\Schema(
+ *     schema="LeaveResponse",
+ *     title="Leave Response",
+ *
+ *     @OA\Property(property="id", type="string", example="01JKXYZ1234567890ABCDEFGH", description="ULID public identifier"),
+ *     @OA\Property(property="employee_id", type="string", example="01JKABC0987654321ZYXWVUTS", description="Employee public_id (ULID)"),
+ *     @OA\Property(property="leave_type", type="object",
+ *         @OA\Property(property="id", type="integer", example=1),
+ *         @OA\Property(property="code", type="string", example="VACATION"),
+ *         @OA\Property(property="name", type="string", example="Vacaciones"),
+ *         @OA\Property(property="calculation_mode", type="string", enum={"FULL_DAY", "PROPORTIONAL_HOURS"}, example="FULL_DAY")
+ *     ),
+ *     @OA\Property(property="start_date", type="string", format="date", example="2026-03-01"),
+ *     @OA\Property(property="end_date", type="string", format="date", example="2026-03-03"),
+ *     @OA\Property(property="resolved_pay_percentage", type="number", format="float", example=100.0),
+ *     @OA\Property(property="resolved_rest_day_factor", type="string", enum={"FULL", "PROPORTIONAL", "NONE"}, example="FULL"),
+ *     @OA\Property(property="time_mode", type="string", nullable=true, enum={"SCHEDULED", "OPEN_ENDED"}, example=null),
+ *     @OA\Property(property="scheduled_start_time", type="string", nullable=true, example="09:00"),
+ *     @OA\Property(property="scheduled_end_time", type="string", nullable=true, example="13:00"),
+ *     @OA\Property(property="actual_start_time", type="string", nullable=true, example="09:05"),
+ *     @OA\Property(property="actual_end_time", type="string", nullable=true, example="12:55"),
+ *     @OA\Property(property="actual_duration_minutes", type="integer", nullable=true, example=230),
+ *     @OA\Property(property="computed_duration_minutes", type="integer", nullable=true, example=240),
+ *     @OA\Property(property="status", type="string", enum={"APPROVED", "PENDING", "REJECTED", "CANCELLED"}, example="APPROVED"),
+ *     @OA\Property(property="requested_by", type="string", example="Admin User"),
+ *     @OA\Property(property="approved_by", type="string", nullable=true, example="Admin User"),
+ *     @OA\Property(property="approved_at", type="string", format="date-time", nullable=true, example="2026-03-01T10:00:00+00:00"),
+ *     @OA\Property(property="notes", type="string", nullable=true, example="Vacaciones familiares"),
+ *     @OA\Property(property="created_at", type="string", format="date-time", example="2026-03-01T08:00:00+00:00")
+ * )
  */
 class LeaveResource extends BaseResource
 {

--- a/code/api/app/Http/Resources/Leave/LeaveTypeResource.php
+++ b/code/api/app/Http/Resources/Leave/LeaveTypeResource.php
@@ -7,6 +7,19 @@ use App\Models\LeaveType;
 
 /**
  * @mixin LeaveType
+ *
+ * @OA\Schema(
+ *     schema="LeaveTypeResponse",
+ *     title="Leave Type Response",
+ *
+ *     @OA\Property(property="id", type="integer", example=1),
+ *     @OA\Property(property="code", type="string", example="VACATION"),
+ *     @OA\Property(property="name", type="string", example="Vacaciones"),
+ *     @OA\Property(property="calculation_mode", type="string", enum={"FULL_DAY", "PROPORTIONAL_HOURS"}, example="FULL_DAY"),
+ *     @OA\Property(property="default_pay_percentage", type="number", format="float", example=100.0),
+ *     @OA\Property(property="default_rest_day_factor", type="string", enum={"FULL", "PROPORTIONAL", "NONE"}, example="FULL"),
+ *     @OA\Property(property="counts_for_bonus", type="boolean", example=true)
+ * )
  */
 class LeaveTypeResource extends BaseResource
 {

--- a/code/api/app/Http/Resources/Schedule/ScheduleDayResource.php
+++ b/code/api/app/Http/Resources/Schedule/ScheduleDayResource.php
@@ -4,6 +4,20 @@ namespace App\Http\Resources\Schedule;
 
 use Illuminate\Http\Resources\Json\JsonResource;
 
+/**
+ * @OA\Schema(
+ *     schema="ScheduleDayResponse",
+ *     title="Schedule Day Response",
+ *
+ *     @OA\Property(property="day_of_week", type="integer", example=1, description="ISO day of week (1=Monday, 7=Sunday)"),
+ *     @OA\Property(property="is_day_off", type="boolean", example=false),
+ *     @OA\Property(property="expected_start", type="string", nullable=true, example="09:00"),
+ *     @OA\Property(property="expected_lunch_start", type="string", nullable=true, example="13:00"),
+ *     @OA\Property(property="expected_lunch_end", type="string", nullable=true, example="14:00"),
+ *     @OA\Property(property="lunch_duration_minutes", type="integer", nullable=true, example=60),
+ *     @OA\Property(property="expected_end", type="string", nullable=true, example="18:00")
+ * )
+ */
 class ScheduleDayResource extends JsonResource
 {
     /**

--- a/code/api/database/seeders/Development/PermissionSeeder.php
+++ b/code/api/database/seeders/Development/PermissionSeeder.php
@@ -66,6 +66,12 @@ class PermissionSeeder extends LockedSeeder
             'employees.view',
             'employees.create',
             'employees.update',
+
+            // Leaves
+            'leaves.register-direct',
+            'leaves.request',
+            'leaves.approve',
+            'leaves.reject',
         ];
 
         foreach ($permissions as $permission) {
@@ -81,14 +87,15 @@ class PermissionSeeder extends LockedSeeder
             $superAdminRole->syncPermissions(Permission::where('guard_name', 'api')->get());
         }
 
-        // admin: user + employee management
+        // admin: user + employee + leave management
         $adminRole = Role::where('name', 'admin')->where('guard_name', 'api')->first();
         if ($adminRole) {
             $adminRole->syncPermissions(
                 Permission::where('guard_name', 'api')
                     ->where(function ($q) {
                         $q->where('name', 'like', 'users.%')
-                            ->orWhere('name', 'like', 'employees.%');
+                            ->orWhere('name', 'like', 'employees.%')
+                            ->orWhere('name', 'like', 'leaves.%');
                     })
                     ->get()
             );
@@ -114,7 +121,8 @@ class PermissionSeeder extends LockedSeeder
                 Permission::where('guard_name', 'api')
                     ->where(function ($q) {
                         $q->whereIn('name', ['users.show', 'users.index'])
-                            ->orWhere('name', 'like', 'employees.%');
+                            ->orWhere('name', 'like', 'employees.%')
+                            ->orWhere('name', 'like', 'leaves.%');
                     })
                     ->get()
             );

--- a/code/api/database/seeders/Development/PermissionSeeder.php
+++ b/code/api/database/seeders/Development/PermissionSeeder.php
@@ -8,6 +8,8 @@ use Spatie\Permission\Models\Role;
 
 class PermissionSeeder extends LockedSeeder
 {
+    private const EMPLOYEES_PATTERN = 'employees.%';
+
     public function run(): void
     {
         $permissions = [
@@ -94,7 +96,7 @@ class PermissionSeeder extends LockedSeeder
                 Permission::where('guard_name', 'api')
                     ->where(function ($q) {
                         $q->where('name', 'like', 'users.%')
-                            ->orWhere('name', 'like', 'employees.%')
+                            ->orWhere('name', 'like', self::EMPLOYEES_PATTERN)
                             ->orWhere('name', 'like', 'leaves.%');
                     })
                     ->get()
@@ -107,7 +109,7 @@ class PermissionSeeder extends LockedSeeder
             $inventoryManagerRole->syncPermissions(
                 Permission::where('guard_name', 'api')
                     ->where(function ($q) {
-                        $q->where('name', 'like', 'employees.%')
+                        $q->where('name', 'like', self::EMPLOYEES_PATTERN)
                             ->orWhere('name', 'like', 'users.%');
                     })
                     ->get()
@@ -121,7 +123,7 @@ class PermissionSeeder extends LockedSeeder
                 Permission::where('guard_name', 'api')
                     ->where(function ($q) {
                         $q->whereIn('name', ['users.show', 'users.index'])
-                            ->orWhere('name', 'like', 'employees.%')
+                            ->orWhere('name', 'like', self::EMPLOYEES_PATTERN)
                             ->orWhere('name', 'like', 'leaves.%');
                     })
                     ->get()

--- a/code/api/database/seeders/Production/PermissionSeeder.php
+++ b/code/api/database/seeders/Production/PermissionSeeder.php
@@ -66,6 +66,12 @@ class PermissionSeeder extends LockedSeeder
             'employees.view',
             'employees.create',
             'employees.update',
+
+            // Leaves
+            'leaves.register-direct',
+            'leaves.request',
+            'leaves.approve',
+            'leaves.reject',
         ];
 
         foreach ($permissions as $permission) {
@@ -88,20 +94,22 @@ class PermissionSeeder extends LockedSeeder
                 Permission::where('guard_name', 'api')
                     ->where(function ($q) {
                         $q->whereIn('name', ['users.show', 'users.index'])
-                            ->orWhere('name', 'like', 'employees.%');
+                            ->orWhere('name', 'like', 'employees.%')
+                            ->orWhere('name', 'like', 'leaves.%');
                     })
                     ->get()
             );
         }
 
-        // admin (position role): full user + employee management
+        // admin (position role): full user + employee + leave management
         $adminRole = Role::where('name', 'admin')->where('guard_name', 'api')->first();
         if ($adminRole) {
             $adminRole->syncPermissions(
                 Permission::where('guard_name', 'api')
                     ->where(function ($q) {
                         $q->where('name', 'like', 'users.%')
-                            ->orWhere('name', 'like', 'employees.%');
+                            ->orWhere('name', 'like', 'employees.%')
+                            ->orWhere('name', 'like', 'leaves.%');
                     })
                     ->get()
             );

--- a/code/api/database/seeders/Testing/CoreTestSeeder.php
+++ b/code/api/database/seeders/Testing/CoreTestSeeder.php
@@ -75,6 +75,10 @@ class CoreTestSeeder extends Seeder
         'employees.view',
         'employees.create',
         'employees.update',
+        'leaves.register-direct',
+        'leaves.request',
+        'leaves.approve',
+        'leaves.reject',
     ];
 
     /** Basic view-only user permissions shared by most roles */
@@ -83,9 +87,9 @@ class CoreTestSeeder extends Seeder
     /** role name => permission name prefixes or exact names */
     private const ROLE_PERMISSIONS = [
         'super-admin' => '*',  // all permissions
-        'admin' => ['users.', 'employees.'],
+        'admin' => ['users.', 'employees.', 'leaves.'],
         'inventory-manager' => ['users.', 'employees.'],
-        'manager' => [...self::BASIC_USER_VIEW, 'employees.'],
+        'manager' => [...self::BASIC_USER_VIEW, 'employees.', 'leaves.'],
         'cook' => self::BASIC_USER_VIEW,
         'kitchen-assistant' => self::BASIC_USER_VIEW,
         'delivery-driver' => self::BASIC_USER_VIEW,

--- a/code/api/routes/api.php
+++ b/code/api/routes/api.php
@@ -258,10 +258,10 @@ Route::prefix('v1')->group(function () {
 
     // Leaves Module (All Protected)
     Route::middleware('auth:api')->prefix('leaves')->name('leaves.')->group(function () {
-        Route::post('/', RegisterDirectLeaveController::class)->name('register-direct');
-        Route::post('/requests', RegisterLeaveRequestController::class)->name('register-request');
-        Route::patch('/{id}/approve', ApproveLeaveController::class)->name('approve');
-        Route::patch('/{id}/reject', RejectLeaveController::class)->name('reject');
+        Route::post('/', RegisterDirectLeaveController::class)->name('register-direct')->middleware('permission:leaves.register-direct');
+        Route::post('/requests', RegisterLeaveRequestController::class)->name('register-request')->middleware('permission:leaves.request');
+        Route::patch('/{id}/approve', ApproveLeaveController::class)->name('approve')->middleware('permission:leaves.approve');
+        Route::patch('/{id}/reject', RejectLeaveController::class)->name('reject')->middleware('permission:leaves.reject');
     });
 
     // Attendances Module (All Protected)

--- a/code/api/routes/api.php
+++ b/code/api/routes/api.php
@@ -43,8 +43,11 @@ use App\Http\Controllers\Api\V1\Items\ShowItemController;
 use App\Http\Controllers\Api\V1\Items\ShowItemVariantController;
 use App\Http\Controllers\Api\V1\Items\UpdateItemController;
 use App\Http\Controllers\Api\V1\Items\UpdateItemVariantController;
+use App\Http\Controllers\Api\V1\Leaves\ApproveLeaveController;
 use App\Http\Controllers\Api\V1\Leaves\ListLeaveTypesController;
 use App\Http\Controllers\Api\V1\Leaves\RegisterDirectLeaveController;
+use App\Http\Controllers\Api\V1\Leaves\RegisterLeaveRequestController;
+use App\Http\Controllers\Api\V1\Leaves\RejectLeaveController;
 use App\Http\Controllers\Api\V1\OperatingUnit\CreateOperatingUnitController;
 use App\Http\Controllers\Api\V1\OperatingUnit\DeleteOperatingUnitController;
 use App\Http\Controllers\Api\V1\OperatingUnit\ListOperatingUnitsController;
@@ -256,6 +259,9 @@ Route::prefix('v1')->group(function () {
     // Leaves Module (All Protected)
     Route::middleware('auth:api')->prefix('leaves')->name('leaves.')->group(function () {
         Route::post('/', RegisterDirectLeaveController::class)->name('register-direct');
+        Route::post('/requests', RegisterLeaveRequestController::class)->name('register-request');
+        Route::patch('/{id}/approve', ApproveLeaveController::class)->name('approve');
+        Route::patch('/{id}/reject', RejectLeaveController::class)->name('reject');
     });
 
     // Attendances Module (All Protected)

--- a/code/api/tests/Feature/AttendancePayroll/LeaveRequestApiTest.php
+++ b/code/api/tests/Feature/AttendancePayroll/LeaveRequestApiTest.php
@@ -1,0 +1,520 @@
+<?php
+
+namespace Tests\Feature\AttendancePayroll;
+
+use App\Enums\DayStatus;
+use App\Enums\LeaveStatus;
+use App\Models\Attendance;
+use App\Models\Employee;
+use App\Models\EmploymentPeriod;
+use App\Models\Leave;
+use App\Models\LeaveType;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+class LeaveRequestApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+
+    private const DATE = '2026-04-15';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        app()[PermissionRegistrar::class]->forgetCachedPermissions();
+
+        Permission::create(['name' => 'attendances.create', 'guard_name' => 'api']);
+        $role = Role::create(['name' => 'manager', 'guard_name' => 'api']);
+        $role->givePermissionTo('attendances.create');
+
+        Role::firstOrCreate(['name' => 'employee', 'guard_name' => 'api']);
+        foreach (Employee::POSITION_ROLES as $roleName) {
+            Role::firstOrCreate(['name' => $roleName, 'guard_name' => 'api']);
+        }
+
+        $this->user = User::factory()->create();
+        $this->user->assignRole('manager');
+
+        Passport::actingAs($this->user);
+
+        $this->seedLeaveTypes();
+
+        Carbon::setTestNow(Carbon::parse(self::DATE.' 10:00:00'));
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // POST /api/v1/leaves/requests — Register Leave Request
+    // ══════════════════════════════════════════════════════════════════════════
+
+    #[Test]
+    public function creates_pending_leave_request_without_attendance_records(): void
+    {
+        $employee = $this->makeEmployee();
+        $leaveType = LeaveType::where('code', LeaveType::MEDICAL)->first();
+
+        $response = $this->postJson('/api/v1/leaves/requests', [
+            'employee_id' => $employee->public_id,
+            'leave_type_id' => $leaveType->id,
+            'start_date' => self::DATE,
+            'end_date' => self::DATE,
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.status', LeaveStatus::PENDING->value)
+            ->assertJsonPath('data.approved_by', null)
+            ->assertJsonPath('data.approved_at', null);
+
+        $this->assertDatabaseHas('leaves', [
+            'employee_id' => $employee->id,
+            'status' => LeaveStatus::PENDING->value,
+        ]);
+
+        // No attendance records should be created for a PENDING request
+        $this->assertDatabaseMissing('attendances', [
+            'employee_id' => $employee->id,
+            'date' => self::DATE,
+        ]);
+    }
+
+    #[Test]
+    public function creates_multi_day_pending_request_without_attendance(): void
+    {
+        $employee = $this->makeEmployee();
+        $leaveType = LeaveType::where('code', LeaveType::MEDICAL)->first();
+
+        $response = $this->postJson('/api/v1/leaves/requests', [
+            'employee_id' => $employee->public_id,
+            'leave_type_id' => $leaveType->id,
+            'start_date' => '2026-04-15',
+            'end_date' => '2026-04-17',
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.status', LeaveStatus::PENDING->value);
+
+        foreach (['2026-04-15', '2026-04-16', '2026-04-17'] as $date) {
+            $this->assertDatabaseMissing('attendances', [
+                'employee_id' => $employee->id,
+                'date' => $date,
+            ]);
+        }
+    }
+
+    #[Test]
+    public function leave_request_stores_notes_and_pay_percentage(): void
+    {
+        $employee = $this->makeEmployee();
+        $leaveType = LeaveType::where('code', LeaveType::PERSONAL)->first();
+
+        $response = $this->postJson('/api/v1/leaves/requests', [
+            'employee_id' => $employee->public_id,
+            'leave_type_id' => $leaveType->id,
+            'start_date' => self::DATE,
+            'end_date' => self::DATE,
+            'pay_percentage' => 50.00,
+            'notes' => 'Cita médica programada',
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.resolved_pay_percentage', 50)
+            ->assertJsonPath('data.notes', 'Cita médica programada');
+    }
+
+    #[Test]
+    public function leave_request_rejects_overlapping_approved_leave(): void
+    {
+        $employee = $this->makeEmployee();
+        $leaveType = LeaveType::where('code', LeaveType::MEDICAL)->first();
+
+        Leave::create([
+            'employee_id' => $employee->id,
+            'leave_type_id' => $leaveType->id,
+            'start_date' => self::DATE,
+            'end_date' => self::DATE,
+            'status' => LeaveStatus::APPROVED,
+            'requested_by' => $this->user->id,
+            'approved_by' => $this->user->id,
+            'approved_at' => now(),
+        ]);
+
+        $response = $this->postJson('/api/v1/leaves/requests', [
+            'employee_id' => $employee->public_id,
+            'leave_type_id' => $leaveType->id,
+            'start_date' => self::DATE,
+            'end_date' => self::DATE,
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrorFor('start_date');
+    }
+
+    #[Test]
+    public function leave_request_rejects_unauthenticated(): void
+    {
+        auth()->forgetGuards();
+
+        $this->postJson('/api/v1/leaves/requests', [
+            'employee_id' => 'any-id',
+            'leave_type_id' => 1,
+            'start_date' => self::DATE,
+            'end_date' => self::DATE,
+        ])->assertStatus(401);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // PATCH /api/v1/leaves/{id}/approve — Approve Leave
+    // ══════════════════════════════════════════════════════════════════════════
+
+    #[Test]
+    public function approves_pending_leave_and_creates_attendance_records(): void
+    {
+        $employee = $this->makeEmployee();
+        $leave = $this->createPendingLeave($employee, self::DATE, self::DATE);
+
+        $response = $this->patchJson("/api/v1/leaves/{$leave->public_id}/approve");
+
+        $response->assertOk()
+            ->assertJsonPath('data.status', LeaveStatus::APPROVED->value)
+            ->assertJsonPath('data.approved_at', fn ($v) => $v !== null);
+
+        $this->assertDatabaseHas('leaves', [
+            'id' => $leave->id,
+            'status' => LeaveStatus::APPROVED->value,
+            'approved_by' => $this->user->id,
+        ]);
+
+        $this->assertDatabaseHas('attendances', [
+            'employee_id' => $employee->id,
+            'date' => self::DATE,
+            'day_status' => DayStatus::LEAVE->value,
+        ]);
+    }
+
+    #[Test]
+    public function approves_multi_day_leave_creates_attendance_for_each_day(): void
+    {
+        $employee = $this->makeEmployee();
+        $leave = $this->createPendingLeave($employee, '2026-04-15', '2026-04-17');
+
+        $response = $this->patchJson("/api/v1/leaves/{$leave->public_id}/approve");
+
+        $response->assertOk()
+            ->assertJsonPath('data.status', LeaveStatus::APPROVED->value);
+
+        foreach (['2026-04-15', '2026-04-16', '2026-04-17'] as $date) {
+            $this->assertDatabaseHas('attendances', [
+                'employee_id' => $employee->id,
+                'date' => $date,
+                'day_status' => DayStatus::LEAVE->value,
+            ]);
+        }
+    }
+
+    #[Test]
+    public function cannot_approve_already_approved_leave(): void
+    {
+        $employee = $this->makeEmployee();
+        $leave = $this->createPendingLeave($employee, self::DATE, self::DATE);
+
+        // First approval
+        $this->patchJson("/api/v1/leaves/{$leave->public_id}/approve")
+            ->assertOk();
+
+        // Second approval attempt
+        $response = $this->patchJson("/api/v1/leaves/{$leave->public_id}/approve");
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrorFor('status');
+    }
+
+    #[Test]
+    public function cannot_approve_rejected_leave(): void
+    {
+        $employee = $this->makeEmployee();
+        $leave = $this->createPendingLeave($employee, self::DATE, self::DATE);
+
+        // Reject first
+        $this->patchJson("/api/v1/leaves/{$leave->public_id}/reject")->assertOk();
+
+        // Attempt to approve
+        $response = $this->patchJson("/api/v1/leaves/{$leave->public_id}/approve");
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrorFor('status');
+    }
+
+    #[Test]
+    public function cannot_approve_if_worked_attendance_exists(): void
+    {
+        $employee = $this->makeEmployee();
+        $leave = $this->createPendingLeave($employee, self::DATE, self::DATE);
+
+        // Create a worked attendance record
+        Attendance::create([
+            'employee_id' => $employee->id,
+            'date' => self::DATE,
+            'day_status' => DayStatus::WORKED,
+            'check_in' => now(),
+        ]);
+
+        $response = $this->patchJson("/api/v1/leaves/{$leave->public_id}/approve");
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrorFor('start_date');
+    }
+
+    #[Test]
+    public function check_in_blocked_after_leave_approval(): void
+    {
+        $employee = $this->makeEmployee();
+        $leave = $this->createPendingLeave($employee, self::DATE, self::DATE);
+
+        // Approve
+        $this->patchJson("/api/v1/leaves/{$leave->public_id}/approve")->assertOk();
+
+        // Attempt check-in on the same day
+        $response = $this->postJson('/api/v1/attendances/check-in', [
+            'employee_id' => $employee->public_id,
+            'check_in' => self::DATE.'T09:00:00-06:00',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrorFor('check_in');
+    }
+
+    #[Test]
+    public function approve_rejects_unauthenticated(): void
+    {
+        auth()->forgetGuards();
+
+        $this->patchJson('/api/v1/leaves/fake-id/approve')
+            ->assertStatus(401);
+    }
+
+    #[Test]
+    public function approve_returns_404_for_nonexistent_leave(): void
+    {
+        $this->patchJson('/api/v1/leaves/nonexistent-id/approve')
+            ->assertStatus(404);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // PATCH /api/v1/leaves/{id}/reject — Reject Leave
+    // ══════════════════════════════════════════════════════════════════════════
+
+    #[Test]
+    public function rejects_pending_leave_without_attendance_impact(): void
+    {
+        $employee = $this->makeEmployee();
+        $leave = $this->createPendingLeave($employee, self::DATE, self::DATE);
+
+        $response = $this->patchJson("/api/v1/leaves/{$leave->public_id}/reject");
+
+        $response->assertOk()
+            ->assertJsonPath('data.status', LeaveStatus::REJECTED->value)
+            ->assertJsonPath('data.approved_at', fn ($v) => $v !== null);
+
+        $this->assertDatabaseHas('leaves', [
+            'id' => $leave->id,
+            'status' => LeaveStatus::REJECTED->value,
+            'approved_by' => $this->user->id,
+        ]);
+
+        // No attendance records should be created
+        $this->assertDatabaseMissing('attendances', [
+            'employee_id' => $employee->id,
+            'date' => self::DATE,
+        ]);
+    }
+
+    #[Test]
+    public function cannot_reject_already_approved_leave(): void
+    {
+        $employee = $this->makeEmployee();
+        $leave = $this->createPendingLeave($employee, self::DATE, self::DATE);
+
+        // Approve first
+        $this->patchJson("/api/v1/leaves/{$leave->public_id}/approve")->assertOk();
+
+        // Attempt to reject
+        $response = $this->patchJson("/api/v1/leaves/{$leave->public_id}/reject");
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrorFor('status');
+    }
+
+    #[Test]
+    public function cannot_reject_already_rejected_leave(): void
+    {
+        $employee = $this->makeEmployee();
+        $leave = $this->createPendingLeave($employee, self::DATE, self::DATE);
+
+        // First rejection
+        $this->patchJson("/api/v1/leaves/{$leave->public_id}/reject")->assertOk();
+
+        // Second rejection attempt
+        $response = $this->patchJson("/api/v1/leaves/{$leave->public_id}/reject");
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrorFor('status');
+    }
+
+    #[Test]
+    public function reject_rejects_unauthenticated(): void
+    {
+        auth()->forgetGuards();
+
+        $this->patchJson('/api/v1/leaves/fake-id/reject')
+            ->assertStatus(401);
+    }
+
+    #[Test]
+    public function reject_returns_404_for_nonexistent_leave(): void
+    {
+        $this->patchJson('/api/v1/leaves/nonexistent-id/reject')
+            ->assertStatus(404);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // Full workflow: Request → Approve → Check-in blocked
+    // ══════════════════════════════════════════════════════════════════════════
+
+    #[Test]
+    public function full_workflow_request_then_approve_then_check_in_blocked(): void
+    {
+        $employee = $this->makeEmployee();
+        $leaveType = LeaveType::where('code', LeaveType::MEDICAL)->first();
+
+        // Step 1: Create leave request
+        $requestResponse = $this->postJson('/api/v1/leaves/requests', [
+            'employee_id' => $employee->public_id,
+            'leave_type_id' => $leaveType->id,
+            'start_date' => self::DATE,
+            'end_date' => self::DATE,
+        ]);
+
+        $requestResponse->assertStatus(201)
+            ->assertJsonPath('data.status', 'PENDING');
+
+        $leaveId = $requestResponse->json('data.id');
+
+        // No attendance
+        $this->assertDatabaseMissing('attendances', [
+            'employee_id' => $employee->id,
+            'date' => self::DATE,
+        ]);
+
+        // Step 2: Approve
+        $approveResponse = $this->patchJson("/api/v1/leaves/{$leaveId}/approve");
+        $approveResponse->assertOk()
+            ->assertJsonPath('data.status', 'APPROVED');
+
+        // Attendance created
+        $this->assertDatabaseHas('attendances', [
+            'employee_id' => $employee->id,
+            'date' => self::DATE,
+            'day_status' => DayStatus::LEAVE->value,
+        ]);
+
+        // Step 3: Check-in blocked
+        $checkInResponse = $this->postJson('/api/v1/attendances/check-in', [
+            'employee_id' => $employee->public_id,
+            'check_in' => self::DATE.'T09:00:00-06:00',
+        ]);
+
+        $checkInResponse->assertStatus(422);
+    }
+
+    #[Test]
+    public function full_workflow_request_then_reject_no_attendance(): void
+    {
+        $employee = $this->makeEmployee();
+        $leaveType = LeaveType::where('code', LeaveType::PERSONAL)->first();
+
+        // Step 1: Create leave request
+        $requestResponse = $this->postJson('/api/v1/leaves/requests', [
+            'employee_id' => $employee->public_id,
+            'leave_type_id' => $leaveType->id,
+            'start_date' => self::DATE,
+            'end_date' => self::DATE,
+            'notes' => 'Necesito el día libre',
+        ]);
+
+        $requestResponse->assertStatus(201);
+        $leaveId = $requestResponse->json('data.id');
+
+        // Step 2: Reject
+        $rejectResponse = $this->patchJson("/api/v1/leaves/{$leaveId}/reject");
+        $rejectResponse->assertOk()
+            ->assertJsonPath('data.status', 'REJECTED');
+
+        // No attendance records
+        $this->assertDatabaseMissing('attendances', [
+            'employee_id' => $employee->id,
+            'date' => self::DATE,
+        ]);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private function seedLeaveTypes(): void
+    {
+        $types = [
+            [LeaveType::MEDICAL, 'Incapacidad médica', 'FIXED_PERCENTAGE', 0.00, 'NONE', false],
+            [LeaveType::PERSONAL, 'Permiso personal', 'FIXED_PERCENTAGE', 0.00, 'NONE', false],
+            [LeaveType::PERMISSION_PAID, 'Permiso con goce de sueldo', 'FIXED_PERCENTAGE', 100.00, 'FULL', true],
+            [LeaveType::PERMISSION_HOURS, 'Permiso por horas', 'PROPORTIONAL_HOURS', 0.00, 'PROPORTIONAL', false],
+        ];
+
+        foreach ($types as [$code, $name, $mode, $pay, $rest, $bonus]) {
+            LeaveType::create([
+                'code' => $code,
+                'name' => $name,
+                'calculation_mode' => $mode,
+                'default_pay_percentage' => $pay,
+                'default_rest_day_factor' => $rest,
+                'counts_for_bonus' => $bonus,
+            ]);
+        }
+    }
+
+    private function makeEmployee(): Employee
+    {
+        $period = EmploymentPeriod::factory()->create([
+            'is_active' => true,
+            'start_date' => '2026-01-01',
+        ]);
+
+        return $period->employee;
+    }
+
+    private function createPendingLeave(Employee $employee, string $startDate, string $endDate): Leave
+    {
+        $leaveType = LeaveType::where('code', LeaveType::MEDICAL)->first();
+
+        return Leave::create([
+            'employee_id' => $employee->id,
+            'leave_type_id' => $leaveType->id,
+            'start_date' => $startDate,
+            'end_date' => $endDate,
+            'status' => LeaveStatus::PENDING,
+            'requested_by' => $this->user->id,
+        ]);
+    }
+}

--- a/code/api/tests/Feature/AttendancePayroll/LeaveRequestApiTest.php
+++ b/code/api/tests/Feature/AttendancePayroll/LeaveRequestApiTest.php
@@ -34,8 +34,14 @@ class LeaveRequestApiTest extends TestCase
         app()[PermissionRegistrar::class]->forgetCachedPermissions();
 
         Permission::create(['name' => 'attendances.create', 'guard_name' => 'api']);
+        Permission::create(['name' => 'leaves.request', 'guard_name' => 'api']);
+        Permission::create(['name' => 'leaves.approve', 'guard_name' => 'api']);
+        Permission::create(['name' => 'leaves.reject', 'guard_name' => 'api']);
         $role = Role::create(['name' => 'manager', 'guard_name' => 'api']);
         $role->givePermissionTo('attendances.create');
+        $role->givePermissionTo('leaves.request');
+        $role->givePermissionTo('leaves.approve');
+        $role->givePermissionTo('leaves.reject');
 
         Role::firstOrCreate(['name' => 'employee', 'guard_name' => 'api']);
         foreach (Employee::POSITION_ROLES as $roleName) {
@@ -177,6 +183,20 @@ class LeaveRequestApiTest extends TestCase
         ])->assertStatus(401);
     }
 
+    #[Test]
+    public function leave_request_rejects_without_leaves_request_permission(): void
+    {
+        $userWithoutPermission = User::factory()->create();
+        Passport::actingAs($userWithoutPermission);
+
+        $this->postJson('/api/v1/leaves/requests', [
+            'employee_id' => 'any-id',
+            'leave_type_id' => 1,
+            'start_date' => self::DATE,
+            'end_date' => self::DATE,
+        ])->assertStatus(403);
+    }
+
     // ══════════════════════════════════════════════════════════════════════════
     // PATCH /api/v1/leaves/{id}/approve — Approve Leave
     // ══════════════════════════════════════════════════════════════════════════
@@ -308,6 +328,16 @@ class LeaveRequestApiTest extends TestCase
     }
 
     #[Test]
+    public function approve_rejects_without_leaves_approve_permission(): void
+    {
+        $userWithoutPermission = User::factory()->create();
+        Passport::actingAs($userWithoutPermission);
+
+        $this->patchJson('/api/v1/leaves/fake-id/approve')
+            ->assertStatus(403);
+    }
+
+    #[Test]
     public function approve_returns_404_for_nonexistent_leave(): void
     {
         $this->patchJson('/api/v1/leaves/nonexistent-id/approve')
@@ -382,6 +412,16 @@ class LeaveRequestApiTest extends TestCase
 
         $this->patchJson('/api/v1/leaves/fake-id/reject')
             ->assertStatus(401);
+    }
+
+    #[Test]
+    public function reject_rejects_without_leaves_reject_permission(): void
+    {
+        $userWithoutPermission = User::factory()->create();
+        Passport::actingAs($userWithoutPermission);
+
+        $this->patchJson('/api/v1/leaves/fake-id/reject')
+            ->assertStatus(403);
     }
 
     #[Test]

--- a/code/api/tests/Feature/AttendancePayroll/RegisterDirectLeaveApiTest.php
+++ b/code/api/tests/Feature/AttendancePayroll/RegisterDirectLeaveApiTest.php
@@ -34,8 +34,10 @@ class RegisterDirectLeaveApiTest extends TestCase
         app()[PermissionRegistrar::class]->forgetCachedPermissions();
 
         Permission::create(['name' => 'attendances.create', 'guard_name' => 'api']);
+        Permission::create(['name' => 'leaves.register-direct', 'guard_name' => 'api']);
         $role = Role::create(['name' => 'manager', 'guard_name' => 'api']);
         $role->givePermissionTo('attendances.create');
+        $role->givePermissionTo('leaves.register-direct');
 
         Role::firstOrCreate(['name' => 'employee', 'guard_name' => 'api']);
         foreach (Employee::POSITION_ROLES as $roleName) {
@@ -410,6 +412,20 @@ class RegisterDirectLeaveApiTest extends TestCase
             'start_date' => self::DATE,
             'end_date' => self::DATE,
         ])->assertStatus(401);
+    }
+
+    #[Test]
+    public function rejects_request_without_leaves_register_direct_permission(): void
+    {
+        $userWithoutPermission = User::factory()->create();
+        Passport::actingAs($userWithoutPermission);
+
+        $this->postJson('/api/v1/leaves', [
+            'employee_id' => 'any-id',
+            'leave_type_id' => 1,
+            'start_date' => self::DATE,
+            'end_date' => self::DATE,
+        ])->assertStatus(403);
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/code/webapp/cypress/e2e/leave-request-approve.cy.ts
+++ b/code/webapp/cypress/e2e/leave-request-approve.cy.ts
@@ -1,0 +1,98 @@
+/**
+ * Leave Request — Submit & Approve flow — E2E test
+ *
+ * Happy-path: admin creates a leave request (PENDING) for an employee
+ * from the employee detail panel, then approves it from the same panel.
+ *
+ * DB reset strategy
+ * ─────────────────
+ * • before()     → cy.task('test:reset', 'attendance') ONCE per file.
+ * • beforeEach() → login via API + navigate to /employees.
+ *
+ * Para correr solo este archivo:
+ *   make cypress-spec SPEC=leave-request-approve
+ */
+
+import users from '../fixtures/users.json'
+
+const { email: adminEmail, password: adminPassword } = users.admin
+
+// ── Suite setup ──────────────────────────────────────────────────────────────
+
+before(() => {
+  cy.task('test:reset', 'attendance', { timeout: 60_000 })
+})
+
+const TEST_TIME_ISO = '2026-04-09T10:00:00-06:00'
+const TEST_TIME_UTC = new Date('2026-04-09T16:00:00Z')
+
+beforeEach(() => {
+  cy.intercept({ url: /\/api\/v1\// }, (req) => {
+    req.headers['X-Test-Time'] = TEST_TIME_ISO
+    req.continue()
+  }).as('apiWithTestTime')
+
+  cy.loginByApi(adminEmail, adminPassword)
+  cy.visitWithAuth('/employees')
+  cy.url().should('include', '/employees', { timeout: 10_000 })
+  cy.closeDevDebugger()
+
+  cy.clock(TEST_TIME_UTC.getTime(), ['Date'])
+})
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function openEmployeeDetail(name: string) {
+  cy.contains('td', name, { timeout: 10_000 })
+    .closest('tr')
+    .find('button[title="Ver detalle"]')
+    .click()
+  cy.contains('h2', 'Detalle de Empleado', { timeout: 10_000 }).should('be.visible')
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// 1. Happy path — submit leave request → appears as PENDING → approve
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('Leave Request — submit & approve (happy path)', () => {
+  it('creates a leave request as PENDING, then approves it', () => {
+    cy.intercept('GET', '**/leave-types*').as('leaveTypesLoad')
+    cy.intercept('POST', '**/leaves/requests').as('createRequest')
+    cy.intercept('PATCH', '**/leaves/*/approve').as('approveLeave')
+
+    // 1. Open employee detail panel
+    openEmployeeDetail('Carlos Mendoza')
+
+    // 2. Find "Ausencias" section and click "Solicitar permiso"
+    cy.contains('h3', 'Ausencias', { timeout: 10_000 }).should('be.visible')
+    cy.contains('button', 'Solicitar permiso').click({ force: true })
+
+    // 3. Dialog should open with request mode title
+    cy.contains('h3', 'Solicitar permiso').should('be.visible')
+    cy.contains('Solicitud — requiere aprobación').should('be.visible')
+
+    // 4. Select leave type and submit
+    cy.wait('@leaveTypesLoad')
+    cy.get('dialog select').first().select('Incapacidad médica')
+    cy.get('dialog').contains('button', 'Enviar solicitud').click({ force: true })
+
+    // 5. Verify API response
+    cy.wait('@createRequest').its('response.statusCode').should('eq', 201)
+
+    // 6. Verify PENDING leave appears in the history
+    cy.contains('button', 'Ver historial').click({ force: true })
+    cy.contains('Historial de ausencias', { timeout: 10_000 }).should('be.visible')
+
+    // Filter by PENDING
+    cy.get('select[aria-label="Filtrar por estado"]').select('Pendiente')
+    cy.contains('td', 'Pendiente', { timeout: 10_000 }).should('be.visible')
+
+    // 7. Approve the leave
+    cy.get('button[aria-label="Aprobar ausencia"]').first().click({ force: true })
+    cy.wait('@approveLeave').its('response.statusCode').should('eq', 200)
+
+    // 8. After approval the row should show "Aprobada"
+    cy.get('select[aria-label="Filtrar por estado"]').select('Todos los estados')
+    cy.contains('td', 'Aprobada', { timeout: 10_000 }).should('be.visible')
+  })
+})

--- a/code/webapp/cypress/e2e/leave-request-approve.cy.ts
+++ b/code/webapp/cypress/e2e/leave-request-approve.cy.ts
@@ -20,34 +20,34 @@ const { email: adminEmail, password: adminPassword } = users.admin
 // ── Suite setup ──────────────────────────────────────────────────────────────
 
 before(() => {
-  cy.task('test:reset', 'attendance', { timeout: 60_000 })
+    cy.task('test:reset', 'attendance', { timeout: 60_000 })
 })
 
 const TEST_TIME_ISO = '2026-04-09T10:00:00-06:00'
 const TEST_TIME_UTC = new Date('2026-04-09T16:00:00Z')
 
 beforeEach(() => {
-  cy.intercept({ url: /\/api\/v1\// }, (req) => {
-    req.headers['X-Test-Time'] = TEST_TIME_ISO
-    req.continue()
-  }).as('apiWithTestTime')
+    cy.intercept({ url: /\/api\/v1\// }, (req) => {
+        req.headers['X-Test-Time'] = TEST_TIME_ISO
+        req.continue()
+    }).as('apiWithTestTime')
 
-  cy.loginByApi(adminEmail, adminPassword)
-  cy.visitWithAuth('/employees')
-  cy.url().should('include', '/employees', { timeout: 10_000 })
-  cy.closeDevDebugger()
+    cy.loginByApi(adminEmail, adminPassword)
+    cy.visitWithAuth('/employees')
+    cy.url().should('include', '/employees', { timeout: 10_000 })
+    cy.closeDevDebugger()
 
-  cy.clock(TEST_TIME_UTC.getTime(), ['Date'])
+    cy.clock(TEST_TIME_UTC.getTime(), ['Date'])
 })
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 function openEmployeeDetail(name: string) {
-  cy.contains('td', name, { timeout: 10_000 })
-    .closest('tr')
-    .find('button[title="Ver detalle"]')
-    .click()
-  cy.contains('h2', 'Detalle de Empleado', { timeout: 10_000 }).should('be.visible')
+    cy.contains('td', name, { timeout: 10_000 })
+        .closest('tr')
+        .find('button[title="Ver detalle"]')
+        .click()
+    cy.contains('h2', 'Detalle de Empleado', { timeout: 10_000 }).should('be.visible')
 }
 
 // ══════════════════════════════════════════════════════════════════════════════
@@ -55,44 +55,44 @@ function openEmployeeDetail(name: string) {
 // ══════════════════════════════════════════════════════════════════════════════
 
 describe('Leave Request — submit & approve (happy path)', () => {
-  it('creates a leave request as PENDING, then approves it', () => {
-    cy.intercept('GET', '**/leave-types*').as('leaveTypesLoad')
-    cy.intercept('POST', '**/leaves/requests').as('createRequest')
-    cy.intercept('PATCH', '**/leaves/*/approve').as('approveLeave')
+    it('creates a leave request as PENDING, then approves it', () => {
+        cy.intercept('GET', '**/leave-types*').as('leaveTypesLoad')
+        cy.intercept('POST', '**/leaves/requests').as('createRequest')
+        cy.intercept('PATCH', '**/leaves/*/approve').as('approveLeave')
 
-    // 1. Open employee detail panel
-    openEmployeeDetail('Carlos Mendoza')
+        // 1. Open employee detail panel
+        openEmployeeDetail('Carlos Mendoza')
 
-    // 2. Find "Ausencias" section and click "Solicitar permiso"
-    cy.contains('h3', 'Ausencias', { timeout: 10_000 }).should('be.visible')
-    cy.contains('button', 'Solicitar permiso').click({ force: true })
+        // 2. Find "Ausencias" section and click "Solicitar permiso"
+        cy.contains('h3', 'Ausencias', { timeout: 10_000 }).should('be.visible')
+        cy.contains('button', 'Solicitar permiso').click({ force: true })
 
-    // 3. Dialog should open with request mode title
-    cy.contains('h3', 'Solicitar permiso').should('be.visible')
-    cy.contains('Solicitud — requiere aprobación').should('be.visible')
+        // 3. Dialog should open with request mode title
+        cy.contains('h3', 'Solicitar permiso').should('be.visible')
+        cy.contains('Solicitud — requiere aprobación').should('be.visible')
 
-    // 4. Select leave type and submit
-    cy.wait('@leaveTypesLoad')
-    cy.get('dialog select').first().select('Incapacidad médica')
-    cy.get('dialog').contains('button', 'Solicitar permiso').click({ force: true })
+        // 4. Select leave type and submit
+        cy.wait('@leaveTypesLoad')
+        cy.get('dialog select').first().select('Incapacidad médica')
+        cy.get('dialog').contains('button', 'Solicitar permiso').click({ force: true })
 
-    // 5. Verify API response
-    cy.wait('@createRequest').its('response.statusCode').should('eq', 201)
+        // 5. Verify API response
+        cy.wait('@createRequest').its('response.statusCode').should('eq', 201)
 
-    // 6. Verify PENDING leave appears in the history
-    cy.contains('button', 'Ver historial').click({ force: true })
-    cy.contains('Historial de ausencias', { timeout: 10_000 }).should('be.visible')
+        // 6. Verify PENDING leave appears in the history
+        cy.contains('button', 'Ver historial').click({ force: true })
+        cy.contains('Historial de ausencias', { timeout: 10_000 }).should('be.visible')
 
-    // Filter by PENDING
-    cy.get('select[aria-label="Filtrar por estado"]').select('Pendiente')
-    cy.contains('td', 'Pendiente', { timeout: 10_000 }).should('be.visible')
+        // Filter by PENDING
+        cy.get('select[aria-label="Filtrar por estado"]').select('Pendiente')
+        cy.contains('td', 'Pendiente', { timeout: 10_000 }).should('be.visible')
 
-    // 7. Approve the leave
-    cy.get('button[aria-label="Aprobar ausencia"]').first().click({ force: true })
-    cy.wait('@approveLeave').its('response.statusCode').should('eq', 200)
+        // 7. Approve the leave
+        cy.get('button[aria-label="Aprobar ausencia"]').first().click({ force: true })
+        cy.wait('@approveLeave').its('response.statusCode').should('eq', 200)
 
-    // 8. After approval the row should show "Aprobada"
-    cy.get('select[aria-label="Filtrar por estado"]').select('Todos los estados')
-    cy.contains('td', 'Aprobada', { timeout: 10_000 }).should('be.visible')
-  })
+        // 8. After approval the row should show "Aprobada"
+        cy.get('select[aria-label="Filtrar por estado"]').select('Todos los estados')
+        cy.contains('td', 'Aprobada', { timeout: 10_000 }).should('be.visible')
+    })
 })

--- a/code/webapp/cypress/e2e/leave-request-approve.cy.ts
+++ b/code/webapp/cypress/e2e/leave-request-approve.cy.ts
@@ -74,7 +74,7 @@ describe('Leave Request — submit & approve (happy path)', () => {
     // 4. Select leave type and submit
     cy.wait('@leaveTypesLoad')
     cy.get('dialog select').first().select('Incapacidad médica')
-    cy.get('dialog').contains('button', 'Enviar solicitud').click({ force: true })
+    cy.get('dialog').contains('button', 'Solicitar permiso').click({ force: true })
 
     // 5. Verify API response
     cy.wait('@createRequest').its('response.statusCode').should('eq', 201)

--- a/code/webapp/src/components/attendance/RegisterLeaveDialog.tsx
+++ b/code/webapp/src/components/attendance/RegisterLeaveDialog.tsx
@@ -22,6 +22,7 @@ export interface RegisterLeaveDialogProps {
   isOpen: boolean
   employee: TodayAttendanceEmployee | null
   onClose: () => void
+  mode?: 'direct' | 'request'
 }
 
 // ── Component ───────────────────────────────────────────────────────────────────
@@ -30,6 +31,7 @@ export function RegisterLeaveDialog({
   isOpen,
   employee,
   onClose,
+  mode = 'direct',
 }: Readonly<RegisterLeaveDialogProps>) {
   const [visible, setVisible] = useState(false)
   const [animating, setAnimating] = useState<'enter' | 'exit' | null>(null)
@@ -47,6 +49,7 @@ export function RegisterLeaveDialog({
   } = useRegisterLeaveDialog({
     employee,
     onSuccess: onClose,
+    mode,
   })
 
   const { register, formState: { errors } } = form
@@ -111,9 +114,12 @@ export function RegisterLeaveDialog({
               id="register-leave-title"
               className="text-base font-semibold text-foreground"
             >
-              Registrar ausencia
+              {mode === 'request' ? 'Solicitar permiso' : 'Registrar ausencia'}
             </h3>
             <p className="mt-0.5 text-sm text-muted-foreground">{employeeName}</p>
+            {mode === 'request' && (
+              <p className="mt-0.5 text-xs text-amber-600">Solicitud — requiere aprobación</p>
+            )}
           </div>
           <button
             type="button"
@@ -248,7 +254,7 @@ export function RegisterLeaveDialog({
               className="bg-amber-600 text-white hover:bg-amber-700"
             >
               {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              Registrar ausencia
+              {mode === 'request' ? 'Solicitar permiso' : 'Registrar ausencia'}
             </Button>
           </div>
         </form>

--- a/code/webapp/src/components/attendance/__tests__/use-register-leave-dialog.test.ts
+++ b/code/webapp/src/components/attendance/__tests__/use-register-leave-dialog.test.ts
@@ -348,4 +348,72 @@ describe('useRegisterLeaveDialog', () => {
 
     expect(leaveApi.registerDirectLeave).not.toHaveBeenCalled()
   })
+
+  it('sets error when SCHEDULED mode has no scheduled_end_time', async () => {
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(
+      () => useRegisterLeaveDialog({ employee: mockEmployee, onSuccess: vi.fn() }),
+      { wrapper }
+    )
+
+    await waitFor(() => expect(result.current.isLoadingTypes).toBe(false))
+
+    act(() => {
+      result.current.form.setValue('leave_type_id', 4) // PROPORTIONAL_HOURS
+      result.current.form.setValue('time_mode', 'SCHEDULED')
+      result.current.form.setValue('scheduled_start_time', '10:00')
+      result.current.form.setValue('scheduled_end_time', null)
+    })
+
+    await act(async () => {
+      await result.current.handleSubmit()
+    })
+
+    expect(leaveApi.registerDirectLeave).not.toHaveBeenCalled()
+  })
+
+  it('sets error when pay_percentage is invalid', async () => {
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(
+      () => useRegisterLeaveDialog({ employee: mockEmployee, onSuccess: vi.fn() }),
+      { wrapper }
+    )
+
+    await waitFor(() => expect(result.current.isLoadingTypes).toBe(false))
+
+    act(() => {
+      result.current.form.setValue('leave_type_id', 1)
+      result.current.form.setValue('pay_percentage', 'abc')
+    })
+
+    await act(async () => {
+      await result.current.handleSubmit()
+    })
+
+    // The API must NOT be called — pay_percentage is invalid
+    expect(leaveApi.registerDirectLeave).not.toHaveBeenCalled()
+  })
+
+  it('sets error when PROPORTIONAL_HOURS has no scheduled_start_time', async () => {
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(
+      () => useRegisterLeaveDialog({ employee: mockEmployee, onSuccess: vi.fn() }),
+      { wrapper }
+    )
+
+    await waitFor(() => expect(result.current.isLoadingTypes).toBe(false))
+
+    act(() => {
+      result.current.form.setValue('leave_type_id', 4) // PROPORTIONAL_HOURS
+      result.current.form.setValue('time_mode', 'OPEN_ENDED')
+      result.current.form.setValue('scheduled_start_time', null)
+    })
+
+    await act(async () => {
+      await result.current.handleSubmit()
+    })
+
+    // The API must NOT be called — scheduled_start_time is missing
+    expect(leaveApi.registerDirectLeave).not.toHaveBeenCalled()
+  })
 })

--- a/code/webapp/src/components/attendance/__tests__/use-register-leave-dialog.test.ts
+++ b/code/webapp/src/components/attendance/__tests__/use-register-leave-dialog.test.ts
@@ -20,6 +20,7 @@ vi.mock('@/services/leave-api', () => ({
   leaveApi: {
     listLeaveTypes: vi.fn(),
     registerDirectLeave: vi.fn(),
+    registerLeaveRequest: vi.fn(),
   },
 }))
 
@@ -310,5 +311,41 @@ describe('useRegisterLeaveDialog', () => {
 
     expect(result.current.form.getValues('leave_type_id')).toBe(0)
     expect(result.current.form.getValues('notes')).toBeNull()
+  })
+
+  it('submits via registerLeaveRequest when mode is request', async () => {
+    vi.mocked(leaveApi.registerLeaveRequest).mockResolvedValue({
+      data: { status: 201, data: {} },
+    } as never)
+
+    const onSuccess = vi.fn()
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(
+      () => useRegisterLeaveDialog({ employee: mockEmployee, onSuccess, mode: 'request' }),
+      { wrapper }
+    )
+
+    await waitFor(() => expect(result.current.isLoadingTypes).toBe(false))
+
+    act(() => {
+      result.current.form.setValue('leave_type_id', 1)
+    })
+
+    await act(async () => {
+      await result.current.handleSubmit()
+    })
+
+    await waitFor(() => {
+      expect(leaveApi.registerLeaveRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          employee_id: '01HZTEST00000001',
+          leave_type_id: 1,
+          start_date: '2026-04-09',
+          end_date: '2026-04-09',
+        })
+      )
+    })
+
+    expect(leaveApi.registerDirectLeave).not.toHaveBeenCalled()
   })
 })

--- a/code/webapp/src/components/attendance/use-register-leave-dialog.ts
+++ b/code/webapp/src/components/attendance/use-register-leave-dialog.ts
@@ -3,7 +3,7 @@ import { useForm } from 'react-hook-form'
 import type { UseFormReturn } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
-import { useLeaveTypes, useRegisterDirectLeave } from '@/services/leave-hooks'
+import { useLeaveTypes, useRegisterDirectLeave, useRegisterLeaveRequest } from '@/services/leave-hooks'
 import { todayDateCdmx } from '@/lib/datetime'
 import type { LeaveType } from '@/types/leave'
 import type { TodayAttendanceEmployee } from '@/types/attendance'
@@ -37,6 +37,7 @@ export type RegisterLeaveFormValues = z.infer<typeof schema>
 export interface UseRegisterLeaveDialogProps {
   employee: TodayAttendanceEmployee | null
   onSuccess: () => void
+  mode?: 'direct' | 'request'
 }
 
 export interface UseRegisterLeaveDialogResult {
@@ -55,9 +56,12 @@ export interface UseRegisterLeaveDialogResult {
 export function useRegisterLeaveDialog({
   employee,
   onSuccess,
+  mode = 'direct',
 }: UseRegisterLeaveDialogProps): UseRegisterLeaveDialogResult {
   const { data: leaveTypes = [], isLoading: isLoadingTypes } = useLeaveTypes()
-  const mutation = useRegisterDirectLeave()
+  const directMutation = useRegisterDirectLeave()
+  const requestMutation = useRegisterLeaveRequest()
+  const mutation = mode === 'request' ? requestMutation : directMutation
 
   const form = useForm<RegisterLeaveFormValues>({
     resolver: zodResolver(schema),

--- a/code/webapp/src/components/employees/__tests__/leave-summary-section.test.tsx
+++ b/code/webapp/src/components/employees/__tests__/leave-summary-section.test.tsx
@@ -27,6 +27,14 @@ interface MockHookReturn {
     pendingLeaveEmployee: TodayAttendanceEmployee | null
     openRegisterLeave: () => void
     closeRegisterLeave: () => void
+    showRegisterLeave: boolean
+    showRequestLeave: boolean
+    openRequestLeave: () => void
+    closeRequestLeave: () => void
+    handleApprove: (leaveId: string) => void
+    handleReject: (leaveId: string) => void
+    isApproving: boolean
+    isRejecting: boolean
 }
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
@@ -49,6 +57,14 @@ const defaultHookReturn: MockHookReturn = {
     pendingLeaveEmployee: null,
     openRegisterLeave: vi.fn(),
     closeRegisterLeave: vi.fn(),
+    showRegisterLeave: false,
+    showRequestLeave: false,
+    openRequestLeave: vi.fn(),
+    closeRequestLeave: vi.fn(),
+    handleApprove: vi.fn(),
+    handleReject: vi.fn(),
+    isApproving: false,
+    isRejecting: false,
 }
 
 let currentHook = { ...defaultHookReturn }
@@ -58,8 +74,8 @@ vi.mock('@/components/employees/use-leave-summary-section', () => ({
 }))
 
 vi.mock('@/components/attendance', () => ({
-    RegisterLeaveDialog: ({ isOpen }: { isOpen: boolean }) =>
-        isOpen ? <div data-testid="register-leave-dialog">RegisterLeaveDialog</div> : null,
+    RegisterLeaveDialog: ({ isOpen, mode }: { isOpen: boolean; mode?: string }) =>
+        isOpen ? <div data-testid={`register-leave-dialog${mode === 'request' ? '-request' : ''}`}>RegisterLeaveDialog</div> : null,
 }))
 
 const employee = { id: 'emp-1', first_name: 'Ana', last_name: 'López', code: 'E001' }
@@ -94,7 +110,7 @@ function makeLeave(overrides: Partial<Leave> = {}): Leave {
 
 describe('LeaveSummarySection', () => {
     beforeEach(() => {
-        currentHook = { ...defaultHookReturn, openFullHistory: vi.fn(), openRegisterLeave: vi.fn(), closeFullHistory: vi.fn() }
+        currentHook = { ...defaultHookReturn, openFullHistory: vi.fn(), openRegisterLeave: vi.fn(), openRequestLeave: vi.fn(), closeFullHistory: vi.fn() }
     })
 
     afterEach(() => {
@@ -216,6 +232,7 @@ describe('LeaveSummarySection', () => {
         currentHook = {
             ...currentHook,
             pendingLeaveEmployee: { id: 'emp-1', code: 'E001', first_name: 'Ana', last_name: 'López', roles: [] },
+            showRegisterLeave: true,
         }
 
         render(<LeaveSummarySection employeeId="emp-1" employee={employee} />)

--- a/code/webapp/src/components/employees/__tests__/leave-summary-section.test.tsx
+++ b/code/webapp/src/components/employees/__tests__/leave-summary-section.test.tsx
@@ -387,4 +387,158 @@ describe('LeaveSummarySection', () => {
         render(<LeaveSummarySection employeeId="emp-1" employee={employee} />)
         expect(screen.getByText('1 ausencia')).toBeDefined()
     })
+
+    it('calls updateFilter when status select changes', () => {
+        currentHook = {
+            ...currentHook,
+            showFullHistory: true,
+            fullLeaves: [],
+            isLoadingFull: false,
+            updateFilter: vi.fn(),
+            leaveTypes: [],
+        }
+
+        render(<LeaveSummarySection employeeId="emp-1" employee={employee} />)
+
+        const selects = screen.getAllByRole('combobox')
+        fireEvent.change(selects[0]!, { target: { value: 'APPROVED' } })
+        expect(currentHook.updateFilter).toHaveBeenCalledWith('status', 'APPROVED')
+    })
+
+    it('calls updateFilter with undefined when status select cleared', () => {
+        currentHook = {
+            ...currentHook,
+            showFullHistory: true,
+            fullLeaves: [],
+            isLoadingFull: false,
+            updateFilter: vi.fn(),
+            leaveTypes: [],
+        }
+
+        render(<LeaveSummarySection employeeId="emp-1" employee={employee} />)
+
+        const selects = screen.getAllByRole('combobox')
+        fireEvent.change(selects[0]!, { target: { value: '' } })
+        expect(currentHook.updateFilter).toHaveBeenCalledWith('status', undefined)
+    })
+
+    it('calls updateFilter when leave type select changes', () => {
+        currentHook = {
+            ...currentHook,
+            showFullHistory: true,
+            fullLeaves: [],
+            isLoadingFull: false,
+            updateFilter: vi.fn(),
+            leaveTypes: [
+                { id: 1, code: 'MEDICAL', name: 'Incapacidad', calculation_mode: 'FIXED_PERCENTAGE' as const, default_pay_percentage: 0, default_rest_day_factor: 'NONE' as const, counts_for_bonus: false },
+            ],
+        }
+
+        render(<LeaveSummarySection employeeId="emp-1" employee={employee} />)
+
+        const selects = screen.getAllByRole('combobox')
+        fireEvent.change(selects[1]!, { target: { value: '1' } })
+        expect(currentHook.updateFilter).toHaveBeenCalledWith('leave_type_id', 1)
+    })
+
+    it('calls handleApprove when approve button clicked in dialog', () => {
+        currentHook = {
+            ...currentHook,
+            showFullHistory: true,
+            fullLeaves: [makeLeave({ id: 'pending-1', status: 'PENDING' })],
+            isLoadingFull: false,
+            handleApprove: vi.fn(),
+            handleReject: vi.fn(),
+        }
+
+        render(<LeaveSummarySection employeeId="emp-1" employee={employee} />)
+        fireEvent.click(screen.getByLabelText('Aprobar ausencia'))
+        expect(currentHook.handleApprove).toHaveBeenCalledWith('pending-1')
+    })
+
+    it('calls handleReject when reject button clicked in dialog', () => {
+        currentHook = {
+            ...currentHook,
+            showFullHistory: true,
+            fullLeaves: [makeLeave({ id: 'pending-2', status: 'PENDING' })],
+            isLoadingFull: false,
+            handleApprove: vi.fn(),
+            handleReject: vi.fn(),
+        }
+
+        render(<LeaveSummarySection employeeId="emp-1" employee={employee} />)
+        fireEvent.click(screen.getByLabelText('Rechazar ausencia'))
+        expect(currentHook.handleReject).toHaveBeenCalledWith('pending-2')
+    })
+
+    it('disables approve/reject buttons when isApproving is true', () => {
+        currentHook = {
+            ...currentHook,
+            showFullHistory: true,
+            fullLeaves: [makeLeave({ id: 'pending-3', status: 'PENDING' })],
+            isLoadingFull: false,
+            isApproving: true,
+        }
+
+        render(<LeaveSummarySection employeeId="emp-1" employee={employee} />)
+        const approveBtn = screen.getByLabelText('Aprobar ausencia') as HTMLButtonElement
+        const rejectBtn = screen.getByLabelText('Rechazar ausencia') as HTMLButtonElement
+        expect(approveBtn.disabled).toBe(true)
+        expect(rejectBtn.disabled).toBe(true)
+    })
+
+    it('calls setPage when pagination buttons are clicked', () => {
+        currentHook = {
+            ...currentHook,
+            showFullHistory: true,
+            fullLeaves: [makeLeave()],
+            fullMeta: { current_page: 2, last_page: 3, total: 30 },
+            isLoadingFull: false,
+            page: 2,
+            setPage: vi.fn(),
+        }
+
+        render(<LeaveSummarySection employeeId="emp-1" employee={employee} />)
+
+        // Use aria role to find pagination buttons — they wrap ChevronLeft/ChevronRight icons
+        const paginationButtons = document.body.querySelectorAll('button')
+        const prevBtn = Array.from(paginationButtons).find(b => b.querySelector('.lucide-chevron-left'))
+        const nextBtn = Array.from(paginationButtons).find(b => b.querySelector('.lucide-chevron-right'))
+
+        if (prevBtn) fireEvent.click(prevBtn)
+        expect(currentHook.setPage).toHaveBeenCalledWith(1)
+
+        if (nextBtn) fireEvent.click(nextBtn)
+        expect(currentHook.setPage).toHaveBeenCalledWith(3)
+    })
+
+    it('calls openRequestLeave when Solicitar permiso button clicked', () => {
+        render(<LeaveSummarySection employeeId="emp-1" employee={employee} />)
+        fireEvent.click(screen.getByText('Solicitar permiso'))
+        expect(currentHook.openRequestLeave).toHaveBeenCalled()
+    })
+
+    it('renders request leave dialog when showRequestLeave is true', () => {
+        currentHook = {
+            ...currentHook,
+            pendingLeaveEmployee: { id: 'emp-1', code: 'E001', first_name: 'Ana', last_name: 'López', roles: [] },
+            showRequestLeave: true,
+        }
+
+        render(<LeaveSummarySection employeeId="emp-1" employee={employee} />)
+        expect(screen.getByTestId('register-leave-dialog-request')).toBeDefined()
+    })
+
+    it('does not show approve/reject buttons for non-PENDING leaves', () => {
+        currentHook = {
+            ...currentHook,
+            showFullHistory: true,
+            fullLeaves: [makeLeave({ id: 'l1', status: 'APPROVED' })],
+            isLoadingFull: false,
+        }
+
+        render(<LeaveSummarySection employeeId="emp-1" employee={employee} />)
+        expect(screen.queryByLabelText('Aprobar ausencia')).toBeNull()
+        expect(screen.queryByLabelText('Rechazar ausencia')).toBeNull()
+    })
 })

--- a/code/webapp/src/components/employees/__tests__/use-leave-summary-section.test.ts
+++ b/code/webapp/src/components/employees/__tests__/use-leave-summary-section.test.ts
@@ -11,6 +11,8 @@ vi.mock('@/services/leave-api', () => ({
     leaveApi: {
         listEmployeeLeaves: vi.fn(),
         listLeaveTypes: vi.fn(),
+        approveLeave: vi.fn(),
+        rejectLeave: vi.fn(),
     },
 }))
 

--- a/code/webapp/src/components/employees/__tests__/use-leave-summary-section.test.ts
+++ b/code/webapp/src/components/employees/__tests__/use-leave-summary-section.test.ts
@@ -218,4 +218,138 @@ describe('useLeaveSummarySection', () => {
         act(() => result.current.closeRegisterLeave())
         expect(result.current.pendingLeaveEmployee).toBeNull()
     })
+
+    it('openRequestLeave sets pendingLeaveEmployee and showRequestLeave', async () => {
+        const { result } = renderHook(
+            () => useLeaveSummarySection('emp-1', employee),
+            { wrapper: createWrapper() },
+        )
+
+        expect(result.current.showRequestLeave).toBe(false)
+
+        act(() => result.current.openRequestLeave())
+
+        expect(result.current.showRequestLeave).toBe(true)
+        expect(result.current.pendingLeaveEmployee).toEqual({
+            id: 'emp-1',
+            code: 'E001',
+            first_name: 'Ana',
+            last_name: 'López',
+            roles: [],
+        })
+    })
+
+    it('openRequestLeave does nothing when employee is undefined', async () => {
+        const { result } = renderHook(
+            () => useLeaveSummarySection('emp-1', undefined),
+            { wrapper: createWrapper() },
+        )
+
+        act(() => result.current.openRequestLeave())
+        expect(result.current.showRequestLeave).toBe(false)
+        expect(result.current.pendingLeaveEmployee).toBeNull()
+    })
+
+    it('closeRequestLeave clears pendingLeaveEmployee and showRequestLeave', async () => {
+        const { result } = renderHook(
+            () => useLeaveSummarySection('emp-1', employee),
+            { wrapper: createWrapper() },
+        )
+
+        act(() => result.current.openRequestLeave())
+        expect(result.current.showRequestLeave).toBe(true)
+        expect(result.current.pendingLeaveEmployee).not.toBeNull()
+
+        act(() => result.current.closeRequestLeave())
+        expect(result.current.showRequestLeave).toBe(false)
+        expect(result.current.pendingLeaveEmployee).toBeNull()
+    })
+
+    it('openRegisterLeave closes showRequestLeave', async () => {
+        const { result } = renderHook(
+            () => useLeaveSummarySection('emp-1', employee),
+            { wrapper: createWrapper() },
+        )
+
+        act(() => result.current.openRequestLeave())
+        expect(result.current.showRequestLeave).toBe(true)
+
+        act(() => result.current.openRegisterLeave())
+        expect(result.current.showRegisterLeave).toBe(true)
+        expect(result.current.showRequestLeave).toBe(false)
+    })
+
+    it('openRequestLeave closes showRegisterLeave', async () => {
+        const { result } = renderHook(
+            () => useLeaveSummarySection('emp-1', employee),
+            { wrapper: createWrapper() },
+        )
+
+        act(() => result.current.openRegisterLeave())
+        expect(result.current.showRegisterLeave).toBe(true)
+
+        act(() => result.current.openRequestLeave())
+        expect(result.current.showRequestLeave).toBe(true)
+        expect(result.current.showRegisterLeave).toBe(false)
+    })
+
+    it('handleApprove calls approve when confirm returns true', async () => {
+        const confirmSpy = vi.spyOn(globalThis, 'confirm').mockReturnValue(true)
+        vi.mocked(leaveApi.approveLeave).mockResolvedValue({ data: { status: 200, data: {} } } as never)
+
+        const { result } = renderHook(
+            () => useLeaveSummarySection('emp-1', employee),
+            { wrapper: createWrapper() },
+        )
+
+        act(() => result.current.handleApprove('leave-123'))
+
+        expect(confirmSpy).toHaveBeenCalledWith('¿Aprobar esta ausencia? Se crearán los registros de asistencia.')
+        confirmSpy.mockRestore()
+    })
+
+    it('handleApprove does nothing when confirm returns false', async () => {
+        const confirmSpy = vi.spyOn(globalThis, 'confirm').mockReturnValue(false)
+
+        const { result } = renderHook(
+            () => useLeaveSummarySection('emp-1', employee),
+            { wrapper: createWrapper() },
+        )
+
+        act(() => result.current.handleApprove('leave-123'))
+
+        expect(confirmSpy).toHaveBeenCalled()
+        expect(leaveApi.approveLeave).not.toHaveBeenCalled()
+        confirmSpy.mockRestore()
+    })
+
+    it('handleReject calls reject when confirm returns true', async () => {
+        const confirmSpy = vi.spyOn(globalThis, 'confirm').mockReturnValue(true)
+        vi.mocked(leaveApi.rejectLeave).mockResolvedValue({ data: { status: 200, data: {} } } as never)
+
+        const { result } = renderHook(
+            () => useLeaveSummarySection('emp-1', employee),
+            { wrapper: createWrapper() },
+        )
+
+        act(() => result.current.handleReject('leave-456'))
+
+        expect(confirmSpy).toHaveBeenCalledWith('¿Rechazar esta solicitud de ausencia?')
+        confirmSpy.mockRestore()
+    })
+
+    it('handleReject does nothing when confirm returns false', async () => {
+        const confirmSpy = vi.spyOn(globalThis, 'confirm').mockReturnValue(false)
+
+        const { result } = renderHook(
+            () => useLeaveSummarySection('emp-1', employee),
+            { wrapper: createWrapper() },
+        )
+
+        act(() => result.current.handleReject('leave-456'))
+
+        expect(confirmSpy).toHaveBeenCalled()
+        expect(leaveApi.rejectLeave).not.toHaveBeenCalled()
+        confirmSpy.mockRestore()
+    })
 })

--- a/code/webapp/src/components/employees/leave-summary-section.tsx
+++ b/code/webapp/src/components/employees/leave-summary-section.tsx
@@ -1,4 +1,4 @@
-import { CalendarX, Plus, ChevronLeft, ChevronRight, X, History } from 'lucide-react'
+import { CalendarX, Plus, ChevronLeft, ChevronRight, X, History, Check, XCircle } from 'lucide-react'
 import { createPortal } from 'react-dom'
 import { Button } from '@/components/ui/button'
 import { RegisterLeaveDialog } from '@/components/attendance'
@@ -107,6 +107,10 @@ function FullHistoryDialog({
     page,
     setPage,
     updateFilter,
+    onApprove,
+    onReject,
+    isApproving,
+    isRejecting,
 }: {
     isOpen: boolean
     onClose: () => void
@@ -118,6 +122,10 @@ function FullHistoryDialog({
     page: number
     setPage: (p: number) => void
     updateFilter: (key: LeaveFilterBarKey, value: FilterValue) => void
+    onApprove: (leaveId: string) => void
+    onReject: (leaveId: string) => void
+    isApproving: boolean
+    isRejecting: boolean
 }) {
     const { visible, backdropCls, panelCls } = useDialogAnimation(isOpen, onClose)
 
@@ -168,7 +176,8 @@ function FullHistoryDialog({
                                         <th className="pb-2 pr-3">Tipo</th>
                                         <th className="pb-2 pr-3">Pago</th>
                                         <th className="pb-2 pr-3">Estado</th>
-                                        <th className="pb-2">Notas</th>
+                                        <th className="pb-2 pr-3">Notas</th>
+                                        <th className="pb-2">Acciones</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -178,7 +187,33 @@ function FullHistoryDialog({
                                             <td className="py-2 pr-3 font-medium">{leave.leave_type.name}</td>
                                             <td className="py-2 pr-3">{payBadge(leave.resolved_pay_percentage)}</td>
                                             <td className="py-2 pr-3">{statusBadge(leave.status)}</td>
-                                            <td className="max-w-[180px] truncate py-2 text-muted-foreground">{leave.notes ?? '—'}</td>
+                                            <td className="max-w-[180px] truncate py-2 pr-3 text-muted-foreground">{leave.notes ?? '—'}</td>
+                                            <td className="py-2">
+                                                {leave.status === 'PENDING' && (
+                                                    <div className="flex items-center gap-1">
+                                                        <button
+                                                            type="button"
+                                                            onClick={() => onApprove(leave.id)}
+                                                            disabled={isApproving || isRejecting}
+                                                            className="rounded p-1 text-green-600 hover:bg-green-50 disabled:opacity-50 dark:hover:bg-green-900/30"
+                                                            aria-label="Aprobar ausencia"
+                                                            title="Aprobar"
+                                                        >
+                                                            <Check className="h-4 w-4" />
+                                                        </button>
+                                                        <button
+                                                            type="button"
+                                                            onClick={() => onReject(leave.id)}
+                                                            disabled={isApproving || isRejecting}
+                                                            className="rounded p-1 text-red-600 hover:bg-red-50 disabled:opacity-50 dark:hover:bg-red-900/30"
+                                                            aria-label="Rechazar ausencia"
+                                                            title="Rechazar"
+                                                        >
+                                                            <XCircle className="h-4 w-4" />
+                                                        </button>
+                                                    </div>
+                                                )}
+                                            </td>
                                         </tr>
                                     ))}
                                 </tbody>
@@ -230,6 +265,10 @@ export function LeaveSummarySection({ employeeId, employee }: LeaveSummarySectio
                         Ausencias
                     </h3>
                     <div className="flex items-center gap-1">
+                        <Button size="sm" variant="ghost" onClick={ctx.openRequestLeave} className="h-7 gap-1 px-2 text-xs">
+                            <Plus className="h-3.5 w-3.5" />
+                            Solicitar permiso
+                        </Button>
                         <Button size="sm" variant="ghost" onClick={ctx.openRegisterLeave} className="h-7 gap-1 px-2 text-xs">
                             <Plus className="h-3.5 w-3.5" />
                             Registrar
@@ -304,13 +343,25 @@ export function LeaveSummarySection({ employeeId, employee }: LeaveSummarySectio
                 page={ctx.page}
                 setPage={ctx.setPage}
                 updateFilter={ctx.updateFilter}
+                onApprove={ctx.handleApprove}
+                onReject={ctx.handleReject}
+                isApproving={ctx.isApproving}
+                isRejecting={ctx.isRejecting}
             />
 
-            {/* Register leave dialog */}
+            {/* Register leave dialog (direct) */}
             <RegisterLeaveDialog
-                isOpen={!!ctx.pendingLeaveEmployee}
+                isOpen={ctx.showRegisterLeave}
                 employee={ctx.pendingLeaveEmployee}
                 onClose={ctx.closeRegisterLeave}
+            />
+
+            {/* Request leave dialog */}
+            <RegisterLeaveDialog
+                isOpen={ctx.showRequestLeave}
+                employee={ctx.pendingLeaveEmployee}
+                onClose={ctx.closeRequestLeave}
+                mode="request"
             />
         </>
     )

--- a/code/webapp/src/components/employees/use-leave-summary-section.ts
+++ b/code/webapp/src/components/employees/use-leave-summary-section.ts
@@ -64,6 +64,7 @@ export function useLeaveSummarySection(employeeId: string, employee: { id: strin
     function openRegisterLeave() {
         const emp = buildEmployee()
         if (!emp) return
+        setShowRequestLeave(false)
         setPendingLeaveEmployee(emp)
         setShowRegisterLeave(true)
     }
@@ -76,6 +77,7 @@ export function useLeaveSummarySection(employeeId: string, employee: { id: strin
     function openRequestLeave() {
         const emp = buildEmployee()
         if (!emp) return
+        setShowRegisterLeave(false)
         setPendingLeaveEmployee(emp)
         setShowRequestLeave(true)
     }

--- a/code/webapp/src/components/employees/use-leave-summary-section.ts
+++ b/code/webapp/src/components/employees/use-leave-summary-section.ts
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react'
-import { useEmployeeLeaves, useLeaveTypes } from '@/services/leave-hooks'
+import { useEmployeeLeaves, useLeaveTypes, useLeaveActions } from '@/services/leave-hooks'
 import type { LeaveFilters } from '@/services/leave-api'
 import type { Leave } from '@/types/leave'
 import type { TodayAttendanceEmployee } from '@/types/attendance'
@@ -44,20 +44,57 @@ export function useLeaveSummarySection(employeeId: string, employee: { id: strin
 
     // Register leave state
     const [pendingLeaveEmployee, setPendingLeaveEmployee] = useState<TodayAttendanceEmployee | null>(null)
+    const [showRegisterLeave, setShowRegisterLeave] = useState(false)
+    const [showRequestLeave, setShowRequestLeave] = useState(false)
 
-    function openRegisterLeave() {
-        if (!employee) return
-        setPendingLeaveEmployee({
+    // Leave actions (approve/reject)
+    const leaveActions = useLeaveActions(employeeId)
+
+    function buildEmployee(): TodayAttendanceEmployee | null {
+        if (!employee) return null
+        return {
             id: employee.id,
             code: employee.code,
             first_name: employee.first_name,
             last_name: employee.last_name,
             roles: [],
-        })
+        }
+    }
+
+    function openRegisterLeave() {
+        const emp = buildEmployee()
+        if (!emp) return
+        setPendingLeaveEmployee(emp)
+        setShowRegisterLeave(true)
     }
 
     function closeRegisterLeave() {
+        setShowRegisterLeave(false)
         setPendingLeaveEmployee(null)
+    }
+
+    function openRequestLeave() {
+        const emp = buildEmployee()
+        if (!emp) return
+        setPendingLeaveEmployee(emp)
+        setShowRequestLeave(true)
+    }
+
+    function closeRequestLeave() {
+        setShowRequestLeave(false)
+        setPendingLeaveEmployee(null)
+    }
+
+    function handleApprove(leaveId: string) {
+        if (confirm('¿Aprobar esta ausencia? Se crearán los registros de asistencia.')) {
+            leaveActions.approve(leaveId)
+        }
+    }
+
+    function handleReject(leaveId: string) {
+        if (confirm('¿Rechazar esta solicitud de ausencia?')) {
+            leaveActions.reject(leaveId)
+        }
     }
 
     function updateFilter(key: keyof LeaveFilters, value: LeaveFilters[keyof LeaveFilters]) {
@@ -89,9 +126,19 @@ export function useLeaveSummarySection(employeeId: string, employee: { id: strin
         page,
         setPage,
         updateFilter,
-        // Register leave
+        // Register leave (direct)
+        showRegisterLeave,
         pendingLeaveEmployee,
         openRegisterLeave,
         closeRegisterLeave,
+        // Request leave (PENDING)
+        showRequestLeave,
+        openRequestLeave,
+        closeRequestLeave,
+        // Approve/Reject
+        handleApprove,
+        handleReject,
+        isApproving: leaveActions.isApproving,
+        isRejecting: leaveActions.isRejecting,
     }
 }

--- a/code/webapp/src/services/__tests__/leave-api.test.ts
+++ b/code/webapp/src/services/__tests__/leave-api.test.ts
@@ -7,6 +7,7 @@ vi.mock('@/lib/api-client', () => ({
     apiClient: {
         get: vi.fn(),
         post: vi.fn(),
+        patch: vi.fn(),
     },
 }))
 
@@ -137,6 +138,49 @@ describe('leaveApi', () => {
             expect(calledUrl).toContain('status=PENDING')
             expect(calledUrl).not.toContain('date_from')
             expect(calledUrl).not.toContain('leave_type_id')
+        })
+    })
+
+    describe('registerLeaveRequest', () => {
+        it('calls POST /leaves/requests with correct payload', async () => {
+            const mockResponse = { data: { status: 201, data: {} } }
+            vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
+
+            const payload = {
+                employee_id: '01HZTEST00000001',
+                leave_type_id: 1,
+                start_date: '2026-04-15',
+                end_date: '2026-04-15',
+            }
+
+            const result = await leaveApi.registerLeaveRequest(payload)
+
+            expect(apiClient.post).toHaveBeenCalledWith('/leaves/requests', payload)
+            expect(result).toEqual(mockResponse)
+        })
+    })
+
+    describe('approveLeave', () => {
+        it('calls PATCH /leaves/{id}/approve', async () => {
+            const mockResponse = { data: { status: 200, data: { id: 'leave-001', status: 'APPROVED' } } }
+            vi.mocked(apiClient.patch).mockResolvedValue(mockResponse)
+
+            const result = await leaveApi.approveLeave('leave-001')
+
+            expect(apiClient.patch).toHaveBeenCalledWith('/leaves/leave-001/approve')
+            expect(result).toEqual(mockResponse)
+        })
+    })
+
+    describe('rejectLeave', () => {
+        it('calls PATCH /leaves/{id}/reject', async () => {
+            const mockResponse = { data: { status: 200, data: { id: 'leave-001', status: 'REJECTED' } } }
+            vi.mocked(apiClient.patch).mockResolvedValue(mockResponse)
+
+            const result = await leaveApi.rejectLeave('leave-001')
+
+            expect(apiClient.patch).toHaveBeenCalledWith('/leaves/leave-001/reject')
+            expect(result).toEqual(mockResponse)
         })
     })
 })

--- a/code/webapp/src/services/__tests__/leave-hooks.test.ts
+++ b/code/webapp/src/services/__tests__/leave-hooks.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
 import React from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { useEmployeeLeaves } from '@/services/leave-hooks'
+import { useEmployeeLeaves, useLeaveActions, useRegisterLeaveRequest } from '@/services/leave-hooks'
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
 
@@ -18,6 +18,9 @@ vi.mock('@/services/leave-api', () => ({
     leaveApi: {
         listLeaveTypes: vi.fn(),
         registerDirectLeave: vi.fn(),
+        registerLeaveRequest: vi.fn(),
+        approveLeave: vi.fn(),
+        rejectLeave: vi.fn(),
         listEmployeeLeaves: vi.fn(),
     },
 }))
@@ -141,5 +144,118 @@ describe('useEmployeeLeaves', () => {
 
         const cached = queryClient.getQueryData(['employees', 'emp-001', 'leaves', filters])
         expect(cached).toBeDefined()
+    })
+})
+
+// ── useRegisterLeaveRequest ─────────────────────────────────────────────────
+
+describe('useRegisterLeaveRequest', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('calls registerLeaveRequest API and shows success toast', async () => {
+        const mockResponse = { data: { status: 201, data: { id: 'leave-new', status: 'PENDING' } } }
+        vi.mocked(leaveApi.registerLeaveRequest).mockResolvedValue(mockResponse as never)
+
+        const { wrapper, queryClient } = makeWrapper()
+        const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+        const { result } = renderHook(() => useRegisterLeaveRequest(), { wrapper })
+
+        result.current.mutate({
+            employee_id: 'emp-001',
+            leave_type_id: 1,
+            start_date: '2026-04-15',
+            end_date: '2026-04-15',
+        })
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+        expect(leaveApi.registerLeaveRequest).toHaveBeenCalledOnce()
+        expect(mockShowSuccess).toHaveBeenCalledWith(
+            'Solicitud de ausencia creada. Pendiente de aprobación.',
+            'Solicitud'
+        )
+        expect(invalidateSpy).toHaveBeenCalled()
+    })
+
+    it('shows error toast on failure', async () => {
+        vi.mocked(leaveApi.registerLeaveRequest).mockRejectedValue(new Error('Server error'))
+
+        const { wrapper } = makeWrapper()
+        const { result } = renderHook(() => useRegisterLeaveRequest(), { wrapper })
+
+        result.current.mutate({
+            employee_id: 'emp-001',
+            leave_type_id: 1,
+            start_date: '2026-04-15',
+            end_date: '2026-04-15',
+        })
+
+        await waitFor(() => expect(result.current.isError).toBe(true))
+        expect(mockShowError).toHaveBeenCalled()
+    })
+})
+
+// ── useLeaveActions ─────────────────────────────────────────────────────────
+
+describe('useLeaveActions', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('approve calls approveLeave API and invalidates queries', async () => {
+        const mockResponse = { data: { status: 200, data: { id: 'leave-001', status: 'APPROVED' } } }
+        vi.mocked(leaveApi.approveLeave).mockResolvedValue(mockResponse as never)
+
+        const { wrapper, queryClient } = makeWrapper()
+        const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+        const { result } = renderHook(() => useLeaveActions('emp-001'), { wrapper })
+
+        result.current.approve('leave-001')
+
+        await waitFor(() => expect(leaveApi.approveLeave).toHaveBeenCalledWith('leave-001'))
+        expect(mockShowSuccess).toHaveBeenCalledWith('Ausencia aprobada correctamente.', 'Aprobación')
+        expect(invalidateSpy).toHaveBeenCalled()
+    })
+
+    it('reject calls rejectLeave API and invalidates queries', async () => {
+        const mockResponse = { data: { status: 200, data: { id: 'leave-001', status: 'REJECTED' } } }
+        vi.mocked(leaveApi.rejectLeave).mockResolvedValue(mockResponse as never)
+
+        const { wrapper, queryClient } = makeWrapper()
+        const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+        const { result } = renderHook(() => useLeaveActions('emp-001'), { wrapper })
+
+        result.current.reject('leave-001')
+
+        await waitFor(() => expect(leaveApi.rejectLeave).toHaveBeenCalledWith('leave-001'))
+        expect(mockShowSuccess).toHaveBeenCalledWith('Ausencia rechazada.', 'Rechazo')
+        expect(invalidateSpy).toHaveBeenCalled()
+    })
+
+    it('approve shows error toast on failure', async () => {
+        vi.mocked(leaveApi.approveLeave).mockRejectedValue(new Error('Fail'))
+
+        const { wrapper } = makeWrapper()
+        const { result } = renderHook(() => useLeaveActions('emp-001'), { wrapper })
+
+        result.current.approve('leave-001')
+
+        await waitFor(() => expect(mockShowError).toHaveBeenCalled())
+    })
+
+    it('reject shows error toast on failure', async () => {
+        vi.mocked(leaveApi.rejectLeave).mockRejectedValue(new Error('Fail'))
+
+        const { wrapper } = makeWrapper()
+        const { result } = renderHook(() => useLeaveActions('emp-001'), { wrapper })
+
+        result.current.reject('leave-001')
+
+        await waitFor(() => expect(mockShowError).toHaveBeenCalled())
     })
 })

--- a/code/webapp/src/services/leave-api.ts
+++ b/code/webapp/src/services/leave-api.ts
@@ -1,5 +1,5 @@
 import { apiClient } from '@/lib/api-client'
-import type { Leave, LeaveType, LeaveStatus, RegisterDirectLeaveRequest } from '@/types/leave'
+import type { Leave, LeaveType, LeaveStatus, RegisterDirectLeaveRequest, RegisterLeaveRequestData } from '@/types/leave'
 import type { PaginatedResponse } from '@/types/employee'
 
 export interface LeaveFilters {
@@ -27,6 +27,27 @@ export const leaveApi = {
    */
   registerDirectLeave: (data: RegisterDirectLeaveRequest) =>
     apiClient.post<{ status: number; data: Leave }>('/leaves', data),
+
+  /**
+   * POST /leaves/requests
+   * Registers a leave request (status = PENDING, awaiting approval).
+   */
+  registerLeaveRequest: (data: RegisterLeaveRequestData) =>
+    apiClient.post<{ status: number; data: Leave }>('/leaves/requests', data),
+
+  /**
+   * PATCH /leaves/{id}/approve
+   * Approves a PENDING leave → creates Attendance records.
+   */
+  approveLeave: (id: string) =>
+    apiClient.patch<{ status: number; data: Leave }>(`/leaves/${id}/approve`),
+
+  /**
+   * PATCH /leaves/{id}/reject
+   * Rejects a PENDING leave — no attendance impact.
+   */
+  rejectLeave: (id: string) =>
+    apiClient.patch<{ status: number; data: Leave }>(`/leaves/${id}/reject`),
 
   /**
    * GET /employees/{employeeId}/leaves

--- a/code/webapp/src/services/leave-hooks.ts
+++ b/code/webapp/src/services/leave-hooks.ts
@@ -3,7 +3,7 @@ import { leaveApi } from './leave-api'
 import type { LeaveFilters } from './leave-api'
 import { useToast } from '@/components/ui/toast-provider'
 import { getApiErrorMessage } from '@/lib/api-error'
-import type { LeaveType, Leave, RegisterDirectLeaveRequest } from '@/types/leave'
+import type { LeaveType, Leave, RegisterDirectLeaveRequest, RegisterLeaveRequestData } from '@/types/leave'
 
 /**
  * Fetch all active leave types for the register-absence form.
@@ -43,6 +43,77 @@ export function useRegisterDirectLeave() {
       )
     },
   })
+}
+
+/**
+ * Mutation: register a leave REQUEST (status = PENDING).
+ * On success: invalidates employee leaves so the list updates.
+ */
+export function useRegisterLeaveRequest() {
+  const queryClient = useQueryClient()
+  const { showSuccess, showError } = useToast()
+
+  return useMutation({
+    mutationFn: (data: RegisterLeaveRequestData) =>
+      leaveApi.registerLeaveRequest(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['employees'] })
+      showSuccess('Solicitud de ausencia creada. Pendiente de aprobación.', 'Solicitud')
+    },
+    onError: (error: unknown) => {
+      showError(
+        getApiErrorMessage(error, 'No se pudo crear la solicitud.'),
+        'Error al solicitar'
+      )
+    },
+  })
+}
+
+/**
+ * Hook: approve/reject mutations for managing leave requests.
+ * Invalidates attendance + employee leave queries on success.
+ */
+export function useLeaveActions(employeeId: string) {
+  const queryClient = useQueryClient()
+  const { showSuccess, showError } = useToast()
+
+  const approveMutation = useMutation({
+    mutationFn: (leaveId: string) => leaveApi.approveLeave(leaveId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['attendances', 'today'] })
+      queryClient.invalidateQueries({ queryKey: ['employees', employeeId, 'leaves'] })
+      queryClient.invalidateQueries({ queryKey: ['employees'] })
+      showSuccess('Ausencia aprobada correctamente.', 'Aprobación')
+    },
+    onError: (error: unknown) => {
+      showError(
+        getApiErrorMessage(error, 'No se pudo aprobar la ausencia.'),
+        'Error al aprobar'
+      )
+    },
+  })
+
+  const rejectMutation = useMutation({
+    mutationFn: (leaveId: string) => leaveApi.rejectLeave(leaveId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['employees', employeeId, 'leaves'] })
+      queryClient.invalidateQueries({ queryKey: ['employees'] })
+      showSuccess('Ausencia rechazada.', 'Rechazo')
+    },
+    onError: (error: unknown) => {
+      showError(
+        getApiErrorMessage(error, 'No se pudo rechazar la ausencia.'),
+        'Error al rechazar'
+      )
+    },
+  })
+
+  return {
+    approve: approveMutation.mutate,
+    reject: rejectMutation.mutate,
+    isApproving: approveMutation.isPending,
+    isRejecting: rejectMutation.isPending,
+  }
 }
 
 /**

--- a/code/webapp/src/types/leave.ts
+++ b/code/webapp/src/types/leave.ts
@@ -66,3 +66,6 @@ export interface RegisterDirectLeaveRequest {
   actual_end_time?: string | null
   notes?: string | null
 }
+
+// Leave request uses the same shape as direct registration
+export type RegisterLeaveRequestData = RegisterDirectLeaveRequest


### PR DESCRIPTION
Story: #096 · Leave Request — Prior Solicitud + Approve/Reject

- 🏗️ Created RegisterLeaveRequestAction with PENDING status and no attendance records
- 🏗️ Created ApproveLeaveAction with guards and DB transaction to create attendance
- 🏗️ Created RejectLeaveAction to set REJECTED status without attendance impact
- 🎯 Created RegisterLeaveRequestController, ApproveLeaveController, RejectLeaveController (SAC)
- 📝 Created RegisterLeaveRequestRequest with same validation as direct leave
- 🛤️ Added routes: POST /leaves/requests, PATCH /leaves/{id}/approve, PATCH /leaves/{id}/reject
- 🧪 Created LeaveRequestApiTest with 20 tests (64 assertions) covering all endpoints and workflows
- 🌐 Added registerLeaveRequest, approveLeave, rejectLeave to leave-api.ts
- 🪝 Added useRegisterLeaveRequest and useLeaveActions hooks with toast notifications
- 🖼️ Added "Solicitar permiso" button and approve/reject actions in leave-summary-section
- 🔀 Updated RegisterLeaveDialog to support mode prop (direct vs request)
- ✅ Updated 6 frontend test files with new mock props, 84 tests passing (1299 total)
- 🌲 Created Cypress E2E test for leave request submit and approve happy path
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pakodiazdev/sushigo/pull/100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
