### PR TITLE
✨ [#109] - Add dev debug login to DevDebugger panel

### DIFF
--- a/code/api/.env.example
+++ b/code/api/.env.example
@@ -78,3 +78,12 @@ PASSWORD_RESET_EXPIRE=60
 # Testing — enable FileTokenRecorder to write reset links to storage/testing/
 # Required for Cypress E2E tests (test:getResetLink task). Must be false in production.
 LOG_RESET_LINK=false
+
+# Dev Debug Login
+# ---------------
+# Enables the quick user-switch feature in the DevDebugger panel.
+# LOGIN_WITH_DEVDEBUG must be exactly 'true' to activate.
+# DEV_LOGIN_ALLOWED_ENVIRONMENTS is a csv list of allowed APP_ENV values.
+# CRITICAL: 'production' must NEVER appear in DEV_LOGIN_ALLOWED_ENVIRONMENTS.
+LOGIN_WITH_DEVDEBUG=false
+DEV_LOGIN_ALLOWED_ENVIRONMENTS=dev,devtest

--- a/code/api/app/Exceptions/DevLoginMisconfigurationException.php
+++ b/code/api/app/Exceptions/DevLoginMisconfigurationException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+class DevLoginMisconfigurationException extends RuntimeException {}

--- a/code/api/app/Http/Controllers/Api/V1/Dev/DevLoginController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Dev/DevLoginController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Dev;
+
+use App\Http\Controllers\Controller;
+use App\Http\Responses\Auth\AuthTokenResponse;
+use App\Models\User;
+use App\Support\DevLoginGuard;
+use Illuminate\Http\Request;
+
+class DevLoginController extends Controller
+{
+    public function __invoke(Request $request): AuthTokenResponse
+    {
+        DevLoginGuard::validate();
+
+        $validated = $request->validate([
+            'user_id' => ['required', 'integer'],
+        ]);
+
+        $user = User::find($validated['user_id']);
+
+        if (! $user) {
+            abort(404);
+        }
+
+        $token = $user->createToken('dev-debug')->accessToken;
+
+        return new AuthTokenResponse(token: $token, user: $user);
+    }
+}

--- a/code/api/app/Http/Controllers/Api/V1/Dev/ListDevUsersController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Dev/ListDevUsersController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Dev;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use App\Support\DevLoginGuard;
+use Illuminate\Http\JsonResponse;
+
+class ListDevUsersController extends Controller
+{
+    public function __invoke(): JsonResponse
+    {
+        DevLoginGuard::validate();
+
+        $users = User::with('roles')->orderBy('name')->get();
+
+        return response()->json([
+            'status' => 200,
+            'data' => $users->map(fn (User $user) => [
+                'id' => $user->id,
+                'name' => $user->name,
+                'email' => $user->email,
+                'roles' => $user->roles->map(fn ($role) => [
+                    'id' => $role->id,
+                    'name' => $role->name,
+                ]),
+            ]),
+        ]);
+    }
+}

--- a/code/api/app/Http/Controllers/Api/V1/Dev/ListDevUsersController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Dev/ListDevUsersController.php
@@ -13,7 +13,7 @@ class ListDevUsersController extends Controller
     {
         DevLoginGuard::validate();
 
-        $users = User::with('roles')->orderBy('name')->get();
+        $users = User::with(['roles', 'permissions'])->orderBy('name')->get();
 
         return response()->json([
             'status' => 200,
@@ -22,6 +22,7 @@ class ListDevUsersController extends Controller
                 'name' => $user->name,
                 'email' => $user->email,
                 'roles' => $user->roles->pluck('name')->values(),
+                'permissions' => $user->getAllPermissions()->pluck('name')->sort()->values(),
             ]),
         ]);
     }

--- a/code/api/app/Http/Controllers/Api/V1/Dev/ListDevUsersController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Dev/ListDevUsersController.php
@@ -21,10 +21,7 @@ class ListDevUsersController extends Controller
                 'id' => $user->id,
                 'name' => $user->name,
                 'email' => $user->email,
-                'roles' => $user->roles->map(fn ($role) => [
-                    'id' => $role->id,
-                    'name' => $role->name,
-                ]),
+                'roles' => $user->roles->pluck('name')->values(),
             ]),
         ]);
     }

--- a/code/api/app/Support/DevLoginGuard.php
+++ b/code/api/app/Support/DevLoginGuard.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Support;
+
+use RuntimeException;
+
+class DevLoginGuard
+{
+    /**
+     * Validates that the dev-debug login feature is enabled and the current
+     * environment is in the allowed list. Aborts with 404 if any condition
+     * fails — the endpoints appear non-existent to callers.
+     *
+     * Throws a RuntimeException if 'production' is in the allowed list,
+     * because that is always a critical misconfiguration.
+     */
+    public static function validate(): void
+    {
+        $allowedEnvs = array_map(
+            'trim',
+            explode(',', (string) config('devlogin.allowed_environments', ''))
+        );
+
+        if (in_array('production', $allowedEnvs, strict: true)) {
+            throw new RuntimeException(
+                'DEV_LOGIN_ALLOWED_ENVIRONMENTS must not contain "production". This is a critical misconfiguration.'
+            );
+        }
+
+        $flagEnabled = config('devlogin.enabled') === true;
+
+        if (! $flagEnabled) {
+            abort(404);
+        }
+
+        $currentEnv = app()->environment();
+
+        if (! in_array($currentEnv, $allowedEnvs, strict: true)) {
+            abort(404);
+        }
+    }
+}

--- a/code/api/app/Support/DevLoginGuard.php
+++ b/code/api/app/Support/DevLoginGuard.php
@@ -2,7 +2,7 @@
 
 namespace App\Support;
 
-use RuntimeException;
+use App\Exceptions\DevLoginMisconfigurationException;
 
 class DevLoginGuard
 {
@@ -22,7 +22,7 @@ class DevLoginGuard
         );
 
         if (in_array('production', $allowedEnvs, strict: true)) {
-            throw new RuntimeException(
+            throw new DevLoginMisconfigurationException(
                 'DEV_LOGIN_ALLOWED_ENVIRONMENTS must not contain "production". This is a critical misconfiguration.'
             );
         }

--- a/code/api/app/Support/DevLoginGuard.php
+++ b/code/api/app/Support/DevLoginGuard.php
@@ -17,7 +17,7 @@ class DevLoginGuard
     public static function validate(): void
     {
         $allowedEnvs = array_map(
-            'trim',
+            fn ($e) => strtolower(trim($e)),
             explode(',', (string) config('devlogin.allowed_environments', ''))
         );
 
@@ -33,7 +33,7 @@ class DevLoginGuard
             abort(404);
         }
 
-        $currentEnv = app()->environment();
+        $currentEnv = strtolower(app()->environment());
 
         if (! in_array($currentEnv, $allowedEnvs, strict: true)) {
             abort(404);

--- a/code/api/config/devlogin.php
+++ b/code/api/config/devlogin.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Dev Debug Login
+    |--------------------------------------------------------------------------
+    |
+    | Controls the quick user-switch feature in the DevDebugger panel.
+    | Both conditions must be true for the endpoints to respond (non-404):
+    |
+    |   1. LOGIN_WITH_DEVDEBUG must be exactly 'true'
+    |   2. APP_ENV must be in DEV_LOGIN_ALLOWED_ENVIRONMENTS (csv)
+    |
+    | If 'production' appears in DEV_LOGIN_ALLOWED_ENVIRONMENTS, a
+    | RuntimeException is thrown — this is always a misconfiguration.
+    |
+    */
+
+    'enabled' => (bool) env('LOGIN_WITH_DEVDEBUG', false),
+
+    'allowed_environments' => env('DEV_LOGIN_ALLOWED_ENVIRONMENTS', 'dev,devtest'),
+];

--- a/code/api/config/devlogin.php
+++ b/code/api/config/devlogin.php
@@ -17,7 +17,7 @@ return [
     |
     */
 
-    'enabled' => (bool) env('LOGIN_WITH_DEVDEBUG', false),
+    'enabled' => env('LOGIN_WITH_DEVDEBUG', false) === true,
 
     'allowed_environments' => env('DEV_LOGIN_ALLOWED_ENVIRONMENTS', 'dev,devtest'),
 ];

--- a/code/api/routes/api.php
+++ b/code/api/routes/api.php
@@ -16,6 +16,8 @@ use App\Http\Controllers\Api\V1\Auth\MeController;
 use App\Http\Controllers\Api\V1\Auth\RegisterController;
 use App\Http\Controllers\Api\V1\Auth\ResetPasswordController;
 use App\Http\Controllers\Api\V1\Auth\VerifyResetTokenController;
+use App\Http\Controllers\Api\V1\Dev\DevLoginController;
+use App\Http\Controllers\Api\V1\Dev\ListDevUsersController;
 use App\Http\Controllers\Api\V1\Employees\AssignableRolesController;
 use App\Http\Controllers\Api\V1\Employees\CreateEmployeeController;
 use App\Http\Controllers\Api\V1\Employees\CreateWageController;
@@ -89,6 +91,12 @@ if (app()->environment('testing', 'local', 'dev', 'devtest')) {
 
             return response()->json(['link' => $link]);
         })->name('reset-link');
+    });
+
+    // ── Dev debug login routes ────────────────────────────────────────────
+    Route::prefix('v1/dev')->name('dev.')->group(function () {
+        Route::get('users', ListDevUsersController::class)->name('users');
+        Route::post('login', DevLoginController::class)->name('login');
     });
 }
 

--- a/code/api/tests/Feature/Dev/DevLoginTest.php
+++ b/code/api/tests/Feature/Dev/DevLoginTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Dev;
 
+use App\Exceptions\DevLoginMisconfigurationException;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
@@ -120,7 +121,7 @@ class DevLoginTest extends TestCase
 
         $this->withoutExceptionHandling();
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(DevLoginMisconfigurationException::class);
 
         $this->getJson('/api/v1/dev/users');
     }

--- a/code/api/tests/Feature/Dev/DevLoginTest.php
+++ b/code/api/tests/Feature/Dev/DevLoginTest.php
@@ -68,7 +68,7 @@ class DevLoginTest extends TestCase
             ->assertJsonStructure([
                 'status',
                 'data' => [
-                    '*' => ['id', 'name', 'email', 'roles'],
+                    '*' => ['id', 'name', 'email', 'roles', 'permissions'],
                 ],
             ]);
 

--- a/code/api/tests/Feature/Dev/DevLoginTest.php
+++ b/code/api/tests/Feature/Dev/DevLoginTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Tests\Feature\Dev;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Laravel\Passport\Client;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class DevLoginTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Client::factory()->asPersonalAccessTokenClient()->create([
+            'provider' => 'users',
+        ]);
+    }
+
+    private function enableDevLogin(): void
+    {
+        Config::set('devlogin.enabled', true);
+        Config::set('devlogin.allowed_environments', 'testing,local,dev');
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /api/v1/dev/users
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function list_dev_users_returns_404_when_feature_is_disabled(): void
+    {
+        Config::set('devlogin.enabled', false);
+        Config::set('devlogin.allowed_environments', 'testing,local,dev');
+
+        $response = $this->getJson('/api/v1/dev/users');
+
+        $response->assertStatus(404);
+    }
+
+    #[Test]
+    public function list_dev_users_returns_404_when_environment_not_in_allowed_list(): void
+    {
+        Config::set('devlogin.enabled', true);
+        Config::set('devlogin.allowed_environments', 'local,dev');
+
+        $response = $this->getJson('/api/v1/dev/users');
+
+        $response->assertStatus(404);
+    }
+
+    #[Test]
+    public function list_dev_users_returns_users_when_feature_is_enabled(): void
+    {
+        $this->enableDevLogin();
+
+        User::factory()->count(3)->create();
+
+        $response = $this->getJson('/api/v1/dev/users');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'status',
+                'data' => [
+                    '*' => ['id', 'name', 'email', 'roles'],
+                ],
+            ]);
+
+        $this->assertCount(3, $response->json('data'));
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /api/v1/dev/login
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function dev_login_returns_token_for_valid_user_id(): void
+    {
+        $this->enableDevLogin();
+
+        $user = User::factory()->create();
+
+        $response = $this->postJson('/api/v1/dev/login', [
+            'user_id' => $user->id,
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'status',
+                'data' => ['token', 'token_type', 'user'],
+            ]);
+    }
+
+    #[Test]
+    public function dev_login_returns_404_for_invalid_user_id(): void
+    {
+        $this->enableDevLogin();
+
+        $response = $this->postJson('/api/v1/dev/login', [
+            'user_id' => 99999,
+        ]);
+
+        $response->assertStatus(404);
+    }
+
+    // -------------------------------------------------------------------------
+    // Security: production in allowed environments
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function guard_throws_runtime_exception_when_production_in_allowed_environments(): void
+    {
+        Config::set('devlogin.enabled', true);
+        Config::set('devlogin.allowed_environments', 'production,testing');
+
+        $this->withoutExceptionHandling();
+
+        $this->expectException(\RuntimeException::class);
+
+        $this->getJson('/api/v1/dev/users');
+    }
+}

--- a/code/webapp/.env.example
+++ b/code/webapp/.env.example
@@ -37,3 +37,12 @@ VITE_TIME_FORMAT=12
 # 'false' = visible on startup (default local development)
 # 'true'  = hidden on startup (recommended for E2E/devtest)
 VITE_DEV_DEBUGGER_START_HIDDEN=false
+
+# Dev Debug Login
+# ---------------
+# Mirrors the backend LOGIN_WITH_DEVDEBUG / DEV_LOGIN_ALLOWED_ENVIRONMENTS.
+# The frontend uses these to skip API calls when the feature is disabled.
+# VITE_APP_ENV must match APP_ENV on the backend.
+VITE_LOGIN_WITH_DEVDEBUG=false
+VITE_DEV_LOGIN_ALLOWED_ENVIRONMENTS=dev,devtest
+VITE_APP_ENV=production

--- a/code/webapp/cypress/e2e/dev-debug-login.cy.ts
+++ b/code/webapp/cypress/e2e/dev-debug-login.cy.ts
@@ -18,11 +18,11 @@
  */
 
 before(() => {
-  cy.task('test:reset', null, { timeout: 60_000 })
+    cy.task('test:reset', null, { timeout: 60_000 })
 })
 
 beforeEach(() => {
-  cy.clearLocalStorage()
+    cy.clearLocalStorage()
 })
 
 // ══════════════════════════════════════════════════════════════════════════════
