### PR TITLE
🎨 [#055] Day Status Redesign — Marcar falta + CloseDayAction auto-classify

### DIFF
--- a/code/api/app/Actions/Attendances/CloseDayAction.php
+++ b/code/api/app/Actions/Attendances/CloseDayAction.php
@@ -3,25 +3,33 @@
 namespace App\Actions\Attendances;
 
 use App\Enums\DayStatus;
+use App\Enums\LeaveStatus;
 use App\Models\Attendance;
 use App\Models\Employee;
+use App\Models\EmployeeSchedule;
+use App\Models\EmploymentPeriod;
+use App\Models\Leave;
+use App\Models\ScheduleDayOverride;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 
 /**
  * Close the day for a branch: register pending lunch returns, batch check-out,
- * and mark absences — all in a single transaction.
+ * and auto-classify employees with no attendance — all in a single transaction.
  *
  * Steps:
  *   1. Register lunch_end for attendances with pending lunch returns
  *   2. Register check_out for all attendances that have check_in but no check_out
- *   3. Create ABSENCE attendance records for employees with no attendance today
+ *   3. For each employee with no attendance record today, resolve their day status:
+ *        a. Approved leave covering today  → LEAVE
+ *        b. Schedule marks today as rest day → DAY_OFF
+ *        c. Otherwise                        → ABSENCE
  *
  * Delegates individual lunch-return and check-out logic to existing actions
  * to ensure business rules (late calculations, overtime, etc.) are applied.
  *
- * @see #034, RF-12, RF-14, RF-16
+ * @see #034, #055, RF-12, RF-14, RF-16
  */
 class CloseDayAction
 {
@@ -36,21 +44,22 @@ class CloseDayAction
      *     close_time: string,
      *     lunch_returns?: array<int, array{attendance_id: string, lunch_end: string}>
      * }  $data  Validated request data
-     * @return array{lunch_returns: int, check_outs: int, absences: int}
+     * @return array{lunch_returns: int, check_outs: int, absences: int, leaves: int, day_offs: int}
      */
     public function __invoke(array $data): array
     {
         $branchId = $data['branch_id'];
         $businessTz = config('app.business_timezone');
         $today = Carbon::today($businessTz)->toDateString();
+        $dayOfWeek = Carbon::today($businessTz)->dayOfWeekIso;
 
         // Build the close_time as a full ISO datetime in the business timezone
         $closeTimeLocal = Carbon::parse("{$today} {$data['close_time']}", $businessTz);
         $closeTimeIso = $closeTimeLocal->toIso8601String();
 
-        $counts = ['lunch_returns' => 0, 'check_outs' => 0, 'absences' => 0];
+        $counts = ['lunch_returns' => 0, 'check_outs' => 0, 'absences' => 0, 'leaves' => 0, 'day_offs' => 0];
 
-        DB::transaction(function () use ($data, $branchId, $today, $closeTimeIso, &$counts) {
+        DB::transaction(function () use ($data, $branchId, $today, $dayOfWeek, $closeTimeIso, &$counts) {
             // Resolve active employee IDs for this branch (used in all 3 steps)
             $activeEmployeeIds = Employee::whereHas('employmentPeriods', function ($q) use ($branchId) {
                 $q->where('branch_id', $branchId)->where('is_active', true);
@@ -106,23 +115,109 @@ class CloseDayAction
                 }
             }
 
-            // Step 3: Mark ABSENCE for employees with no attendance record today
+            // Step 3: Classify employees with no attendance record today
             $employeesWithAttendance = Attendance::whereIn('employee_id', $activeEmployeeIds)
                 ->whereDate('date', $today)
                 ->pluck('employee_id');
 
-            $absentEmployeeIds = $activeEmployeeIds->diff($employeesWithAttendance);
+            $noAttendanceIds = $activeEmployeeIds->diff($employeesWithAttendance);
 
-            foreach ($absentEmployeeIds as $employeeId) {
+            foreach ($noAttendanceIds as $employeeId) {
+                $dayStatus = $this->resolveAbsentDayStatus($employeeId, $today, $dayOfWeek);
+
                 Attendance::create([
                     'employee_id' => $employeeId,
                     'date' => $today,
-                    'day_status' => DayStatus::ABSENCE,
+                    'day_status' => $dayStatus,
                 ]);
-                $counts['absences']++;
+
+                match ($dayStatus) {
+                    DayStatus::LEAVE => $counts['leaves']++,
+                    DayStatus::DAY_OFF => $counts['day_offs']++,
+                    default => $counts['absences']++,
+                };
             }
         });
 
         return $counts;
+    }
+
+    /**
+     * Determine the appropriate DayStatus for an employee who has no attendance today.
+     *
+     * Priority:
+     *   1. Approved leave covering today  → LEAVE
+     *   2. Schedule rest day              → DAY_OFF
+     *   3. Default                        → ABSENCE
+     */
+    private function resolveAbsentDayStatus(int $employeeId, string $today, int $dayOfWeek): DayStatus
+    {
+        // 1. Approved leave covering today
+        $hasApprovedLeave = Leave::where('employee_id', $employeeId)
+            ->where('status', LeaveStatus::APPROVED)
+            ->whereDate('start_date', '<=', $today)
+            ->whereDate('end_date', '>=', $today)
+            ->exists();
+
+        if ($hasApprovedLeave) {
+            return DayStatus::LEAVE;
+        }
+
+        // 2. Schedule rest day (override-aware, mirrors ResolvesEffectiveScheduleDay logic)
+        if ($this->isScheduledRestDay($employeeId, $today, $dayOfWeek)) {
+            return DayStatus::DAY_OFF;
+        }
+
+        return DayStatus::ABSENCE;
+    }
+
+    /**
+     * Returns true if the employee's effective schedule marks today as a rest day.
+     *
+     * Resolution order (same as ResolvesEffectiveScheduleDay trait):
+     *   1. Active employment period covering today
+     *   2. Effective EmployeeSchedule for that period
+     *   3. ScheduleDayOverride for today → if is_day_off, rest day
+     *   4. Base ScheduleDay for today's day of week → if is_day_off, rest day
+     *
+     * Returns false (defaults to ABSENCE) when the period or schedule cannot be resolved.
+     */
+    private function isScheduledRestDay(int $employeeId, string $today, int $dayOfWeek): bool
+    {
+        $period = EmploymentPeriod::where('employee_id', $employeeId)
+            ->where('is_active', true)
+            ->whereDate('start_date', '<=', $today)
+            ->where(function ($q) use ($today) {
+                $q->whereNull('end_date')
+                    ->orWhereDate('end_date', '>=', $today);
+            })
+            ->first();
+
+        if (! $period) {
+            return false;
+        }
+
+        $schedule = EmployeeSchedule::effective($today)
+            ->where('employment_period_id', $period->id)
+            ->first();
+
+        if (! $schedule) {
+            return false;
+        }
+
+        // Override takes precedence
+        $override = ScheduleDayOverride::effective($today)
+            ->where('employment_period_id', $period->id)
+            ->where('day_of_week', $dayOfWeek)
+            ->first();
+
+        if ($override) {
+            return $override->is_day_off;
+        }
+
+        // Fall back to base ScheduleDay
+        $scheduleDay = $schedule->dayConfig($dayOfWeek);
+
+        return $scheduleDay?->isDayOff() ?? false;
     }
 }

--- a/code/api/app/Actions/Attendances/MarkDayStatusAction.php
+++ b/code/api/app/Actions/Attendances/MarkDayStatusAction.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Actions\Attendances;
+
+use App\Enums\DayStatus;
+use App\Models\Attendance;
+use App\Models\Employee;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * Mark a specific date for an employee as DAY_OFF or ABSENCE without registering
+ * check-in or check-out times.
+ *
+ * This action:
+ *   1. Resolves the employee from their public_id
+ *   2. Guards against duplicate attendance for the same date
+ *   3. Persists an Attendance record with the given day_status (no check_in/check_out)
+ *
+ * All business rule violations are surfaced as 422 ValidationException.
+ *
+ * @see AP-019, RF-16
+ */
+class MarkDayStatusAction
+{
+    /**
+     * @param  array{employee_id: string, date: string, day_status: string}  $data
+     *
+     * @throws ValidationException
+     */
+    public function __invoke(array $data): Attendance
+    {
+        $employee = Employee::where('public_id', $data['employee_id'])->firstOrFail();
+
+        $this->guardNoDuplicateAttendance($employee->id, $data['date']);
+
+        $attendance = Attendance::create([
+            'employee_id' => $employee->id,
+            'date' => $data['date'],
+            'day_status' => DayStatus::from($data['day_status']),
+        ]);
+
+        return $attendance->load('employee');
+    }
+
+    /**
+     * Throw a 422 if the employee already has an attendance record for this date.
+     *
+     * @throws ValidationException
+     */
+    private function guardNoDuplicateAttendance(int $employeeId, string $date): void
+    {
+        $exists = Attendance::where('employee_id', $employeeId)
+            ->where('date', $date)
+            ->exists();
+
+        if ($exists) {
+            throw ValidationException::withMessages([
+                'date' => 'El empleado ya tiene un registro de asistencia para este día.',
+            ]);
+        }
+    }
+}

--- a/code/api/app/Http/Controllers/Api/V1/Attendances/MarkDayStatusController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Attendances/MarkDayStatusController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Attendances;
+
+use App\Actions\Attendances\MarkDayStatusAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Attendances\DayStatusRequest;
+use App\Http\Resources\Attendance\AttendanceResource;
+
+/**
+ * @OA\Post(
+ *   path="/api/v1/attendances/day-status",
+ *   summary="Mark a day as Day-Off or Absence",
+ *   description="Creates an attendance record for an employee with DAY_OFF or ABSENCE status, without check-in or check-out times. Returns 422 if an attendance record already exists for that employee/date.",
+ *   tags={"Attendances"},
+ *   security={{"passport": {}}},
+ *
+ *   @OA\RequestBody(
+ *       required=true,
+ *
+ *       @OA\JsonContent(ref="#/components/schemas/DayStatusRequest")
+ *   ),
+ *
+ *   @OA\Response(
+ *       response=201,
+ *       description="Day status marked successfully",
+ *
+ *       @OA\JsonContent(
+ *           allOf={
+ *
+ *               @OA\Schema(ref="#/components/schemas/ResponseEntity"),
+ *               @OA\Schema(@OA\Property(property="data", ref="#/components/schemas/AttendanceResponse"))
+ *           }
+ *       )
+ *   ),
+ *
+ *   @OA\Response(response=401, description="Unauthenticated"),
+ *   @OA\Response(response=422, description="Validation Error", @OA\JsonContent(ref="#/components/schemas/ResponseError"))
+ * )
+ */
+class MarkDayStatusController extends Controller
+{
+    public function __invoke(
+        DayStatusRequest $request,
+        MarkDayStatusAction $action
+    ): AttendanceResource {
+        $attendance = $action($request->validated());
+
+        return (new AttendanceResource($attendance))->setStatusCode(201);
+    }
+}

--- a/code/api/app/Http/Requests/Attendances/DayStatusRequest.php
+++ b/code/api/app/Http/Requests/Attendances/DayStatusRequest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Http\Requests\Attendances;
+
+use App\Enums\DayStatus;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * @OA\Schema(
+ *   schema="DayStatusRequest",
+ *   required={"employee_id", "date", "day_status"},
+ *
+ *   @OA\Property(
+ *       property="employee_id",
+ *       type="string",
+ *       example="01JKXYZ1234567890ABCDEFGH",
+ *       description="Employee public_id (ULID)"
+ *   ),
+ *   @OA\Property(
+ *       property="date",
+ *       type="string",
+ *       format="date",
+ *       example="2026-04-12",
+ *       description="Date to mark (YYYY-MM-DD)"
+ *   ),
+ *   @OA\Property(
+ *       property="day_status",
+ *       type="string",
+ *       enum={"DAY_OFF","ABSENCE"},
+ *       example="DAY_OFF",
+ *       description="Status to assign: DAY_OFF (rest day) or ABSENCE (no-show)"
+ *   )
+ * )
+ */
+class DayStatusRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'employee_id' => [
+                'required',
+                'string',
+                Rule::exists('employees', 'public_id')->whereNull('deleted_at'),
+            ],
+            'date' => ['required', 'date_format:Y-m-d'],
+            'day_status' => [
+                'required',
+                Rule::in([DayStatus::DAY_OFF->value, DayStatus::ABSENCE->value]),
+            ],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'employee_id.exists' => 'No se encontró el empleado especificado.',
+            'date.date_format' => 'La fecha debe estar en formato YYYY-MM-DD.',
+            'day_status.in' => 'El estado debe ser DAY_OFF o ABSENCE.',
+        ];
+    }
+}

--- a/code/api/app/Http/Requests/Attendances/DayStatusRequest.php
+++ b/code/api/app/Http/Requests/Attendances/DayStatusRequest.php
@@ -27,9 +27,9 @@ use Illuminate\Validation\Rule;
  *   @OA\Property(
  *       property="day_status",
  *       type="string",
- *       enum={"DAY_OFF","ABSENCE"},
- *       example="DAY_OFF",
- *       description="Status to assign: DAY_OFF (rest day) or ABSENCE (no-show)"
+ *       enum={"ABSENCE"},
+ *       example="ABSENCE",
+ *       description="Only ABSENCE (unexcused no-show) is accepted. DAY_OFF is auto-managed by CloseDayAction."
  *   )
  * )
  */
@@ -51,7 +51,7 @@ class DayStatusRequest extends FormRequest
             'date' => ['required', 'date_format:Y-m-d'],
             'day_status' => [
                 'required',
-                Rule::in([DayStatus::DAY_OFF->value, DayStatus::ABSENCE->value]),
+                Rule::in([DayStatus::ABSENCE->value]),
             ],
         ];
     }
@@ -61,7 +61,7 @@ class DayStatusRequest extends FormRequest
         return [
             'employee_id.exists' => 'No se encontró el empleado especificado.',
             'date.date_format' => 'La fecha debe estar en formato YYYY-MM-DD.',
-            'day_status.in' => 'El estado debe ser DAY_OFF o ABSENCE.',
+            'day_status.in' => 'Solo se permite el estado ABSENCE. El estado DAY_OFF es asignado automáticamente al cerrar el día.',
         ];
     }
 }

--- a/code/api/routes/api.php
+++ b/code/api/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Contracts\PasswordResetTokenRecorder;
 use App\Http\Controllers\Api\V1\Attendances\CloseDayController;
+use App\Http\Controllers\Api\V1\Attendances\MarkDayStatusController;
 use App\Http\Controllers\Api\V1\Attendances\OvertimeDecisionController;
 use App\Http\Controllers\Api\V1\Attendances\RegisterCheckInController;
 use App\Http\Controllers\Api\V1\Attendances\RegisterCheckOutController;
@@ -275,6 +276,7 @@ Route::prefix('v1')->group(function () {
         // Static routes first (must precede {id}/... wildcard routes)
         Route::get('today', TodayAttendanceController::class)->name('today');
         Route::post('check-in', RegisterCheckInController::class)->name('check-in');
+        Route::post('day-status', MarkDayStatusController::class)->name('day-status');
         Route::post('close-day', CloseDayController::class)->name('close-day');
         // Per-attendance actions (identified by public_id)
         Route::patch('{id}/lunch-start', RegisterLunchStartController::class)->name('lunch-start');

--- a/code/api/tests/Feature/AttendancePayroll/CloseDayApiTest.php
+++ b/code/api/tests/Feature/AttendancePayroll/CloseDayApiTest.php
@@ -2,10 +2,13 @@
 
 namespace Tests\Feature\AttendancePayroll;
 
+use App\Enums\LeaveStatus;
 use App\Models\Attendance;
 use App\Models\Employee;
 use App\Models\EmployeeSchedule;
 use App\Models\EmploymentPeriod;
+use App\Models\Leave;
+use App\Models\LeaveType;
 use App\Models\ScheduleDay;
 use App\Models\User;
 use Carbon\Carbon;
@@ -178,8 +181,167 @@ class CloseDayApiTest extends TestCase
                     'lunch_returns',
                     'check_outs',
                     'absences',
+                    'leaves',
+                    'day_offs',
                 ],
             ]);
+    }
+
+    #[Test]
+    public function closes_day_marks_leave_for_employee_with_approved_leave_today(): void
+    {
+        ['employee' => $employee] = $this->makeEmployeeWithSchedule();
+
+        // Create an approved leave covering today
+        $leaveType = LeaveType::create([
+            'name' => 'Permiso Personal',
+            'code' => 'PERSONAL',
+            'calculation_mode' => 'FIXED_PERCENTAGE',
+            'default_pay_percentage' => 100.00,
+            'default_rest_day_factor' => 'PROPORTIONAL',
+            'counts_for_bonus' => true,
+            'is_active' => true,
+        ]);
+
+        Leave::create([
+            'public_id' => str_pad('1', 26, '0', STR_PAD_LEFT),
+            'employee_id' => $employee->id,
+            'leave_type_id' => $leaveType->id,
+            'start_date' => self::DATE,
+            'end_date' => self::DATE,
+            'status' => LeaveStatus::APPROVED,
+            'requested_by' => $this->user->id,
+            'approved_by' => $this->user->id,
+            'approved_at' => now(),
+        ]);
+
+        $response = $this->postJson('/api/v1/attendances/close-day', [
+            'branch_id' => $this->branchId,
+            'close_time' => '22:00',
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.absences', 0)
+            ->assertJsonPath('data.leaves', 1)
+            ->assertJsonPath('data.day_offs', 0);
+
+        $this->assertDatabaseHas('attendances', [
+            'employee_id' => $employee->id,
+            'date' => self::DATE,
+            'day_status' => 'LEAVE',
+        ]);
+    }
+
+    #[Test]
+    public function closes_day_marks_day_off_for_employee_on_scheduled_rest_day(): void
+    {
+        // Create employee with Monday as a rest day
+        $period = EmploymentPeriod::factory()->create([
+            'is_active' => true,
+            'start_date' => '2026-01-01',
+        ]);
+
+        if (! isset($this->branchId)) {
+            $this->branchId = $period->branch_id;
+        } else {
+            $period->update(['branch_id' => $this->branchId]);
+        }
+
+        $employee = $period->employee;
+
+        $schedule = EmployeeSchedule::factory()->current()->create([
+            'employment_period_id' => $period->id,
+            'effective_from' => '2026-01-01',
+        ]);
+
+        // Monday is a rest day for this employee
+        ScheduleDay::factory()
+            ->dayOff()
+            ->monday()
+            ->create(['employee_schedule_id' => $schedule->id]);
+
+        $response = $this->postJson('/api/v1/attendances/close-day', [
+            'branch_id' => $this->branchId,
+            'close_time' => '22:00',
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.absences', 0)
+            ->assertJsonPath('data.leaves', 0)
+            ->assertJsonPath('data.day_offs', 1);
+
+        $this->assertDatabaseHas('attendances', [
+            'employee_id' => $employee->id,
+            'date' => self::DATE,
+            'day_status' => 'DAY_OFF',
+        ]);
+    }
+
+    #[Test]
+    public function closes_day_prioritizes_leave_over_rest_day(): void
+    {
+        // Employee whose schedule marks Monday as rest, but has an approved leave
+        $period = EmploymentPeriod::factory()->create([
+            'is_active' => true,
+            'start_date' => '2026-01-01',
+        ]);
+
+        if (! isset($this->branchId)) {
+            $this->branchId = $period->branch_id;
+        } else {
+            $period->update(['branch_id' => $this->branchId]);
+        }
+
+        $employee = $period->employee;
+
+        $schedule = EmployeeSchedule::factory()->current()->create([
+            'employment_period_id' => $period->id,
+            'effective_from' => '2026-01-01',
+        ]);
+
+        ScheduleDay::factory()
+            ->dayOff()
+            ->monday()
+            ->create(['employee_schedule_id' => $schedule->id]);
+
+        $leaveType = LeaveType::create([
+            'name' => 'Médico',
+            'code' => 'MEDICAL',
+            'calculation_mode' => 'FIXED_PERCENTAGE',
+            'default_pay_percentage' => 100.00,
+            'default_rest_day_factor' => 'PROPORTIONAL',
+            'counts_for_bonus' => true,
+            'is_active' => true,
+        ]);
+
+        Leave::create([
+            'public_id' => str_pad('2', 26, '0', STR_PAD_LEFT),
+            'employee_id' => $employee->id,
+            'leave_type_id' => $leaveType->id,
+            'start_date' => self::DATE,
+            'end_date' => self::DATE,
+            'status' => LeaveStatus::APPROVED,
+            'requested_by' => $this->user->id,
+            'approved_by' => $this->user->id,
+            'approved_at' => now(),
+        ]);
+
+        $response = $this->postJson('/api/v1/attendances/close-day', [
+            'branch_id' => $this->branchId,
+            'close_time' => '22:00',
+        ]);
+
+        // LEAVE wins over DAY_OFF
+        $response->assertStatus(200)
+            ->assertJsonPath('data.leaves', 1)
+            ->assertJsonPath('data.day_offs', 0)
+            ->assertJsonPath('data.absences', 0);
+
+        $this->assertDatabaseHas('attendances', [
+            'employee_id' => $employee->id,
+            'date' => self::DATE,
+            'day_status' => 'LEAVE',
+        ]);
     }
 
     #[Test]

--- a/code/api/tests/Feature/AttendancePayroll/MarkDayStatusApiTest.php
+++ b/code/api/tests/Feature/AttendancePayroll/MarkDayStatusApiTest.php
@@ -34,7 +34,7 @@ class MarkDayStatusApiTest extends TestCase
             Role::firstOrCreate(['name' => $roleName, 'guard_name' => 'api']);
         }
 
-        $role = Role::firstOrCreate(['name' => 'manager', 'guard_name' => 'api']);
+        Role::firstOrCreate(['name' => 'manager', 'guard_name' => 'api']);
 
         $this->user = User::factory()->create();
         $this->user->assignRole('manager');
@@ -43,31 +43,6 @@ class MarkDayStatusApiTest extends TestCase
     }
 
     // #region Happy path
-
-    #[Test]
-    public function marks_day_as_day_off(): void
-    {
-        $employee = Employee::factory()->create();
-
-        $response = $this->postJson('/api/v1/attendances/day-status', [
-            'employee_id' => $employee->public_id,
-            'date' => self::DATE,
-            'day_status' => 'DAY_OFF',
-        ]);
-
-        $response->assertStatus(201)
-            ->assertJsonPath('data.day_status', 'DAY_OFF')
-            ->assertJsonPath('data.date', self::DATE)
-            ->assertJsonPath('data.check_in', null)
-            ->assertJsonPath('data.check_out', null);
-
-        $this->assertDatabaseHas('attendances', [
-            'employee_id' => $employee->id,
-            'date' => self::DATE,
-            'day_status' => DayStatus::DAY_OFF->value,
-            'check_in' => null,
-        ]);
-    }
 
     #[Test]
     public function marks_day_as_absence(): void
@@ -100,7 +75,7 @@ class MarkDayStatusApiTest extends TestCase
         $response = $this->postJson('/api/v1/attendances/day-status', [
             'employee_id' => $employee->public_id,
             'date' => self::DATE,
-            'day_status' => 'DAY_OFF',
+            'day_status' => 'ABSENCE',
         ]);
 
         $response->assertStatus(201)
@@ -126,6 +101,21 @@ class MarkDayStatusApiTest extends TestCase
     // #region 422 error cases
 
     #[Test]
+    public function rejects_day_off_status(): void
+    {
+        $employee = Employee::factory()->create();
+
+        $response = $this->postJson('/api/v1/attendances/day-status', [
+            'employee_id' => $employee->public_id,
+            'date' => self::DATE,
+            'day_status' => 'DAY_OFF',
+        ]);
+
+        $response->assertStatus(422);
+        $this->assertArrayHasKey('day_status', $response->json('errors'));
+    }
+
+    #[Test]
     public function rejects_duplicate_attendance(): void
     {
         $employee = Employee::factory()->create();
@@ -134,7 +124,7 @@ class MarkDayStatusApiTest extends TestCase
         $this->postJson('/api/v1/attendances/day-status', [
             'employee_id' => $employee->public_id,
             'date' => self::DATE,
-            'day_status' => 'DAY_OFF',
+            'day_status' => 'ABSENCE',
         ])->assertStatus(201);
 
         // Second mark for the same employee/date is rejected
@@ -163,7 +153,7 @@ class MarkDayStatusApiTest extends TestCase
         $response = $this->postJson('/api/v1/attendances/day-status', [
             'employee_id' => $employee->public_id,
             'date' => self::DATE,
-            'day_status' => 'DAY_OFF',
+            'day_status' => 'ABSENCE',
         ]);
 
         $response->assertStatus(422);
@@ -176,7 +166,7 @@ class MarkDayStatusApiTest extends TestCase
         $response = $this->postJson('/api/v1/attendances/day-status', [
             'employee_id' => '01ZZZZZZZZZZZZZZZZZZZZZZZ',
             'date' => self::DATE,
-            'day_status' => 'DAY_OFF',
+            'day_status' => 'ABSENCE',
         ]);
 
         $response->assertStatus(422);
@@ -206,7 +196,7 @@ class MarkDayStatusApiTest extends TestCase
         $response = $this->postJson('/api/v1/attendances/day-status', [
             'employee_id' => $employee->public_id,
             'date' => '12/04/2026',
-            'day_status' => 'DAY_OFF',
+            'day_status' => 'ABSENCE',
         ]);
 
         $response->assertStatus(422);
@@ -236,7 +226,7 @@ class MarkDayStatusApiTest extends TestCase
         $response = $this->postJson('/api/v1/attendances/day-status', [
             'employee_id' => 'any-id',
             'date' => self::DATE,
-            'day_status' => 'DAY_OFF',
+            'day_status' => 'ABSENCE',
         ]);
 
         $response->assertStatus(401);

--- a/code/api/tests/Feature/AttendancePayroll/MarkDayStatusApiTest.php
+++ b/code/api/tests/Feature/AttendancePayroll/MarkDayStatusApiTest.php
@@ -1,0 +1,246 @@
+<?php
+
+namespace Tests\Feature\AttendancePayroll;
+
+use App\Enums\DayStatus;
+use App\Models\Attendance;
+use App\Models\Employee;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+class MarkDayStatusApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+
+    private const DATE = '2026-04-12';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        app()[PermissionRegistrar::class]->forgetCachedPermissions();
+
+        // Position roles required by Employee factory
+        Role::firstOrCreate(['name' => 'employee',         'guard_name' => 'api']);
+        Role::firstOrCreate(['name' => 'employee-manager', 'guard_name' => 'api']);
+        foreach (Employee::POSITION_ROLES as $roleName) {
+            Role::firstOrCreate(['name' => $roleName, 'guard_name' => 'api']);
+        }
+
+        $role = Role::firstOrCreate(['name' => 'manager', 'guard_name' => 'api']);
+
+        $this->user = User::factory()->create();
+        $this->user->assignRole('manager');
+
+        Passport::actingAs($this->user);
+    }
+
+    // #region Happy path
+
+    #[Test]
+    public function marks_day_as_day_off(): void
+    {
+        $employee = Employee::factory()->create();
+
+        $response = $this->postJson('/api/v1/attendances/day-status', [
+            'employee_id' => $employee->public_id,
+            'date' => self::DATE,
+            'day_status' => 'DAY_OFF',
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.day_status', 'DAY_OFF')
+            ->assertJsonPath('data.date', self::DATE)
+            ->assertJsonPath('data.check_in', null)
+            ->assertJsonPath('data.check_out', null);
+
+        $this->assertDatabaseHas('attendances', [
+            'employee_id' => $employee->id,
+            'date' => self::DATE,
+            'day_status' => DayStatus::DAY_OFF->value,
+            'check_in' => null,
+        ]);
+    }
+
+    #[Test]
+    public function marks_day_as_absence(): void
+    {
+        $employee = Employee::factory()->create();
+
+        $response = $this->postJson('/api/v1/attendances/day-status', [
+            'employee_id' => $employee->public_id,
+            'date' => self::DATE,
+            'day_status' => 'ABSENCE',
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.day_status', 'ABSENCE')
+            ->assertJsonPath('data.date', self::DATE)
+            ->assertJsonPath('data.check_in', null);
+
+        $this->assertDatabaseHas('attendances', [
+            'employee_id' => $employee->id,
+            'date' => self::DATE,
+            'day_status' => DayStatus::ABSENCE->value,
+        ]);
+    }
+
+    #[Test]
+    public function returns_correct_response_structure(): void
+    {
+        $employee = Employee::factory()->create();
+
+        $response = $this->postJson('/api/v1/attendances/day-status', [
+            'employee_id' => $employee->public_id,
+            'date' => self::DATE,
+            'day_status' => 'DAY_OFF',
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonStructure([
+                'status',
+                'data' => [
+                    'id',
+                    'employee_id',
+                    'date',
+                    'check_in',
+                    'check_out',
+                    'day_status',
+                    'created_at',
+                ],
+            ]);
+
+        $this->assertEquals(26, strlen($response->json('data.id')));
+        $this->assertEquals($employee->public_id, $response->json('data.employee_id'));
+    }
+
+    // #endregion
+
+    // #region 422 error cases
+
+    #[Test]
+    public function rejects_duplicate_attendance(): void
+    {
+        $employee = Employee::factory()->create();
+
+        // First mark succeeds
+        $this->postJson('/api/v1/attendances/day-status', [
+            'employee_id' => $employee->public_id,
+            'date' => self::DATE,
+            'day_status' => 'DAY_OFF',
+        ])->assertStatus(201);
+
+        // Second mark for the same employee/date is rejected
+        $response = $this->postJson('/api/v1/attendances/day-status', [
+            'employee_id' => $employee->public_id,
+            'date' => self::DATE,
+            'day_status' => 'ABSENCE',
+        ]);
+
+        $response->assertStatus(422);
+        $this->assertArrayHasKey('date', $response->json('errors'));
+    }
+
+    #[Test]
+    public function rejects_duplicate_when_check_in_already_exists(): void
+    {
+        $employee = Employee::factory()->create();
+
+        // Existing check-in attendance
+        Attendance::factory()->create([
+            'employee_id' => $employee->id,
+            'date' => self::DATE,
+            'day_status' => DayStatus::WORKED,
+        ]);
+
+        $response = $this->postJson('/api/v1/attendances/day-status', [
+            'employee_id' => $employee->public_id,
+            'date' => self::DATE,
+            'day_status' => 'DAY_OFF',
+        ]);
+
+        $response->assertStatus(422);
+        $this->assertArrayHasKey('date', $response->json('errors'));
+    }
+
+    #[Test]
+    public function rejects_unknown_employee(): void
+    {
+        $response = $this->postJson('/api/v1/attendances/day-status', [
+            'employee_id' => '01ZZZZZZZZZZZZZZZZZZZZZZZ',
+            'date' => self::DATE,
+            'day_status' => 'DAY_OFF',
+        ]);
+
+        $response->assertStatus(422);
+        $this->assertArrayHasKey('employee_id', $response->json('errors'));
+    }
+
+    #[Test]
+    public function rejects_invalid_day_status(): void
+    {
+        $employee = Employee::factory()->create();
+
+        $response = $this->postJson('/api/v1/attendances/day-status', [
+            'employee_id' => $employee->public_id,
+            'date' => self::DATE,
+            'day_status' => 'WORKED',
+        ]);
+
+        $response->assertStatus(422);
+        $this->assertArrayHasKey('day_status', $response->json('errors'));
+    }
+
+    #[Test]
+    public function rejects_invalid_date_format(): void
+    {
+        $employee = Employee::factory()->create();
+
+        $response = $this->postJson('/api/v1/attendances/day-status', [
+            'employee_id' => $employee->public_id,
+            'date' => '12/04/2026',
+            'day_status' => 'DAY_OFF',
+        ]);
+
+        $response->assertStatus(422);
+        $this->assertArrayHasKey('date', $response->json('errors'));
+    }
+
+    #[Test]
+    public function rejects_missing_fields(): void
+    {
+        $response = $this->postJson('/api/v1/attendances/day-status', []);
+
+        $response->assertStatus(422);
+        $this->assertArrayHasKey('employee_id', $response->json('errors'));
+        $this->assertArrayHasKey('date', $response->json('errors'));
+        $this->assertArrayHasKey('day_status', $response->json('errors'));
+    }
+
+    // #endregion
+
+    // #region Auth
+
+    #[Test]
+    public function rejects_unauthenticated_request(): void
+    {
+        auth()->forgetGuards();
+
+        $response = $this->postJson('/api/v1/attendances/day-status', [
+            'employee_id' => 'any-id',
+            'date' => self::DATE,
+            'day_status' => 'DAY_OFF',
+        ]);
+
+        $response->assertStatus(401);
+    }
+
+    // #endregion
+}

--- a/code/webapp/cypress/e2e/attendance-day-status.cy.ts
+++ b/code/webapp/cypress/e2e/attendance-day-status.cy.ts
@@ -1,0 +1,110 @@
+/**
+ * Attendance Day Status — E2E happy-path tests
+ *
+ * Covers marking an employee's day as DAY_OFF (Descanso) and ABSENCE (Falta)
+ * from the Today view using the "Marcar día" dropdown.
+ *
+ * DB reset strategy
+ * ─────────────────
+ * • before()     → cy.task('test:reset', 'attendance') ONCE per file.
+ * • beforeEach() → login via API + navigate to /attendance/today.
+ * • Each it() uses a DIFFERENT employee — no slot is reused.
+ *
+ * Employees used:
+ *   EMP-001  Mendoza, Carlos   → marked as DAY_OFF (Descanso)
+ *   EMP-002  García, María     → marked as ABSENCE (Falta)
+ *
+ * Para correr solo este archivo:
+ *   make cypress-spec SPEC=attendance-day-status
+ */
+
+import users from "../fixtures/users.json";
+
+const { email: adminEmail, password: adminPassword } = users.admin;
+
+// ── Suite setup ─────────────────────────────────────────────────────────────
+
+before(() => {
+  cy.task("test:reset", "attendance", { timeout: 60_000 });
+});
+
+// Test time: 14:30 CDMX
+const TEST_TIME_ISO = "2026-04-02T14:30:00-06:00";
+const TEST_TIME_UTC = new Date("2026-04-02T20:30:00Z");
+
+beforeEach(() => {
+  cy.intercept({ url: /\/api\/v1\// }, (req) => {
+    req.headers["X-Test-Time"] = TEST_TIME_ISO;
+    req.continue();
+  }).as("apiWithTestTime");
+
+  cy.loginByApi(adminEmail, adminPassword);
+  cy.visitWithAuth("/attendance/today");
+  cy.url().should("include", "/attendance/today", { timeout: 10_000 });
+  cy.closeDevDebugger();
+
+  cy.clock(TEST_TIME_UTC.getTime(), ["Date"]);
+});
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Opens the "Marcar día" dropdown for the given employee and clicks an option.
+ */
+function markDay(lastName: string, firstName: string, option: "Descanso" | "Falta") {
+  cy.intercept("GET", "**/attendances/today*").as("refetchAttendance");
+
+  cy.contains("p", `${lastName}, ${firstName}`)
+    .closest("div.rounded-xl")
+    .find("[data-testid='btn-mark-day']")
+    .scrollIntoView()
+    .click({ force: true });
+
+  cy.contains("button", option).click({ force: true });
+
+  cy.wait("@refetchAttendance", { timeout: 10_000 });
+}
+
+/**
+ * Returns a Cypress chain scoped to the employee's card.
+ */
+function getCard(lastName: string, firstName: string) {
+  return cy
+    .contains("p", `${lastName}, ${firstName}`, { timeout: 10_000 })
+    .closest("div.rounded-xl")
+    .scrollIntoView();
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// 1. Marcar como Descanso (DAY_OFF)
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe("Day Status — Marcar Descanso (DAY_OFF)", () => {
+  it("marca el día de Carlos como Descanso y muestra el badge correspondiente", () => {
+    markDay("Mendoza", "Carlos", "Descanso");
+
+    getCard("Mendoza", "Carlos").within(() => {
+      cy.contains("Descanso", { timeout: 10_000 }).should("be.visible");
+      // Action buttons should no longer be visible once day is marked
+      cy.contains("Registrar entrada").should("not.exist");
+      cy.contains("Marcar día").should("not.exist");
+    });
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════════
+// 2. Marcar como Falta (ABSENCE)
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe("Day Status — Marcar Falta (ABSENCE)", () => {
+  it("marca el día de María como Falta y muestra el badge correspondiente", () => {
+    markDay("García", "María", "Falta");
+
+    getCard("García", "María").within(() => {
+      cy.contains("Falta", { timeout: 10_000 }).should("be.visible");
+      // Action buttons should no longer be visible once day is marked
+      cy.contains("Registrar entrada").should("not.exist");
+      cy.contains("Marcar día").should("not.exist");
+    });
+  });
+});

--- a/code/webapp/cypress/e2e/attendance-day-status.cy.ts
+++ b/code/webapp/cypress/e2e/attendance-day-status.cy.ts
@@ -1,8 +1,11 @@
 /**
  * Attendance Day Status — E2E happy-path tests
  *
- * Covers marking an employee's day as DAY_OFF (Descanso) and ABSENCE (Falta)
- * from the Today view using the "Marcar día" dropdown.
+ * Covers marking an employee's day as ABSENCE (Falta) from the Today view
+ * using the "Marcar falta" button + confirmation dialog.
+ *
+ * Note: DAY_OFF (Descanso) is now auto-managed by CloseDayAction — no manual
+ * action is needed from the Today view for rest days.
  *
  * DB reset strategy
  * ─────────────────
@@ -11,7 +14,6 @@
  * • Each it() uses a DIFFERENT employee — no slot is reused.
  *
  * Employees used:
- *   EMP-001  Mendoza, Carlos   → marked as DAY_OFF (Descanso)
  *   EMP-002  García, María     → marked as ABSENCE (Falta)
  *
  * Para correr solo este archivo:
@@ -49,18 +51,20 @@ beforeEach(() => {
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 /**
- * Opens the "Marcar día" dropdown for the given employee and clicks an option.
+ * Clicks "Marcar falta" for the given employee and confirms the dialog.
  */
-function markDay(lastName: string, firstName: string, option: "Descanso" | "Falta") {
+function markFalta(lastName: string, firstName: string) {
   cy.intercept("GET", "**/attendances/today*").as("refetchAttendance");
 
   cy.contains("p", `${lastName}, ${firstName}`)
     .closest("div.rounded-xl")
-    .find("[data-testid='btn-mark-day']")
+    .find("[data-testid='btn-mark-falta']")
     .scrollIntoView()
     .click({ force: true });
 
-  cy.contains("button", option).click({ force: true });
+  // Confirm dialog appears
+  cy.contains("¿Confirmar falta?").should("be.visible");
+  cy.contains("button", "Confirmar falta").click({ force: true });
 
   cy.wait("@refetchAttendance", { timeout: 10_000 });
 }
@@ -76,35 +80,18 @@ function getCard(lastName: string, firstName: string) {
 }
 
 // ══════════════════════════════════════════════════════════════════════════════
-// 1. Marcar como Descanso (DAY_OFF)
-// ══════════════════════════════════════════════════════════════════════════════
-
-describe("Day Status — Marcar Descanso (DAY_OFF)", () => {
-  it("marca el día de Carlos como Descanso y muestra el badge correspondiente", () => {
-    markDay("Mendoza", "Carlos", "Descanso");
-
-    getCard("Mendoza", "Carlos").within(() => {
-      cy.contains("Descanso", { timeout: 10_000 }).should("be.visible");
-      // Action buttons should no longer be visible once day is marked
-      cy.contains("Registrar entrada").should("not.exist");
-      cy.contains("Marcar día").should("not.exist");
-    });
-  });
-});
-
-// ══════════════════════════════════════════════════════════════════════════════
-// 2. Marcar como Falta (ABSENCE)
+// 1. Marcar como Falta (ABSENCE)
 // ══════════════════════════════════════════════════════════════════════════════
 
 describe("Day Status — Marcar Falta (ABSENCE)", () => {
   it("marca el día de María como Falta y muestra el badge correspondiente", () => {
-    markDay("García", "María", "Falta");
+    markFalta("García", "María");
 
     getCard("García", "María").within(() => {
       cy.contains("Falta", { timeout: 10_000 }).should("be.visible");
       // Action buttons should no longer be visible once day is marked
       cy.contains("Registrar entrada").should("not.exist");
-      cy.contains("Marcar día").should("not.exist");
+      cy.contains("Marcar falta").should("not.exist");
     });
   });
 });

--- a/code/webapp/src/components/attendance/EmployeeAttendanceCard.tsx
+++ b/code/webapp/src/components/attendance/EmployeeAttendanceCard.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import {
     UtensilsCrossed,
     AlertTriangle,
@@ -8,15 +9,25 @@ import {
     Undo2,
     CalendarX,
     Clock,
+    ChevronDown,
+    BedDouble,
+    UserX,
 } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import {
+    DropdownMenu,
+    DropdownMenuTrigger,
+    DropdownMenuContent,
+    DropdownMenuItem,
+} from '@/components/ui/dropdown-menu'
 import { cn } from '@/lib/utils'
 import { getAttendancePhase, formatTime, formatSeconds } from '@/types/attendance'
 import type {
     TodayAttendanceRow,
     AttendancePhase,
     TodayAttendanceEmployee,
+    DayStatus,
 } from '@/types/attendance'
 import { getPhaseCardClass } from './attendance-helpers'
 
@@ -46,6 +57,18 @@ export function PhaseBadge({ phase }: Readonly<PhaseBadgeProps>) {
             return (
                 <Badge variant="warning" className="flex items-center gap-1">
                     <CalendarX className="h-3 w-3" /> Ausencia
+                </Badge>
+            )
+        case 'day-off':
+            return (
+                <Badge variant="info" className="flex items-center gap-1">
+                    <BedDouble className="h-3 w-3" /> Descanso
+                </Badge>
+            )
+        case 'absence':
+            return (
+                <Badge variant="error" className="flex items-center gap-1">
+                    <UserX className="h-3 w-3" /> Falta
                 </Badge>
             )
     }
@@ -167,6 +190,7 @@ export interface EmployeeAttendanceCardProps {
     onCheckOut: (employee: TodayAttendanceEmployee, attendanceId: string) => void
     onOvertimeDecision: (employee: TodayAttendanceEmployee, attendanceId: string) => void
     onRegisterLeave: (employee: TodayAttendanceEmployee) => void
+    onMarkDayStatus: (employee: TodayAttendanceEmployee, status: Extract<DayStatus, 'DAY_OFF' | 'ABSENCE'>) => void
 }
 
 export function EmployeeAttendanceCard({
@@ -177,9 +201,11 @@ export function EmployeeAttendanceCard({
     onCheckOut,
     onOvertimeDecision,
     onRegisterLeave,
+    onMarkDayStatus,
 }: Readonly<EmployeeAttendanceCardProps>) {
     const phase = getAttendancePhase(row.attendance)
     const att = row.attendance
+    const [isMarkDayOpen, setIsMarkDayOpen] = useState(false)
 
     return (
         <div
@@ -247,6 +273,38 @@ export function EmployeeAttendanceCard({
                         <CalendarX className="h-3.5 w-3.5 mr-1.5" />
                         Registrar ausencia
                     </Button>
+                    <DropdownMenu>
+                        <DropdownMenuTrigger
+                            className="w-full flex items-center justify-center gap-1.5 rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium hover:bg-accent hover:text-accent-foreground transition-colors"
+                            onClick={() => setIsMarkDayOpen((prev) => !prev)}
+                            data-testid="btn-mark-day"
+                        >
+                            <ChevronDown className="h-3.5 w-3.5" />
+                            Marcar día
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent open={isMarkDayOpen} align="left">
+                            <DropdownMenuItem
+                                icon={<BedDouble className="h-4 w-4" />}
+                                onClick={() => {
+                                    setIsMarkDayOpen(false)
+                                    onMarkDayStatus(row.employee, 'DAY_OFF')
+                                }}
+                                data-testid="mark-day-off"
+                            >
+                                Descanso
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                                icon={<UserX className="h-4 w-4" />}
+                                onClick={() => {
+                                    setIsMarkDayOpen(false)
+                                    onMarkDayStatus(row.employee, 'ABSENCE')
+                                }}
+                                data-testid="mark-absence"
+                            >
+                                Falta
+                            </DropdownMenuItem>
+                        </DropdownMenuContent>
+                    </DropdownMenu>
                 </div>
             )}
 

--- a/code/webapp/src/components/attendance/EmployeeAttendanceCard.tsx
+++ b/code/webapp/src/components/attendance/EmployeeAttendanceCard.tsx
@@ -9,29 +9,22 @@ import {
     Undo2,
     CalendarX,
     Clock,
-    ChevronDown,
     BedDouble,
     UserX,
 } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import {
-    DropdownMenu,
-    DropdownMenuTrigger,
-    DropdownMenuContent,
-    DropdownMenuItem,
-} from '@/components/ui/dropdown-menu'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { cn } from '@/lib/utils'
 import { getAttendancePhase, formatTime, formatSeconds } from '@/types/attendance'
 import type {
     TodayAttendanceRow,
     AttendancePhase,
     TodayAttendanceEmployee,
-    DayStatus,
 } from '@/types/attendance'
 import { getPhaseCardClass } from './attendance-helpers'
 
-// ── Sub-components ─────────────────────────────────────────────────────────────
+// ── Sub-components ─────────────────────────────────────────────────────���───────
 
 interface PhaseBadgeProps {
     phase: AttendancePhase
@@ -180,7 +173,7 @@ export function RoleBadges({ roles }: Readonly<RoleBadgesProps>) {
     )
 }
 
-// ── Main Component ─────────────────────────────────────────────────────────────
+// ── Main Component ──────────────────���───────────────────────────���──────────────
 
 export interface EmployeeAttendanceCardProps {
     row: TodayAttendanceRow
@@ -189,8 +182,7 @@ export interface EmployeeAttendanceCardProps {
     onLunchReturn: (employee: TodayAttendanceEmployee, attendanceId: string) => void
     onCheckOut: (employee: TodayAttendanceEmployee, attendanceId: string) => void
     onOvertimeDecision: (employee: TodayAttendanceEmployee, attendanceId: string) => void
-    onRegisterLeave: (employee: TodayAttendanceEmployee) => void
-    onMarkDayStatus: (employee: TodayAttendanceEmployee, status: Extract<DayStatus, 'DAY_OFF' | 'ABSENCE'>) => void
+    onMarkDayStatus: (employee: TodayAttendanceEmployee, status: 'ABSENCE') => void
 }
 
 export function EmployeeAttendanceCard({
@@ -200,12 +192,13 @@ export function EmployeeAttendanceCard({
     onLunchReturn,
     onCheckOut,
     onOvertimeDecision,
-    onRegisterLeave,
     onMarkDayStatus,
 }: Readonly<EmployeeAttendanceCardProps>) {
     const phase = getAttendancePhase(row.attendance)
     const att = row.attendance
-    const [isMarkDayOpen, setIsMarkDayOpen] = useState(false)
+    const [confirmFaltaOpen, setConfirmFaltaOpen] = useState(false)
+
+    const isScheduledRestDay = row.schedule?.is_day_off === true
 
     return (
         <div
@@ -256,57 +249,53 @@ export function EmployeeAttendanceCard({
             {/* Actions for pending employees */}
             {phase === 'pending' && (
                 <div className="flex flex-col gap-1.5 mt-auto">
-                    <Button
-                        size="sm"
-                        className="w-full"
-                        onClick={() => onCheckIn(row.employee)}
-                    >
-                        <LogIn className="h-3.5 w-3.5 mr-1.5" />
-                        Registrar entrada
-                    </Button>
-                    <Button
-                        size="sm"
-                        variant="outline"
-                        className="w-full border-amber-300 text-amber-700 hover:bg-amber-50 dark:border-amber-700 dark:text-amber-400 dark:hover:bg-amber-950/30"
-                        onClick={() => onRegisterLeave(row.employee)}
-                    >
-                        <CalendarX className="h-3.5 w-3.5 mr-1.5" />
-                        Registrar ausencia
-                    </Button>
-                    <DropdownMenu>
-                        <DropdownMenuTrigger
-                            className="w-full flex items-center justify-center gap-1.5 rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium hover:bg-accent hover:text-accent-foreground transition-colors"
-                            onClick={() => setIsMarkDayOpen((prev) => !prev)}
-                            data-testid="btn-mark-day"
-                        >
-                            <ChevronDown className="h-3.5 w-3.5" />
-                            Marcar día
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent open={isMarkDayOpen} align="left">
-                            <DropdownMenuItem
-                                icon={<BedDouble className="h-4 w-4" />}
-                                onClick={() => {
-                                    setIsMarkDayOpen(false)
-                                    onMarkDayStatus(row.employee, 'DAY_OFF')
-                                }}
-                                data-testid="mark-day-off"
+                    {isScheduledRestDay ? (
+                        /* Scheduled rest day — read-only indicator, no action buttons */
+                        <div className="flex items-center gap-1.5 rounded-md bg-indigo-50 dark:bg-indigo-950/30 border border-indigo-200 dark:border-indigo-800 px-3 py-2">
+                            <BedDouble className="h-3.5 w-3.5 text-indigo-500 dark:text-indigo-400 shrink-0" />
+                            <span className="text-[11px] text-indigo-700 dark:text-indigo-300 font-medium">
+                                Descanso programado
+                            </span>
+                        </div>
+                    ) : (
+                        <>
+                            <Button
+                                size="sm"
+                                className="w-full"
+                                onClick={() => onCheckIn(row.employee)}
                             >
-                                Descanso
-                            </DropdownMenuItem>
-                            <DropdownMenuItem
-                                icon={<UserX className="h-4 w-4" />}
-                                onClick={() => {
-                                    setIsMarkDayOpen(false)
-                                    onMarkDayStatus(row.employee, 'ABSENCE')
-                                }}
-                                data-testid="mark-absence"
+                                <LogIn className="h-3.5 w-3.5 mr-1.5" />
+                                Registrar entrada
+                            </Button>
+                            <Button
+                                size="sm"
+                                variant="outline"
+                                className="w-full border-red-300 text-red-700 hover:bg-red-50 dark:border-red-700 dark:text-red-400 dark:hover:bg-red-950/30"
+                                data-testid="btn-mark-falta"
+                                onClick={() => setConfirmFaltaOpen(true)}
                             >
-                                Falta
-                            </DropdownMenuItem>
-                        </DropdownMenuContent>
-                    </DropdownMenu>
+                                <UserX className="h-3.5 w-3.5 mr-1.5" />
+                                Marcar falta
+                            </Button>
+                        </>
+                    )}
                 </div>
             )}
+
+            {/* Confirm-falta dialog */}
+            <ConfirmDialog
+                isOpen={confirmFaltaOpen}
+                onClose={() => setConfirmFaltaOpen(false)}
+                onConfirm={() => {
+                    setConfirmFaltaOpen(false)
+                    onMarkDayStatus(row.employee, 'ABSENCE')
+                }}
+                title="¿Confirmar falta?"
+                description={`${row.employee.last_name}, ${row.employee.first_name} no tiene registro de entrada. ¿Confirmar que faltó hoy?`}
+                confirmLabel="Confirmar falta"
+                variant="danger"
+                container="viewport"
+            />
 
             {/* Lunch-start action — only for checked-in employees */}
             {phase === 'checked-in' && att && (

--- a/code/webapp/src/components/attendance/__tests__/EmployeeAttendanceCard.test.tsx
+++ b/code/webapp/src/components/attendance/__tests__/EmployeeAttendanceCard.test.tsx
@@ -91,6 +91,16 @@ describe('getPhaseCardClass', () => {
         const result = getPhaseCardClass('done')
         expect(result).toContain('border-green')
     })
+
+    it('returns correct class for day-off phase', () => {
+        const result = getPhaseCardClass('day-off')
+        expect(result).toContain('border-indigo')
+    })
+
+    it('returns correct class for absence phase', () => {
+        const result = getPhaseCardClass('absence')
+        expect(result).toContain('border-red')
+    })
 })
 
 // ── PhaseBadge Tests ───────────────────────────────────────────────────────────
@@ -124,6 +134,16 @@ describe('PhaseBadge', () => {
     it('renders correct label for returned phase', () => {
         const { getByText } = render(<PhaseBadge phase="returned" />)
         expect(getByText(/Regresó/)).toBeDefined()
+    })
+
+    it('renders correct label for day-off phase', () => {
+        const { getByText } = render(<PhaseBadge phase="day-off" />)
+        expect(getByText(/Descanso/)).toBeDefined()
+    })
+
+    it('renders correct label for absence phase', () => {
+        const { getByText } = render(<PhaseBadge phase="absence" />)
+        expect(getByText(/Falta/)).toBeDefined()
     })
 })
 
@@ -209,6 +229,7 @@ describe('EmployeeAttendanceCard', () => {
         onCheckOut: vi.fn(),
         onOvertimeDecision: vi.fn(),
         onRegisterLeave: vi.fn(),
+        onMarkDayStatus: vi.fn(),
     }
 
     it('renders employee name', () => {
@@ -277,6 +298,51 @@ describe('EmployeeAttendanceCard', () => {
 
         fireEvent.click(getByText('Registrar ausencia'))
         expect(onRegisterLeave).toHaveBeenCalledWith(mockRow.employee)
+    })
+
+    it('renders "Marcar día" dropdown trigger for pending employees', () => {
+        const { getByTestId } = render(<EmployeeAttendanceCard {...defaultProps} />)
+        expect(getByTestId('btn-mark-day')).toBeDefined()
+    })
+
+    it('shows Descanso and Falta options when Marcar día is clicked', () => {
+        const { getByTestId, getByText } = render(<EmployeeAttendanceCard {...defaultProps} />)
+
+        fireEvent.click(getByTestId('btn-mark-day'))
+
+        expect(getByText('Descanso')).toBeDefined()
+        expect(getByText('Falta')).toBeDefined()
+    })
+
+    it('calls onMarkDayStatus with DAY_OFF when Descanso is clicked', () => {
+        const onMarkDayStatus = vi.fn()
+        const { getByTestId } = render(
+            <EmployeeAttendanceCard {...defaultProps} onMarkDayStatus={onMarkDayStatus} />
+        )
+
+        fireEvent.click(getByTestId('btn-mark-day'))
+        fireEvent.click(getByTestId('mark-day-off'))
+
+        expect(onMarkDayStatus).toHaveBeenCalledWith(mockRow.employee, 'DAY_OFF')
+    })
+
+    it('calls onMarkDayStatus with ABSENCE when Falta is clicked', () => {
+        const onMarkDayStatus = vi.fn()
+        const { getByTestId } = render(
+            <EmployeeAttendanceCard {...defaultProps} onMarkDayStatus={onMarkDayStatus} />
+        )
+
+        fireEvent.click(getByTestId('btn-mark-day'))
+        fireEvent.click(getByTestId('mark-absence'))
+
+        expect(onMarkDayStatus).toHaveBeenCalledWith(mockRow.employee, 'ABSENCE')
+    })
+
+    it('does not render Marcar día dropdown for employees with attendance', () => {
+        const { queryByTestId } = render(
+            <EmployeeAttendanceCard {...defaultProps} row={mockRowWithAttendance} />
+        )
+        expect(queryByTestId('btn-mark-day')).toBeNull()
     })
 
     it('renders lunch-start button for checked-in phase', () => {

--- a/code/webapp/src/components/attendance/__tests__/EmployeeAttendanceCard.test.tsx
+++ b/code/webapp/src/components/attendance/__tests__/EmployeeAttendanceCard.test.tsx
@@ -12,7 +12,7 @@ import {
     RoleBadges,
 } from '../EmployeeAttendanceCard'
 import { getPhaseCardClass } from '../attendance-helpers'
-import type { TodayAttendanceRow, TodayAttendanceData } from '@/types/attendance'
+import type { TodayAttendanceRow, TodayAttendanceData, TodayScheduleDay } from '@/types/attendance'
 
 afterEach(() => {
     cleanup()
@@ -36,6 +36,26 @@ const makeAttendance = (overrides: Partial<TodayAttendanceData> = {}): TodayAtte
     requires_overtime_decision: false,
     ...overrides,
 })
+
+const workSchedule: TodayScheduleDay = {
+    day_of_week: 1,
+    is_day_off: false,
+    expected_start: '09:00',
+    expected_lunch_start: '13:00',
+    expected_lunch_end: '14:00',
+    lunch_duration_minutes: 60,
+    expected_end: '17:00',
+}
+
+const restSchedule: TodayScheduleDay = {
+    day_of_week: 7,
+    is_day_off: true,
+    expected_start: null,
+    expected_lunch_start: null,
+    expected_lunch_end: null,
+    lunch_duration_minutes: null,
+    expected_end: null,
+}
 
 const mockRow: TodayAttendanceRow = {
     employee: {
@@ -228,7 +248,6 @@ describe('EmployeeAttendanceCard', () => {
         onLunchReturn: vi.fn(),
         onCheckOut: vi.fn(),
         onOvertimeDecision: vi.fn(),
-        onRegisterLeave: vi.fn(),
         onMarkDayStatus: vi.fn(),
     }
 
@@ -247,7 +266,14 @@ describe('EmployeeAttendanceCard', () => {
         expect(container.innerHTML).toContain('Sin registro')
     })
 
-    it('renders check-in button for pending phase', () => {
+    it('renders check-in button for pending employee on a work day', () => {
+        const { getByText } = render(
+            <EmployeeAttendanceCard {...defaultProps} row={{ ...mockRow, schedule: workSchedule }} />
+        )
+        expect(getByText('Registrar entrada')).toBeDefined()
+    })
+
+    it('renders check-in button when schedule is null', () => {
         const { getByText } = render(<EmployeeAttendanceCard {...defaultProps} />)
         expect(getByText('Registrar entrada')).toBeDefined()
     })
@@ -285,64 +311,66 @@ describe('EmployeeAttendanceCard', () => {
         expect(container.innerHTML).toContain('Ausencia')
     })
 
-    it('renders register-leave button for pending employees', () => {
-        const { getByText } = render(<EmployeeAttendanceCard {...defaultProps} />)
-        expect(getByText('Registrar ausencia')).toBeDefined()
-    })
-
-    it('calls onRegisterLeave when register-leave button is clicked', () => {
-        const onRegisterLeave = vi.fn()
-        const { getByText } = render(
-            <EmployeeAttendanceCard {...defaultProps} onRegisterLeave={onRegisterLeave} />
+    it('renders "Marcar falta" button for pending employees on a work day', () => {
+        const { getByTestId } = render(
+            <EmployeeAttendanceCard {...defaultProps} row={{ ...mockRow, schedule: workSchedule }} />
         )
-
-        fireEvent.click(getByText('Registrar ausencia'))
-        expect(onRegisterLeave).toHaveBeenCalledWith(mockRow.employee)
+        expect(getByTestId('btn-mark-falta')).toBeDefined()
     })
 
-    it('renders "Marcar día" dropdown trigger for pending employees', () => {
+    it('renders "Marcar falta" button when schedule is null', () => {
         const { getByTestId } = render(<EmployeeAttendanceCard {...defaultProps} />)
-        expect(getByTestId('btn-mark-day')).toBeDefined()
+        expect(getByTestId('btn-mark-falta')).toBeDefined()
     })
 
-    it('shows Descanso and Falta options when Marcar día is clicked', () => {
+    it('opens confirm dialog when "Marcar falta" is clicked', () => {
         const { getByTestId, getByText } = render(<EmployeeAttendanceCard {...defaultProps} />)
 
-        fireEvent.click(getByTestId('btn-mark-day'))
+        fireEvent.click(getByTestId('btn-mark-falta'))
 
-        expect(getByText('Descanso')).toBeDefined()
-        expect(getByText('Falta')).toBeDefined()
+        expect(getByText('¿Confirmar falta?')).toBeDefined()
     })
 
-    it('calls onMarkDayStatus with DAY_OFF when Descanso is clicked', () => {
+    it('calls onMarkDayStatus with ABSENCE when confirm dialog is confirmed', () => {
         const onMarkDayStatus = vi.fn()
-        const { getByTestId } = render(
+        const { getByTestId, getByText } = render(
             <EmployeeAttendanceCard {...defaultProps} onMarkDayStatus={onMarkDayStatus} />
         )
 
-        fireEvent.click(getByTestId('btn-mark-day'))
-        fireEvent.click(getByTestId('mark-day-off'))
-
-        expect(onMarkDayStatus).toHaveBeenCalledWith(mockRow.employee, 'DAY_OFF')
-    })
-
-    it('calls onMarkDayStatus with ABSENCE when Falta is clicked', () => {
-        const onMarkDayStatus = vi.fn()
-        const { getByTestId } = render(
-            <EmployeeAttendanceCard {...defaultProps} onMarkDayStatus={onMarkDayStatus} />
-        )
-
-        fireEvent.click(getByTestId('btn-mark-day'))
-        fireEvent.click(getByTestId('mark-absence'))
+        fireEvent.click(getByTestId('btn-mark-falta'))
+        fireEvent.click(getByText('Confirmar falta'))
 
         expect(onMarkDayStatus).toHaveBeenCalledWith(mockRow.employee, 'ABSENCE')
     })
 
-    it('does not render Marcar día dropdown for employees with attendance', () => {
+    it('does NOT call onMarkDayStatus when confirm dialog is cancelled', () => {
+        const onMarkDayStatus = vi.fn()
+        const { getByTestId, getByText } = render(
+            <EmployeeAttendanceCard {...defaultProps} onMarkDayStatus={onMarkDayStatus} />
+        )
+
+        fireEvent.click(getByTestId('btn-mark-falta'))
+        fireEvent.click(getByText('Cancelar'))
+
+        expect(onMarkDayStatus).not.toHaveBeenCalled()
+    })
+
+    it('shows "Descanso programado" indicator for scheduled rest-day employees', () => {
+        const restDayRow: TodayAttendanceRow = { ...mockRow, schedule: restSchedule }
+        const { container, queryByTestId } = render(
+            <EmployeeAttendanceCard {...defaultProps} row={restDayRow} />
+        )
+
+        expect(container.innerHTML).toContain('Descanso programado')
+        expect(queryByTestId('btn-mark-falta')).toBeNull()
+        expect(container.innerHTML).not.toContain('Registrar entrada')
+    })
+
+    it('does not render action buttons for employees with attendance', () => {
         const { queryByTestId } = render(
             <EmployeeAttendanceCard {...defaultProps} row={mockRowWithAttendance} />
         )
-        expect(queryByTestId('btn-mark-day')).toBeNull()
+        expect(queryByTestId('btn-mark-falta')).toBeNull()
     })
 
     it('renders lunch-start button for checked-in phase', () => {

--- a/code/webapp/src/components/attendance/attendance-helpers.ts
+++ b/code/webapp/src/components/attendance/attendance-helpers.ts
@@ -17,5 +17,9 @@ export function getPhaseCardClass(phase: AttendancePhase): string {
             return 'border-green-200 dark:border-green-800'
         case 'on-leave':
             return 'border-amber-200 dark:border-amber-800'
+        case 'day-off':
+            return 'border-indigo-200 dark:border-indigo-800 opacity-70'
+        case 'absence':
+            return 'border-red-200 dark:border-red-800 opacity-70'
     }
 }

--- a/code/webapp/src/components/attendance/use-close-day-panel.ts
+++ b/code/webapp/src/components/attendance/use-close-day-panel.ts
@@ -130,9 +130,15 @@ export function useCloseDayPanel(
       if (phase === 'pending') {
         // No check_in → will be marked as ABSENCE
         absences.push({ employeeName: name })
-      } else if (phase !== 'done' && phase !== 'on-leave') {
+      } else if (
+        phase !== 'done' &&
+        phase !== 'on-leave' &&
+        phase !== 'day-off' &&
+        phase !== 'absence'
+      ) {
         // Has check_in but no check_out → will receive check-out
         // (includes 'at-lunch' employees whose lunch_end was just resolved in step 1)
+        // Excludes day-off and absence — already resolved, no checkout needed.
         checkOuts.push({ employeeName: name })
       }
     }

--- a/code/webapp/src/pages/attendance/-use-today-attendance-page.ts
+++ b/code/webapp/src/pages/attendance/-use-today-attendance-page.ts
@@ -1,8 +1,8 @@
 import { useState, useCallback } from 'react'
 import { useAuthStore } from '@/stores/auth.store'
-import { useTodayAttendance, useCheckIn, useLunchStart, useLunchReturn, useCheckOut, useOvertimeDecision } from '@/services/attendance-hooks'
+import { useTodayAttendance, useCheckIn, useLunchStart, useLunchReturn, useCheckOut, useOvertimeDecision, useMarkDayStatus } from '@/services/attendance-hooks'
 import { getAttendancePhase } from '@/types/attendance'
-import type { TodayAttendanceRow, AttendancePhase, TodayAttendanceEmployee } from '@/types/attendance'
+import type { TodayAttendanceRow, AttendancePhase, TodayAttendanceEmployee, DayStatus } from '@/types/attendance'
 import type { AttendanceSummary } from '@/components/attendance'
 
 interface PendingAttendanceData {
@@ -31,6 +31,17 @@ export { currentTimeLabel } from '@/lib/datetime'
 
 /** CDMX timezone offset — hardcoded to UTC-6 (standard time). DST is not handled. */
 const CDMX_OFFSET_HOURS = -6
+
+/**
+ * Today's date in CDMX timezone (YYYY-MM-DD).
+ * Exported for testing.
+ */
+export function todayCdmxDate(): string {
+  const now = new Date()
+  const cdmxTime = new Date(now.getTime() + CDMX_OFFSET_HOURS * 60 * 60 * 1000)
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${cdmxTime.getUTCFullYear()}-${pad(cdmxTime.getUTCMonth() + 1)}-${pad(cdmxTime.getUTCDate())}`
+}
 
 /**
  * ISO 8601 / RFC 3339 from a "HH:mm" string using today's date in CDMX timezone.
@@ -99,6 +110,9 @@ export interface UseTodayAttendancePageResult {
   pendingLeaveEmployee: TodayAttendanceEmployee | null
   openRegisterLeave: (employee: TodayAttendanceEmployee) => void
   closeRegisterLeave: () => void
+  // Mark day status action
+  isMarkingDayStatus: boolean
+  markDayStatus: (employee: TodayAttendanceEmployee, status: Extract<DayStatus, 'DAY_OFF' | 'ABSENCE'>) => void
 }
 
 export function useTodayAttendancePage(): UseTodayAttendancePageResult {
@@ -111,6 +125,7 @@ export function useTodayAttendancePage(): UseTodayAttendancePageResult {
   const lunchReturnMutation = useLunchReturn()
   const checkOutMutation = useCheckOut()
   const overtimeDecisionMutation = useOvertimeDecision()
+  const markDayStatusMutation = useMarkDayStatus()
 
   const summary = computeSummary(data)
 
@@ -226,6 +241,18 @@ export function useTodayAttendancePage(): UseTodayAttendancePageResult {
     setPendingLeaveEmployee(null)
   }, [])
 
+  // ── Mark day status ───────────────────────────────────────────────────────────
+  const markDayStatus = useCallback(
+    (employee: TodayAttendanceEmployee, status: Extract<DayStatus, 'DAY_OFF' | 'ABSENCE'>) => {
+      markDayStatusMutation.mutate({
+        employee_id: employee.id,
+        date: todayCdmxDate(),
+        day_status: status,
+      })
+    },
+    [markDayStatusMutation],
+  )
+
   return {
     rows: data,
     summary,
@@ -269,5 +296,8 @@ export function useTodayAttendancePage(): UseTodayAttendancePageResult {
     pendingLeaveEmployee,
     openRegisterLeave,
     closeRegisterLeave,
+    // Mark day status
+    isMarkingDayStatus: markDayStatusMutation.isPending,
+    markDayStatus,
   }
 }

--- a/code/webapp/src/pages/attendance/-use-today-attendance-page.ts
+++ b/code/webapp/src/pages/attendance/-use-today-attendance-page.ts
@@ -2,7 +2,7 @@ import { useState, useCallback } from 'react'
 import { useAuthStore } from '@/stores/auth.store'
 import { useTodayAttendance, useCheckIn, useLunchStart, useLunchReturn, useCheckOut, useOvertimeDecision, useMarkDayStatus } from '@/services/attendance-hooks'
 import { getAttendancePhase } from '@/types/attendance'
-import type { TodayAttendanceRow, AttendancePhase, TodayAttendanceEmployee, DayStatus } from '@/types/attendance'
+import type { TodayAttendanceRow, AttendancePhase, TodayAttendanceEmployee } from '@/types/attendance'
 import type { AttendanceSummary } from '@/components/attendance'
 
 interface PendingAttendanceData {
@@ -106,13 +106,9 @@ export interface UseTodayAttendancePageResult {
   openOvertimeDecision: (employee: TodayAttendanceEmployee, attendanceId: string) => void
   closeOvertimeDecision: () => void
   confirmOvertimeDecision: (authorize: boolean) => void
-  // Register leave action
-  pendingLeaveEmployee: TodayAttendanceEmployee | null
-  openRegisterLeave: (employee: TodayAttendanceEmployee) => void
-  closeRegisterLeave: () => void
   // Mark day status action
   isMarkingDayStatus: boolean
-  markDayStatus: (employee: TodayAttendanceEmployee, status: Extract<DayStatus, 'DAY_OFF' | 'ABSENCE'>) => void
+  markDayStatus: (employee: TodayAttendanceEmployee, status: 'ABSENCE') => void
 }
 
 export function useTodayAttendancePage(): UseTodayAttendancePageResult {
@@ -229,21 +225,9 @@ export function useTodayAttendancePage(): UseTodayAttendancePageResult {
     )
   }, [pendingOvertimeDecision, overtimeDecisionMutation, closeOvertimeDecision])
 
-  // ── Register leave state ─────────────────────────────────────────────────────
-  const [pendingLeaveEmployee, setPendingLeaveEmployee] =
-    useState<TodayAttendanceEmployee | null>(null)
-
-  const openRegisterLeave = useCallback((employee: TodayAttendanceEmployee) => {
-    setPendingLeaveEmployee(employee)
-  }, [])
-
-  const closeRegisterLeave = useCallback(() => {
-    setPendingLeaveEmployee(null)
-  }, [])
-
   // ── Mark day status ───────────────────────────────────────────────────────────
   const markDayStatus = useCallback(
-    (employee: TodayAttendanceEmployee, status: Extract<DayStatus, 'DAY_OFF' | 'ABSENCE'>) => {
+    (employee: TodayAttendanceEmployee, status: 'ABSENCE') => {
       markDayStatusMutation.mutate({
         employee_id: employee.id,
         date: todayCdmxDate(),
@@ -292,10 +276,6 @@ export function useTodayAttendancePage(): UseTodayAttendancePageResult {
     openOvertimeDecision,
     closeOvertimeDecision,
     confirmOvertimeDecision,
-    // Register leave
-    pendingLeaveEmployee,
-    openRegisterLeave,
-    closeRegisterLeave,
     // Mark day status
     isMarkingDayStatus: markDayStatusMutation.isPending,
     markDayStatus,

--- a/code/webapp/src/pages/attendance/-use-today-attendance-page.ts
+++ b/code/webapp/src/pages/attendance/-use-today-attendance-page.ts
@@ -17,7 +17,7 @@ export function computeSummary(rows: TodayAttendanceRow[]): AttendanceSummary {
   for (const row of rows) {
     const phase = getAttendancePhase(row.attendance)
     if (phase === 'pending') pending++
-    else if (phase === 'done' || phase === 'on-leave') done++
+    else if (phase === 'done' || phase === 'on-leave' || phase === 'day-off' || phase === 'absence') done++
     else checkedIn++
 
     if ((row.attendance?.overtime_minutes ?? 0) > 0) withOvertime++

--- a/code/webapp/src/pages/attendance/__tests__/use-today-attendance-page.test.ts
+++ b/code/webapp/src/pages/attendance/__tests__/use-today-attendance-page.test.ts
@@ -8,6 +8,7 @@ import {
   computeSummary,
   currentTimeLabel,
   timeToIso,
+  todayCdmxDate,
 } from '@/pages/attendance/-use-today-attendance-page'
 import type { TodayAttendanceRow } from '@/types/attendance'
 
@@ -32,6 +33,10 @@ vi.mock('@/services/attendance-api', () => ({
     checkIn: vi.fn(),
     lunchStart: vi.fn(),
     lunchReturn: vi.fn(),
+    checkOut: vi.fn(),
+    overtimeDecision: vi.fn(),
+    closeDay: vi.fn(),
+    markDayStatus: vi.fn(),
   },
 }))
 
@@ -239,6 +244,37 @@ describe('timeToIso', () => {
     const iso = timeToIso('14:30')
     // Should always end with -06:00 (CDMX standard time)
     expect(iso).toMatch(/-06:00$/)
+  })
+})
+
+// ══════════════════════════════════════════════════════════════════════════════
+// todayCdmxDate
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('todayCdmxDate', () => {
+  it('returns a YYYY-MM-DD formatted date string', () => {
+    const result = todayCdmxDate()
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+
+  it('returns the CDMX date (UTC-6) when system time is set', () => {
+    vi.useFakeTimers()
+    // UTC 2026-04-12T04:00:00Z = CDMX (UTC-6) 2026-04-11T22:00:00
+    vi.setSystemTime(new Date('2026-04-12T04:00:00Z'))
+
+    expect(todayCdmxDate()).toBe('2026-04-11')
+
+    vi.useRealTimers()
+  })
+
+  it('returns the next day in UTC when CDMX is still the same day', () => {
+    vi.useFakeTimers()
+    // UTC 2026-04-12T07:00:00Z = CDMX (UTC-6) 2026-04-12T01:00:00
+    vi.setSystemTime(new Date('2026-04-12T07:00:00Z'))
+
+    expect(todayCdmxDate()).toBe('2026-04-12')
+
+    vi.useRealTimers()
   })
 })
 

--- a/code/webapp/src/pages/attendance/today.tsx
+++ b/code/webapp/src/pages/attendance/today.tsx
@@ -65,6 +65,8 @@ export function TodayAttendancePage() {
     pendingLeaveEmployee,
     openRegisterLeave,
     closeRegisterLeave,
+    // Mark day status
+    markDayStatus,
   } = useTodayAttendancePage()
 
   const closeDayPanel = useCloseDayPanel(rows, branchId)
@@ -126,6 +128,7 @@ export function TodayAttendancePage() {
               onCheckOut={openCheckOut}
               onOvertimeDecision={openOvertimeDecision}
               onRegisterLeave={openRegisterLeave}
+              onMarkDayStatus={markDayStatus}
             />
           ))}
         </div>

--- a/code/webapp/src/pages/attendance/today.tsx
+++ b/code/webapp/src/pages/attendance/today.tsx
@@ -12,7 +12,6 @@ import {
   ErrorState,
   NoBranchState,
   OvertimeDecisionDialog,
-  RegisterLeaveDialog,
   SkeletonGrid,
   useCloseDayPanel,
 } from '@/components/attendance'
@@ -61,10 +60,6 @@ export function TodayAttendancePage() {
     openOvertimeDecision,
     closeOvertimeDecision,
     confirmOvertimeDecision,
-    // Register leave
-    pendingLeaveEmployee,
-    openRegisterLeave,
-    closeRegisterLeave,
     // Mark day status
     markDayStatus,
   } = useTodayAttendancePage()
@@ -127,7 +122,6 @@ export function TodayAttendancePage() {
               onLunchReturn={openLunchReturn}
               onCheckOut={openCheckOut}
               onOvertimeDecision={openOvertimeDecision}
-              onRegisterLeave={openRegisterLeave}
               onMarkDayStatus={markDayStatus}
             />
           ))}
@@ -223,13 +217,6 @@ export function TodayAttendancePage() {
         onAuthorize={() => confirmOvertimeDecision(true)}
         onReject={() => confirmOvertimeDecision(false)}
         onClose={closeOvertimeDecision}
-      />
-
-      {/* Register Leave Dialog */}
-      <RegisterLeaveDialog
-        isOpen={!!pendingLeaveEmployee}
-        employee={pendingLeaveEmployee}
-        onClose={closeRegisterLeave}
       />
 
       {/* Close Day Panel */}

--- a/code/webapp/src/services/__tests__/attendance-hooks-day-status.test.ts
+++ b/code/webapp/src/services/__tests__/attendance-hooks-day-status.test.ts
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import React from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useMarkDayStatus } from '@/services/attendance-hooks'
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockShowSuccess = vi.fn()
+const mockShowError = vi.fn()
+
+vi.mock('@/components/ui/toast-provider', () => ({
+  useToast: () => ({ showSuccess: mockShowSuccess, showError: mockShowError }),
+}))
+
+vi.mock('@/services/attendance-api', () => ({
+  attendanceApi: {
+    today: vi.fn(),
+    checkIn: vi.fn(),
+    lunchStart: vi.fn(),
+    lunchReturn: vi.fn(),
+    checkOut: vi.fn(),
+    closeDay: vi.fn(),
+    overtimeDecision: vi.fn(),
+    markDayStatus: vi.fn(),
+  },
+}))
+
+import { attendanceApi } from '@/services/attendance-api'
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children)
+  return { queryClient, wrapper }
+}
+
+const mockDayOffResponse = {
+  data: {
+    status: 201,
+    data: {
+      id: 'att-001',
+      employee_id: 'emp-001',
+      date: '2026-04-12',
+      day_status: 'DAY_OFF',
+      check_in: null,
+      check_out: null,
+    },
+  },
+}
+
+const mockAbsenceResponse = {
+  data: {
+    status: 201,
+    data: {
+      id: 'att-002',
+      employee_id: 'emp-001',
+      date: '2026-04-12',
+      day_status: 'ABSENCE',
+      check_in: null,
+      check_out: null,
+    },
+  },
+}
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+// ── useMarkDayStatus ───────────────────────────────────────────────────────────
+
+describe('useMarkDayStatus', () => {
+  it('calls attendanceApi.markDayStatus with correct payload for DAY_OFF', async () => {
+    vi.mocked(attendanceApi.markDayStatus).mockResolvedValue(mockDayOffResponse as never)
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useMarkDayStatus(), { wrapper })
+
+    await act(async () => {
+      result.current.mutate({
+        employee_id: 'emp-001',
+        date: '2026-04-12',
+        day_status: 'DAY_OFF',
+      })
+    })
+
+    expect(attendanceApi.markDayStatus).toHaveBeenCalledWith({
+      employee_id: 'emp-001',
+      date: '2026-04-12',
+      day_status: 'DAY_OFF',
+    })
+  })
+
+  it('shows success toast with "descanso" label when DAY_OFF succeeds', async () => {
+    vi.mocked(attendanceApi.markDayStatus).mockResolvedValue(mockDayOffResponse as never)
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useMarkDayStatus(), { wrapper })
+
+    await act(async () => {
+      result.current.mutate({
+        employee_id: 'emp-001',
+        date: '2026-04-12',
+        day_status: 'DAY_OFF',
+      })
+    })
+
+    expect(mockShowSuccess).toHaveBeenCalledWith(
+      expect.stringContaining('descanso'),
+      'Día marcado',
+    )
+  })
+
+  it('shows success toast with "falta" label when ABSENCE succeeds', async () => {
+    vi.mocked(attendanceApi.markDayStatus).mockResolvedValue(mockAbsenceResponse as never)
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useMarkDayStatus(), { wrapper })
+
+    await act(async () => {
+      result.current.mutate({
+        employee_id: 'emp-001',
+        date: '2026-04-12',
+        day_status: 'ABSENCE',
+      })
+    })
+
+    expect(mockShowSuccess).toHaveBeenCalledWith(
+      expect.stringContaining('falta'),
+      'Día marcado',
+    )
+  })
+
+  it('shows error toast when mutation fails', async () => {
+    vi.mocked(attendanceApi.markDayStatus).mockRejectedValue(new Error('Server error'))
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useMarkDayStatus(), { wrapper })
+
+    await act(async () => {
+      result.current.mutate({
+        employee_id: 'emp-001',
+        date: '2026-04-12',
+        day_status: 'DAY_OFF',
+      })
+    })
+
+    expect(mockShowError).toHaveBeenCalled()
+  })
+})

--- a/code/webapp/src/services/__tests__/attendance-hooks-day-status.test.ts
+++ b/code/webapp/src/services/__tests__/attendance-hooks-day-status.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { renderHook, act } from '@testing-library/react'
+import { renderHook, act, waitFor } from '@testing-library/react'
 import React from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useMarkDayStatus } from '@/services/attendance-hooks'
@@ -43,20 +43,6 @@ function makeWrapper() {
   return { queryClient, wrapper }
 }
 
-const mockDayOffResponse = {
-  data: {
-    status: 201,
-    data: {
-      id: 'att-001',
-      employee_id: 'emp-001',
-      date: '2026-04-12',
-      day_status: 'DAY_OFF',
-      check_in: null,
-      check_out: null,
-    },
-  },
-}
-
 const mockAbsenceResponse = {
   data: {
     status: 201,
@@ -78,51 +64,12 @@ afterEach(() => {
 // ── useMarkDayStatus ───────────────────────────────────────────────────────────
 
 describe('useMarkDayStatus', () => {
-  it('calls attendanceApi.markDayStatus with correct payload for DAY_OFF', async () => {
-    vi.mocked(attendanceApi.markDayStatus).mockResolvedValue(mockDayOffResponse as never)
-    const { wrapper } = makeWrapper()
-    const { result } = renderHook(() => useMarkDayStatus(), { wrapper })
-
-    await act(async () => {
-      result.current.mutate({
-        employee_id: 'emp-001',
-        date: '2026-04-12',
-        day_status: 'DAY_OFF',
-      })
-    })
-
-    expect(attendanceApi.markDayStatus).toHaveBeenCalledWith({
-      employee_id: 'emp-001',
-      date: '2026-04-12',
-      day_status: 'DAY_OFF',
-    })
-  })
-
-  it('shows success toast with "descanso" label when DAY_OFF succeeds', async () => {
-    vi.mocked(attendanceApi.markDayStatus).mockResolvedValue(mockDayOffResponse as never)
-    const { wrapper } = makeWrapper()
-    const { result } = renderHook(() => useMarkDayStatus(), { wrapper })
-
-    await act(async () => {
-      result.current.mutate({
-        employee_id: 'emp-001',
-        date: '2026-04-12',
-        day_status: 'DAY_OFF',
-      })
-    })
-
-    expect(mockShowSuccess).toHaveBeenCalledWith(
-      expect.stringContaining('descanso'),
-      'Día marcado',
-    )
-  })
-
-  it('shows success toast with "falta" label when ABSENCE succeeds', async () => {
+  it('calls attendanceApi.markDayStatus with ABSENCE payload', async () => {
     vi.mocked(attendanceApi.markDayStatus).mockResolvedValue(mockAbsenceResponse as never)
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => useMarkDayStatus(), { wrapper })
 
-    await act(async () => {
+    act(() => {
       result.current.mutate({
         employee_id: 'emp-001',
         date: '2026-04-12',
@@ -130,9 +77,31 @@ describe('useMarkDayStatus', () => {
       })
     })
 
-    expect(mockShowSuccess).toHaveBeenCalledWith(
-      expect.stringContaining('falta'),
-      'Día marcado',
+    await waitFor(() => expect(attendanceApi.markDayStatus).toHaveBeenCalledWith({
+      employee_id: 'emp-001',
+      date: '2026-04-12',
+      day_status: 'ABSENCE',
+    }))
+  })
+
+  it('shows success toast with "falta" label when ABSENCE succeeds', async () => {
+    vi.mocked(attendanceApi.markDayStatus).mockResolvedValue(mockAbsenceResponse as never)
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useMarkDayStatus(), { wrapper })
+
+    act(() => {
+      result.current.mutate({
+        employee_id: 'emp-001',
+        date: '2026-04-12',
+        day_status: 'ABSENCE',
+      })
+    })
+
+    await waitFor(() =>
+      expect(mockShowSuccess).toHaveBeenCalledWith(
+        expect.stringContaining('falta'),
+        'Día marcado',
+      )
     )
   })
 
@@ -141,14 +110,36 @@ describe('useMarkDayStatus', () => {
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => useMarkDayStatus(), { wrapper })
 
-    await act(async () => {
+    act(() => {
       result.current.mutate({
         employee_id: 'emp-001',
         date: '2026-04-12',
-        day_status: 'DAY_OFF',
+        day_status: 'ABSENCE',
       })
     })
 
-    expect(mockShowError).toHaveBeenCalled()
+    await waitFor(() => expect(mockShowError).toHaveBeenCalled())
+  })
+
+  it('invalidates today attendance queries on success', async () => {
+    vi.mocked(attendanceApi.markDayStatus).mockResolvedValue(mockAbsenceResponse as never)
+    const { wrapper, queryClient } = makeWrapper()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useMarkDayStatus(), { wrapper })
+
+    act(() => {
+      result.current.mutate({
+        employee_id: 'emp-001',
+        date: '2026-04-12',
+        day_status: 'ABSENCE',
+      })
+    })
+
+    await waitFor(() =>
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: ['attendances', 'today'] })
+      )
+    )
   })
 })

--- a/code/webapp/src/services/attendance-api.ts
+++ b/code/webapp/src/services/attendance-api.ts
@@ -1,5 +1,5 @@
 import { apiClient } from '@/lib/api-client'
-import type { TodayAttendanceResponse, AttendanceRecord, CloseDayRequest, CloseDayResponse, DayStatus } from '@/types/attendance'
+import type { TodayAttendanceResponse, AttendanceRecord, CloseDayRequest, CloseDayResponse } from '@/types/attendance'
 
 export const attendanceApi = {
   /**
@@ -65,10 +65,11 @@ export const attendanceApi = {
 
   /**
    * POST /attendances/day-status
-   * Marks an employee's day as DAY_OFF or ABSENCE without registering check-in/check-out.
-   * Body: { employee_id: ULID, date: "YYYY-MM-DD", day_status: "DAY_OFF" | "ABSENCE" }
+   * Marks an employee's day as ABSENCE (unexcused no-show).
+   * DAY_OFF is auto-managed by CloseDayAction — cannot be set via this endpoint.
+   * Body: { employee_id: ULID, date: "YYYY-MM-DD", day_status: "ABSENCE" }
    */
-  markDayStatus: (data: { employee_id: string; date: string; day_status: Extract<DayStatus, 'DAY_OFF' | 'ABSENCE'> }) =>
+  markDayStatus: (data: { employee_id: string; date: string; day_status: 'ABSENCE' }) =>
     apiClient.post<{ status: number; data: AttendanceRecord }>('/attendances/day-status', data),
 
   /**

--- a/code/webapp/src/services/attendance-api.ts
+++ b/code/webapp/src/services/attendance-api.ts
@@ -1,5 +1,5 @@
 import { apiClient } from '@/lib/api-client'
-import type { TodayAttendanceResponse, AttendanceRecord, CloseDayRequest, CloseDayResponse } from '@/types/attendance'
+import type { TodayAttendanceResponse, AttendanceRecord, CloseDayRequest, CloseDayResponse, DayStatus } from '@/types/attendance'
 
 export const attendanceApi = {
   /**
@@ -62,6 +62,14 @@ export const attendanceApi = {
       `/attendances/${attendanceId}/overtime-decision`,
       data,
     ),
+
+  /**
+   * POST /attendances/day-status
+   * Marks an employee's day as DAY_OFF or ABSENCE without registering check-in/check-out.
+   * Body: { employee_id: ULID, date: "YYYY-MM-DD", day_status: "DAY_OFF" | "ABSENCE" }
+   */
+  markDayStatus: (data: { employee_id: string; date: string; day_status: Extract<DayStatus, 'DAY_OFF' | 'ABSENCE'> }) =>
+    apiClient.post<{ status: number; data: AttendanceRecord }>('/attendances/day-status', data),
 
   /**
    * POST /attendances/close-day

--- a/code/webapp/src/services/attendance-hooks.ts
+++ b/code/webapp/src/services/attendance-hooks.ts
@@ -2,7 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { attendanceApi } from './attendance-api'
 import { useToast } from '@/components/ui/toast-provider'
 import { getApiErrorMessage } from '@/lib/api-error'
-import type { TodayAttendanceRow, CloseDayRequest } from '@/types/attendance'
+import type { TodayAttendanceRow, CloseDayRequest, DayStatus } from '@/types/attendance'
 
 /**
  * Fetch today's attendance for all active employees of a branch.
@@ -141,6 +141,31 @@ export function useOvertimeDecision() {
       showError(
         getApiErrorMessage(error, 'No se pudo registrar la decisión.'),
         'Error al registrar'
+      )
+    },
+  })
+}
+
+/**
+ * Mutation: mark an employee's day as DAY_OFF or ABSENCE.
+ * On success: invalidates the today attendance query and shows a toast.
+ */
+export function useMarkDayStatus() {
+  const queryClient = useQueryClient()
+  const { showSuccess, showError } = useToast()
+
+  return useMutation({
+    mutationFn: (data: { employee_id: string; date: string; day_status: Extract<DayStatus, 'DAY_OFF' | 'ABSENCE'> }) =>
+      attendanceApi.markDayStatus(data),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['attendances', 'today'] })
+      const label = variables.day_status === 'DAY_OFF' ? 'Día marcado como descanso.' : 'Día marcado como falta.'
+      showSuccess(label, 'Día marcado')
+    },
+    onError: (error: unknown) => {
+      showError(
+        getApiErrorMessage(error, 'No se pudo marcar el día.'),
+        'Error al marcar'
       )
     },
   })

--- a/code/webapp/src/services/attendance-hooks.ts
+++ b/code/webapp/src/services/attendance-hooks.ts
@@ -2,7 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { attendanceApi } from './attendance-api'
 import { useToast } from '@/components/ui/toast-provider'
 import { getApiErrorMessage } from '@/lib/api-error'
-import type { TodayAttendanceRow, CloseDayRequest, DayStatus } from '@/types/attendance'
+import type { TodayAttendanceRow, CloseDayRequest } from '@/types/attendance'
 
 /**
  * Fetch today's attendance for all active employees of a branch.
@@ -147,7 +147,8 @@ export function useOvertimeDecision() {
 }
 
 /**
- * Mutation: mark an employee's day as DAY_OFF or ABSENCE.
+ * Mutation: mark an employee's day as ABSENCE (unexcused no-show).
+ * DAY_OFF is auto-managed by CloseDayAction — do not send it here.
  * On success: invalidates the today attendance query and shows a toast.
  */
 export function useMarkDayStatus() {
@@ -155,12 +156,11 @@ export function useMarkDayStatus() {
   const { showSuccess, showError } = useToast()
 
   return useMutation({
-    mutationFn: (data: { employee_id: string; date: string; day_status: Extract<DayStatus, 'DAY_OFF' | 'ABSENCE'> }) =>
+    mutationFn: (data: { employee_id: string; date: string; day_status: 'ABSENCE' }) =>
       attendanceApi.markDayStatus(data),
-    onSuccess: (_, variables) => {
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['attendances', 'today'] })
-      const label = variables.day_status === 'DAY_OFF' ? 'Día marcado como descanso.' : 'Día marcado como falta.'
-      showSuccess(label, 'Día marcado')
+      showSuccess('Día marcado como falta.', 'Día marcado')
     },
     onError: (error: unknown) => {
       showError(
@@ -188,6 +188,8 @@ export function useCloseDay() {
       if (d.lunch_returns > 0) parts.push(`${d.lunch_returns} regresos`)
       if (d.check_outs > 0) parts.push(`${d.check_outs} salidas`)
       if (d.absences > 0) parts.push(`${d.absences} faltas`)
+      if (d.leaves > 0) parts.push(`${d.leaves} permisos`)
+      if (d.day_offs > 0) parts.push(`${d.day_offs} descansos`)
       showSuccess(parts.join(', ') || 'Sin cambios', 'Día cerrado')
     },
     onError: (error: unknown) => {

--- a/code/webapp/src/types/__tests__/attendance.test.ts
+++ b/code/webapp/src/types/__tests__/attendance.test.ts
@@ -105,6 +105,44 @@ describe('getAttendancePhase', () => {
         }
         expect(getAttendancePhase(attendance)).toBe('returned')
     })
+
+    it('returns "day-off" when day_status is DAY_OFF', () => {
+        const attendance: TodayAttendanceData = {
+            id: '1',
+            check_in: null,
+            lunch_start: null,
+            lunch_end: null,
+            check_out: null,
+            day_status: 'DAY_OFF',
+            entry_late_seconds: null,
+            entry_late_minutes: null,
+            is_entry_deductible: false,
+            overtime_minutes: 0,
+            overtime_authorized: false,
+            overtime_authorized_at: null,
+            requires_overtime_decision: false,
+        }
+        expect(getAttendancePhase(attendance)).toBe('day-off')
+    })
+
+    it('returns "absence" when day_status is ABSENCE', () => {
+        const attendance: TodayAttendanceData = {
+            id: '1',
+            check_in: null,
+            lunch_start: null,
+            lunch_end: null,
+            check_out: null,
+            day_status: 'ABSENCE',
+            entry_late_seconds: null,
+            entry_late_minutes: null,
+            is_entry_deductible: false,
+            overtime_minutes: 0,
+            overtime_authorized: false,
+            overtime_authorized_at: null,
+            requires_overtime_decision: false,
+        }
+        expect(getAttendancePhase(attendance)).toBe('absence')
+    })
 })
 
 describe('formatSeconds', () => {

--- a/code/webapp/src/types/attendance.ts
+++ b/code/webapp/src/types/attendance.ts
@@ -91,6 +91,8 @@ export interface CloseDayResponse {
   lunch_returns: number
   check_outs: number
   absences: number
+  leaves: number
+  day_offs: number
 }
 
 // #endregion

--- a/code/webapp/src/types/attendance.ts
+++ b/code/webapp/src/types/attendance.ts
@@ -103,11 +103,15 @@ export type AttendancePhase =
   | 'at-lunch'      // Has lunch_start, no lunch_end
   | 'returned'      // Has lunch_end, no check_out
   | 'done'          // Has check_out (with or without lunch)
-  | 'on-leave'      // Absence registered for today (day_status = LEAVE)
+  | 'on-leave'      // Formal leave (day_status = LEAVE)
+  | 'day-off'       // Manually marked rest day (day_status = DAY_OFF)
+  | 'absence'       // Manually marked no-show (day_status = ABSENCE)
 
 export function getAttendancePhase(attendance: TodayAttendanceData | null): AttendancePhase {
   if (!attendance) return 'pending'
   if (attendance.day_status === 'LEAVE') return 'on-leave'
+  if (attendance.day_status === 'DAY_OFF') return 'day-off'
+  if (attendance.day_status === 'ABSENCE') return 'absence'
   if (!attendance.check_in) return 'pending'
   if (attendance.check_out) return 'done'
   if (!attendance.lunch_start) return 'checked-in'

--- a/doc/tasks/backlog/055-day-status-mark.md
+++ b/doc/tasks/backlog/055-day-status-mark.md
@@ -1,47 +1,97 @@
-# 🗓️ Task #055: Mark Day as Day-Off or Absence
+# 🗓️ Task #055: Mark Day Status — Falta, Descanso, Permiso (Redesign)
 
 ## 📖 Story
 
 **English:**
-As a Manager, I want to mark a day as a day-off or absence for an employee without registering check-in or check-out, so the system can correctly account for that day in the weekly close.
+As a Manager, I want to mark an employee's day as "Falta" (unexcused absence) from the Today view, while the system automatically handles "Descanso" (scheduled rest day) and "Permiso" (approved leave) at close-day time, so the weekly close is accurate without requiring redundant manual steps.
 
 **Español:**
-Como Manager, quiero marcar un día como descanso o ausencia para un empleado sin registrar entrada ni salida, para que el sistema contabilice correctamente ese día en el cierre semanal.
+Como Manager, quiero marcar el día de un empleado como "Falta" (ausencia no justificada) desde la vista de hoy, mientras el sistema resuelve automáticamente el "Descanso" (día libre según calendario) y el "Permiso" (permiso aprobado) al cerrar el día, para que el cierre semanal sea preciso sin pasos manuales redundantes.
+
+---
+
+## 🧠 Key Design Decisions
+
+- **ABSENCE** is the only status a manager manually assigns from the Today view. It represents an unexcused, unplanned absence.
+- **DAY_OFF** is auto-detected at close-day time: if the employee has no attendance and their schedule marks today as a rest day (`ScheduleDay.is_work_day = false` or `ScheduleDayOverride.is_work_day = false`), CloseDayAction marks them as DAY_OFF.
+- **LEAVE** is auto-detected at close-day time: if the employee has an approved leave covering today, CloseDayAction marks them as LEAVE.
+- Priority in CloseDayAction: `already-has-attendance` → skip; `approved-leave` → LEAVE; `schedule-rest-day` → DAY_OFF; `no-attendance + work-day` → ABSENCE.
+- The "Registrar ausencia" button (which created LEAVE directly) is **removed** from the Today view card — leave registration belongs in the Employee Detail leave tab (#077/#078). Leave requests flow through #096.
+- The "Marcar día" dropdown (DAY_OFF | ABSENCE) is **replaced** by a single "Marcar falta" button.
+- The backend endpoint is narrowed to accept **only ABSENCE** (DAY_OFF is system-managed).
+- Today view shows a `Descanso programado` indicator (read-only) if the schedule marks today as a rest day, so managers are not confused by why the employee is absent.
 
 ---
 
 ## ✅ Backend Tasks
 
-- [ ] 🌐 `POST /api/v1/attendances/day-status` — DayStatusController
-- [ ] 📝 DayStatusRequest — `{ employee_id, date, day_status: DAY_OFF|ABSENCE }`
-- [ ] 🔧 Creates an Attendance record without check_in/check_out
-- [ ] 🔧 422 if an attendance record already exists for that employee/date
-- [ ] 🧪 Feature tests: mark day-off, mark absence, duplicate rejected
+- [x] 🌐 `POST /api/v1/attendances/day-status` — `MarkDayStatusController`
+- [x] 📝 `DayStatusRequest` — `{ employee_id, date, day_status: DAY_OFF|ABSENCE }`
+- [x] 🔧 `MarkDayStatusAction` — creates Attendance with day_status, guards duplicate 422
+- [x] 🧪 10 PHPUnit feature tests (mark day-off, mark absence, duplicate, unknown employee, invalid status, etc.)
+- [ ] 🔧 **Narrow endpoint**: Update `DayStatusRequest` validation to **reject DAY_OFF** (only ABSENCE allowed going forward); update existing tests to assert DAY_OFF returns 422
+- [ ] 🔧 **CloseDayAction fix** — add pre-ABSENCE logic:
+  1. If employee has an approved `Leave` covering today → set `day_status = LEAVE`
+  2. Else if schedule resolves today as a rest day (use `resolveEffectiveScheduleDay`) → set `day_status = DAY_OFF`
+  3. Else → set `day_status = ABSENCE` (existing behavior)
+- [ ] 🧪 PHPUnit tests for updated CloseDayAction:
+  - Employee with approved leave today → marked LEAVE, not ABSENCE
+  - Employee with schedule rest day today → marked DAY_OFF, not ABSENCE
+  - Employee with no attendance and no leave/rest → marked ABSENCE (regression)
+  - Employee with check_in present → NOT re-closed (regression)
 
 ## ✅ Frontend Tasks
 
-- [ ] 📱 **"Marcar día" action** on each row in the Today view (#054) — dropdown button with options: "Descanso" / "Ausencia"
-- [ ] 📱 Only visible for employees with no attendance record yet for today
-- [ ] 📱 After marking: row updates to show the corresponding day_status badge (no reload needed)
-- [ ] 🔧 `markDayStatus(employeeId, date, status)` in `src/services/attendance.service.ts`
-- [ ] 🔧 Mutation added to `useTodayView` hook
+- [x] 📝 Extended `AttendancePhase` with `'day-off'` and `'absence'`
+- [x] 📝 Updated `getAttendancePhase()` to resolve DAY_OFF and ABSENCE before the check_in null check
+- [x] 🎨 `PhaseBadge` cases for `'day-off'` (Descanso) and `'absence'` (Falta)
+- [x] 🎨 `getPhaseCardClass` entries for `'day-off'` and `'absence'`
+- [x] 🔧 `attendanceApi.markDayStatus()` — POST to `/attendances/day-status`
+- [x] 🔧 `useMarkDayStatus()` hook — mutation, invalidates today query, shows toast
+- [x] 📱 "Marcar día" dropdown (Descanso | Falta) on pending cards — **to be replaced**
+- [ ] 📱 **Replace dropdown** with single "Marcar falta" button on pending cards:
+  - Remove `useState(isMarkDayOpen)`, `DropdownMenu`, and all dropdown imports
+  - Replace with a plain `<Button>` labeled "Marcar falta" with a `UserX` icon
+  - Clicking shows a minimal `AlertDialog` confirmation: "¿Confirmar que [Nombre] faltó hoy? Esta acción no se puede deshacer." — Confirmar / Cancelar
+  - On confirm: calls `onMarkDayStatus(employee, 'ABSENCE')`
+- [ ] 📱 **Remove "Registrar ausencia" button** from the pending card section
+- [ ] 📱 **Scheduled rest-day indicator**: when `row.schedule` resolves today as a non-work-day, show a read-only `Descanso programado` chip instead of action buttons (employee is expected off — no action needed today)
+- [ ] 🔧 Remove `onRegisterLeave` prop and `onMarkDayStatus` DAY_OFF path from `EmployeeAttendanceCard` (and update its tests)
+- [ ] 🔧 Remove `registerLeave` from `useTodayAttendancePage` hook and `today.tsx`
+
+---
+
+## 🧪 Tests
+
+- [x] ✅ PHPUnit: 10 feature tests (all passing)
+- [x] ✅ Vitest: `getAttendancePhase` day-off/absence, `PhaseBadge` day-off/absence, `getPhaseCardClass` day-off/absence, `useMarkDayStatus` mutations
+- [x] 🌲 Cypress E2E: mark Carlos as Descanso, mark María as Falta
+- [ ] ✅ Vitest: update `EmployeeAttendanceCard` tests — remove dropdown/onRegisterLeave tests, add "Marcar falta" button + AlertDialog confirmation tests
+- [ ] 🌲 Cypress E2E: update spec — use "Marcar falta" button + confirmation dialog instead of dropdown; remove DAY_OFF spec (auto-managed)
+- [ ] ✅ PHPUnit: CloseDayAction tests (LEAVE, DAY_OFF, ABSENCE priority)
 
 ---
 
 ## 🎯 Acceptance Criteria
 
-- [ ] Manager can mark "Descanso" or "Ausencia" from the Today view
-- [ ] Row immediately reflects the new status after the action
-- [ ] Action is hidden for employees who already have an attendance record
+- [ ] Manager sees a single "Marcar falta" button on pending cards (no dropdown)
+- [ ] Clicking "Marcar falta" shows a confirmation dialog before submitting
+- [ ] Card updates to show "Falta" badge without page reload
+- [ ] Cards for employees on a scheduled rest day show a read-only indicator — no action buttons
+- [ ] CloseDayAction correctly classifies: approved leave → LEAVE, schedule rest day → DAY_OFF, otherwise → ABSENCE
+- [ ] "Registrar ausencia" button no longer exists on Today view cards
+- [ ] DAY_OFF cannot be set via the API endpoint (returns 422)
 
 ---
 
 ## 🔗 References
 
 - **Backlog:** AP-019 · RF-16
+- **Depends on:** #054 (Today view), #053 (schedule data on row)
+- **Blocks:** #098 (Today view leave context), #096 (leave request flow)
 
 ---
 
 ## ⏱️ Estimates
 
-- **Optimistic:** `1h` · **Pessimistic:** `2h`
+- **Remaining:** `2h backend (CloseDayAction fix + tests) + 1.5h frontend (card redesign + tests)`

--- a/doc/tasks/backlog/057-partial-leave-register.md
+++ b/doc/tasks/backlog/057-partial-leave-register.md
@@ -1,47 +1,23 @@
-# 🕐 Task #057: Register Partial Leave
+# ~~🕐 Task #057: Register Partial Leave~~ — DEPRECATED
 
-## 📖 Story
+> **⚠️ DEPRECATED — Superseded by #096 (Leave Request) and #077 (Leave Foundation)**
+>
+> **Reason:** This task originally planned a separate `partial_leaves` table with its own model and endpoints. After architectural review, partial leaves are handled by the existing `leaves` table (created in #077) using `calculation_mode = PROPORTIONAL_HOURS` and `time_mode = SCHEDULED`. No new table or model is needed.
+>
+> **Where the functionality lives:**
+> - **Register a partial leave** → `POST /api/v1/leaves` (from #077) with `calculation_mode = PROPORTIONAL_HOURS`, `time_mode = SCHEDULED`, `starts_at`, `ends_at`
+> - **Express same-day partial leave** → same endpoint, `status = APPROVED` directly (manager approves inline)
+> - **Anticipated partial leave** → same endpoint with `submit_as_request = true` (see #096 for approve/reject flow)
+> - **Today view context** → #098 surfaces the approved leave on the employee card
+>
+> **Do not implement this task.** Close GitHub issue #57.
+
+---
+
+## 📖 Original Story (archived)
 
 **English:**
 As a Manager, I want to register a partial leave event for an employee (arrive late by permission, leave early, or take time off during the shift), specifying whether it is paid or unpaid, so the system has the evidence to apply deductions at close time.
 
 **Español:**
 Como Manager, quiero registrar un permiso parcial para un empleado (llegó tarde con permiso, salió temprano, o tomó tiempo durante el turno), indicando si es pagado o no, para que el sistema tenga la evidencia y aplique deducciones en el cierre.
-
----
-
-## ✅ Backend Tasks
-
-- [ ] 📂 Migration `create_partial_leaves_table` — employee_id (FK), attendance_id (FK nullable), type (enum: ARRIVE_LATE|LEAVE_EARLY|TAKE_TIME), is_paid (bool), start_time (nullable), end_time (nullable), duration_minutes, reason, approved_by (FK), timestamps
-- [ ] 🔧 `PartialLeave` model — `belongsTo(Employee)`, `belongsTo(Attendance)`, method `deductionAmount(minuteRate)`: returns `duration_minutes × minuteRate` if unpaid, 0 if paid
-- [ ] 🌐 `POST /api/v1/partial-leaves` — RegisterPartialLeaveController
-- [ ] 📝 StorePartialLeaveRequest — employee_id, date, type, is_paid, start_time (opt), end_time (opt), duration_minutes, reason; `approved_by` from auth user; auto-links attendance_id if attendance exists; auto-computes duration_minutes when start+end provided
-- [ ] 🧪 Feature tests: paid leave, unpaid leave, with time window, duration only
-
-## ✅ Frontend Tasks
-
-- [ ] 📝 Add `PartialLeave`, `PartialLeaveType` types to `src/types/attendance-payroll.ts`
-- [ ] 🔧 `registerPartialLeave(data)` in `src/services/partial-leave.service.ts`
-- [ ] 📱 **"Permiso parcial" button** on each attendance row in the Today view — opens a modal
-- [ ] 📱 **Partial leave modal** (react-hook-form + zod) — fields: type (select), is_paid (toggle), start_time + end_time or duration_minutes, reason; duration auto-calculated when both times provided
-- [ ] 🔧 `useRegisterPartialLeave()` hook — mutation, on success closes modal and updates row
-
----
-
-## 🎯 Acceptance Criteria
-
-- [ ] Manager can register a partial leave from the Today view
-- [ ] Duration is auto-calculated when start and end times are both entered
-- [ ] Paid/unpaid toggle is clearly visible with a label explaining the payroll impact
-
----
-
-## 🔗 References
-
-- **Backlog:** AP-020, AP-021 · RF-25a, RN-00c
-
----
-
-## ⏱️ Estimates
-
-- **Optimistic:** `3h` · **Pessimistic:** `5h`

--- a/doc/tasks/backlog/058-partial-leave-history.md
+++ b/doc/tasks/backlog/058-partial-leave-history.md
@@ -1,45 +1,21 @@
-# 📋 Task #058: View Partial Leave History
+# ~~📋 Task #058: View Partial Leave History~~ — DEPRECATED
 
-## 📖 Story
+> **⚠️ DEPRECATED — Superseded by #078 (Employee Leaves Tab)**
+>
+> **Reason:** This task originally planned a standalone "Partial Leave History" panel or page. After architectural review, partial leaves are regular `Leave` records with `calculation_mode = PROPORTIONAL_HOURS`. Their history is therefore visible in the same Leaves tab built in #078, which already supports date range filtering, status badges, and pagination.
+>
+> **Where the functionality lives:**
+> - **View leave history (all types, including partial)** → Employee Detail → "Ausencias" tab (#078)
+> - Partial leaves are identifiable in the table by their `calculation_mode` badge (shows "Parcial" or similar) and by the presence of `starts_at` / `ends_at` times
+>
+> **Do not implement this task.** Close GitHub issue #58.
+
+---
+
+## 📖 Original Story (archived)
 
 **English:**
 As a Manager, I want to query an employee's partial leaves within a date range, so I can review their history and verify what has been deducted.
 
 **Español:**
 Como Manager, quiero consultar los permisos parciales de un empleado dentro de un rango de fechas, para revisar su historial y verificar qué se ha descontado.
-
----
-
-## ✅ Backend Tasks
-
-- [ ] 🌐 `GET /api/v1/partial-leaves?employee_id=&date_from=&date_to=` — ListPartialLeavesController
-- [ ] 🔧 Response includes: type, is_paid, duration_minutes, reason, approved_by (name), date
-- [ ] 🔧 Pagination
-- [ ] 🧪 Feature tests: filter by employee, filter by date range, pagination
-
-## ✅ Frontend Tasks
-
-- [ ] 📝 Add `getPartialLeaves(filters)` to `src/services/partial-leave.service.ts`
-- [ ] 📱 **Partial leaves panel** in Employee Detail (new "Permisos" tab or section) — table with columns: date, type badge, duration, paid/unpaid badge, reason, approved by
-- [ ] 📱 Date range filter inputs above the table
-- [ ] 🔧 `usePartialLeaveHistory(employeeId)` hook — query with filter state
-
----
-
-## 🎯 Acceptance Criteria
-
-- [ ] Manager can filter partial leaves by date range
-- [ ] Each row shows whether the leave was paid or unpaid
-- [ ] Empty state message when no results
-
----
-
-## 🔗 References
-
-- **Backlog:** AP-022 · RF-25a
-
----
-
-## ⏱️ Estimates
-
-- **Optimistic:** `2h` · **Pessimistic:** `3h`

--- a/doc/tasks/backlog/096-leave-request.md
+++ b/doc/tasks/backlog/096-leave-request.md
@@ -1,84 +1,100 @@
-# 📝 Task #096: Leave Request — Prior Solicitud + Approve/Reject
+# 📝 Task #096: Leave Request — Solicitud Anticipada + Express + Aprobar/Rechazar
 
 ## 📖 Story
 
 **English:**
-As an employee (via manager), I want to submit a leave request in advance so that the manager can review, approve, or reject it. On approval, attendance records are automatically created and check-in is blocked for those days.
+As an employee (submitted by manager on their behalf), I want to submit a leave request in advance so the manager can approve or reject it. For same-day situations (employee calls in late or needs to leave early), the manager uses an express approval flow. On approval, attendance records are automatically set and the Today view reflects the leave context.
 
 **Español:**
-Como empleado (a través del manager), quiero solicitar una ausencia con anticipación para que el manager pueda revisarla, aprobarla o rechazarla. Al aprobar, los registros de asistencia se crean automáticamente y el check-in queda bloqueado para esos días.
+Como empleado (registrado por el manager en su nombre), quiero solicitar un permiso con anticipación para que el manager pueda aprobarlo o rechazarlo. Para situaciones del mismo día (el empleado avisa tarde o necesita salir temprano), el manager usa un flujo de aprobación exprés. Al aprobar, los registros de asistencia se ajustan y la vista de Hoy refleja el contexto del permiso.
 
 ---
 
 ## 🧠 Key Design Decisions
 
-- Extends the `leaves` table (already created in #077). Only adds the PENDING → APPROVED/REJECTED flow.
-- Direct registration (#077) skips PENDING and goes straight to APPROVED.
-- Solicitud registration (this task) creates the leave with `status = PENDING`, awaiting approval.
-- On approval: creates Attendance records with `day_status = LEAVE` for each date in range.
-- On rejection: no attendance impact. Status = REJECTED.
-- Approve/Reject buttons appear only on PENDING rows in the Employee Detail leaves tab (#078).
+- All leaves (full-day, partial, anticipated, express) use the **same `leaves` table** created in #077. No new tables.
+- **`calculation_mode = FIXED_PERCENTAGE`**: full-day leave. `affected_hours = null`. Paid 100% or 0% based on `is_paid`.
+- **`calculation_mode = PROPORTIONAL_HOURS`**: partial-day leave. `affected_hours` required. Payroll deduction proportional to hours.
+- **Anticipated flow**: manager creates leave with `status = PENDING`, awaiting their own (or another manager's) approval. Useful for formal requests entered in advance.
+- **Express flow**: manager creates leave directly with `status = APPROVED` (same as direct registration in #077, but may be for a partial/today scenario). No PENDING step required.
+- **Self-service (future)**: employee-initiated requests are architecturally the same — `status = PENDING`, `submitted_by = employee_id`. Not scoped here but the data model supports it.
+- On approval: for `OPEN_ENDED` leaves, creates Attendance records with `day_status = LEAVE` for each calendar day in range. For `SCHEDULED` partial leaves, no attendance record is created — the leave is read by CloseDayAction and Today view.
+- On rejection: `status = REJECTED`, no attendance impact.
+- Approve/Reject buttons appear only on PENDING rows in the Employee Leaves tab (#078).
+- Express partial leaves (same-day, `calculation_mode = PROPORTIONAL_HOURS`): manager opens the "Registrar permiso" form from the Employee Detail leaves tab, fills in times, and approves immediately. The Today view (via #098) picks up the approved leave and shows the context chip on the card.
 
 ---
 
 ## ✅ Backend Tasks
 
-- [ ] 🌐 `POST /api/v1/leave-requests` — `RegisterLeaveRequestController`
-  - Same fields as direct registration but `status = PENDING`, `approved_by = null`
-  - Does NOT create Attendance records yet
+- [ ] 🌐 `POST /api/v1/leaves` (already in #077) — add support for `status = PENDING` when `submit_as_request = true` flag is passed
+  - If `submit_as_request = true`: creates leave with `status = PENDING`, `approved_by = null`
+  - If `submit_as_request = false` (default): creates with `status = APPROVED` (existing behavior)
+  - Does NOT create Attendance records when `status = PENDING`
 - [ ] 🌐 `PATCH /api/v1/leaves/{id}/approve` — `ApproveLeaveController`
   - Sets `status = APPROVED`, `approved_by`, `approved_at`
-  - Creates/updates Attendance records for each date in range with `day_status = LEAVE`
-  - Validates leave is currently PENDING
+  - For `OPEN_ENDED` leaves: creates Attendance records with `day_status = LEAVE` for each date in range
+  - For `SCHEDULED` leaves: no attendance records created (leave context surfaced at runtime by #098 and CloseDayAction)
+  - Validates leave is currently `PENDING`; returns 422 if already APPROVED/REJECTED
 - [ ] 🌐 `PATCH /api/v1/leaves/{id}/reject` — `RejectLeaveController`
-  - Sets `status = REJECTED`, `approved_by`, `approved_at`
+  - Sets `status = REJECTED`, `approved_by`, `approved_at`, optional `rejection_note`
   - No attendance impact
-- [ ] 🧪 Feature tests:
-  - Submit request → status PENDING, no attendance records
-  - Approve request → status APPROVED, attendance records created with LEAVE status
-  - Reject request → status REJECTED, no attendance records
-  - Cannot approve an already APPROVED leave
-  - Check-in blocked after approval
+  - Validates leave is currently `PENDING`
+- [ ] 🔧 Update `CloseDayAction` (done in #055) to handle SCHEDULED approved partial leaves:
+  - If `time_mode = SCHEDULED` and employee worked but departed early per leave: leave overtime/early-out calculation to the payroll module (#072+)
+  - If `time_mode = SCHEDULED` and employee never checked in: same priority as full-day LEAVE (mark LEAVE, not ABSENCE)
+- [ ] 🧪 PHPUnit feature tests:
+  - Submit with `submit_as_request = true` → status PENDING, no attendance records created
+  - Submit with default → status APPROVED (regression, #077 behavior)
+  - Approve OPEN_ENDED request → status APPROVED, Attendance records with LEAVE created for each date
+  - Approve SCHEDULED partial → status APPROVED, no Attendance records created
+  - Reject request → status REJECTED, no attendance impact
+  - Cannot approve already APPROVED leave (422)
+  - Cannot reject already REJECTED leave (422)
   - Unauthorized access (401/403)
 
 ---
 
 ## ✅ Frontend Tasks
 
-- [ ] 🔧 `registerLeaveRequest(data)` + `approveLeave(id)` + `rejectLeave(id)` in `src/services/leave.service.ts`
-- [ ] 📱 **"Solicitar permiso" button** in the Ausencias tab (#078) — opens the same form but submits as PENDING
-  - Form shows a "solicitud" indicator vs "registro directo"
-- [ ] 📱 **Approve / Reject buttons** on PENDING rows in the Ausencias table (#078)
-  - Approve: confirmation dialog — "¿Aprobar ausencia del [fecha] al [fecha]? Se crearán los registros de asistencia."
-  - Reject: confirmation dialog with optional rejection note
-- [ ] 📱 After approve: row status badge → APPROVED; Today view shows LEAVE badge on affected days
-- [ ] 📱 After reject: row status badge → REJECTED; no attendance change
-- [ ] 🔧 `useLeaveActions(employeeId)` hook — owns approve/reject mutations and optimistic updates
+- [ ] 🔧 Add `approveLeave(id)` + `rejectLeave(id)` to `src/services/leave-api.ts` (or equivalent leave service)
+- [ ] 🔧 Update `RegisterLeaveForm` (from #077/#078) to expose a "Guardar como solicitud" toggle — when on, sends `submit_as_request: true`; hidden by default (default = direct registration)
+- [ ] 📱 **Approve / Reject buttons** on PENDING rows in Employee Detail → Leaves tab (#078):
+  - Approve: `AlertDialog` confirmation — "¿Aprobar permiso del [fecha] al [fecha]?" — Aprobar / Cancelar
+  - Reject: `AlertDialog` with optional `rejection_note` text input — Rechazar / Cancelar
+- [ ] 📱 After approve: row status badge → APPROVED (green); if OPEN_ENDED, Today view shows LEAVE badge on affected days via #098
+- [ ] 📱 After reject: row status badge → REJECTED (muted red); no attendance change
+- [ ] 🔧 `useLeaveActions(employeeId)` hook — owns approve/reject mutations, invalidates leaves list + today attendance queries on success
 
 ---
 
 ## 🧪 Tests
 
 - [ ] ✅ PHPUnit: all backend feature tests listed above
-- [ ] ✅ Vitest: `useLeaveActions` — approve mutation triggers attendance refetch; reject mutation updates row status
-- [ ] 🌲 Cypress E2E (happy path): Ausencias tab → "Solicitar permiso" → fill form → submit → row shows PENDING → click Approve → row shows APPROVED → Today view shows LEAVE badge
+- [ ] ✅ Vitest: `useLeaveActions` — approve mutation invalidates `['attendances', 'today']` and `['leaves', employeeId]`; reject mutation updates row status without touching attendance cache
+- [ ] 🌲 Cypress E2E (anticipated flow happy path):
+  - Employee Detail → Ausencias tab → "Registrar permiso" → toggle "Guardar como solicitud" → submit → row shows PENDING badge
+  - Click Approve on PENDING row → confirm dialog → row shows APPROVED badge
+- [ ] 🌲 Cypress E2E (express partial happy path):
+  - Employee Detail → Ausencias tab → "Registrar permiso" → fill times (PROPORTIONAL_HOURS) → submit (no PENDING toggle) → Today view card shows leave context chip (#098)
 
 ---
 
 ## 🎯 Acceptance Criteria
 
-- [ ] Solicitud creates a PENDING leave — no attendance impact yet
-- [ ] Approving creates LEAVE attendance records for all dates in range
-- [ ] Rejecting shows REJECTED status without touching attendance
-- [ ] Approve/Reject buttons visible only on PENDING rows
-- [ ] Check-in attempt on an approved leave day returns a clear 422 error
+- [ ] "Guardar como solicitud" toggle creates a PENDING leave without attendance impact
+- [ ] Approve button visible only on PENDING rows; clicking creates LEAVE attendance records (OPEN_ENDED only)
+- [ ] Reject button visible only on PENDING rows; clicking changes status to REJECTED only
+- [ ] Express partial leave (PROPORTIONAL_HOURS, APPROVED directly) surfaces as leave context chip in Today view
+- [ ] Cannot approve an already approved leave (UI hides button + API returns 422)
+- [ ] All actions show clear success/error toasts
 
 ---
 
 ## 🔗 References
 
 - **Backlog:** AP-050 · RF-25, RF-28
-- **Depends on:** #077 (leave foundation), #078 (employee leaves tab)
+- **Depends on:** #077 (leave foundation), #078 (employee leaves tab), #055 (CloseDayAction fix), #098 (Today view leave context)
 
 ---
 

--- a/doc/tasks/backlog/098-today-view-leave-context.md
+++ b/doc/tasks/backlog/098-today-view-leave-context.md
@@ -1,0 +1,97 @@
+# 📋 Task #098: Today View — Leave Context on Employee Cards
+
+## 📖 Story
+
+**English:**
+As a Manager, I want the Today view to show approved leave context on each employee's card (e.g., "Permiso c/g — sale a las 14:00" or "Día de permiso aprobado"), so I can quickly understand why an employee is absent or leaving early without navigating to their detail page.
+
+**Español:**
+Como Manager, quiero que la vista de Hoy muestre el contexto del permiso aprobado en cada tarjeta de empleado (ej. "Permiso c/g — sale a las 14:00" o "Día de permiso aprobado"), para entender rápidamente por qué un empleado está ausente o sale temprano sin navegar a su detalle.
+
+---
+
+## 🧠 Key Design Decisions
+
+- `TodayAttendanceController` already returns a row per employee. We add an optional `today_leave` field to each row.
+- `today_leave` is populated by a query: approved Leave records whose `start_date <= today <= end_date` for each employee.
+- The Leave model supports two `time_mode` values: `SCHEDULED` (fixed start/end times per day) and `OPEN_ENDED` (full day). Only `SCHEDULED` leaves expose `starts_at` / `ends_at` on the card.
+- The Leave model supports two `calculation_mode` values: `FIXED_PERCENTAGE` (fully paid/deducted) and `PROPORTIONAL_HOURS` (partial day). The card displays a "c/g" (con goce) or "s/g" (sin goce) badge based on whether the leave is paid.
+- Full-day OPEN_ENDED leaves: the employee should not show up — the card shows "Permiso aprobado (todo el día)" and hides action buttons.
+- Partial PROPORTIONAL_HOURS SCHEDULED leaves: employee shows up for part of the shift. The card shows context ("sale a las X:XX" or "llega a las X:XX") but action buttons remain active.
+- `today_leave` is `null` when no approved leave exists for today.
+
+---
+
+## ✅ Backend Tasks
+
+- [ ] 📝 Add `today_leave` field to `TodayAttendanceRow` API response (via `AttendanceResource` or a new `TodayLeaveResource`)
+  - Fields: `id`, `time_mode`, `calculation_mode`, `is_paid`, `starts_at` (nullable), `ends_at` (nullable), `note` (nullable)
+- [ ] 🔧 Update `TodayAttendanceController` query: eager-load approved leaves for each employee covering today's date
+  - Use `whereDate('start_date', '<=', $today)->whereDate('end_date', '>=', $today)->where('status', 'APPROVED')`
+  - Take only the first matching leave per employee (most recent if multiple)
+- [ ] 🧪 PHPUnit feature tests:
+  - Employee with approved full-day leave today → `today_leave` present, `time_mode = OPEN_ENDED`
+  - Employee with approved partial leave today → `today_leave` present, `time_mode = SCHEDULED`, `starts_at`/`ends_at` populated
+  - Employee with no leave → `today_leave = null`
+  - Employee with PENDING leave → `today_leave = null` (only APPROVED counts)
+  - Employee with REJECTED leave → `today_leave = null`
+
+## ✅ Frontend Tasks
+
+- [ ] 📝 Add `TodayLeave` type to `src/types/attendance.ts`:
+  ```ts
+  interface TodayLeave {
+    id: string
+    time_mode: 'SCHEDULED' | 'OPEN_ENDED'
+    calculation_mode: 'FIXED_PERCENTAGE' | 'PROPORTIONAL_HOURS'
+    is_paid: boolean
+    starts_at: string | null  // ISO UTC
+    ends_at: string | null    // ISO UTC
+    note: string | null
+  }
+  ```
+- [ ] 📝 Add `today_leave: TodayLeave | null` to `TodayAttendanceRow` type
+- [ ] 📱 **Leave context chip** on `EmployeeAttendanceCard`:
+  - If `today_leave` is present and `time_mode = OPEN_ENDED`: show `CalendarX` icon + "Permiso aprobado" chip (blue/info) — hide "Registrar entrada" and "Marcar falta" buttons
+  - If `today_leave` is present and `time_mode = SCHEDULED`:
+    - If `starts_at` is after now: "Llega a las HH:mm (permiso)" chip
+    - If `ends_at` is before now: "Salió a las HH:mm (permiso)" chip
+    - Otherwise: "Permiso c/g hasta HH:mm" or "Permiso s/g hasta HH:mm" chip
+  - Chip shows `c/g` (con goce) when `is_paid = true`, `s/g` (sin goce) when `false`
+- [ ] 🔧 Update `EmployeeAttendanceCardProps` — add `row.today_leave` (already on the row, no new prop needed)
+
+---
+
+## 🧪 Tests
+
+- [ ] ✅ PHPUnit: all backend feature tests listed above
+- [ ] ✅ Vitest: `EmployeeAttendanceCard` — renders leave chip for OPEN_ENDED leave, hides action buttons; renders partial leave chip for SCHEDULED leave with times; no chip when `today_leave = null`
+- [ ] 🌲 Cypress E2E (happy path): Employee with pre-seeded approved leave → Today view shows the leave chip on their card
+
+---
+
+## 🎯 Acceptance Criteria
+
+- [ ] Employee card shows leave context chip when an approved leave covers today
+- [ ] Full-day leave: action buttons are hidden (no "Registrar entrada" or "Marcar falta")
+- [ ] Partial leave: action buttons remain active; chip shows departure or arrival time
+- [ ] c/g / s/g badge correctly reflects `is_paid`
+- [ ] No leave → no chip, no change in behavior
+
+---
+
+## 🔗 References
+
+- **Backlog:** AP-050 · RF-25, RF-28
+- **Depends on:** #077 (Leave model), #055 (Today card redesign)
+- **Blocks:** #096 (leave request flow — Today view must display the leave before the flow is complete)
+
+---
+
+## ⏱️ Estimates
+
+- **Optimistic:** `2h` · **Pessimistic:** `3.5h`
+
+---
+
+> **GitHub Issue:** pakodiazdev/sushigo#104


### PR DESCRIPTION
## Summary

- **`DayStatusRequest`** now accepts only `ABSENCE`; sending `DAY_OFF` returns 422 — rest days are system-managed
- **`CloseDayAction`** auto-classifies absent employees: approved leave → `LEAVE`, schedule rest day → `DAY_OFF`, otherwise → `ABSENCE` (override-aware, same logic as `ResolvesEffectiveScheduleDay`)
- **`EmployeeAttendanceCard`** redesigned: dropdown removed, single "Marcar falta" button with `ConfirmDialog` confirmation; scheduled rest days show a read-only "Descanso programado" chip and no action buttons
- **`RegisterLeaveDialog`** removed from the Today view — leave registration belongs in Employee Detail (#077/#078)

## Changes

### Backend
- `DayStatusRequest` — `day_status` accepts only `ABSENCE`
- `CloseDayAction` — priority logic LEAVE → DAY_OFF → ABSENCE; response adds `leaves` + `day_offs` counters
- `MarkDayStatusApiTest` — updated: `marks_day_as_day_off` → `rejects_day_off_status` (422)
- `CloseDayApiTest` — +3 tests: approved leave → LEAVE, rest day → DAY_OFF, LEAVE wins over DAY_OFF

### Frontend
- `EmployeeAttendanceCard` — "Marcar falta" button + `ConfirmDialog`; `isScheduledRestDay` chip
- `-use-today-attendance-page.ts` — removed `pendingLeaveEmployee`/`openRegisterLeave`/`closeRegisterLeave`
- `today.tsx` — removed `RegisterLeaveDialog` and `onRegisterLeave` wiring
- Vitest: updated card tests for new design; Cypress E2E: single spec for "Marcar falta" flow

### Tasks
- `055-day-status-mark.md` — scope updated
- `096-leave-request.md` — rewritten (anticipated + express + approve/reject)
- `057-partial-leave-register.md` / `058-partial-leave-history.md` — deprecated
- `098-today-view-leave-context.md` — new (Today view leave chip)

## Test plan

- [ ] `php artisan test --filter=MarkDayStatusApiTest` — 10 tests pass
- [ ] `php artisan test --filter=CloseDayApiTest` — 17 tests pass (3 new)
- [ ] `npm run lint && npm run typecheck` — 0 errors
- [ ] `npx vitest run` — 1422 tests pass
- [ ] Cypress E2E: `attendance-day-status` spec — Marcar falta button + dialog flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)