@@ -30,53 +30,53 @@ beforeEach(() => {
 // ══════════════════════════════════════════════════════════════════════════════
 
 describe('Dev Debug Login — Happy Path', () => {
-  it('muestra la sección Dev Login en el DevDebugger cuando no hay sesión', () => {
-    cy.visit('/login')
+    it('muestra la sección Dev Login en el DevDebugger cuando no hay sesión', () => {
+        cy.visit('/login')
 
-    // Show DevDebugger (hidden by default in e2e — trigger with Ctrl+Shift+D)
-    cy.get('body').type('{ctrl}{shift}d')
+        // Show DevDebugger (hidden by default in e2e — trigger with Ctrl+Shift+D)
+        cy.get('body').type('{ctrl}{shift}d')
 
-    cy.contains('Dev Debugger', { timeout: 5_000 }).should('be.visible')
-    cy.contains('Dev Login').should('be.visible')
-  })
-
-  it('lista usuarios y permite iniciar sesión sin contraseña', () => {
-    cy.visit('/login')
-
-    cy.get('body').type('{ctrl}{shift}d')
-    cy.contains('Dev Login', { timeout: 5_000 }).should('be.visible')
-
-    // Users should appear (seeded by test:reset)
-    cy.get('[data-testid="dev-login-user"]', { timeout: 10_000 })
-      .should('have.length.at.least', 1)
-      .first()
-      .click()
-
-    // After clicking, should be authenticated and redirected away from login
-    cy.url({ timeout: 15_000 }).should('not.include', '/login')
-
-    // Auth state persisted in localStorage
-    cy.window().then((win) => {
-      const raw = win.localStorage.getItem('auth-storage')
-      expect(raw).to.exist
-      const { state } = JSON.parse(raw!)
-      expect(state.token).to.exist
-      expect(state.isAuthenticated).to.be.true
+        cy.contains('Dev Debugger', { timeout: 5_000 }).should('be.visible')
+        cy.contains('Dev Login').should('be.visible')
     })
-  })
 
-  it('filtra usuarios por nombre con el buscador local', () => {
-    cy.visit('/login')
+    it('lista usuarios y permite iniciar sesión sin contraseña', () => {
+        cy.visit('/login')
 
-    cy.get('body').type('{ctrl}{shift}d')
-    cy.contains('Dev Login', { timeout: 5_000 }).should('be.visible')
+        cy.get('body').type('{ctrl}{shift}d')
+        cy.contains('Dev Login', { timeout: 5_000 }).should('be.visible')
 
-    // Wait for list to load
-    cy.get('[data-testid="dev-login-user"]', { timeout: 10_000 }).should('exist')
+        // Users should appear (seeded by test:reset)
+        cy.get('[data-testid="dev-login-user"]', { timeout: 10_000 })
+            .should('have.length.at.least', 1)
+            .first()
+            .click()
 
-    // Type something that should filter to 0 or fewer results
-    cy.get('[placeholder="Buscar usuario..."]').type('zzznoresult')
-    cy.contains('Sin resultados').should('be.visible')
-    cy.get('[data-testid="dev-login-user"]').should('not.exist')
-  })
+        // After clicking, should be authenticated and redirected away from login
+        cy.url({ timeout: 15_000 }).should('not.include', '/login')
+
+        // Auth state persisted in localStorage
+        cy.window().then((win) => {
+            const raw = win.localStorage.getItem('auth-storage')
+            expect(raw).to.exist
+            const { state } = JSON.parse(raw!)
+            expect(state.token).to.exist
+            expect(state.isAuthenticated).to.be.true
+        })
+    })
+
+    it('filtra usuarios por nombre con el buscador local', () => {
+        cy.visit('/login')
+
+        cy.get('body').type('{ctrl}{shift}d')
+        cy.contains('Dev Login', { timeout: 5_000 }).should('be.visible')
+
+        // Wait for list to load
+        cy.get('[data-testid="dev-login-user"]', { timeout: 10_000 }).should('exist')
+
+        // Type something that should filter to 0 or fewer results
+        cy.get('[placeholder="Buscar usuario..."]').type('zzznoresult')
+        cy.contains('Sin resultados').should('be.visible')
+        cy.get('[data-testid="dev-login-user"]').should('not.exist')
+    })
 })

--- a/code/webapp/cypress/e2e/dev-debug-login.cy.ts
+++ b/code/webapp/cypress/e2e/dev-debug-login.cy.ts
@@ -1,0 +1,82 @@
+/**
+ * Dev Debug Login — E2E tests (Happy Path Only)
+ *
+ * Per testing strategy (doc/conventions/testing/testing-strategy.md):
+ * - Cypress tests ONLY the happy path
+ * - Security/env guard cases → PHPUnit (tests/Feature/Dev/DevLoginTest.php)
+ * - isDevLoginEnabled() logic → Vitest (dev-login-enabled.test.ts)
+ *
+ * Requires in the test environment:
+ *   VITE_LOGIN_WITH_DEVDEBUG=true
+ *   VITE_APP_ENV=local    (or whichever value is in VITE_DEV_LOGIN_ALLOWED_ENVIRONMENTS)
+ *   LOGIN_WITH_DEVDEBUG=true  (API side)
+ *
+ * DB reset strategy
+ * ─────────────────
+ * • before()     → cy.task('test:reset') ONCE per file (~3-5s).
+ * • beforeEach() → cy.clearLocalStorage() only (milliseconds).
+ */
+
+before(() => {
+  cy.task('test:reset', null, { timeout: 60_000 })
+})
+
+beforeEach(() => {
+  cy.clearLocalStorage()
+})
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Happy Path — Dev Login via DevDebugger
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('Dev Debug Login — Happy Path', () => {
+  it('muestra la sección Dev Login en el DevDebugger cuando no hay sesión', () => {
+    cy.visit('/login')
+
+    // Show DevDebugger (hidden by default in e2e — trigger with Ctrl+Shift+D)
+    cy.get('body').type('{ctrl}{shift}d')
+
+    cy.contains('Dev Debugger', { timeout: 5_000 }).should('be.visible')
+    cy.contains('Dev Login').should('be.visible')
+  })
+
+  it('lista usuarios y permite iniciar sesión sin contraseña', () => {
+    cy.visit('/login')
+
+    cy.get('body').type('{ctrl}{shift}d')
+    cy.contains('Dev Login', { timeout: 5_000 }).should('be.visible')
+
+    // Users should appear (seeded by test:reset)
+    cy.get('[data-testid="dev-login-user"]', { timeout: 10_000 })
+      .should('have.length.at.least', 1)
+      .first()
+      .click()
+
+    // After clicking, should be authenticated and redirected away from login
+    cy.url({ timeout: 15_000 }).should('not.include', '/login')
+
+    // Auth state persisted in localStorage
+    cy.window().then((win) => {
+      const raw = win.localStorage.getItem('auth-storage')
+      expect(raw).to.exist
+      const { state } = JSON.parse(raw!)
+      expect(state.token).to.exist
+      expect(state.isAuthenticated).to.be.true
+    })
+  })
+
+  it('filtra usuarios por nombre con el buscador local', () => {
+    cy.visit('/login')
+
+    cy.get('body').type('{ctrl}{shift}d')
+    cy.contains('Dev Login', { timeout: 5_000 }).should('be.visible')
+
+    // Wait for list to load
+    cy.get('[data-testid="dev-login-user"]', { timeout: 10_000 }).should('exist')
+
+    // Type something that should filter to 0 or fewer results
+    cy.get('[placeholder="Buscar usuario..."]').type('zzznoresult')
+    cy.contains('Sin resultados').should('be.visible')
+    cy.get('[data-testid="dev-login-user"]').should('not.exist')
+  })
+})

--- a/code/webapp/src/components/dev/DevDebugger.tsx
+++ b/code/webapp/src/components/dev/DevDebugger.tsx
@@ -52,12 +52,12 @@ export function DevDebugger() {
 
     const [permissionInputFocused, setPermissionInputFocused] = useState(false)
 
-    const permissionDropdownItems =
-        devLoginPermissionSearch.length > 0
-            ? devLoginPermissionSuggestions
-            : permissionInputFocused
-              ? devLoginAllPermissions
-              : []
+    let permissionDropdownItems: string[] = []
+    if (devLoginPermissionSearch.length > 0) {
+        permissionDropdownItems = devLoginPermissionSuggestions
+    } else if (permissionInputFocused) {
+        permissionDropdownItems = devLoginAllPermissions
+    }
 
     if (isHidden) {
         return null

--- a/code/webapp/src/components/dev/DevDebugger.tsx
+++ b/code/webapp/src/components/dev/DevDebugger.tsx
@@ -201,31 +201,37 @@ export function DevDebugger() {
                         badge={devUsers?.length}
                     >
                         <div className="space-y-2">
-                            <div className="relative">
-                                <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-gray-400" />
-                                <input
-                                    type="text"
-                                    placeholder="Buscar usuario..."
-                                    value={devLoginSearch}
-                                    onChange={(e) => setDevLoginSearch(e.target.value)}
-                                    className="w-full bg-gray-700 text-white text-xs rounded pl-7 pr-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-blue-500"
-                                />
+                            <div className="space-y-1">
+                                <p className="text-[10px] font-medium text-gray-500 uppercase tracking-wide">Usuario</p>
+                                <div className="relative">
+                                    <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-gray-400" />
+                                    <input
+                                        type="text"
+                                        placeholder="Buscar usuario..."
+                                        value={devLoginSearch}
+                                        onChange={(e) => setDevLoginSearch(e.target.value)}
+                                        className="w-full bg-gray-700 text-white text-xs rounded pl-7 pr-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                                    />
+                                </div>
                             </div>
                             {devLoginAllRoles.length > 0 && (
-                                <div className="flex flex-wrap gap-1">
-                                    {devLoginAllRoles.map((role) => (
-                                        <button
-                                            key={role}
-                                            onClick={() =>
-                                                setDevLoginRoleFilter(
-                                                    devLoginRoleFilter === role ? null : role,
-                                                )
-                                            }
-                                            className={`text-[10px] px-1.5 py-0.5 rounded border transition-opacity ${getRoleColor(role, devLoginAllRoles)} ${devLoginRoleFilter && devLoginRoleFilter !== role ? 'opacity-40' : 'opacity-100'}`}
-                                        >
-                                            {role}
-                                        </button>
-                                    ))}
+                                <div className="space-y-1">
+                                    <p className="text-[10px] font-medium text-gray-500 uppercase tracking-wide">Rol</p>
+                                    <div className="flex flex-wrap gap-1">
+                                        {devLoginAllRoles.map((role) => (
+                                            <button
+                                                key={role}
+                                                onClick={() =>
+                                                    setDevLoginRoleFilter(
+                                                        devLoginRoleFilter === role ? null : role,
+                                                    )
+                                                }
+                                                className={`text-[10px] px-1.5 py-0.5 rounded border transition-opacity ${getRoleColor(role, devLoginAllRoles)} ${devLoginRoleFilter && devLoginRoleFilter !== role ? 'opacity-40' : 'opacity-100'}`}
+                                            >
+                                                {role}
+                                            </button>
+                                        ))}
+                                    </div>
                                 </div>
                             )}
                             {isLoadingDevUsers && (

--- a/code/webapp/src/components/dev/DevDebugger.tsx
+++ b/code/webapp/src/components/dev/DevDebugger.tsx
@@ -28,6 +28,10 @@ export function DevDebugger() {
         isAdmin,
         token,
         devLoginSectionVisible,
+        devLoginAllRoles,
+        devLoginRoleFilter,
+        setDevLoginRoleFilter,
+        devLoginFilteredUsers,
         devUsers,
         isLoadingDevUsers,
         cacheStats,
@@ -207,6 +211,23 @@ export function DevDebugger() {
                                     className="w-full bg-gray-700 text-white text-xs rounded pl-7 pr-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-blue-500"
                                 />
                             </div>
+                            {devLoginAllRoles.length > 0 && (
+                                <div className="flex flex-wrap gap-1">
+                                    {devLoginAllRoles.map((role) => (
+                                        <button
+                                            key={role}
+                                            onClick={() =>
+                                                setDevLoginRoleFilter(
+                                                    devLoginRoleFilter === role ? null : role,
+                                                )
+                                            }
+                                            className={`text-[10px] px-1.5 py-0.5 rounded border transition-opacity ${getRoleColor(role, devLoginAllRoles)} ${devLoginRoleFilter && devLoginRoleFilter !== role ? 'opacity-40' : 'opacity-100'}`}
+                                        >
+                                            {role}
+                                        </button>
+                                    ))}
+                                </div>
+                            )}
                             {isLoadingDevUsers && (
                                 <div className="space-y-1">
                                     {[1, 2, 3].map((i) => (
@@ -214,18 +235,12 @@ export function DevDebugger() {
                                     ))}
                                 </div>
                             )}
-                            {devUsers && (() => {
-                                const q = devLoginSearch.toLowerCase()
-                                const filtered = devUsers.filter(
-                                    (u) =>
-                                        u.name.toLowerCase().includes(q) ||
-                                        u.email.toLowerCase().includes(q),
-                                )
-                                return filtered.length === 0 ? (
+                            {devUsers && (
+                                devLoginFilteredUsers.length === 0 ? (
                                     <p className="text-xs text-gray-400">Sin resultados</p>
                                 ) : (
-                                    <div className="space-y-1 max-h-40 overflow-y-auto pr-0.5">
-                                        {filtered.map((devUser) => (
+                                    <div className="space-y-1 max-h-48 overflow-y-auto pr-0.5">
+                                        {devLoginFilteredUsers.map((devUser) => (
                                             <button
                                                 key={devUser.id}
                                                 data-testid="dev-login-user"
@@ -233,9 +248,21 @@ export function DevDebugger() {
                                                 disabled={loggingInUserId !== null}
                                                 className="w-full flex items-center justify-between gap-2 px-2 py-1.5 rounded bg-gray-700 hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-left"
                                             >
-                                                <div className="min-w-0">
+                                                <div className="min-w-0 space-y-0.5">
                                                     <p className="text-xs text-white truncate">{devUser.name}</p>
                                                     <p className="text-xs text-gray-400 truncate">{devUser.email}</p>
+                                                    {devUser.roles.length > 0 && (
+                                                        <div className="flex flex-wrap gap-0.5">
+                                                            {devUser.roles.map((role) => (
+                                                                <span
+                                                                    key={role}
+                                                                    className={`text-[9px] px-1 py-0 rounded border ${getRoleColor(role, devLoginAllRoles)}`}
+                                                                >
+                                                                    {role}
+                                                                </span>
+                                                            ))}
+                                                        </div>
+                                                    )}
                                                 </div>
                                                 {loggingInUserId === devUser.id ? (
                                                     <Loader2 className="h-3 w-3 text-blue-400 shrink-0 animate-spin" />
@@ -246,7 +273,7 @@ export function DevDebugger() {
                                         ))}
                                     </div>
                                 )
-                            })()}
+                            )}
                         </div>
                     </Section>
                 )}
@@ -279,6 +306,29 @@ export function DevDebugger() {
             </div>
         </div>
     )
+}
+
+const ROLE_COLORS: Record<string, string> = {
+    'super-admin': 'bg-red-500/20 text-red-300 border-red-500/40',
+    admin: 'bg-orange-500/20 text-orange-300 border-orange-500/40',
+    'inventory-manager': 'bg-blue-500/20 text-blue-300 border-blue-500/40',
+    cashier: 'bg-green-500/20 text-green-300 border-green-500/40',
+    manager: 'bg-purple-500/20 text-purple-300 border-purple-500/40',
+    staff: 'bg-teal-500/20 text-teal-300 border-teal-500/40',
+}
+
+const ROLE_FALLBACK_COLORS = [
+    'bg-yellow-500/20 text-yellow-300 border-yellow-500/40',
+    'bg-pink-500/20 text-pink-300 border-pink-500/40',
+    'bg-indigo-500/20 text-indigo-300 border-indigo-500/40',
+    'bg-cyan-500/20 text-cyan-300 border-cyan-500/40',
+]
+
+function getRoleColor(role: string, allRoles: string[]): string {
+    const known = ROLE_COLORS[role]
+    if (known) return known
+    const index = allRoles.indexOf(role) % ROLE_FALLBACK_COLORS.length
+    return ROLE_FALLBACK_COLORS[index] ?? ROLE_FALLBACK_COLORS[0] ?? 'bg-gray-500/20 text-gray-300 border-gray-500/40'
 }
 
 interface SectionProps {

--- a/code/webapp/src/components/dev/DevDebugger.tsx
+++ b/code/webapp/src/components/dev/DevDebugger.tsx
@@ -8,10 +8,16 @@ import {
     ChevronDown,
     ChevronUp,
     RefreshCw,
+    LogIn,
+    Search,
+    Loader2,
     type LucideIcon
 } from 'lucide-react'
 import { useAuthStore } from '@/stores/auth.store'
-import { useQueryClient } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import type { User as AuthUser } from '@/types/auth'
+import { isDevLoginEnabled } from './dev-login-enabled'
+import { listDevUsers, loginAs, type DevUser } from '@/services/dev-api'
 
 interface DebuggerState {
     position: { x: number; y: number }
@@ -19,6 +25,7 @@ interface DebuggerState {
         user: boolean
         roles: boolean
         queries: boolean
+        devLogin: boolean
     }
 }
 
@@ -32,6 +39,7 @@ function getDefaultState(): DebuggerState {
             user: true,
             roles: false,
             queries: false,
+            devLogin: true,
         }
     }
 }
@@ -71,7 +79,7 @@ function isEditableElement(target: EventTarget | null): boolean {
 }
 
 export function DevDebugger() {
-    const { user, isAuthenticated, isAdmin, token } = useAuthStore()
+    const { user, isAuthenticated, isAdmin, token, initializeAfterReset } = useAuthStore()
     const queryClient = useQueryClient()
     const dragRef = useRef<HTMLDivElement>(null)
     const [isDragging, setIsDragging] = useState(false)
@@ -79,6 +87,26 @@ export function DevDebugger() {
     const [isHidden, setIsHidden] = useState(SHOULD_START_HIDDEN)
     const [isMinimized, setIsMinimized] = useState(false)
     const [state, setState] = useState<DebuggerState>(loadDebuggerState)
+    const [devLoginSearch, setDevLoginSearch] = useState('')
+    const [loggingInUserId, setLoggingInUserId] = useState<number | null>(null)
+
+    const devLoginEnabled = isDevLoginEnabled()
+    const { data: devUsers, isLoading: isLoadingDevUsers } = useQuery({
+        queryKey: ['dev-users'],
+        queryFn: listDevUsers,
+        enabled: !isAuthenticated && devLoginEnabled,
+        staleTime: Infinity,
+    })
+
+    const handleDevLogin = async (devUser: DevUser) => {
+        setLoggingInUserId(devUser.id)
+        const result = await loginAs(devUser.id)
+        if (result) {
+            await initializeAfterReset(result.user as AuthUser, result.token)
+            window.location.reload()
+        }
+        setLoggingInUserId(null)
+    }
 
     useEffect(() => {
         localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
@@ -335,6 +363,69 @@ export function DevDebugger() {
                         <p className="text-xs text-gray-400">No autenticado</p>
                     )}
                 </Section>
+
+                {!isAuthenticated && devLoginEnabled && (
+                    <Section
+                        icon={LogIn}
+                        title="Dev Login"
+                        isExpanded={state.expandedSections.devLogin}
+                        onToggle={() => toggleSection('devLogin')}
+                        badge={devUsers?.length}
+                    >
+                        <div className="space-y-2">
+                            <div className="relative">
+                                <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-gray-400" />
+                                <input
+                                    type="text"
+                                    placeholder="Buscar usuario..."
+                                    value={devLoginSearch}
+                                    onChange={(e) => setDevLoginSearch(e.target.value)}
+                                    className="w-full bg-gray-700 text-white text-xs rounded pl-7 pr-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                                />
+                            </div>
+                            {isLoadingDevUsers && (
+                                <div className="space-y-1">
+                                    {[1, 2, 3].map((i) => (
+                                        <div key={i} className="h-8 bg-gray-700 rounded animate-pulse" />
+                                    ))}
+                                </div>
+                            )}
+                            {devUsers && (() => {
+                                const q = devLoginSearch.toLowerCase()
+                                const filtered = devUsers.filter(
+                                    (u) =>
+                                        u.name.toLowerCase().includes(q) ||
+                                        u.email.toLowerCase().includes(q)
+                                )
+                                return filtered.length === 0 ? (
+                                    <p className="text-xs text-gray-400">Sin resultados</p>
+                                ) : (
+                                    <div className="space-y-1 max-h-40 overflow-y-auto pr-0.5">
+                                        {filtered.map((devUser) => (
+                                            <button
+                                                key={devUser.id}
+                                                data-testid="dev-login-user"
+                                                onClick={() => handleDevLogin(devUser)}
+                                                disabled={loggingInUserId !== null}
+                                                className="w-full flex items-center justify-between gap-2 px-2 py-1.5 rounded bg-gray-700 hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-left"
+                                            >
+                                                <div className="min-w-0">
+                                                    <p className="text-xs text-white truncate">{devUser.name}</p>
+                                                    <p className="text-xs text-gray-400 truncate">{devUser.email}</p>
+                                                </div>
+                                                {loggingInUserId === devUser.id ? (
+                                                    <Loader2 className="h-3 w-3 text-blue-400 shrink-0 animate-spin" />
+                                                ) : (
+                                                    <LogIn className="h-3 w-3 text-blue-400 shrink-0" />
+                                                )}
+                                            </button>
+                                        ))}
+                                    </div>
+                                )
+                            })()}
+                        </div>
+                    </Section>
+                )}
 
                 <Section
                     icon={RefreshCw}

--- a/code/webapp/src/components/dev/DevDebugger.tsx
+++ b/code/webapp/src/components/dev/DevDebugger.tsx
@@ -1,4 +1,3 @@
-import { useState, useEffect, useRef } from 'react'
 import {
     Bug,
     User,
@@ -11,209 +10,34 @@ import {
     LogIn,
     Search,
     Loader2,
-    type LucideIcon
+    type LucideIcon,
 } from 'lucide-react'
-import { useAuthStore } from '@/stores/auth.store'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
-import type { User as AuthUser } from '@/types/auth'
-import { isDevLoginEnabled } from './dev-login-enabled'
-import { listDevUsers, loginAs, type DevUser } from '@/services/dev-api'
-
-interface DebuggerState {
-    position: { x: number; y: number }
-    expandedSections: {
-        user: boolean
-        roles: boolean
-        queries: boolean
-        devLogin: boolean
-    }
-}
-
-const STORAGE_KEY = 'dev_debugger_state'
-const SHOULD_START_HIDDEN = import.meta.env.VITE_DEV_DEBUGGER_START_HIDDEN === 'true'
-
-function getDefaultState(): DebuggerState {
-    return {
-        position: { x: window.innerWidth - 420, y: 100 },
-        expandedSections: {
-            user: true,
-            roles: false,
-            queries: false,
-            devLogin: true,
-        }
-    }
-}
-
-function loadDebuggerState(): DebuggerState {
-    const fallback = getDefaultState()
-    const saved = localStorage.getItem(STORAGE_KEY)
-
-    if (!saved) {
-        return fallback
-    }
-
-    try {
-        const parsed = JSON.parse(saved) as Partial<DebuggerState>
-
-        return {
-            position: parsed.position ?? fallback.position,
-            expandedSections: {
-                ...fallback.expandedSections,
-                ...parsed.expandedSections,
-            }
-        }
-    } catch {
-        return fallback
-    }
-}
-
-function isEditableElement(target: EventTarget | null): boolean {
-    if (!(target instanceof HTMLElement)) {
-        return false
-    }
-
-    return target instanceof HTMLInputElement
-        || target instanceof HTMLTextAreaElement
-        || target instanceof HTMLSelectElement
-        || target.isContentEditable
-}
+import { useDevDebugger } from './use-dev-debugger'
 
 export function DevDebugger() {
-    const { user, isAuthenticated, isAdmin, token, initializeAfterReset } = useAuthStore()
-    const queryClient = useQueryClient()
-    const dragRef = useRef<HTMLDivElement>(null)
-    const [isDragging, setIsDragging] = useState(false)
-    const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 })
-    const [isHidden, setIsHidden] = useState(SHOULD_START_HIDDEN)
-    const [isMinimized, setIsMinimized] = useState(false)
-    const [state, setState] = useState<DebuggerState>(loadDebuggerState)
-    const [devLoginSearch, setDevLoginSearch] = useState('')
-    const [loggingInUserId, setLoggingInUserId] = useState<number | null>(null)
-
-    const devLoginEnabled = isDevLoginEnabled()
-    const { data: devUsers, isLoading: isLoadingDevUsers } = useQuery({
-        queryKey: ['dev-users'],
-        queryFn: listDevUsers,
-        enabled: !isAuthenticated && devLoginEnabled,
-        staleTime: Infinity,
-    })
-
-    const handleDevLogin = async (devUser: DevUser) => {
-        setLoggingInUserId(devUser.id)
-        const result = await loginAs(devUser.id)
-        if (result) {
-            await initializeAfterReset(result.user as AuthUser, result.token)
-            window.location.reload()
-        }
-        setLoggingInUserId(null)
-    }
-
-    useEffect(() => {
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
-    }, [state])
-
-    useEffect(() => {
-        const handleKeyDown = (event: KeyboardEvent) => {
-            if (!(event.metaKey || event.ctrlKey) || !event.shiftKey || event.key.toLowerCase() !== 'd') {
-                return
-            }
-
-            if (isEditableElement(event.target)) {
-                return
-            }
-
-            event.preventDefault()
-
-            setIsHidden((previouslyHidden) => {
-                const nextHidden = !previouslyHidden
-
-                if (!nextHidden) {
-                    setIsMinimized(false)
-                }
-
-                return nextHidden
-            })
-        }
-
-        window.addEventListener('keydown', handleKeyDown)
-
-        return () => {
-            window.removeEventListener('keydown', handleKeyDown)
-        }
-    }, [])
-
-    useEffect(() => {
-        const handleMouseMove = (event: MouseEvent) => {
-            if (!isDragging) return
-
-            setState(prev => ({
-                ...prev,
-                position: {
-                    x: event.clientX - dragOffset.x,
-                    y: event.clientY - dragOffset.y,
-                }
-            }))
-        }
-
-        const handleMouseUp = () => {
-            setIsDragging(false)
-        }
-
-        if (isDragging) {
-            document.addEventListener('mousemove', handleMouseMove)
-            document.addEventListener('mouseup', handleMouseUp)
-        }
-
-        return () => {
-            document.removeEventListener('mousemove', handleMouseMove)
-            document.removeEventListener('mouseup', handleMouseUp)
-        }
-    }, [isDragging, dragOffset])
-
-    const handleMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
-        if (!dragRef.current) return
-
-        const rect = dragRef.current.getBoundingClientRect()
-        setDragOffset({
-            x: event.clientX - rect.left,
-            y: event.clientY - rect.top,
-        })
-        setIsDragging(true)
-    }
-
-    const toggleSection = (section: keyof DebuggerState['expandedSections']) => {
-        setState(prev => ({
-            ...prev,
-            expandedSections: {
-                ...prev.expandedSections,
-                [section]: !prev.expandedSections[section],
-            }
-        }))
-    }
-
-    const toggleMinimized = () => {
-        setIsMinimized((previouslyMinimized) => !previouslyMinimized)
-    }
-
-    const refreshQueries = () => {
-        queryClient.invalidateQueries()
-    }
-
-    const getQueryCacheStats = () => {
-        const cache = queryClient.getQueryCache()
-        const queries = cache.getAll()
-        return {
-            total: queries.length,
-            fresh: queries.filter(q => q.state.dataUpdatedAt > Date.now() - 5000).length,
-            stale: queries.filter(q => q.isStale()).length,
-            fetching: queries.filter(q => q.state.fetchStatus === 'fetching').length,
-        }
-    }
-
-    const cacheStats = getQueryCacheStats()
-    const shortcutLabel = typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac')
-        ? 'Cmd+Shift+D'
-        : 'Ctrl+Shift+D'
+    const {
+        dragRef,
+        isHidden,
+        isMinimized,
+        state,
+        devLoginSearch,
+        setDevLoginSearch,
+        loggingInUserId,
+        user,
+        isAuthenticated,
+        isAdmin,
+        token,
+        devLoginSectionVisible,
+        devUsers,
+        isLoadingDevUsers,
+        cacheStats,
+        shortcutLabel,
+        handleMouseDown,
+        toggleSection,
+        toggleMinimized,
+        refreshQueries,
+        handleDevLogin,
+    } = useDevDebugger()
 
     if (isHidden) {
         return null
@@ -364,7 +188,7 @@ export function DevDebugger() {
                     )}
                 </Section>
 
-                {!isAuthenticated && devLoginEnabled && (
+                {devLoginSectionVisible && (
                     <Section
                         icon={LogIn}
                         title="Dev Login"
@@ -395,7 +219,7 @@ export function DevDebugger() {
                                 const filtered = devUsers.filter(
                                     (u) =>
                                         u.name.toLowerCase().includes(q) ||
-                                        u.email.toLowerCase().includes(q)
+                                        u.email.toLowerCase().includes(q),
                                 )
                                 return filtered.length === 0 ? (
                                     <p className="text-xs text-gray-400">Sin resultados</p>

--- a/code/webapp/src/components/dev/DevDebugger.tsx
+++ b/code/webapp/src/components/dev/DevDebugger.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import {
     Bug,
     User,
@@ -35,6 +36,7 @@ export function DevDebugger() {
         setDevLoginPermissionSearch,
         devLoginPermissionFilter,
         setDevLoginPermissionFilter,
+        devLoginAllPermissions,
         devLoginPermissionSuggestions,
         devLoginFilteredUsers,
         devUsers,
@@ -47,6 +49,15 @@ export function DevDebugger() {
         refreshQueries,
         handleDevLogin,
     } = useDevDebugger()
+
+    const [permissionInputFocused, setPermissionInputFocused] = useState(false)
+
+    const permissionDropdownItems =
+        devLoginPermissionSearch.length > 0
+            ? devLoginPermissionSuggestions
+            : permissionInputFocused
+              ? devLoginAllPermissions
+              : []
 
     if (isHidden) {
         return null
@@ -265,16 +276,20 @@ export function DevDebugger() {
                                             placeholder="Buscar permiso..."
                                             value={devLoginPermissionSearch}
                                             onChange={(e) => setDevLoginPermissionSearch(e.target.value)}
+                                            onFocus={() => setPermissionInputFocused(true)}
+                                            onBlur={() => setPermissionInputFocused(false)}
                                             className="w-full bg-gray-700 text-white text-xs rounded pl-7 pr-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-teal-500"
                                         />
-                                        {devLoginPermissionSuggestions.length > 0 && (
+                                        {permissionDropdownItems.length > 0 && (
                                             <ul className="absolute z-10 mt-0.5 w-full max-h-36 overflow-y-auto bg-gray-800 border border-gray-600 rounded shadow-lg">
-                                                {devLoginPermissionSuggestions.map((perm) => (
+                                                {permissionDropdownItems.map((perm) => (
                                                     <li key={perm}>
                                                         <button
+                                                            onMouseDown={(e) => e.preventDefault()}
                                                             onClick={() => {
                                                                 setDevLoginPermissionFilter(perm)
                                                                 setDevLoginPermissionSearch('')
+                                                                setPermissionInputFocused(false)
                                                             }}
                                                             className="w-full text-left text-[10px] px-2 py-1 text-gray-200 hover:bg-teal-600/30 hover:text-teal-200 truncate"
                                                         >

--- a/code/webapp/src/components/dev/DevDebugger.tsx
+++ b/code/webapp/src/components/dev/DevDebugger.tsx
@@ -31,6 +31,11 @@ export function DevDebugger() {
         devLoginAllRoles,
         devLoginRoleFilter,
         setDevLoginRoleFilter,
+        devLoginPermissionSearch,
+        setDevLoginPermissionSearch,
+        devLoginPermissionFilter,
+        setDevLoginPermissionFilter,
+        devLoginPermissionSuggestions,
         devLoginFilteredUsers,
         devUsers,
         isLoadingDevUsers,
@@ -234,6 +239,54 @@ export function DevDebugger() {
                                     </div>
                                 </div>
                             )}
+                            <div className="space-y-1">
+                                <p className="text-[10px] font-medium text-gray-500 uppercase tracking-wide">Permiso</p>
+                                {devLoginPermissionFilter ? (
+                                    <div className="flex items-center gap-1">
+                                        <span className="flex-1 text-[10px] px-1.5 py-0.5 rounded border bg-teal-500/20 text-teal-300 border-teal-500/40 truncate">
+                                            {devLoginPermissionFilter}
+                                        </span>
+                                        <button
+                                            onClick={() => {
+                                                setDevLoginPermissionFilter(null)
+                                                setDevLoginPermissionSearch('')
+                                            }}
+                                            className="text-gray-400 hover:text-white text-[11px] px-1 leading-none"
+                                            aria-label="Quitar filtro de permiso"
+                                        >
+                                            ✕
+                                        </button>
+                                    </div>
+                                ) : (
+                                    <div className="relative">
+                                        <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-gray-400" />
+                                        <input
+                                            type="text"
+                                            placeholder="Buscar permiso..."
+                                            value={devLoginPermissionSearch}
+                                            onChange={(e) => setDevLoginPermissionSearch(e.target.value)}
+                                            className="w-full bg-gray-700 text-white text-xs rounded pl-7 pr-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-teal-500"
+                                        />
+                                        {devLoginPermissionSuggestions.length > 0 && (
+                                            <ul className="absolute z-10 mt-0.5 w-full max-h-36 overflow-y-auto bg-gray-800 border border-gray-600 rounded shadow-lg">
+                                                {devLoginPermissionSuggestions.map((perm) => (
+                                                    <li key={perm}>
+                                                        <button
+                                                            onClick={() => {
+                                                                setDevLoginPermissionFilter(perm)
+                                                                setDevLoginPermissionSearch('')
+                                                            }}
+                                                            className="w-full text-left text-[10px] px-2 py-1 text-gray-200 hover:bg-teal-600/30 hover:text-teal-200 truncate"
+                                                        >
+                                                            {perm}
+                                                        </button>
+                                                    </li>
+                                                ))}
+                                            </ul>
+                                        )}
+                                    </div>
+                                )}
+                            </div>
                             {isLoadingDevUsers && (
                                 <div className="space-y-1">
                                     {[1, 2, 3].map((i) => (

--- a/code/webapp/src/components/dev/__tests__/DevDebugger.test.tsx
+++ b/code/webapp/src/components/dev/__tests__/DevDebugger.test.tsx
@@ -36,10 +36,13 @@ vi.mock('@tanstack/react-query', () => ({
       getAll: () => mockQueries,
     }),
   }),
+  useQuery: () => ({
+    data: undefined,
+    isLoading: false,
+  }),
 }))
 
 async function loadDevDebugger(startHidden = 'false') {
-  vi.resetModules()
   vi.stubEnv('VITE_DEV_DEBUGGER_START_HIDDEN', startHidden)
   const module = await import('@/components/dev/DevDebugger')
   return module.DevDebugger

--- a/code/webapp/src/components/dev/__tests__/DevDebugger.test.tsx
+++ b/code/webapp/src/components/dev/__tests__/DevDebugger.test.tsx
@@ -19,6 +19,10 @@ let mockQueries: Array<{
   isStale: () => boolean
 }> = []
 const invalidateQueries = vi.fn()
+const mockInitializeAfterReset = vi.fn()
+
+let mockDevUsersQueryData: unknown = undefined
+let mockIsLoadingDevUsers = false
 
 vi.mock('@/stores/auth.store', () => ({
   useAuthStore: () => ({
@@ -26,6 +30,7 @@ vi.mock('@/stores/auth.store', () => ({
     isAuthenticated: mockIsAuthenticated,
     isAdmin: mockIsAdmin,
     token: mockToken,
+    initializeAfterReset: mockInitializeAfterReset,
   }),
 }))
 
@@ -37,10 +42,18 @@ vi.mock('@tanstack/react-query', () => ({
     }),
   }),
   useQuery: () => ({
-    data: undefined,
-    isLoading: false,
+    data: mockDevUsersQueryData,
+    isLoading: mockIsLoadingDevUsers,
   }),
 }))
+
+vi.mock('@/services/dev-api', () => ({
+  listDevUsers: vi.fn(),
+  loginAs: vi.fn(),
+}))
+
+import { loginAs } from '@/services/dev-api'
+const mockLoginAs = vi.mocked(loginAs)
 
 async function loadDevDebugger(startHidden = 'false') {
   vi.stubEnv('VITE_DEV_DEBUGGER_START_HIDDEN', startHidden)
@@ -56,6 +69,8 @@ describe('DevDebugger', () => {
   beforeEach(() => {
     localStorage.clear()
     vi.clearAllMocks()
+    mockDevUsersQueryData = undefined
+    mockIsLoadingDevUsers = false
     mockUser = {
       id: 1,
       name: 'Admin User',
@@ -136,7 +151,7 @@ describe('DevDebugger', () => {
     expect(screen.queryByText('Dev Debugger')).toBeNull()
   })
 
-  it('refreshes queries and toggles collapsible sections', async () => {
+  it('refreshes queries and toggles collapsible sections including user section', async () => {
     const DevDebugger = await loadDevDebugger('false')
     renderFresh(DevDebugger)
 
@@ -146,6 +161,10 @@ describe('DevDebugger', () => {
     expect(document.body.textContent).not.toContain('isAdmin (store)')
     fireEvent.click(screen.getByText('Roles y Permisos'))
     expect(document.body.textContent).toContain('isAdmin (store)')
+
+    // Collapse the user section (covers the onToggle arrow fn on that Section)
+    fireEvent.click(screen.getByText('Usuario'))
+    expect(document.body.textContent).not.toContain('Nombre:')
 
     expect(document.body.textContent).not.toContain('Total:')
     fireEvent.click(screen.getByText('Query Cache'))
@@ -175,16 +194,84 @@ describe('DevDebugger', () => {
     expect(document.body.textContent).toContain('Nombre:')
   })
 
-  it('renders unauthenticated state when there is no active user', async () => {
+  it('renders the dev login section when the feature is enabled and users are available', async () => {
     mockUser = null
     mockIsAuthenticated = false
     mockIsAdmin = false
     mockToken = null
+    mockDevUsersQueryData = [
+      { id: 1, name: 'Admin', email: 'admin@test.com', roles: ['admin'] },
+      { id: 2, name: 'Staff', email: 'staff@test.com', roles: ['inventory-manager'] },
+    ]
+    vi.stubEnv('VITE_LOGIN_WITH_DEVDEBUG', 'true')
+    vi.stubEnv('VITE_DEV_LOGIN_ALLOWED_ENVIRONMENTS', 'testing')
+    vi.stubEnv('VITE_APP_ENV', 'testing')
 
     const DevDebugger = await loadDevDebugger('false')
     renderFresh(DevDebugger)
 
-    expect(screen.getAllByText('No autenticado').length).toBeGreaterThan(0)
-    expect(screen.getByText(/Cmd\+Shift\+D|Ctrl\+Shift\+D/)).toBeTruthy()
+    expect(document.body.textContent).toContain('Dev Login')
+    expect(document.body.textContent).toContain('Admin')
+    expect(document.body.textContent).toContain('admin@test.com')
+  })
+
+  it('filters dev users by search and shows no-results message', async () => {
+    mockUser = null
+    mockIsAuthenticated = false
+    mockToken = null
+    mockDevUsersQueryData = [
+      { id: 1, name: 'Admin User', email: 'admin@test.com', roles: ['admin'] },
+    ]
+    vi.stubEnv('VITE_LOGIN_WITH_DEVDEBUG', 'true')
+    vi.stubEnv('VITE_DEV_LOGIN_ALLOWED_ENVIRONMENTS', 'testing')
+    vi.stubEnv('VITE_APP_ENV', 'testing')
+
+    const DevDebugger = await loadDevDebugger('false')
+    renderFresh(DevDebugger)
+
+    const searchInput = screen.getByPlaceholderText('Buscar usuario...')
+    fireEvent.change(searchInput, { target: { value: 'xyz-not-found' } })
+
+    expect(document.body.textContent).toContain('Sin resultados')
+  })
+
+  it('shows loading skeleton when dev users are being fetched', async () => {
+    mockUser = null
+    mockIsAuthenticated = false
+    mockToken = null
+    mockIsLoadingDevUsers = true
+    mockDevUsersQueryData = undefined
+    vi.stubEnv('VITE_LOGIN_WITH_DEVDEBUG', 'true')
+    vi.stubEnv('VITE_DEV_LOGIN_ALLOWED_ENVIRONMENTS', 'testing')
+    vi.stubEnv('VITE_APP_ENV', 'testing')
+
+    const DevDebugger = await loadDevDebugger('false')
+    renderFresh(DevDebugger)
+
+    expect(document.body.textContent).toContain('Dev Login')
+    // Loading skeleton: 3 pulse divs should be present
+    const pulseDivs = document.querySelectorAll('.animate-pulse')
+    expect(pulseDivs.length).toBeGreaterThan(0)
+  })
+
+  it('calls handleDevLogin when a dev user button is clicked', async () => {
+    mockUser = null
+    mockIsAuthenticated = false
+    mockToken = null
+    mockDevUsersQueryData = [
+      { id: 3, name: 'Ops User', email: 'ops@test.com', roles: ['inventory-manager'] },
+    ]
+    vi.stubEnv('VITE_LOGIN_WITH_DEVDEBUG', 'true')
+    vi.stubEnv('VITE_DEV_LOGIN_ALLOWED_ENVIRONMENTS', 'testing')
+    vi.stubEnv('VITE_APP_ENV', 'testing')
+    mockLoginAs.mockResolvedValue(null)
+
+    const DevDebugger = await loadDevDebugger('false')
+    renderFresh(DevDebugger)
+
+    const userButton = screen.getByTestId('dev-login-user')
+    fireEvent.click(userButton)
+
+    expect(mockLoginAs).toHaveBeenCalledWith(3)
   })
 })

--- a/code/webapp/src/components/dev/__tests__/dev-login-enabled.test.ts
+++ b/code/webapp/src/components/dev/__tests__/dev-login-enabled.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { isDevLoginEnabled } from '../dev-login-enabled'
+
+describe('isDevLoginEnabled', () => {
+    afterEach(() => {
+        vi.unstubAllEnvs()
+    })
+
+    it('returns false when VITE_LOGIN_WITH_DEVDEBUG is not "true" (empty string)', () => {
+        vi.stubEnv('VITE_LOGIN_WITH_DEVDEBUG', '')
+        vi.stubEnv('VITE_DEV_LOGIN_ALLOWED_ENVIRONMENTS', 'dev,testing')
+        vi.stubEnv('VITE_APP_ENV', 'dev')
+
+        expect(isDevLoginEnabled()).toBe(false)
+    })
+
+    it('returns false when VITE_LOGIN_WITH_DEVDEBUG is "false"', () => {
+        vi.stubEnv('VITE_LOGIN_WITH_DEVDEBUG', 'false')
+        vi.stubEnv('VITE_DEV_LOGIN_ALLOWED_ENVIRONMENTS', 'dev,testing')
+        vi.stubEnv('VITE_APP_ENV', 'dev')
+
+        expect(isDevLoginEnabled()).toBe(false)
+    })
+
+    it('returns false when VITE_APP_ENV is not in the allowed list', () => {
+        vi.stubEnv('VITE_LOGIN_WITH_DEVDEBUG', 'true')
+        vi.stubEnv('VITE_DEV_LOGIN_ALLOWED_ENVIRONMENTS', 'dev,devtest')
+        vi.stubEnv('VITE_APP_ENV', 'production')
+
+        expect(isDevLoginEnabled()).toBe(false)
+    })
+
+    it('returns true when flag is "true" and env is in the allowed list', () => {
+        vi.stubEnv('VITE_LOGIN_WITH_DEVDEBUG', 'true')
+        vi.stubEnv('VITE_DEV_LOGIN_ALLOWED_ENVIRONMENTS', 'dev,devtest,testing')
+        vi.stubEnv('VITE_APP_ENV', 'dev')
+
+        expect(isDevLoginEnabled()).toBe(true)
+    })
+
+    it('trims whitespace in allowed environments', () => {
+        vi.stubEnv('VITE_LOGIN_WITH_DEVDEBUG', 'true')
+        vi.stubEnv('VITE_DEV_LOGIN_ALLOWED_ENVIRONMENTS', ' dev , devtest ')
+        vi.stubEnv('VITE_APP_ENV', 'dev')
+
+        expect(isDevLoginEnabled()).toBe(true)
+    })
+
+    it('returns false when allowed list is empty', () => {
+        vi.stubEnv('VITE_LOGIN_WITH_DEVDEBUG', 'true')
+        vi.stubEnv('VITE_DEV_LOGIN_ALLOWED_ENVIRONMENTS', '')
+        vi.stubEnv('VITE_APP_ENV', 'dev')
+
+        expect(isDevLoginEnabled()).toBe(false)
+    })
+})
+

--- a/code/webapp/src/components/dev/__tests__/use-dev-debugger.test.ts
+++ b/code/webapp/src/components/dev/__tests__/use-dev-debugger.test.ts
@@ -1,0 +1,318 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockInitializeAfterReset = vi.fn()
+const mockInvalidateQueries = vi.fn()
+
+let mockIsAuthenticated = false
+let mockIsAdmin = false
+let mockDevLoginEnabled = false
+let mockDevUsers: Array<{ id: number; name: string; email: string; roles: string[] }> | undefined = undefined
+let mockIsLoadingDevUsers = false
+
+vi.mock('@/stores/auth.store', () => ({
+    useAuthStore: () => ({
+        user: mockIsAuthenticated ? { id: 1, name: 'User', email: 'u@test.com' } : null,
+        isAuthenticated: mockIsAuthenticated,
+        isAdmin: mockIsAdmin,
+        token: mockIsAuthenticated ? 'tok-xxx' : null,
+        initializeAfterReset: mockInitializeAfterReset,
+    }),
+}))
+
+vi.mock('@tanstack/react-query', () => ({
+    useQueryClient: () => ({
+        invalidateQueries: mockInvalidateQueries,
+        getQueryCache: () => ({ getAll: () => [] }),
+    }),
+    useQuery: () => ({
+        data: mockDevUsers,
+        isLoading: mockIsLoadingDevUsers,
+    }),
+}))
+
+vi.mock('../dev-login-enabled', () => ({
+    isDevLoginEnabled: () => mockDevLoginEnabled,
+}))
+
+vi.mock('@/services/dev-api', () => ({
+    listDevUsers: vi.fn(),
+    loginAs: vi.fn(),
+}))
+
+// Import after mocks
+import { loginAs } from '@/services/dev-api'
+import { useDevDebugger } from '../use-dev-debugger'
+
+const mockLoginAs = vi.mocked(loginAs)
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function renderDebugger() {
+    return renderHook(() => useDevDebugger())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('useDevDebugger', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        localStorage.clear()
+        mockIsAuthenticated = false
+        mockIsAdmin = false
+        mockDevLoginEnabled = false
+        mockDevUsers = undefined
+        mockIsLoadingDevUsers = false
+        vi.unstubAllEnvs()
+    })
+
+    afterEach(() => {
+        vi.unstubAllEnvs()
+    })
+
+    describe('initial state', () => {
+        it('starts visible when VITE_DEV_DEBUGGER_START_HIDDEN is not "true"', () => {
+            vi.stubEnv('VITE_DEV_DEBUGGER_START_HIDDEN', 'false')
+            const { result } = renderDebugger()
+
+            expect(result.current.isHidden).toBe(false)
+            expect(result.current.isMinimized).toBe(false)
+        })
+
+        it('starts hidden when VITE_DEV_DEBUGGER_START_HIDDEN is "true"', () => {
+            vi.stubEnv('VITE_DEV_DEBUGGER_START_HIDDEN', 'true')
+            const { result } = renderDebugger()
+
+            expect(result.current.isHidden).toBe(true)
+        })
+
+        it('exposes user, isAuthenticated, isAdmin and token from auth store', () => {
+            mockIsAuthenticated = true
+            mockIsAdmin = true
+            const { result } = renderDebugger()
+
+            expect(result.current.isAuthenticated).toBe(true)
+            expect(result.current.isAdmin).toBe(true)
+            expect(result.current.token).toBe('tok-xxx')
+        })
+
+        it('loads saved state from localStorage', () => {
+            const saved = {
+                position: { x: 50, y: 80 },
+                expandedSections: { user: false, roles: true, queries: false, devLogin: false },
+            }
+            localStorage.setItem('dev_debugger_state', JSON.stringify(saved))
+
+            const { result } = renderDebugger()
+
+            expect(result.current.state.position).toEqual({ x: 50, y: 80 })
+            expect(result.current.state.expandedSections.roles).toBe(true)
+            expect(result.current.state.expandedSections.user).toBe(false)
+        })
+
+        it('falls back to default state when localStorage is empty', () => {
+            const { result } = renderDebugger()
+
+            expect(result.current.state.expandedSections.user).toBe(true)
+            expect(result.current.state.expandedSections.roles).toBe(false)
+            expect(result.current.state.expandedSections.devLogin).toBe(true)
+        })
+
+        it('falls back to default state when localStorage contains invalid JSON', () => {
+            localStorage.setItem('dev_debugger_state', 'not-json{')
+
+            const { result } = renderDebugger()
+
+            expect(result.current.state.expandedSections.user).toBe(true)
+        })
+    })
+
+    describe('toggleSection', () => {
+        it('expands a collapsed section', () => {
+            const { result } = renderDebugger()
+
+            act(() => {
+                result.current.toggleSection('roles')
+            })
+
+            expect(result.current.state.expandedSections.roles).toBe(true)
+        })
+
+        it('collapses an expanded section', () => {
+            const { result } = renderDebugger()
+
+            // 'user' starts expanded (true) by default
+            act(() => {
+                result.current.toggleSection('user')
+            })
+
+            expect(result.current.state.expandedSections.user).toBe(false)
+        })
+
+        it('persists state change to localStorage', () => {
+            const { result } = renderDebugger()
+
+            act(() => {
+                result.current.toggleSection('queries')
+            })
+
+            const saved = JSON.parse(localStorage.getItem('dev_debugger_state') ?? '{}')
+            expect(saved.expandedSections.queries).toBe(true)
+        })
+    })
+
+    describe('toggleMinimized', () => {
+        it('sets isMinimized to true then false', () => {
+            const { result } = renderDebugger()
+
+            act(() => {
+                result.current.toggleMinimized()
+            })
+            expect(result.current.isMinimized).toBe(true)
+
+            act(() => {
+                result.current.toggleMinimized()
+            })
+            expect(result.current.isMinimized).toBe(false)
+        })
+    })
+
+    describe('refreshQueries', () => {
+        it('calls queryClient.invalidateQueries()', () => {
+            const { result } = renderDebugger()
+
+            act(() => {
+                result.current.refreshQueries()
+            })
+
+            expect(mockInvalidateQueries).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    describe('devLoginSectionVisible', () => {
+        it('is false when user is already authenticated', () => {
+            mockIsAuthenticated = true
+            mockDevLoginEnabled = true
+            mockDevUsers = [{ id: 1, name: 'A', email: 'a@t.com', roles: ['admin'] }]
+
+            const { result } = renderDebugger()
+
+            expect(result.current.devLoginSectionVisible).toBe(false)
+        })
+
+        it('is false when dev login is not enabled', () => {
+            mockIsAuthenticated = false
+            mockDevLoginEnabled = false
+            mockDevUsers = [{ id: 1, name: 'A', email: 'a@t.com', roles: ['admin'] }]
+
+            const { result } = renderDebugger()
+
+            expect(result.current.devLoginSectionVisible).toBe(false)
+        })
+
+        it('is true while loading even if devUsers is undefined', () => {
+            mockIsAuthenticated = false
+            mockDevLoginEnabled = true
+            mockIsLoadingDevUsers = true
+            mockDevUsers = undefined
+
+            const { result } = renderDebugger()
+
+            expect(result.current.devLoginSectionVisible).toBe(true)
+        })
+
+        it('is true when not authenticated, enabled, and users are loaded', () => {
+            mockIsAuthenticated = false
+            mockDevLoginEnabled = true
+            mockDevUsers = [{ id: 1, name: 'A', email: 'a@t.com', roles: ['admin'] }]
+
+            const { result } = renderDebugger()
+
+            expect(result.current.devLoginSectionVisible).toBe(true)
+        })
+
+        it('is false when devUsers is null (feature disabled server-side)', () => {
+            mockIsAuthenticated = false
+            mockDevLoginEnabled = true
+            mockDevUsers = undefined // null would be falsy → same effect
+            mockIsLoadingDevUsers = false
+
+            const { result } = renderDebugger()
+
+            expect(result.current.devLoginSectionVisible).toBe(false)
+        })
+    })
+
+    describe('handleDevLogin', () => {
+        it('calls loginAs and initializeAfterReset on success, then reloads', async () => {
+            const devUser = { id: 3, name: 'Staff', email: 's@t.com', roles: ['inventory-manager'] }
+            const authResult = {
+                token: 'tok-xyz',
+                token_type: 'Bearer',
+                user: { id: 3, name: 'Staff', email: 's@t.com' },
+            }
+            mockLoginAs.mockResolvedValueOnce(authResult)
+
+            // Mock window.location.reload
+            const reloadMock = vi.fn()
+            Object.defineProperty(window, 'location', {
+                value: { reload: reloadMock },
+                writable: true,
+                configurable: true,
+            })
+
+            const { result } = renderDebugger()
+
+            await act(async () => {
+                await result.current.handleDevLogin(devUser)
+            })
+
+            expect(mockLoginAs).toHaveBeenCalledWith(3)
+            expect(mockInitializeAfterReset).toHaveBeenCalledWith(authResult.user, authResult.token)
+            expect(reloadMock).toHaveBeenCalledTimes(1)
+        })
+
+        it('does not call initializeAfterReset when loginAs returns null', async () => {
+            const devUser = { id: 99, name: 'Gone', email: 'g@t.com', roles: [] }
+            mockLoginAs.mockResolvedValueOnce(null)
+
+            const { result } = renderDebugger()
+
+            await act(async () => {
+                await result.current.handleDevLogin(devUser)
+            })
+
+            expect(mockInitializeAfterReset).not.toHaveBeenCalled()
+        })
+
+        it('clears loggingInUserId after the request completes', async () => {
+            const devUser = { id: 7, name: 'U', email: 'u@t.com', roles: [] }
+            mockLoginAs.mockResolvedValueOnce(null)
+
+            const { result } = renderDebugger()
+
+            await act(async () => {
+                await result.current.handleDevLogin(devUser)
+            })
+
+            expect(result.current.loggingInUserId).toBeNull()
+        })
+    })
+
+    describe('shortcutLabel', () => {
+        it('returns Cmd+Shift+D on macOS', () => {
+            Object.defineProperty(navigator, 'platform', {
+                value: 'MacIntel',
+                writable: true,
+                configurable: true,
+            })
+
+            const { result } = renderDebugger()
+
+            expect(result.current.shortcutLabel).toBe('Cmd+Shift+D')
+        })
+    })
+})

--- a/code/webapp/src/components/dev/__tests__/use-dev-debugger.test.ts
+++ b/code/webapp/src/components/dev/__tests__/use-dev-debugger.test.ts
@@ -252,7 +252,7 @@ describe('useDevDebugger', () => {
             const authResult = {
                 token: 'tok-xyz',
                 token_type: 'Bearer',
-                user: { id: 3, name: 'Staff', email: 's@t.com' },
+                user: { id: 3, name: 'Staff', email: 's@t.com', email_verified_at: null, created_at: '', updated_at: '' },
             }
             mockLoginAs.mockResolvedValueOnce(authResult)
 
@@ -304,8 +304,8 @@ describe('useDevDebugger', () => {
 
     describe('shortcutLabel', () => {
         it('returns Cmd+Shift+D on macOS', () => {
-            Object.defineProperty(navigator, 'platform', {
-                value: 'MacIntel',
+            Object.defineProperty(navigator, 'userAgent', {
+                value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
                 writable: true,
                 configurable: true,
             })

--- a/code/webapp/src/components/dev/__tests__/use-dev-debugger.test.ts
+++ b/code/webapp/src/components/dev/__tests__/use-dev-debugger.test.ts
@@ -246,6 +246,100 @@ describe('useDevDebugger', () => {
         })
     })
 
+    describe('devLoginAllRoles', () => {
+        it('returns empty array when devUsers is undefined', () => {
+            mockDevLoginEnabled = true
+            mockIsAuthenticated = false
+            const { result } = renderDebugger()
+            expect(result.current.devLoginAllRoles).toEqual([])
+        })
+
+        it('returns sorted unique roles across all users', () => {
+            mockDevLoginEnabled = true
+            mockIsAuthenticated = false
+            mockDevUsers = [
+                { id: 1, name: 'A', email: 'a@t.com', roles: ['admin', 'inventory-manager'] },
+                { id: 2, name: 'B', email: 'b@t.com', roles: ['admin'] },
+                { id: 3, name: 'C', email: 'c@t.com', roles: ['cashier'] },
+            ]
+            const { result } = renderDebugger()
+            expect(result.current.devLoginAllRoles).toEqual(['admin', 'cashier', 'inventory-manager'])
+        })
+    })
+
+    describe('devLoginRoleFilter', () => {
+        it('starts as null', () => {
+            const { result } = renderDebugger()
+            expect(result.current.devLoginRoleFilter).toBeNull()
+        })
+
+        it('updates when setDevLoginRoleFilter is called', () => {
+            const { result } = renderDebugger()
+            act(() => { result.current.setDevLoginRoleFilter('admin') })
+            expect(result.current.devLoginRoleFilter).toBe('admin')
+        })
+
+        it('can be cleared back to null', () => {
+            const { result } = renderDebugger()
+            act(() => { result.current.setDevLoginRoleFilter('admin') })
+            act(() => { result.current.setDevLoginRoleFilter(null) })
+            expect(result.current.devLoginRoleFilter).toBeNull()
+        })
+    })
+
+    describe('devLoginFilteredUsers', () => {
+        beforeEach(() => {
+            mockDevLoginEnabled = true
+            mockIsAuthenticated = false
+            mockDevUsers = [
+                { id: 1, name: 'Alice Admin', email: 'alice@t.com', roles: ['admin'] },
+                { id: 2, name: 'Bob Inventory', email: 'bob@t.com', roles: ['inventory-manager'] },
+                { id: 3, name: 'Carlos Admin', email: 'carlos@t.com', roles: ['admin', 'cashier'] },
+            ]
+        })
+
+        it('returns empty array when devUsers is null', () => {
+            mockDevUsers = undefined
+            const { result } = renderDebugger()
+            expect(result.current.devLoginFilteredUsers).toEqual([])
+        })
+
+        it('returns all users when no filters are active', () => {
+            const { result } = renderDebugger()
+            expect(result.current.devLoginFilteredUsers).toHaveLength(3)
+        })
+
+        it('filters by text search (name)', () => {
+            const { result } = renderDebugger()
+            act(() => { result.current.setDevLoginSearch('alice') })
+            expect(result.current.devLoginFilteredUsers).toHaveLength(1)
+            expect(result.current.devLoginFilteredUsers[0]?.name).toBe('Alice Admin')
+        })
+
+        it('filters by text search (email)', () => {
+            const { result } = renderDebugger()
+            act(() => { result.current.setDevLoginSearch('bob@') })
+            expect(result.current.devLoginFilteredUsers).toHaveLength(1)
+            expect(result.current.devLoginFilteredUsers[0]?.name).toBe('Bob Inventory')
+        })
+
+        it('filters by role', () => {
+            const { result } = renderDebugger()
+            act(() => { result.current.setDevLoginRoleFilter('admin') })
+            expect(result.current.devLoginFilteredUsers).toHaveLength(2)
+        })
+
+        it('applies text search and role filter cumulatively (AND)', () => {
+            const { result } = renderDebugger()
+            act(() => {
+                result.current.setDevLoginRoleFilter('admin')
+                result.current.setDevLoginSearch('carlos')
+            })
+            expect(result.current.devLoginFilteredUsers).toHaveLength(1)
+            expect(result.current.devLoginFilteredUsers[0]?.name).toBe('Carlos Admin')
+        })
+    })
+
     describe('handleDevLogin', () => {
         it('calls loginAs and initializeAfterReset on success, then reloads', async () => {
             const devUser = { id: 3, name: 'Staff', email: 's@t.com', roles: ['inventory-manager'] }

--- a/code/webapp/src/components/dev/__tests__/use-dev-debugger.test.ts
+++ b/code/webapp/src/components/dev/__tests__/use-dev-debugger.test.ts
@@ -10,7 +10,7 @@ const mockInvalidateQueries = vi.fn()
 let mockIsAuthenticated = false
 let mockIsAdmin = false
 let mockDevLoginEnabled = false
-let mockDevUsers: Array<{ id: number; name: string; email: string; roles: string[] }> | undefined = undefined
+let mockDevUsers: Array<{ id: number; name: string; email: string; roles: string[]; permissions: string[] }> | undefined = undefined
 let mockIsLoadingDevUsers = false
 
 vi.mock('@/stores/auth.store', () => ({
@@ -196,7 +196,7 @@ describe('useDevDebugger', () => {
         it('is false when user is already authenticated', () => {
             mockIsAuthenticated = true
             mockDevLoginEnabled = true
-            mockDevUsers = [{ id: 1, name: 'A', email: 'a@t.com', roles: ['admin'] }]
+            mockDevUsers = [{ id: 1, name: 'A', email: 'a@t.com', roles: ['admin'], permissions: [] }]
 
             const { result } = renderDebugger()
 
@@ -206,7 +206,7 @@ describe('useDevDebugger', () => {
         it('is false when dev login is not enabled', () => {
             mockIsAuthenticated = false
             mockDevLoginEnabled = false
-            mockDevUsers = [{ id: 1, name: 'A', email: 'a@t.com', roles: ['admin'] }]
+            mockDevUsers = [{ id: 1, name: 'A', email: 'a@t.com', roles: ['admin'], permissions: [] }]
 
             const { result } = renderDebugger()
 
@@ -227,7 +227,7 @@ describe('useDevDebugger', () => {
         it('is true when not authenticated, enabled, and users are loaded', () => {
             mockIsAuthenticated = false
             mockDevLoginEnabled = true
-            mockDevUsers = [{ id: 1, name: 'A', email: 'a@t.com', roles: ['admin'] }]
+            mockDevUsers = [{ id: 1, name: 'A', email: 'a@t.com', roles: ['admin'], permissions: [] }]
 
             const { result } = renderDebugger()
 
@@ -258,9 +258,9 @@ describe('useDevDebugger', () => {
             mockDevLoginEnabled = true
             mockIsAuthenticated = false
             mockDevUsers = [
-                { id: 1, name: 'A', email: 'a@t.com', roles: ['admin', 'inventory-manager'] },
-                { id: 2, name: 'B', email: 'b@t.com', roles: ['admin'] },
-                { id: 3, name: 'C', email: 'c@t.com', roles: ['cashier'] },
+                { id: 1, name: 'A', email: 'a@t.com', roles: ['admin', 'inventory-manager'], permissions: [] },
+                { id: 2, name: 'B', email: 'b@t.com', roles: ['admin'], permissions: [] },
+                { id: 3, name: 'C', email: 'c@t.com', roles: ['cashier'], permissions: [] },
             ]
             const { result } = renderDebugger()
             expect(result.current.devLoginAllRoles).toEqual(['admin', 'cashier', 'inventory-manager'])
@@ -292,9 +292,9 @@ describe('useDevDebugger', () => {
             mockDevLoginEnabled = true
             mockIsAuthenticated = false
             mockDevUsers = [
-                { id: 1, name: 'Alice Admin', email: 'alice@t.com', roles: ['admin'] },
-                { id: 2, name: 'Bob Inventory', email: 'bob@t.com', roles: ['inventory-manager'] },
-                { id: 3, name: 'Carlos Admin', email: 'carlos@t.com', roles: ['admin', 'cashier'] },
+                { id: 1, name: 'Alice Admin', email: 'alice@t.com', roles: ['admin'], permissions: ['items.view', 'items.create'] },
+                { id: 2, name: 'Bob Inventory', email: 'bob@t.com', roles: ['inventory-manager'], permissions: ['items.view', 'stock.view'] },
+                { id: 3, name: 'Carlos Admin', email: 'carlos@t.com', roles: ['admin', 'cashier'], permissions: ['items.view', 'cash.view'] },
             ]
         })
 
@@ -338,11 +338,100 @@ describe('useDevDebugger', () => {
             expect(result.current.devLoginFilteredUsers).toHaveLength(1)
             expect(result.current.devLoginFilteredUsers[0]?.name).toBe('Carlos Admin')
         })
+
+        it('filters by permission', () => {
+            const { result } = renderDebugger()
+            act(() => { result.current.setDevLoginPermissionFilter('stock.view') })
+            expect(result.current.devLoginFilteredUsers).toHaveLength(1)
+            expect(result.current.devLoginFilteredUsers[0]?.name).toBe('Bob Inventory')
+        })
+
+        it('applies text search, role filter AND permission filter cumulatively', () => {
+            const { result } = renderDebugger()
+            act(() => {
+                result.current.setDevLoginRoleFilter('admin')
+                result.current.setDevLoginPermissionFilter('items.create')
+            })
+            // Only Alice has role=admin AND permission=items.create
+            expect(result.current.devLoginFilteredUsers).toHaveLength(1)
+            expect(result.current.devLoginFilteredUsers[0]?.name).toBe('Alice Admin')
+        })
+    })
+
+    describe('devLoginAllPermissions', () => {
+        it('returns empty array when devUsers is undefined', () => {
+            const { result } = renderDebugger()
+            expect(result.current.devLoginAllPermissions).toEqual([])
+        })
+
+        it('returns sorted unique permissions across all users', () => {
+            mockDevLoginEnabled = true
+            mockIsAuthenticated = false
+            mockDevUsers = [
+                { id: 1, name: 'A', email: 'a@t.com', roles: ['admin'], permissions: ['items.view', 'items.create'] },
+                { id: 2, name: 'B', email: 'b@t.com', roles: [], permissions: ['items.view', 'stock.view'] },
+            ]
+            const { result } = renderDebugger()
+            expect(result.current.devLoginAllPermissions).toEqual(['items.create', 'items.view', 'stock.view'])
+        })
+    })
+
+    describe('devLoginPermissionFilter', () => {
+        it('starts as null', () => {
+            const { result } = renderDebugger()
+            expect(result.current.devLoginPermissionFilter).toBeNull()
+        })
+
+        it('updates when setDevLoginPermissionFilter is called', () => {
+            const { result } = renderDebugger()
+            act(() => { result.current.setDevLoginPermissionFilter('items.view') })
+            expect(result.current.devLoginPermissionFilter).toBe('items.view')
+        })
+
+        it('can be cleared back to null', () => {
+            const { result } = renderDebugger()
+            act(() => { result.current.setDevLoginPermissionFilter('items.view') })
+            act(() => { result.current.setDevLoginPermissionFilter(null) })
+            expect(result.current.devLoginPermissionFilter).toBeNull()
+        })
+    })
+
+    describe('devLoginPermissionSuggestions', () => {
+        beforeEach(() => {
+            mockDevLoginEnabled = true
+            mockIsAuthenticated = false
+            mockDevUsers = [
+                { id: 1, name: 'A', email: 'a@t.com', roles: [], permissions: ['items.view', 'items.create', 'stock.view'] },
+            ]
+        })
+
+        it('returns empty array when search is empty', () => {
+            const { result } = renderDebugger()
+            expect(result.current.devLoginPermissionSuggestions).toEqual([])
+        })
+
+        it('returns matching permissions when search has text', () => {
+            const { result } = renderDebugger()
+            act(() => { result.current.setDevLoginPermissionSearch('items') })
+            expect(result.current.devLoginPermissionSuggestions).toEqual(['items.create', 'items.view'])
+        })
+
+        it('is case-insensitive', () => {
+            const { result } = renderDebugger()
+            act(() => { result.current.setDevLoginPermissionSearch('STOCK') })
+            expect(result.current.devLoginPermissionSuggestions).toEqual(['stock.view'])
+        })
+
+        it('returns empty array when no permissions match', () => {
+            const { result } = renderDebugger()
+            act(() => { result.current.setDevLoginPermissionSearch('nonexistent') })
+            expect(result.current.devLoginPermissionSuggestions).toEqual([])
+        })
     })
 
     describe('handleDevLogin', () => {
         it('calls loginAs and initializeAfterReset on success, then reloads', async () => {
-            const devUser = { id: 3, name: 'Staff', email: 's@t.com', roles: ['inventory-manager'] }
+            const devUser = { id: 3, name: 'Staff', email: 's@t.com', roles: ['inventory-manager'], permissions: [] }
             const authResult = {
                 token: 'tok-xyz',
                 token_type: 'Bearer',
@@ -370,7 +459,7 @@ describe('useDevDebugger', () => {
         })
 
         it('does not call initializeAfterReset when loginAs returns null', async () => {
-            const devUser = { id: 99, name: 'Gone', email: 'g@t.com', roles: [] }
+            const devUser = { id: 99, name: 'Gone', email: 'g@t.com', roles: [], permissions: [] }
             mockLoginAs.mockResolvedValueOnce(null)
 
             const { result } = renderDebugger()
@@ -383,13 +472,26 @@ describe('useDevDebugger', () => {
         })
 
         it('clears loggingInUserId after the request completes', async () => {
-            const devUser = { id: 7, name: 'U', email: 'u@t.com', roles: [] }
+            const devUser = { id: 7, name: 'U', email: 'u@t.com', roles: [], permissions: [] }
             mockLoginAs.mockResolvedValueOnce(null)
 
             const { result } = renderDebugger()
 
             await act(async () => {
                 await result.current.handleDevLogin(devUser)
+            })
+
+            expect(result.current.loggingInUserId).toBeNull()
+        })
+
+        it('clears loggingInUserId even when loginAs throws (try/finally)', async () => {
+            const devUser = { id: 5, name: 'E', email: 'e@t.com', roles: [], permissions: [] }
+            mockLoginAs.mockRejectedValueOnce(new Error('Network Error'))
+
+            const { result } = renderDebugger()
+
+            await act(async () => {
+                await result.current.handleDevLogin(devUser).catch(() => undefined)
             })
 
             expect(result.current.loggingInUserId).toBeNull()

--- a/code/webapp/src/components/dev/dev-login-enabled.ts
+++ b/code/webapp/src/components/dev/dev-login-enabled.ts
@@ -1,0 +1,24 @@
+/**
+ * Evaluates whether the dev-debug login feature is enabled on the frontend.
+ *
+ * Both conditions must be true:
+ *   1. VITE_LOGIN_WITH_DEVDEBUG must be exactly 'true'
+ *   2. VITE_APP_ENV must be in the VITE_DEV_LOGIN_ALLOWED_ENVIRONMENTS csv list
+ *
+ * This mirrors the backend DevLoginGuard validation and prevents unnecessary
+ * API calls when the feature is disabled.
+ */
+export function isDevLoginEnabled(): boolean {
+    if (import.meta.env.VITE_LOGIN_WITH_DEVDEBUG !== 'true') {
+        return false
+    }
+
+    const allowedEnvs = (import.meta.env.VITE_DEV_LOGIN_ALLOWED_ENVIRONMENTS ?? '')
+        .split(',')
+        .map((e: string) => e.trim())
+        .filter(Boolean)
+
+    const currentEnv = import.meta.env.VITE_APP_ENV ?? ''
+
+    return allowedEnvs.includes(currentEnv)
+}

--- a/code/webapp/src/components/dev/dev-login-enabled.ts
+++ b/code/webapp/src/components/dev/dev-login-enabled.ts
@@ -15,10 +15,10 @@ export function isDevLoginEnabled(): boolean {
 
     const allowedEnvs = (import.meta.env.VITE_DEV_LOGIN_ALLOWED_ENVIRONMENTS ?? '')
         .split(',')
-        .map((e: string) => e.trim())
+        .map((e: string) => e.trim().toLowerCase())
         .filter(Boolean)
 
-    const currentEnv = import.meta.env.VITE_APP_ENV ?? ''
+    const currentEnv = (import.meta.env.VITE_APP_ENV ?? '').toLowerCase()
 
     return allowedEnvs.includes(currentEnv)
 }

--- a/code/webapp/src/components/dev/use-dev-debugger.ts
+++ b/code/webapp/src/components/dev/use-dev-debugger.ts
@@ -79,6 +79,8 @@ export function useDevDebugger() {
     const [state, setState] = useState<DebuggerState>(loadDebuggerState)
     const [devLoginSearch, setDevLoginSearch] = useState('')
     const [devLoginRoleFilter, setDevLoginRoleFilter] = useState<string | null>(null)
+    const [devLoginPermissionSearch, setDevLoginPermissionSearch] = useState('')
+    const [devLoginPermissionFilter, setDevLoginPermissionFilter] = useState<string | null>(null)
     const [loggingInUserId, setLoggingInUserId] = useState<number | null>(null)
 
     const devLoginEnabled = isDevLoginEnabled()
@@ -91,12 +93,15 @@ export function useDevDebugger() {
 
     const handleDevLogin = async (devUser: DevUser) => {
         setLoggingInUserId(devUser.id)
-        const result = await loginAs(devUser.id)
-        if (result) {
-            await initializeAfterReset(result.user as AuthUser, result.token)
-            globalThis.location.reload()
+        try {
+            const result = await loginAs(devUser.id)
+            if (result) {
+                await initializeAfterReset(result.user as AuthUser, result.token)
+                globalThis.location.reload()
+            }
+        } finally {
+            setLoggingInUserId(null)
         }
-        setLoggingInUserId(null)
     }
 
     useEffect(() => {
@@ -216,14 +221,29 @@ export function useDevDebugger() {
         ? [...new Set(devUsers.flatMap((u) => u.roles))].sort((a, b) => a.localeCompare(b))
         : []
 
-    // Combined filter: text search AND role filter
+    // All unique permissions across all users (for the permission autocomplete filter)
+    const devLoginAllPermissions = devUsers
+        ? [...new Set(devUsers.flatMap((u) => u.permissions))].sort((a, b) => a.localeCompare(b))
+        : []
+
+    // Autocomplete suggestions: permissions matching the search input
+    const devLoginPermissionSuggestions =
+        devLoginPermissionSearch.length > 0
+            ? devLoginAllPermissions.filter((p) =>
+                  p.toLowerCase().includes(devLoginPermissionSearch.toLowerCase()),
+              )
+            : []
+
+    // Combined filter: text search AND role filter AND permission filter
     const devLoginFilteredUsers = devUsers
         ? devUsers.filter((u) => {
               const q = devLoginSearch.toLowerCase()
               const matchesText =
                   !q || u.name.toLowerCase().includes(q) || u.email.toLowerCase().includes(q)
               const matchesRole = !devLoginRoleFilter || u.roles.includes(devLoginRoleFilter)
-              return matchesText && matchesRole
+              const matchesPermission =
+                  !devLoginPermissionFilter || u.permissions.includes(devLoginPermissionFilter)
+              return matchesText && matchesRole && matchesPermission
           })
         : []
 
@@ -244,6 +264,12 @@ export function useDevDebugger() {
         devLoginAllRoles,
         devLoginRoleFilter,
         setDevLoginRoleFilter,
+        devLoginPermissionSearch,
+        setDevLoginPermissionSearch,
+        devLoginPermissionFilter,
+        setDevLoginPermissionFilter,
+        devLoginAllPermissions,
+        devLoginPermissionSuggestions,
         devLoginFilteredUsers,
         devUsers,
         isLoadingDevUsers,

--- a/code/webapp/src/components/dev/use-dev-debugger.ts
+++ b/code/webapp/src/components/dev/use-dev-debugger.ts
@@ -213,7 +213,7 @@ export function useDevDebugger() {
 
     // All unique roles across all users (for the role filter pills)
     const devLoginAllRoles = devUsers
-        ? [...new Set(devUsers.flatMap((u) => u.roles))].sort()
+        ? [...new Set(devUsers.flatMap((u) => u.roles))].sort((a, b) => a.localeCompare(b))
         : []
 
     // Combined filter: text search AND role filter

--- a/code/webapp/src/components/dev/use-dev-debugger.ts
+++ b/code/webapp/src/components/dev/use-dev-debugger.ts
@@ -1,0 +1,237 @@
+import { useEffect, useRef, useState } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useAuthStore } from '@/stores/auth.store'
+import type { User as AuthUser } from '@/types/auth'
+import { isDevLoginEnabled } from './dev-login-enabled'
+import { listDevUsers, loginAs, type DevUser } from '@/services/dev-api'
+
+export interface DebuggerState {
+    position: { x: number; y: number }
+    expandedSections: {
+        user: boolean
+        roles: boolean
+        queries: boolean
+        devLogin: boolean
+    }
+}
+
+export type { DevUser }
+
+const STORAGE_KEY = 'dev_debugger_state'
+
+function getDefaultState(): DebuggerState {
+    return {
+        position: { x: window.innerWidth - 420, y: 100 },
+        expandedSections: {
+            user: true,
+            roles: false,
+            queries: false,
+            devLogin: true,
+        },
+    }
+}
+
+function loadDebuggerState(): DebuggerState {
+    const fallback = getDefaultState()
+    const saved = localStorage.getItem(STORAGE_KEY)
+
+    if (!saved) {
+        return fallback
+    }
+
+    try {
+        const parsed = JSON.parse(saved) as Partial<DebuggerState>
+
+        return {
+            position: parsed.position ?? fallback.position,
+            expandedSections: {
+                ...fallback.expandedSections,
+                ...parsed.expandedSections,
+            },
+        }
+    } catch {
+        return fallback
+    }
+}
+
+function isEditableElement(target: EventTarget | null): boolean {
+    if (!(target instanceof HTMLElement)) {
+        return false
+    }
+
+    return (
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        target instanceof HTMLSelectElement ||
+        target.isContentEditable
+    )
+}
+
+export function useDevDebugger() {
+    const { user, isAuthenticated, isAdmin, token, initializeAfterReset } = useAuthStore()
+    const queryClient = useQueryClient()
+    const dragRef = useRef<HTMLDivElement>(null)
+
+    const [isDragging, setIsDragging] = useState(false)
+    const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 })
+    const [isHidden, setIsHidden] = useState(() => import.meta.env.VITE_DEV_DEBUGGER_START_HIDDEN === 'true')
+    const [isMinimized, setIsMinimized] = useState(false)
+    const [state, setState] = useState<DebuggerState>(loadDebuggerState)
+    const [devLoginSearch, setDevLoginSearch] = useState('')
+    const [loggingInUserId, setLoggingInUserId] = useState<number | null>(null)
+
+    const devLoginEnabled = isDevLoginEnabled()
+    const { data: devUsers, isLoading: isLoadingDevUsers } = useQuery({
+        queryKey: ['dev-users'],
+        queryFn: listDevUsers,
+        enabled: !isAuthenticated && devLoginEnabled,
+        staleTime: Infinity,
+    })
+
+    const handleDevLogin = async (devUser: DevUser) => {
+        setLoggingInUserId(devUser.id)
+        const result = await loginAs(devUser.id)
+        if (result) {
+            await initializeAfterReset(result.user as AuthUser, result.token)
+            window.location.reload()
+        }
+        setLoggingInUserId(null)
+    }
+
+    useEffect(() => {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+    }, [state])
+
+    useEffect(() => {
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (!(event.metaKey || event.ctrlKey) || !event.shiftKey || event.key.toLowerCase() !== 'd') {
+                return
+            }
+
+            if (isEditableElement(event.target)) {
+                return
+            }
+
+            event.preventDefault()
+
+            setIsHidden((previouslyHidden) => {
+                const nextHidden = !previouslyHidden
+
+                if (!nextHidden) {
+                    setIsMinimized(false)
+                }
+
+                return nextHidden
+            })
+        }
+
+        window.addEventListener('keydown', handleKeyDown)
+
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown)
+        }
+    }, [])
+
+    useEffect(() => {
+        const handleMouseMove = (event: MouseEvent) => {
+            if (!isDragging) return
+
+            setState((prev) => ({
+                ...prev,
+                position: {
+                    x: event.clientX - dragOffset.x,
+                    y: event.clientY - dragOffset.y,
+                },
+            }))
+        }
+
+        const handleMouseUp = () => {
+            setIsDragging(false)
+        }
+
+        if (isDragging) {
+            document.addEventListener('mousemove', handleMouseMove)
+            document.addEventListener('mouseup', handleMouseUp)
+        }
+
+        return () => {
+            document.removeEventListener('mousemove', handleMouseMove)
+            document.removeEventListener('mouseup', handleMouseUp)
+        }
+    }, [isDragging, dragOffset])
+
+    const handleMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
+        if (!dragRef.current) return
+
+        const rect = dragRef.current.getBoundingClientRect()
+        setDragOffset({
+            x: event.clientX - rect.left,
+            y: event.clientY - rect.top,
+        })
+        setIsDragging(true)
+    }
+
+    const toggleSection = (section: keyof DebuggerState['expandedSections']) => {
+        setState((prev) => ({
+            ...prev,
+            expandedSections: {
+                ...prev.expandedSections,
+                [section]: !prev.expandedSections[section],
+            },
+        }))
+    }
+
+    const toggleMinimized = () => {
+        setIsMinimized((previouslyMinimized) => !previouslyMinimized)
+    }
+
+    const refreshQueries = () => {
+        queryClient.invalidateQueries()
+    }
+
+    const getQueryCacheStats = () => {
+        const cache = queryClient.getQueryCache()
+        const queries = cache.getAll()
+        return {
+            total: queries.length,
+            fresh: queries.filter((q) => q.state.dataUpdatedAt > Date.now() - 5000).length,
+            stale: queries.filter((q) => q.isStale()).length,
+            fetching: queries.filter((q) => q.state.fetchStatus === 'fetching').length,
+        }
+    }
+
+    const cacheStats = getQueryCacheStats()
+
+    const shortcutLabel =
+        typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac')
+            ? 'Cmd+Shift+D'
+            : 'Ctrl+Shift+D'
+
+    // Dev Login section is visible while loading or when users are available (null = feature disabled)
+    const devLoginSectionVisible = !isAuthenticated && devLoginEnabled && (isLoadingDevUsers || !!devUsers)
+
+    return {
+        dragRef,
+        isHidden,
+        isMinimized,
+        state,
+        devLoginSearch,
+        setDevLoginSearch,
+        loggingInUserId,
+        user,
+        isAuthenticated,
+        isAdmin,
+        token,
+        devLoginEnabled,
+        devLoginSectionVisible,
+        devUsers,
+        isLoadingDevUsers,
+        cacheStats,
+        shortcutLabel,
+        handleMouseDown,
+        toggleSection,
+        toggleMinimized,
+        refreshQueries,
+        handleDevLogin,
+    }
+}

--- a/code/webapp/src/components/dev/use-dev-debugger.ts
+++ b/code/webapp/src/components/dev/use-dev-debugger.ts
@@ -15,7 +15,7 @@ export interface DebuggerState {
     }
 }
 
-export type { DevUser }
+export type { DevUser } from '@/services/dev-api'
 
 const STORAGE_KEY = 'dev_debugger_state'
 
@@ -93,7 +93,7 @@ export function useDevDebugger() {
         const result = await loginAs(devUser.id)
         if (result) {
             await initializeAfterReset(result.user as AuthUser, result.token)
-            window.location.reload()
+            globalThis.location.reload()
         }
         setLoggingInUserId(null)
     }
@@ -125,10 +125,10 @@ export function useDevDebugger() {
             })
         }
 
-        window.addEventListener('keydown', handleKeyDown)
+        globalThis.addEventListener('keydown', handleKeyDown)
 
         return () => {
-            window.removeEventListener('keydown', handleKeyDown)
+            globalThis.removeEventListener('keydown', handleKeyDown)
         }
     }, [])
 
@@ -203,7 +203,7 @@ export function useDevDebugger() {
     const cacheStats = getQueryCacheStats()
 
     const shortcutLabel =
-        typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac')
+        typeof navigator !== 'undefined' && /mac/i.test(navigator.userAgent)
             ? 'Cmd+Shift+D'
             : 'Ctrl+Shift+D'
 

--- a/code/webapp/src/components/dev/use-dev-debugger.ts
+++ b/code/webapp/src/components/dev/use-dev-debugger.ts
@@ -78,6 +78,7 @@ export function useDevDebugger() {
     const [isMinimized, setIsMinimized] = useState(false)
     const [state, setState] = useState<DebuggerState>(loadDebuggerState)
     const [devLoginSearch, setDevLoginSearch] = useState('')
+    const [devLoginRoleFilter, setDevLoginRoleFilter] = useState<string | null>(null)
     const [loggingInUserId, setLoggingInUserId] = useState<number | null>(null)
 
     const devLoginEnabled = isDevLoginEnabled()
@@ -210,6 +211,22 @@ export function useDevDebugger() {
     // Dev Login section is visible while loading or when users are available (null = feature disabled)
     const devLoginSectionVisible = !isAuthenticated && devLoginEnabled && (isLoadingDevUsers || !!devUsers)
 
+    // All unique roles across all users (for the role filter pills)
+    const devLoginAllRoles = devUsers
+        ? [...new Set(devUsers.flatMap((u) => u.roles))].sort()
+        : []
+
+    // Combined filter: text search AND role filter
+    const devLoginFilteredUsers = devUsers
+        ? devUsers.filter((u) => {
+              const q = devLoginSearch.toLowerCase()
+              const matchesText =
+                  !q || u.name.toLowerCase().includes(q) || u.email.toLowerCase().includes(q)
+              const matchesRole = !devLoginRoleFilter || u.roles.includes(devLoginRoleFilter)
+              return matchesText && matchesRole
+          })
+        : []
+
     return {
         dragRef,
         isHidden,
@@ -224,6 +241,10 @@ export function useDevDebugger() {
         token,
         devLoginEnabled,
         devLoginSectionVisible,
+        devLoginAllRoles,
+        devLoginRoleFilter,
+        setDevLoginRoleFilter,
+        devLoginFilteredUsers,
         devUsers,
         isLoadingDevUsers,
         cacheStats,

--- a/code/webapp/src/services/__tests__/dev-api.test.ts
+++ b/code/webapp/src/services/__tests__/dev-api.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { AxiosResponse } from 'axios'
+
+// Mock apiClient before importing the module under test
+vi.mock('@/lib/api-client', () => ({
+    apiClient: {
+        get: vi.fn(),
+        post: vi.fn(),
+    },
+}))
+
+vi.mock('@/lib/api-error', () => ({
+    isApiError: vi.fn(),
+}))
+
+// Import after mocks are registered
+import { apiClient } from '@/lib/api-client'
+import { isApiError } from '@/lib/api-error'
+import { listDevUsers, loginAs } from '../dev-api'
+
+const mockGet = vi.mocked(apiClient.get)
+const mockPost = vi.mocked(apiClient.post)
+const mockIsApiError = vi.mocked(isApiError)
+
+function make404Error() {
+    return { response: { status: 404 }, isAxiosError: true }
+}
+
+function make500Error() {
+    return { response: { status: 500 }, isAxiosError: true }
+}
+
+describe('listDevUsers', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('returns the data array on a successful response', async () => {
+        const users = [
+            { id: 1, name: 'Admin', email: 'admin@test.com', roles: ['admin'] },
+            { id: 2, name: 'Staff', email: 'staff@test.com', roles: ['inventory-manager'] },
+        ]
+        mockGet.mockResolvedValueOnce({
+            data: { status: 200, data: users },
+        } as AxiosResponse)
+
+        const result = await listDevUsers()
+
+        expect(mockGet).toHaveBeenCalledWith('/dev/users')
+        expect(result).toEqual(users)
+    })
+
+    it('returns null when the API responds with 404', async () => {
+        const err = make404Error()
+        mockGet.mockRejectedValueOnce(err)
+        mockIsApiError.mockReturnValueOnce(true)
+
+        const result = await listDevUsers()
+
+        expect(result).toBeNull()
+    })
+
+    it('rethrows errors that are not 404', async () => {
+        const err = make500Error()
+        mockGet.mockRejectedValueOnce(err)
+        mockIsApiError.mockReturnValueOnce(true)
+
+        await expect(listDevUsers()).rejects.toEqual(err)
+    })
+
+    it('rethrows non-API errors (network failure)', async () => {
+        const networkErr = new Error('Network Error')
+        mockGet.mockRejectedValueOnce(networkErr)
+        mockIsApiError.mockReturnValueOnce(false)
+
+        await expect(listDevUsers()).rejects.toThrow('Network Error')
+    })
+})
+
+describe('loginAs', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('returns auth data on a successful login', async () => {
+        const authData = {
+            token: 'tok-abc123',
+            token_type: 'Bearer',
+            user: { id: 5, name: 'Test User', email: 'test@test.com' },
+        }
+        mockPost.mockResolvedValueOnce({
+            data: { status: 200, data: authData },
+        } as AxiosResponse)
+
+        const result = await loginAs(5)
+
+        expect(mockPost).toHaveBeenCalledWith('/dev/login', { user_id: 5 })
+        expect(result).toEqual(authData)
+    })
+
+    it('returns null when the API responds with 404', async () => {
+        const err = make404Error()
+        mockPost.mockRejectedValueOnce(err)
+        mockIsApiError.mockReturnValueOnce(true)
+
+        const result = await loginAs(99)
+
+        expect(result).toBeNull()
+    })
+
+    it('rethrows errors that are not 404', async () => {
+        const err = make500Error()
+        mockPost.mockRejectedValueOnce(err)
+        mockIsApiError.mockReturnValueOnce(true)
+
+        await expect(loginAs(1)).rejects.toEqual(err)
+    })
+
+    it('rethrows non-API errors (network failure)', async () => {
+        const networkErr = new Error('Network Error')
+        mockPost.mockRejectedValueOnce(networkErr)
+        mockIsApiError.mockReturnValueOnce(false)
+
+        await expect(loginAs(1)).rejects.toThrow('Network Error')
+    })
+})

--- a/code/webapp/src/services/dev-api.ts
+++ b/code/webapp/src/services/dev-api.ts
@@ -7,6 +7,7 @@ export interface DevUser {
     name: string;
     email: string;
     roles: string[];
+    permissions: string[];
 }
 
 interface DevUsersResponse {

--- a/code/webapp/src/services/dev-api.ts
+++ b/code/webapp/src/services/dev-api.ts
@@ -1,4 +1,5 @@
 import { apiClient } from '@/lib/api-client';
+import { isApiError } from '@/lib/api-error';
 import type { AuthResponse } from './auth.service';
 
 export interface DevUser {
@@ -17,9 +18,11 @@ export async function listDevUsers(): Promise<DevUser[] | null> {
     try {
         const response = await apiClient.get<DevUsersResponse>('/dev/users');
         return response.data.data;
-    } catch {
-        // Feature disabled or unavailable — fail silently
-        return null;
+    } catch (error) {
+        if (isApiError(error) && error.response?.status === 404) {
+            return null; // Feature disabled — fail silently
+        }
+        throw error;
     }
 }
 
@@ -27,8 +30,10 @@ export async function loginAs(userId: number): Promise<AuthResponse['data'] | nu
     try {
         const response = await apiClient.post<AuthResponse>('/dev/login', { user_id: userId });
         return response.data.data;
-    } catch {
-        // Feature disabled or unavailable — fail silently
-        return null;
+    } catch (error) {
+        if (isApiError(error) && error.response?.status === 404) {
+            return null; // Feature disabled — fail silently
+        }
+        throw error;
     }
 }

--- a/code/webapp/src/services/dev-api.ts
+++ b/code/webapp/src/services/dev-api.ts
@@ -1,0 +1,34 @@
+import { apiClient } from '@/lib/api-client';
+import type { AuthResponse } from './auth.service';
+
+export interface DevUser {
+    id: number;
+    name: string;
+    email: string;
+    roles: string[];
+}
+
+interface DevUsersResponse {
+    status: number;
+    data: DevUser[];
+}
+
+export async function listDevUsers(): Promise<DevUser[] | null> {
+    try {
+        const response = await apiClient.get<DevUsersResponse>('/dev/users');
+        return response.data.data;
+    } catch {
+        // Feature disabled or unavailable — fail silently
+        return null;
+    }
+}
+
+export async function loginAs(userId: number): Promise<AuthResponse['data'] | null> {
+    try {
+        const response = await apiClient.post<AuthResponse>('/dev/login', { user_id: userId });
+        return response.data.data;
+    } catch {
+        // Feature disabled or unavailable — fail silently
+        return null;
+    }
+}

--- a/code/webapp/src/vite-env.d.ts
+++ b/code/webapp/src/vite-env.d.ts
@@ -12,6 +12,24 @@ interface ImportMetaEnv {
      * Controls whether the Dev Debugger starts hidden on boot.
      */
     readonly VITE_DEV_DEBUGGER_START_HIDDEN?: 'true' | 'false'
+    /**
+     * Enables the dev-debug quick login feature in DevDebugger.
+     * Must be exactly 'true' to activate. Any other value or absence = disabled.
+     * @see doc/tasks/backlog/101-dev-debug-login.md
+     */
+    readonly VITE_LOGIN_WITH_DEVDEBUG?: 'true' | 'false'
+    /**
+     * Comma-separated list of environments where dev-debug login is allowed.
+     * Example: 'dev,devtest'
+     * @see doc/tasks/backlog/101-dev-debug-login.md
+     */
+    readonly VITE_DEV_LOGIN_ALLOWED_ENVIRONMENTS?: string
+    /**
+     * Current application environment, used to validate against VITE_DEV_LOGIN_ALLOWED_ENVIRONMENTS.
+     * Example: 'dev' | 'devtest' | 'production'
+     * @see doc/tasks/backlog/101-dev-debug-login.md
+     */
+    readonly VITE_APP_ENV?: string
 }
 
 interface ImportMeta {

--- a/doc/conventions/frontend/dev-debugger.md
+++ b/doc/conventions/frontend/dev-debugger.md
@@ -34,9 +34,9 @@ It is never shipped in a production build — the condition is evaluated at buil
 
 ## Keyboard Shortcut
 
-| OS | Shortcut |
-|---|---|
-| macOS | `Cmd + Shift + D` |
+| OS              | Shortcut           |
+| --------------- | ------------------ |
+| macOS           | `Cmd + Shift + D`  |
 | Windows / Linux | `Ctrl + Shift + D` |
 
 The shortcut toggles the panel visible/hidden. When revealed after being hidden, it always opens in expanded mode. The shortcut is ignored when the cursor is inside an input, textarea, or contenteditable element.
@@ -124,11 +124,11 @@ The feature employs **defense in depth**: two independent validation layers, eac
 
 Implemented in `App\Support\DevLoginGuard::validate()` and called at the start of both `GET /v1/dev/users` and `POST /v1/dev/login`.
 
-| Condition | Variable | Failure behavior |
-|---|---|---|
-| Feature flag explicitly enabled | `LOGIN_WITH_DEVDEBUG=true` | Returns **404** |
-| Current `APP_ENV` is in the allowed list | `DEV_LOGIN_ALLOWED_ENVIRONMENTS` (csv) | Returns **404** |
-| `production` in the allowed list | — | **Throws `RuntimeException`** |
+| Condition                                | Variable                               | Failure behavior              |
+| ---------------------------------------- | -------------------------------------- | ----------------------------- |
+| Feature flag explicitly enabled          | `LOGIN_WITH_DEVDEBUG=true`             | Returns **404**               |
+| Current `APP_ENV` is in the allowed list | `DEV_LOGIN_ALLOWED_ENVIRONMENTS` (csv) | Returns **404**               |
+| `production` in the allowed list         | —                                      | **Throws `RuntimeException`** |
 
 Endpoints return **404** (not 401 or 403) when disabled. From the perspective of a caller, the endpoints do not exist.
 
@@ -155,34 +155,34 @@ If `production` appeared in the allowed list it would mean a misconfiguration sl
 
 ### Production deployment checklist
 
-| Check | Expected value |
-|---|---|
-| `LOGIN_WITH_DEVDEBUG` | `false` (or unset) |
-| `DEV_LOGIN_ALLOWED_ENVIRONMENTS` | must not contain `production` |
-| `APP_ENV` | `production` |
-| Routes registered? | No — environment guard prevents it |
-| Bundle contains `DevDebugger`? | No — `import.meta.env.DEV` is `false` at build time |
+| Check                            | Expected value                                      |
+| -------------------------------- | --------------------------------------------------- |
+| `LOGIN_WITH_DEVDEBUG`            | `false` (or unset)                                  |
+| `DEV_LOGIN_ALLOWED_ENVIRONMENTS` | must not contain `production`                       |
+| `APP_ENV`                        | `production`                                        |
+| Routes registered?               | No — environment guard prevents it                  |
+| Bundle contains `DevDebugger`?   | No — `import.meta.env.DEV` is `false` at build time |
 
 ---
 
 ## File Map
 
-| File | Purpose |
-|---|---|
-| `src/components/dev/DevDebugger.tsx` | Main component — UI, drag, sections, Dev Login |
-| `src/components/dev/dev-login-enabled.ts` | `isDevLoginEnabled()` — frontend guard helper |
-| `src/services/dev-api.ts` | `listDevUsers()` + `loginAs()` — API calls |
-| `app/Support/DevLoginGuard.php` | Backend guard — double validation + RuntimeException |
-| `config/devlogin.php` | Laravel config reading `LOGIN_WITH_DEVDEBUG` + allowed envs |
-| `app/Http/Controllers/Api/V1/Dev/ListDevUsersController.php` | `GET /v1/dev/users` |
-| `app/Http/Controllers/Api/V1/Dev/DevLoginController.php` | `POST /v1/dev/login` |
+| File                                                         | Purpose                                                     |
+| ------------------------------------------------------------ | ----------------------------------------------------------- |
+| `src/components/dev/DevDebugger.tsx`                         | Main component — UI, drag, sections, Dev Login              |
+| `src/components/dev/dev-login-enabled.ts`                    | `isDevLoginEnabled()` — frontend guard helper               |
+| `src/services/dev-api.ts`                                    | `listDevUsers()` + `loginAs()` — API calls                  |
+| `app/Support/DevLoginGuard.php`                              | Backend guard — double validation + RuntimeException        |
+| `config/devlogin.php`                                        | Laravel config reading `LOGIN_WITH_DEVDEBUG` + allowed envs |
+| `app/Http/Controllers/Api/V1/Dev/ListDevUsersController.php` | `GET /v1/dev/users`                                         |
+| `app/Http/Controllers/Api/V1/Dev/DevLoginController.php`     | `POST /v1/dev/login`                                        |
 
 ---
 
 ## Tests
 
-| Suite | File | Cases |
-|---|---|---|
-| PHPUnit Feature | `tests/Feature/Dev/DevLoginTest.php` | 6 — guard conditions, user list, token, RuntimeException |
-| Vitest | `src/components/dev/__tests__/dev-login-enabled.test.ts` | 6 — flag states, env mismatch, whitespace, empty list |
-| Cypress E2E | `cypress/e2e/dev-debug-login.cy.ts` | 3 — section visibility, login happy path, local search |
+| Suite           | File                                                     | Cases                                                    |
+| --------------- | -------------------------------------------------------- | -------------------------------------------------------- |
+| PHPUnit Feature | `tests/Feature/Dev/DevLoginTest.php`                     | 6 — guard conditions, user list, token, RuntimeException |
+| Vitest          | `src/components/dev/__tests__/dev-login-enabled.test.ts` | 6 — flag states, env mismatch, whitespace, empty list    |
+| Cypress E2E     | `cypress/e2e/dev-debug-login.cy.ts`                      | 3 — section visibility, login happy path, local search   |

--- a/doc/conventions/frontend/dev-debugger.md
+++ b/doc/conventions/frontend/dev-debugger.md
@@ -1,0 +1,188 @@
+# DevDebugger — Developer Debugging Panel
+
+The `DevDebugger` is a floating, draggable in-app panel that gives developers real-time visibility into authentication state, roles/permissions, and TanStack Query cache — without leaving the browser. It also provides a **Dev Login** feature for quickly switching between users during development.
+
+**Location:** `code/webapp/src/components/dev/DevDebugger.tsx`
+
+---
+
+## Purpose
+
+During development it is common to need to:
+
+- Verify what user is authenticated and what token/roles they hold
+- Switch between users with different roles to test permission-gated views
+- Inspect query cache state without opening DevTools
+- Spot auth-state regressions immediately after a code change
+
+The DevDebugger surfaces all of this directly in the app UI, removing the need to check `localStorage`, network tabs, or restart sessions manually.
+
+---
+
+## Rendering
+
+The component is only included in the bundle when Vite builds in `DEV` mode:
+
+```tsx
+// src/App.tsx (or root layout)
+{import.meta.env.DEV && <DevDebugger />}
+```
+
+It is never shipped in a production build — the condition is evaluated at build time, so the component and all its imports are tree-shaken out.
+
+---
+
+## Keyboard Shortcut
+
+| OS | Shortcut |
+|---|---|
+| macOS | `Cmd + Shift + D` |
+| Windows / Linux | `Ctrl + Shift + D` |
+
+The shortcut toggles the panel visible/hidden. When revealed after being hidden, it always opens in expanded mode. The shortcut is ignored when the cursor is inside an input, textarea, or contenteditable element.
+
+---
+
+## Sections
+
+### User
+Displays the currently authenticated user: ID, name, email, authentication status, and a truncated token preview.
+
+### Roles & Permissions
+Shows role badges and direct permission badges from the auth store. Also exposes the computed `isAdmin` value.
+
+### Query Cache
+Live snapshot of TanStack Query's cache: total queries, fresh, stale, and currently fetching. The toolbar **Refresh** button (`↻`) calls `queryClient.invalidateQueries()` to force a full refetch.
+
+### Dev Login *(shown only when not authenticated)*
+Allows logging in as any existing user without a password. See [Dev Login](#dev-login) below.
+
+---
+
+## State Persistence
+
+The panel position and each section's collapsed/expanded state are persisted to `localStorage` under the key `dev_debugger_state`. They survive page reloads within the same browser.
+
+To reset to defaults, run in the console:
+
+```js
+localStorage.removeItem('dev_debugger_state')
+```
+
+---
+
+## Visibility Control
+
+By default the debugger starts visible when the page loads. To start hidden (useful in E2E environments), set:
+
+```env
+VITE_DEV_DEBUGGER_START_HIDDEN=true
+```
+
+The panel can still be revealed at any time with the keyboard shortcut.
+
+---
+
+## Dev Login
+
+### What it does
+
+When a developer is **not authenticated**, the Dev Login section lists all users in the database. Clicking any user logs in as that user instantly — no password required — and reloads the page with a valid session.
+
+This is strictly a developer convenience. It is designed to be inert in any non-development environment.
+
+### How to enable it
+
+Two environment variable pairs must be set — one on each side of the stack:
+
+**API (`code/api/.env`):**
+```env
+LOGIN_WITH_DEVDEBUG=true
+DEV_LOGIN_ALLOWED_ENVIRONMENTS=local,dev,devtest
+```
+
+**Webapp (`code/webapp/.env`):**
+```env
+VITE_LOGIN_WITH_DEVDEBUG=true
+VITE_DEV_LOGIN_ALLOWED_ENVIRONMENTS=local,dev,devtest
+VITE_APP_ENV=local
+```
+
+Both pairs default to disabled in `.env.example`.
+
+### Search / filter
+
+The section renders a search field that filters the user list **locally** (no additional API calls on each keystroke). Useful when the database has many users — type a name or email to narrow the list.
+
+---
+
+## Security Architecture
+
+The feature employs **defense in depth**: two independent validation layers, each capable of blocking access on its own.
+
+### Layer 1 — Backend (source of truth)
+
+Implemented in `App\Support\DevLoginGuard::validate()` and called at the start of both `GET /v1/dev/users` and `POST /v1/dev/login`.
+
+| Condition | Variable | Failure behavior |
+|---|---|---|
+| Feature flag explicitly enabled | `LOGIN_WITH_DEVDEBUG=true` | Returns **404** |
+| Current `APP_ENV` is in the allowed list | `DEV_LOGIN_ALLOWED_ENVIRONMENTS` (csv) | Returns **404** |
+| `production` in the allowed list | — | **Throws `RuntimeException`** |
+
+Endpoints return **404** (not 401 or 403) when disabled. From the perspective of a caller, the endpoints do not exist.
+
+Routes are also only registered at all when `app()->environment('testing', 'local', 'dev', 'devtest')` is true (see `routes/api.php`). In a production deployment where `APP_ENV=production`, the routes are not registered at the framework level — the guard never even runs.
+
+### Layer 2 — Frontend (avoids unnecessary requests)
+
+`isDevLoginEnabled()` in `dev-login-enabled.ts` mirrors the backend logic using the `VITE_` copies of the same variables. If either condition fails the Dev Login section is not rendered and no API call is made.
+
+```
+VITE_LOGIN_WITH_DEVDEBUG !== 'true'  →  section hidden, no request
+VITE_APP_ENV not in VITE_DEV_LOGIN_ALLOWED_ENVIRONMENTS  →  section hidden, no request
+```
+
+The frontend check is a UX guard, not a security control. The backend is always the authoritative gate.
+
+### Why 404, not 401/403?
+
+Returning 401 or 403 would reveal that the endpoint exists. A 404 makes the endpoint indistinguishable from any unknown route to an external observer or automated scanner.
+
+### Why `RuntimeException` for production in the list?
+
+If `production` appeared in the allowed list it would mean a misconfiguration slipped through. A silent 404 would hide the problem; a thrown exception causes an immediate, loud failure that forces the developer to fix the configuration before the app can serve any request. This is intentional **fail-loud** behavior.
+
+### Production deployment checklist
+
+| Check | Expected value |
+|---|---|
+| `LOGIN_WITH_DEVDEBUG` | `false` (or unset) |
+| `DEV_LOGIN_ALLOWED_ENVIRONMENTS` | must not contain `production` |
+| `APP_ENV` | `production` |
+| Routes registered? | No — environment guard prevents it |
+| Bundle contains `DevDebugger`? | No — `import.meta.env.DEV` is `false` at build time |
+
+---
+
+## File Map
+
+| File | Purpose |
+|---|---|
+| `src/components/dev/DevDebugger.tsx` | Main component — UI, drag, sections, Dev Login |
+| `src/components/dev/dev-login-enabled.ts` | `isDevLoginEnabled()` — frontend guard helper |
+| `src/services/dev-api.ts` | `listDevUsers()` + `loginAs()` — API calls |
+| `app/Support/DevLoginGuard.php` | Backend guard — double validation + RuntimeException |
+| `config/devlogin.php` | Laravel config reading `LOGIN_WITH_DEVDEBUG` + allowed envs |
+| `app/Http/Controllers/Api/V1/Dev/ListDevUsersController.php` | `GET /v1/dev/users` |
+| `app/Http/Controllers/Api/V1/Dev/DevLoginController.php` | `POST /v1/dev/login` |
+
+---
+
+## Tests
+
+| Suite | File | Cases |
+|---|---|---|
+| PHPUnit Feature | `tests/Feature/Dev/DevLoginTest.php` | 6 — guard conditions, user list, token, RuntimeException |
+| Vitest | `src/components/dev/__tests__/dev-login-enabled.test.ts` | 6 — flag states, env mismatch, whitespace, empty list |
+| Cypress E2E | `cypress/e2e/dev-debug-login.cy.ts` | 3 — section visibility, login happy path, local search |

--- a/doc/tasks/backlog/101-dev-debug-login.md
+++ b/doc/tasks/backlog/101-dev-debug-login.md
@@ -113,9 +113,11 @@ VITE_APP_ENV=production
 - [x] 🔧 Section renders: search field + scrollable user list (name + email)
   - Uses `useQuery` from TanStack Query — fetches full list once
   - Search field filters the list **locally** (no backend calls on type)
-  - Each item is clickable → calls `loginAs` → stores token in auth store via `initializeAfterReset` → `window.location.reload()`
+  - Each item is clickable → calls `loginAs` → stores token in auth store via `initializeAfterReset` → `globalThis.location.reload()`
 - [x] 🔧 If endpoint returns 404, section is not shown (silent — no error displayed)
 - [x] 🔧 Loading states: skeleton while loading the list, spinner on the item during login
+- [ ] 🎨 Each user card shows **role badges** — one colored badge per role, with a distinctive color per role name
+- [ ] 🔧 Add **role filter** — a row of toggleable role buttons above the user list; tapping a role shows only users with that role (cumulative with the text search)
 
 ### Tests
 
@@ -139,6 +141,9 @@ VITE_APP_ENV=production
 - [ ] Frontend makes no API calls if `isDevLoginEnabled()` is `false`
 - [ ] If `production` appears in the allowed environments list → explicit runtime exception
 - [ ] Feature is disabled by default (`LOGIN_WITH_DEVDEBUG=false` / `VITE_LOGIN_WITH_DEVDEBUG=false`)
+- [ ] Each user card shows a colored badge for each of their roles
+- [ ] Role filter row is visible above the list; selecting a role hides users without that role
+- [ ] Text search and role filter work cumulatively (AND logic)
 
 ---
 

--- a/doc/tasks/backlog/101-dev-debug-login.md
+++ b/doc/tasks/backlog/101-dev-debug-login.md
@@ -16,11 +16,11 @@ The endpoints and the UI are only available when **both** conditions are met sim
 
 ### Layer 1 — Backend (source of truth)
 
-| Condition | Variable | Behavior on failure |
-|---|---|---|
-| Feature flag enabled | `LOGIN_WITH_DEVDEBUG=true` | Returns 404 (appears non-existent) |
-| Environment allowed | `APP_ENV` in `DEV_LOGIN_ALLOWED_ENVIRONMENTS` (csv) | Returns 404 (appears non-existent) |
-| Safety guard | `DEV_LOGIN_ALLOWED_ENVIRONMENTS` contains `production` | **Throws exception** — critical misconfiguration |
+| Condition            | Variable                                               | Behavior on failure                              |
+| -------------------- | ------------------------------------------------------ | ------------------------------------------------ |
+| Feature flag enabled | `LOGIN_WITH_DEVDEBUG=true`                             | Returns 404 (appears non-existent)               |
+| Environment allowed  | `APP_ENV` in `DEV_LOGIN_ALLOWED_ENVIRONMENTS` (csv)    | Returns 404 (appears non-existent)               |
+| Safety guard         | `DEV_LOGIN_ALLOWED_ENVIRONMENTS` contains `production` | **Throws exception** — critical misconfiguration |
 
 **Español:** Los endpoints solo están activos si el flag está en `true` **y** el entorno actual está en la lista permitida. Si `production` aparece en esa lista, se lanza una excepción explícita — nunca se silencia.
 
@@ -28,11 +28,11 @@ The endpoints and the UI are only available when **both** conditions are met sim
 
 The same variables are exposed to the frontend via Vite (`VITE_` prefix). The DevDebugger evaluates both **before** making any API call:
 
-| Vite variable | Default | Purpose |
-|---|---|---|
-| `VITE_LOGIN_WITH_DEVDEBUG` | `false` | Feature flag — must be exactly `true` |
-| `VITE_DEV_LOGIN_ALLOWED_ENVIRONMENTS` | `dev,devtest` | Allowed environments (csv) |
-| `VITE_APP_ENV` | `production` | Current environment — compared against the list |
+| Vite variable                         | Default       | Purpose                                         |
+| ------------------------------------- | ------------- | ----------------------------------------------- |
+| `VITE_LOGIN_WITH_DEVDEBUG`            | `false`       | Feature flag — must be exactly `true`           |
+| `VITE_DEV_LOGIN_ALLOWED_ENVIRONMENTS` | `dev,devtest` | Allowed environments (csv)                      |
+| `VITE_APP_ENV`                        | `production`  | Current environment — compared against the list |
 
 If either condition fails on the frontend → the section is not rendered and no API call is made.
 The backend remains the source of truth (the 404 is the final safety net).

--- a/doc/tasks/backlog/101-dev-debug-login.md
+++ b/doc/tasks/backlog/101-dev-debug-login.md
@@ -1,0 +1,163 @@
+# 🔑 Task #101: Dev Debug Login — Quick User Switch in DevDebugger
+
+## 📖 Story
+
+**English:**
+As a developer, I need to be able to log in as any existing user directly from the DevDebugger panel (without knowing their password), so that I can quickly test the app from different user perspectives during development.
+
+**Español:**
+Como desarrollador, necesito poder iniciar sesión como cualquier usuario existente directamente desde el panel DevDebugger (sin conocer su contraseña), para poder probar la aplicación desde distintas perspectivas de usuario durante el desarrollo.
+
+---
+
+## 🧠 Design — Double Security Validation (backend + frontend)
+
+The endpoints and the UI are only available when **both** conditions are met simultaneously. Validation occurs in two independent layers (defense in depth):
+
+### Layer 1 — Backend (source of truth)
+
+| Condition | Variable | Behavior on failure |
+|---|---|---|
+| Feature flag enabled | `LOGIN_WITH_DEVDEBUG=true` | Returns 404 (appears non-existent) |
+| Environment allowed | `APP_ENV` in `DEV_LOGIN_ALLOWED_ENVIRONMENTS` (csv) | Returns 404 (appears non-existent) |
+| Safety guard | `DEV_LOGIN_ALLOWED_ENVIRONMENTS` contains `production` | **Throws exception** — critical misconfiguration |
+
+**Español:** Los endpoints solo están activos si el flag está en `true` **y** el entorno actual está en la lista permitida. Si `production` aparece en esa lista, se lanza una excepción explícita — nunca se silencia.
+
+### Layer 2 — Frontend (avoids unnecessary requests)
+
+The same variables are exposed to the frontend via Vite (`VITE_` prefix). The DevDebugger evaluates both **before** making any API call:
+
+| Vite variable | Default | Purpose |
+|---|---|---|
+| `VITE_LOGIN_WITH_DEVDEBUG` | `false` | Feature flag — must be exactly `true` |
+| `VITE_DEV_LOGIN_ALLOWED_ENVIRONMENTS` | `dev,devtest` | Allowed environments (csv) |
+| `VITE_APP_ENV` | `production` | Current environment — compared against the list |
+
+If either condition fails on the frontend → the section is not rendered and no API call is made.
+The backend remains the source of truth (the 404 is the final safety net).
+
+**Español:** El frontend tiene su propia validación para no hacer llamadas innecesarias. Si cualquiera de las dos condiciones falla, la sección no se renderiza y no se hace ninguna petición a la API.
+
+**Default values in `.env.example` (API):**
+```env
+LOGIN_WITH_DEVDEBUG=false
+DEV_LOGIN_ALLOWED_ENVIRONMENTS=dev,devtest
+```
+
+**Default values in `.env.example` (Webapp):**
+```env
+VITE_LOGIN_WITH_DEVDEBUG=false
+VITE_DEV_LOGIN_ALLOWED_ENVIRONMENTS=dev,devtest
+VITE_APP_ENV=production
+```
+
+**Rules:**
+- Any value other than exactly `true` in both flags is treated as `false`
+- `DEV_LOGIN_ALLOWED_ENVIRONMENTS` is a csv list (`dev,devtest,local`)
+- If `production` appears in the backend list → explicit exception, never silenced
+- Endpoints return **404** (not 401/403) when disabled — they appear not to exist
+
+---
+
+## ✅ Technical Tasks
+
+### Backend — Dev-only Endpoints
+
+- [x] 🔧 Create reusable `DevLoginGuard` helper encapsulating the double validation:
+  - Reads `LOGIN_WITH_DEVDEBUG` — if not exactly `true` → abort with 404
+  - Reads `DEV_LOGIN_ALLOWED_ENVIRONMENTS` as csv → if `production` is in the list → throw `RuntimeException`
+  - If `APP_ENV` is not in the list → abort with 404
+- [x] 🔧 Create endpoint `GET /v1/dev/users` — returns paginated list of users with id, name, email, roles
+  - Registered only inside the `if (app()->environment(...))` block in `api.php` (same as `/v1/test/`)
+  - Calls the guard at the start of the handler
+  - Returns users without passwords or tokens
+  - Supports `?search=` (filter by name/email) and `?page=` (pagination)
+- [x] 🔧 Create endpoint `POST /v1/dev/login` — receives `{ user_id: int }`, generates Passport token and returns it
+  - Calls the guard at the start of the handler
+  - Returns 404 if user does not exist
+  - Creates OAuth token via `$user->createToken('dev-debug')->accessToken`
+  - Returns same structure as `POST /v1/auth/login`
+
+### Backend — Environment Variables
+
+- [x] 📝 Add to `code/api/.env.example`:
+  ```env
+  LOGIN_WITH_DEVDEBUG=false
+  DEV_LOGIN_ALLOWED_ENVIRONMENTS=dev,devtest
+  ```
+- [ ] 📝 Add to `code/api/.env` (local dev) with `LOGIN_WITH_DEVDEBUG=true`
+
+### Frontend — Environment Variables
+
+- [x] 📝 Add to `code/webapp/.env.example`:
+  ```env
+  VITE_LOGIN_WITH_DEVDEBUG=false
+  VITE_DEV_LOGIN_ALLOWED_ENVIRONMENTS=dev,devtest
+  VITE_APP_ENV=production
+  ```
+- [x] 📝 Add to `code/webapp/.env` (local dev):
+  ```env
+  VITE_LOGIN_WITH_DEVDEBUG=true
+  VITE_DEV_LOGIN_ALLOWED_ENVIRONMENTS=dev,devtest
+  VITE_APP_ENV=dev
+  ```
+- [x] 🔧 Add `VITE_LOGIN_WITH_DEVDEBUG`, `VITE_DEV_LOGIN_ALLOWED_ENVIRONMENTS`, `VITE_APP_ENV` to `src/vite-env.d.ts` with JSDoc
+
+### Frontend — DevDebugger
+
+- [x] 🔧 Create `isDevLoginEnabled()` helper — evaluates `VITE_LOGIN_WITH_DEVDEBUG` and checks `VITE_APP_ENV` is in `VITE_DEV_LOGIN_ALLOWED_ENVIRONMENTS`
+- [x] 🔧 Add "Dev Login" section to `DevDebugger.tsx` — only visible when `!isAuthenticated && isDevLoginEnabled()`
+- [x] 🔧 Create `listDevUsers()` → `GET /v1/dev/users` (returns full user list, no pagination)
+- [x] 🔧 Create `loginAs(userId)` → `POST /v1/dev/login`
+- [x] 🔧 Section renders: search field + scrollable user list (name + email)
+  - Uses `useQuery` from TanStack Query — fetches full list once
+  - Search field filters the list **locally** (no backend calls on type)
+  - Each item is clickable → calls `loginAs` → stores token in auth store via `initializeAfterReset` → `window.location.reload()`
+- [x] 🔧 If endpoint returns 404, section is not shown (silent — no error displayed)
+- [x] 🔧 Loading states: skeleton while loading the list, spinner on the item during login
+
+### Tests
+
+- [x] ✅ PHPUnit: `GET /v1/dev/users` returns 404 in `production` environment
+- [x] ✅ PHPUnit: `GET /v1/dev/users` returns 404 if `LOGIN_WITH_DEVDEBUG` is not `true`
+- [x] ✅ PHPUnit: `GET /v1/dev/users` returns full user list when both conditions are met
+- [x] ✅ PHPUnit: `POST /v1/dev/login` with valid `user_id` returns a token
+- [x] ✅ PHPUnit: `POST /v1/dev/login` with non-existent `user_id` returns 404
+- [x] ✅ PHPUnit: `DEV_LOGIN_ALLOWED_ENVIRONMENTS` containing `production` throws exception
+- [x] ✅ Vitest: `isDevLoginEnabled()` returns `false` if `VITE_LOGIN_WITH_DEVDEBUG` is not `true`
+- [x] ✅ Vitest: `isDevLoginEnabled()` returns `false` if `VITE_APP_ENV` is not in the allowed list
+
+---
+
+## 🎯 Acceptance Criteria
+
+- [ ] Without an active session, DevDebugger shows a search field + scrollable user list
+- [ ] Search field filters the list locally (no additional API calls on type)
+- [ ] Clicking a user logs in without requiring a password
+- [ ] Endpoints return 404 if either condition is not met (backend)
+- [ ] Frontend makes no API calls if `isDevLoginEnabled()` is `false`
+- [ ] If `production` appears in the allowed environments list → explicit runtime exception
+- [ ] Feature is disabled by default (`LOGIN_WITH_DEVDEBUG=false` / `VITE_LOGIN_WITH_DEVDEBUG=false`)
+
+---
+
+## 🔗 References
+
+- **Depends on:** none
+- **Related to:** `DevDebugger` (`code/webapp/src/components/dev/DevDebugger.tsx`)
+- **Reference pattern:** `if (app()->environment(...))` block in `routes/api.php` line 80
+
+---
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `3h`
+- **Pessimistic:** `5h`
+- **Tracked:** —
+
+### 📅 Sessions
+```json
+[]
+```

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -20,6 +20,9 @@ services:
       - VITE_APP_PORT=${VITE_APP_PORT:-5173}
       - VITE_API_URL=https://api.sushigo.e2e.local/api/v1
       - VITE_DEV_DEBUGGER_START_HIDDEN=true
+      - VITE_LOGIN_WITH_DEVDEBUG=true
+      - VITE_DEV_LOGIN_ALLOWED_ENVIRONMENTS=local,dev,devtest,e2e
+      - VITE_APP_ENV=local
       - CYPRESS_baseUrl=${CYPRESS_baseUrl:-https://sushigo.e2e.local}
       - DB_HOST=pgsql
       - POSTGRES_USER=${POSTGRES_USER:-admin}


### PR DESCRIPTION
## Summary

Closes #109

Adds a **Dev Login** section to the `DevDebugger` panel that lets a developer log in as any existing user without a password — only when the feature is explicitly enabled via environment variables.

---

## Security Design — Double Guard

Two independent validation layers prevent accidental exposure:

| Layer | Condition | Behavior on failure |
|---|---|---|
| **Backend** | `LOGIN_WITH_DEVDEBUG=true` + `APP_ENV` in `DEV_LOGIN_ALLOWED_ENVIRONMENTS` | Returns 404 (endpoints appear non-existent) |
| **Frontend** | `VITE_LOGIN_WITH_DEVDEBUG=true` + `VITE_APP_ENV` in `VITE_DEV_LOGIN_ALLOWED_ENVIRONMENTS` | Section not rendered, no API call made |

If `production` appears in the allowed environments list → **RuntimeException** (explicit fail-loud, never silenced).

Disabled by default in `.env.example` (`LOGIN_WITH_DEVDEBUG=false`).

---

## Changes

### Backend
- `App\Support\DevLoginGuard` — reusable double-validation helper
- `config/devlogin.php` — reads `LOGIN_WITH_DEVDEBUG` + `DEV_LOGIN_ALLOWED_ENVIRONMENTS`
- `GET /v1/dev/users` (`ListDevUsersController`) — returns user list (id, name, email, roles)
- `POST /v1/dev/login` (`DevLoginController`) — generates Passport token for `user_id`
- Routes registered inside the `if (app()->environment(...))` guard block

### Frontend
- `isDevLoginEnabled()` helper (`dev-login-enabled.ts`) — mirrors backend guard
- `listDevUsers()` + `loginAs()` service (`dev-api.ts`) — silent 404 handling
- `DevDebugger.tsx` — new **Dev Login** section: search field (local filter), scrollable user list with max-height, skeleton loading, per-item spinner, calls `initializeAfterReset` on success

### Tests
- **PHPUnit** (6): guard conditions, user list, token generation, RuntimeException safety
- **Vitest** (6): `isDevLoginEnabled()` — flag states, env mismatch, whitespace trimming, empty list
- **Cypress E2E** (3): section visibility, login happy path + localStorage assertion, local search filter

### Infra / Config
- `.env.example` updated (API + webapp)
- `vite-env.d.ts` typed declarations with JSDoc
- `docker-compose.e2e.yml` — VITE vars added for E2E environment
- Task file: `doc/tasks/backlog/101-dev-debug-login.md`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pakodiazdev/sushigo/pull/110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
