### PR TITLE
📚 [#126] Pivot EmployeeRequest — domain model v1.1 + tasks #126 #127

### DIFF
--- a/doc/modules/attendance-payroll/attendance-payroll-domain-model.en.md
+++ b/doc/modules/attendance-payroll/attendance-payroll-domain-model.en.md
@@ -1,9 +1,11 @@
 # 📐 Domain Model — Attendance & Payroll (SushiGo)
 
-**Version:** 1.0
-**Date:** 2026-02-09
+**Version:** 1.1
+**Date:** 2026-04-21
 **Base:** attendance-payroll-spec v0.8 + mvp-scope
-**Status:** Frozen domain contract
+**Status:** Active domain contract
+
+**Changelog v1.1 (2026-04-21):** Added `EmployeeRequest` as the unified approval wrapper for all employee requests. Concrete entities (`NegotiatedExtraDay`, `Leave`, `VacationRequest`) are now created only upon approval — keeping the DB semantically clean. Approval lifecycle fields (`status`, `approved_by`, `approved_at`) removed from concrete entities and centralized in `EmployeeRequest`. Added subdomain 1.7 (Requests ER), section 2.24 (employee_requests dict), and sequence 6.5 (request lifecycle).
 
 ---
 
@@ -16,6 +18,8 @@
 5. [State Diagrams](#5-state-diagrams)
 6. [Sequence Diagrams](#6-sequence-diagrams)
 7. [Integrity Rules and Constraints](#7-integrity-rules-and-constraints)
+
+> **Subdomains:** 1.1 Employees & Config · 1.2 Daily Operations · 1.3 Leaves, Vacations & Holidays · 1.4 Payroll Close · 1.5 Punctuality Config · 1.6 Audit · **1.7 Requests (new)**
 
 ---
 
@@ -138,6 +142,7 @@ erDiagram
     Attendance ||--o{ OvertimeBankMovement : "attendance_id"
 
     NegotiatedExtraDay }|--|| Branch : "branch_id"
+    NegotiatedExtraDay }|--|| EmployeeRequest : "request_id"
 
     Attendance {
         bigint id PK
@@ -164,8 +169,25 @@ erDiagram
         bigint employee_id FK
         date date
         bigint branch_id FK
-        decimal agreed_pay
-        bigint approved_by FK
+        decimal salary_day "10,2"
+        decimal prima "10,2"
+        decimal seventh_day "10,2"
+        decimal agreed_pay "10,2 total"
+        bigint request_id FK "→ employee_requests"
+        text notes "nullable"
+    }
+
+    EmployeeRequest {
+        bigint id PK
+        bigint employee_id FK
+        enum type "EXTRA_DAY|LEAVE|VACATION|..."
+        enum status "PENDING|APPROVED|REJECTED|CANCELLED"
+        string requestable_type "nullable - set on approval"
+        bigint requestable_id "nullable - set on approval"
+        json payload "type-specific data"
+        bigint requested_by FK
+        bigint approved_by FK "nullable"
+        datetime approved_at "nullable"
         text notes "nullable"
     }
 
@@ -195,6 +217,8 @@ erDiagram
     Employee ||--|{ VacationRequest : "employee_id"
 
     Leave }|--|| LeaveType : "leave_type_id"
+    Leave }|--|| EmployeeRequest : "request_id"
+    VacationRequest }|--|| EmployeeRequest : "request_id"
 
     LeaveType {
         bigint id PK
@@ -221,10 +245,7 @@ erDiagram
         time actual_start_time "nullable"
         time actual_end_time "nullable"
         integer actual_duration_minutes "nullable"
-        enum status "PENDING|APPROVED|REJECTED|CANCELLED"
-        bigint requested_by FK
-        bigint approved_by FK "nullable"
-        datetime approved_at "nullable"
+        bigint request_id FK "→ employee_requests"
         text notes "nullable"
     }
 
@@ -250,9 +271,7 @@ erDiagram
         date start_date
         date end_date
         decimal days_count
-        enum status "PENDING|APPROVED|REJECTED|CANCELLED"
-        bigint approved_by FK "nullable"
-        datetime approved_at "nullable"
+        bigint request_id FK "→ employee_requests"
         text notes "nullable"
     }
 ```
@@ -342,6 +361,50 @@ erDiagram
         text reason "nullable"
     }
 ```
+
+### 1.7 Subdomain: Requests (Employee Requests & Approval Workflow)
+
+> **Design decision:** `EmployeeRequest` is the unified approval wrapper for all employee requests. Concrete entities are created **only upon approval** — if a record exists in `negotiated_extra_days`, `leaves`, or `vacation_requests`, it is approved by definition. No status filtering needed on those tables.
+
+```mermaid
+erDiagram
+    Employee ||--|{ EmployeeRequest : "employee_id"
+    EmployeeRequest ||--o| NegotiatedExtraDay : "requestable (EXTRA_DAY)"
+    EmployeeRequest ||--o| Leave : "requestable (LEAVE)"
+    EmployeeRequest ||--o| VacationRequest : "requestable (VACATION)"
+
+    EmployeeRequest {
+        bigint id PK
+        bigint employee_id FK
+        enum type "EXTRA_DAY|LEAVE|VACATION|SCHEDULE_CHANGE"
+        enum status "PENDING|APPROVED|REJECTED|CANCELLED"
+        string requestable_type "nullable - set on approval"
+        bigint requestable_id "nullable - set on approval"
+        json payload "type-specific data while pending"
+        bigint requested_by FK "→ users"
+        bigint approved_by FK "nullable → users"
+        datetime approved_at "nullable"
+        text notes "nullable"
+        timestamp created_at
+        timestamp updated_at
+    }
+```
+
+**Lifecycle:**
+
+```
+Manager registers → EmployeeRequest{APPROVED} → concrete entity created immediately
+Employee requests → EmployeeRequest{PENDING} → inbox → Manager approves → concrete entity created
+                                                      → Manager rejects  → no entity created
+```
+
+**payload JSON shape by type:**
+
+| type | payload fields |
+|---|---|
+| `EXTRA_DAY` | `date`, `branch_id`, `salary_pct`, `prima_pct`, `salary_day`, `prima_amount`, `seventh_day`, `total` |
+| `LEAVE` | `leave_type_id`, `start_date`, `end_date`, `pay_percentage`, `time_mode`, … |
+| `VACATION` | `start_date`, `end_date`, `days_count` |
 
 ---
 
@@ -485,19 +548,24 @@ erDiagram
 
 ### 2.9 `negotiated_extra_days` — Negotiated Extra Days
 
-| Field         | Type          | Null | Default | Description               | FR           |
-| ------------- | ------------- | ---- | ------- | ------------------------- | ------------ |
-| `id`          | bigint        | NO   | auto    | PK                        | —            |
-| `employee_id` | bigint FK     | NO   | —       | Employee.                 | RF-38        |
-| `date`        | date          | NO   | —       | Extra day date.           | RF-39        |
-| `branch_id`   | bigint FK     | NO   | —       | Branch where they worked. | RF-39        |
-| `agreed_pay`  | decimal(10,2) | NO   | —       | Agreed pay.               | RF-39, RN-10 |
-| `approved_by` | bigint FK     | NO   | —       | Who approved (→ `users`). | RF-39, RN-09 |
-| `notes`       | text          | YES  | NULL    | Notes/observations.       | RF-39        |
-| `created_at`  | timestamp     | NO   | now     | —                         | —            |
-| `updated_at`  | timestamp     | NO   | now     | —                         | —            |
+> **v1.1:** Records exist only in approved state. Approval lifecycle (`status`, `approved_by`, `approved_at`) is managed by `EmployeeRequest`. `agreed_pay` was split into three components for payroll line-item breakdown.
 
-**Constraints:** UNIQUE(`employee_id`, `date`).
+| Field         | Type          | Null | Default | Description                                         | FR           |
+| ------------- | ------------- | ---- | ------- | --------------------------------------------------- | ------------ |
+| `id`          | bigint        | NO   | auto    | PK                                                  | —            |
+| `employee_id` | bigint FK     | NO   | —       | Employee.                                           | RF-38        |
+| `date`        | date          | NO   | —       | Extra day date.                                     | RF-39        |
+| `branch_id`   | bigint FK     | NO   | —       | Branch where they worked.                           | RF-39        |
+| `salary_day`  | decimal(10,2) | NO   | —       | Salary component (agreed daily wage).               | RF-39, RN-10 |
+| `prima`       | decimal(10,2) | NO   | —       | Rest-day premium component.                         | RF-39, RN-10 |
+| `seventh_day` | decimal(10,2) | NO   | —       | Seventh-day component (1/6 of salary_day).          | RF-39        |
+| `agreed_pay`  | decimal(10,2) | NO   | —       | Total agreed pay (= salary_day + prima + seventh_day). | RF-39, RN-10 |
+| `request_id`  | bigint FK     | NO   | —       | Originating request (→ `employee_requests`).        | RF-39, RN-09 |
+| `notes`       | text          | YES  | NULL    | Notes/observations.                                 | RF-39        |
+| `created_at`  | timestamp     | NO   | now     | —                                                   | —            |
+| `updated_at`  | timestamp     | NO   | now     | —                                                   | —            |
+
+**Constraints:** UNIQUE(`employee_id`, `date`). INDEX(`request_id`).
 
 ---
 
@@ -551,36 +619,35 @@ erDiagram
 
 ---
 
-### 2.12 `leaves` — Leave Requests (Full Day, Range, or Partial Hours)
+### 2.12 `leaves` — Leave Records (Full Day, Range, or Partial Hours)
 
-| Field                     | Type          | Null | Default   | Description                                                                                                                         | FR     |
-| ------------------------- | ------------- | ---- | --------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------ |
-| `id`                      | bigint        | NO   | auto      | PK                                                                                                                                  | —      |
-| `employee_id`             | bigint FK     | NO   | —         | Employee.                                                                                                                           | RF-25  |
-| `leave_type_id`           | bigint FK     | NO   | —         | Leave type from catalog.                                                                                                            | RF-25  |
-| `start_date`              | date          | NO   | —         | Start date (= end_date for partial/hourly leaves).                                                                                  | RF-25  |
-| `end_date`                | date          | NO   | —         | End date (= start_date if single day or partial).                                                                                   | RF-25  |
-| `pay_percentage`          | decimal(5,2)  | YES  | NULL      | Pay % override for this instance (0–100). NULL = use `leave_types.default_pay_percentage`. Only for `FIXED_PERCENTAGE` types.       | RF-25  |
-| `rest_day_factor`         | enum          | YES  | NULL      | Rest-day impact override: `FULL`, `PROPORTIONAL`, or `NONE`. NULL = use `leave_types.default_rest_day_factor`.                      | RF-25  |
-| `time_mode`               | enum          | YES  | NULL      | `SCHEDULED` or `OPEN_ENDED`. Required for `PROPORTIONAL_HOURS` types. `SCHEDULED` = known start+end; `OPEN_ENDED` = start only.    | RF-25a |
-| `scheduled_start_time`    | time          | YES  | NULL      | Planned departure time. Required when `time_mode` is set.                                                                           | RF-25a |
-| `scheduled_end_time`      | time          | YES  | NULL      | Planned return time. NULL when `time_mode = OPEN_ENDED`.                                                                            | RF-25a |
-| `actual_start_time`       | time          | YES  | NULL      | Actual departure recorded from Today view after approval.                                                                           | RF-25a |
-| `actual_end_time`         | time          | YES  | NULL      | Actual return recorded from Today view. NULL if employee did not return.                                                            | RF-25a |
-| `actual_duration_minutes` | integer       | YES  | NULL      | Minutes away from work. Computed from actual times if recorded; falls back to scheduled times. Used for payroll deduction.          | RF-25a |
-| `status`                  | enum          | NO   | `PENDING` | `PENDING`, `APPROVED`, `REJECTED`, `CANCELLED`.                                                                                     | RF-25  |
-| `requested_by`            | bigint FK     | NO   | —         | User who registered the leave (→ `users`).                                                                                          | RF-25  |
-| `approved_by`             | bigint FK     | YES  | NULL      | User who approved/rejected (→ `users`).                                                                                             | RF-25  |
-| `approved_at`             | datetime      | YES  | NULL      | When approved or rejected.                                                                                                          | RF-25  |
-| `notes`                   | text          | YES  | NULL      | Notes / justification.                                                                                                              | RF-25  |
-| `created_at`              | timestamp     | NO   | now       | —                                                                                                                                   | —      |
-| `updated_at`              | timestamp     | NO   | now       | —                                                                                                                                   | —      |
+> **v1.1:** Records exist only in approved state. Approval lifecycle (`status`, `requested_by`, `approved_by`, `approved_at`) is managed by `EmployeeRequest`. `request_id` provides traceability to the originating request.
+
+| Field                     | Type          | Null | Default | Description                                                                                                                         | FR     |
+| ------------------------- | ------------- | ---- | ------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| `id`                      | bigint        | NO   | auto    | PK                                                                                                                                  | —      |
+| `employee_id`             | bigint FK     | NO   | —       | Employee.                                                                                                                           | RF-25  |
+| `leave_type_id`           | bigint FK     | NO   | —       | Leave type from catalog.                                                                                                            | RF-25  |
+| `start_date`              | date          | NO   | —       | Start date (= end_date for partial/hourly leaves).                                                                                  | RF-25  |
+| `end_date`                | date          | NO   | —       | End date (= start_date if single day or partial).                                                                                   | RF-25  |
+| `pay_percentage`          | decimal(5,2)  | YES  | NULL    | Pay % override for this instance (0–100). NULL = use `leave_types.default_pay_percentage`. Only for `FIXED_PERCENTAGE` types.       | RF-25  |
+| `rest_day_factor`         | enum          | YES  | NULL    | Rest-day impact override: `FULL`, `PROPORTIONAL`, or `NONE`. NULL = use `leave_types.default_rest_day_factor`.                      | RF-25  |
+| `time_mode`               | enum          | YES  | NULL    | `SCHEDULED` or `OPEN_ENDED`. Required for `PROPORTIONAL_HOURS` types. `SCHEDULED` = known start+end; `OPEN_ENDED` = start only.    | RF-25a |
+| `scheduled_start_time`    | time          | YES  | NULL    | Planned departure time. Required when `time_mode` is set.                                                                           | RF-25a |
+| `scheduled_end_time`      | time          | YES  | NULL    | Planned return time. NULL when `time_mode = OPEN_ENDED`.                                                                            | RF-25a |
+| `actual_start_time`       | time          | YES  | NULL    | Actual departure recorded from Today view.                                                                                          | RF-25a |
+| `actual_end_time`         | time          | YES  | NULL    | Actual return recorded from Today view. NULL if employee did not return.                                                            | RF-25a |
+| `actual_duration_minutes` | integer       | YES  | NULL    | Minutes away from work. Computed from actual times; falls back to scheduled times. Used for payroll deduction.                      | RF-25a |
+| `request_id`              | bigint FK     | NO   | —       | Originating request (→ `employee_requests`).                                                                                        | RF-25  |
+| `notes`                   | text          | YES  | NULL    | Notes / justification.                                                                                                              | RF-25  |
+| `created_at`              | timestamp     | NO   | now     | —                                                                                                                                   | —      |
+| `updated_at`              | timestamp     | NO   | now     | —                                                                                                                                   | —      |
 
 **Business rules:**
 - `pay_percentage` and `rest_day_factor` on the instance always override the type defaults when not NULL.
-- For `PROPORTIONAL_HOURS` leaves: payroll deduction = `actual_duration_minutes / scheduled_work_minutes × daily_wage`. `rest_day_factor` determines if the proportional rest day is also reduced.
-- For `FIXED_PERCENTAGE` leaves: payroll = `pay_percentage / 100 × daily_wage` per day in range. `rest_day_factor` determines rest-day contribution.
-- `actual_start_time` and `actual_end_time` are filled from the Today attendance view; they do not block approval.
+- For `PROPORTIONAL_HOURS` leaves: payroll deduction = `actual_duration_minutes / scheduled_work_minutes × daily_wage`.
+- For `FIXED_PERCENTAGE` leaves: payroll = `pay_percentage / 100 × daily_wage` per day in range.
+- `actual_start_time` and `actual_end_time` are filled from the Today attendance view.
 
 ---
 
@@ -618,21 +685,21 @@ erDiagram
 
 ---
 
-### 2.15 `vacation_requests` — Vacation Requests
+### 2.15 `vacation_requests` — Approved Vacation Periods
 
-| Field         | Type         | Null | Default   | Description                                     | FR    |
-| ------------- | ------------ | ---- | --------- | ----------------------------------------------- | ----- |
-| `id`          | bigint       | NO   | auto      | PK                                              | —     |
-| `employee_id` | bigint FK    | NO   | —         | Employee.                                       | RF-27 |
-| `start_date`  | date         | NO   | —         | Start date.                                     | RF-27 |
-| `end_date`    | date         | NO   | —         | End date.                                       | RF-27 |
-| `days_count`  | decimal(5,2) | NO   | —         | Days requested.                                 | RF-27 |
-| `status`      | enum         | NO   | `PENDING` | `PENDING`, `APPROVED`, `REJECTED`, `CANCELLED`. | RF-27 |
-| `approved_by` | bigint FK    | YES  | NULL      | Who approved (→ `users`).                       | RF-27 |
-| `approved_at` | datetime     | YES  | NULL      | When.                                           | RF-27 |
-| `notes`       | text         | YES  | NULL      | Notes.                                          | RF-27 |
-| `created_at`  | timestamp    | NO   | now       | —                                               | —     |
-| `updated_at`  | timestamp    | NO   | now       | —                                               | —     |
+> **v1.1:** Records exist only in approved state. Approval lifecycle is managed by `EmployeeRequest`. Renamed conceptually from "request" to "approved vacation period" — the name is kept for DB compatibility.
+
+| Field         | Type         | Null | Default | Description                                          | FR    |
+| ------------- | ------------ | ---- | ------- | ---------------------------------------------------- | ----- |
+| `id`          | bigint       | NO   | auto    | PK                                                   | —     |
+| `employee_id` | bigint FK    | NO   | —       | Employee.                                            | RF-27 |
+| `start_date`  | date         | NO   | —       | Start date.                                          | RF-27 |
+| `end_date`    | date         | NO   | —       | End date.                                            | RF-27 |
+| `days_count`  | decimal(5,2) | NO   | —       | Vacation days approved.                              | RF-27 |
+| `request_id`  | bigint FK    | NO   | —       | Originating request (→ `employee_requests`).         | RF-27 |
+| `notes`       | text         | YES  | NULL    | Notes.                                               | RF-27 |
+| `created_at`  | timestamp    | NO   | now     | —                                                    | —     |
+| `updated_at`  | timestamp    | NO   | now     | —                                                    | —     |
 
 ---
 
@@ -770,6 +837,35 @@ total_pay = base_pay
 
 ---
 
+### 2.24 `employee_requests` — Employee Request & Approval Wrapper
+
+> Unified approval entity. Holds the request in pending state (payload JSON) until the manager approves or rejects. On approval, the concrete entity is created and `requestable_type / requestable_id` are assigned.
+
+| Field              | Type         | Null | Default   | Description                                                              | RF    |
+| ------------------ | ------------ | ---- | --------- | ------------------------------------------------------------------------ | ----- |
+| `id`               | bigint       | NO   | auto      | PK                                                                       | —     |
+| `employee_id`      | bigint FK    | NO   | —         | Employee the request is for (→ `employees`).                             | RF-38 |
+| `type`             | enum         | NO   | —         | `EXTRA_DAY`, `LEAVE`, `VACATION`, `SCHEDULE_CHANGE`.                     | —     |
+| `status`           | enum         | NO   | `PENDING` | `PENDING`, `APPROVED`, `REJECTED`, `CANCELLED`.                          | RN-09 |
+| `requestable_type` | varchar(100) | YES  | NULL      | Polymorphic model class. Set on approval (e.g. `NegotiatedExtraDay`).    | —     |
+| `requestable_id`   | bigint       | YES  | NULL      | FK to concrete entity. Set on approval.                                  | —     |
+| `payload`          | json         | NO   | —         | Type-specific data while pending. Consumed by handler on approval.       | —     |
+| `requested_by`     | bigint FK    | NO   | —         | User who created the request (→ `users`).                                | RF-38 |
+| `approved_by`      | bigint FK    | YES  | NULL      | User who approved or rejected (→ `users`). NULL = auto-approved by system. | RN-09 |
+| `approved_at`      | datetime     | YES  | NULL      | When approved or rejected.                                               | —     |
+| `notes`            | text         | YES  | NULL      | Notes / justification.                                                   | —     |
+| `created_at`       | timestamp    | NO   | now       | —                                                                        | —     |
+| `updated_at`       | timestamp    | NO   | now       | —                                                                        | —     |
+
+**Constraints:** INDEX(`employee_id`, `status`). INDEX(`requestable_type`, `requestable_id`). INDEX(`type`, `status`).
+
+**Business rules:**
+- When `requested_by = manager` and `type = EXTRA_DAY`: status is set to `APPROVED` at creation (auto-approval). Concrete entity is created in the same transaction.
+- `requestable_type` and `requestable_id` are NULL while `status = PENDING` or `REJECTED`. Set only on `APPROVED`.
+- Rejecting a request never creates a concrete entity.
+
+---
+
 ### 2.23 `attendance_audit_logs` — Change Audit Log
 
 | Field            | Type         | Null | Default | Description                                                  | FR    |
@@ -792,19 +888,20 @@ total_pay = base_pay
 
 | Enum                        | Values                                                                                                          | Used in                                                                   |
 | --------------------------- | --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| **EmployeeRole**            | `MANAGER`, `COOK`, `KITCHEN_ASSISTANT`, `DELIVERY_DRIVER`                                                       | `employees.role`                                                          |
-| **WorkdayType**             | `FULL`, `PARTIAL`                                                                                               | `employee_schedules.workday_type`                                         |
-| **DayStatus**               | `WORKED`, `DAY_OFF`, `LEAVE`, `VACATION`, `HOLIDAY`, `ABSENCE`, `EXTRA`                                         | `attendances.day_status`                                                  |
-| **LeaveCalculationMode**    | `FIXED_PERCENTAGE`, `PROPORTIONAL_HOURS`                                                                        | `leave_types.calculation_mode`                                            |
-| **RestDayFactor**           | `FULL`, `PROPORTIONAL`, `NONE`                                                                                  | `leave_types.default_rest_day_factor`, `leaves.rest_day_factor`           |
-| **LeaveTimeMode**           | `SCHEDULED`, `OPEN_ENDED`                                                                                       | `leaves.time_mode`                                                        |
-| **LeaveStatus**             | `PENDING`, `APPROVED`, `REJECTED`, `CANCELLED`                                                                  | `leaves.status`, `vacation_requests.status`                               |
-| **OvertimeMovementType**    | `EARNED`, `USED`, `PAID`, `ADJUSTMENT`                                                                          | `overtime_bank_movements.movement_type`                                   |
-| **OvertimeOrigin**          | `AUTO`, `MANUAL`                                                                                                | `overtime_bank_movements.origin`                                          |
-| **OvertimeValuationMethod** | `LFT_PROPORTIONAL`, `AGREED_RATE`                                                                               | `overtime_pay_configs.method`, `overtime_bank_movements.valuation_method` |
-| **PayPeriodStatus**         | `OPEN`, `CLOSED`, `REOPENED`                                                                                    | `pay_periods.status`                                                      |
-| **PayConcept**              | `BASE_PAY`, `LATE_DEDUCTION`, `LEAVE_DEDUCTION`, `OVERTIME`, `EXTRA_DAY`, `PUNCTUALITY_BONUS`, `HOLIDAY`, `OTHER` | `pay_period_lines.concept`                                                |
-| **AuditAction**             | `CREATE`, `UPDATE`, `DELETE`                                                                                    | `attendance_audit_logs.action`                                            |
+| **EmployeeRole**            | `MANAGER`, `COOK`, `KITCHEN_ASSISTANT`, `DELIVERY_DRIVER`                                                          | `employees.role`                                                          |
+| **WorkdayType**             | `FULL`, `PARTIAL`                                                                                                  | `employee_schedules.workday_type`                                         |
+| **DayStatus**               | `WORKED`, `DAY_OFF`, `LEAVE`, `VACATION`, `HOLIDAY`, `ABSENCE`, `EXTRA`                                            | `attendances.day_status`                                                  |
+| **RequestType**             | `EXTRA_DAY`, `LEAVE`, `VACATION`, `SCHEDULE_CHANGE`                                                                | `employee_requests.type`                                                  |
+| **RequestStatus**           | `PENDING`, `APPROVED`, `REJECTED`, `CANCELLED`                                                                     | `employee_requests.status`                                                |
+| **LeaveCalculationMode**    | `FIXED_PERCENTAGE`, `PROPORTIONAL_HOURS`                                                                           | `leave_types.calculation_mode`                                            |
+| **RestDayFactor**           | `FULL`, `PROPORTIONAL`, `NONE`                                                                                     | `leave_types.default_rest_day_factor`, `leaves.rest_day_factor`           |
+| **LeaveTimeMode**           | `SCHEDULED`, `OPEN_ENDED`                                                                                          | `leaves.time_mode`                                                        |
+| **OvertimeMovementType**    | `EARNED`, `USED`, `PAID`, `ADJUSTMENT`                                                                             | `overtime_bank_movements.movement_type`                                   |
+| **OvertimeOrigin**          | `AUTO`, `MANUAL`                                                                                                   | `overtime_bank_movements.origin`                                          |
+| **OvertimeValuationMethod** | `LFT_PROPORTIONAL`, `AGREED_RATE`                                                                                  | `overtime_pay_configs.method`, `overtime_bank_movements.valuation_method` |
+| **PayPeriodStatus**         | `OPEN`, `CLOSED`, `REOPENED`                                                                                       | `pay_periods.status`                                                      |
+| **PayConcept**              | `BASE_PAY`, `LATE_DEDUCTION`, `LEAVE_DEDUCTION`, `OVERTIME`, `EXTRA_DAY`, `PUNCTUALITY_BONUS`, `HOLIDAY`, `OTHER`  | `pay_period_lines.concept`                                                |
+| **AuditAction**             | `CREATE`, `UPDATE`, `DELETE`                                                                                       | `attendance_audit_logs.action`                                            |
 
 ---
 
@@ -961,11 +1058,33 @@ classDiagram
         +int employee_id
         +date date
         +int branch_id
+        +decimal salary_day
+        +decimal prima
+        +decimal seventh_day
         +decimal agreed_pay
-        +int approved_by
+        +int request_id
         +string notes
         --
+        +totalPay() decimal
+    }
+
+    class EmployeeRequest {
+        +int id
+        +int employee_id
+        +RequestType type
+        +RequestStatus status
+        +string requestable_type
+        +int requestable_id
+        +json payload
+        +int requested_by
+        +int approved_by
+        +datetime approved_at
+        --
+        +isPending() bool
         +isApproved() bool
+        +approve(userId) void
+        +reject(userId) void
+        +requestable() Model
     }
 
     class OvertimeBankMovement {
@@ -992,6 +1111,8 @@ classDiagram
     Employee "1" --> "*" PartialLeave
     Employee "1" --> "*" NegotiatedExtraDay
     Employee "1" --> "*" OvertimeBankMovement
+    Employee "1" --> "*" EmployeeRequest
+    EmployeeRequest "1" --> "0..1" NegotiatedExtraDay : requestable
 ```
 
 ### 4.3 Domain Classes — Payroll Close
@@ -1153,13 +1274,25 @@ stateDiagram-v2
     CLOSED --> [*] : Period finalized
 ```
 
-### 5.2 Request Lifecycle (Leave / VacationRequest)
+### 5.2 EmployeeRequest Lifecycle
+
+> Applies to all request types: `EXTRA_DAY`, `LEAVE`, `VACATION`, `SCHEDULE_CHANGE`.
+> The concrete entity (NegotiatedExtraDay, Leave, etc.) is created **only on APPROVED**.
 
 ```mermaid
 stateDiagram-v2
-    [*] --> PENDING : Employee/Manager creates request
+    [*] --> PENDING : Employee submits request
+    [*] --> APPROVED : Manager registers on behalf (auto-approval)
+    note right of APPROVED
+        Concrete entity created
+        in the same transaction.
+    end note
 
     PENDING --> APPROVED : Manager/Admin approves
+    note right of PENDING
+        Appears in manager inbox.
+        payload holds the data.
+    end note
     PENDING --> REJECTED : Manager/Admin rejects
     PENDING --> CANCELLED : Requester cancels
 
@@ -1371,6 +1504,47 @@ sequenceDiagram
     UI-->>M: Successful close confirmation
 ```
 
+### 6.5 EmployeeRequest — Creation and Approval
+
+```mermaid
+sequenceDiagram
+    actor A as Actor (Employee or Manager)
+    participant UI as Request Form
+    participant API as EmployeeRequestController
+    participant Svc as EmployeeRequestService
+    participant Handler as RequestHandler (e.g. ExtraDayRequestHandler)
+    participant DB as Database
+
+    A->>UI: Fills request form (date, salary%, prima%)
+    UI->>API: POST /employee-requests { type, employee_id, payload }
+    API->>Svc: create(data, autoApprove: bool)
+
+    alt autoApprove = true (Manager registers on behalf)
+        Svc->>DB: INSERT employee_requests { status: APPROVED, approved_by: manager }
+        Svc->>Handler: handle(employeeRequest)
+        Handler->>Handler: Build entity from payload
+        Handler->>DB: INSERT negotiated_extra_days (or Leave, etc.)
+        Handler-->>Svc: concrete entity
+        Svc->>DB: UPDATE employee_requests { requestable_type, requestable_id }
+        API-->>UI: 201 Created (approved + entity created)
+    else autoApprove = false (Employee requests)
+        Svc->>DB: INSERT employee_requests { status: PENDING }
+        API-->>UI: 201 Created (pending — in manager inbox)
+    end
+
+    note over API,DB: Separate approval flow (when pending)
+
+    actor M as Manager
+    M->>UI: Opens inbox, approves request
+    UI->>API: PATCH /employee-requests/{id}/approve
+    API->>Svc: approve(employeeRequest, manager)
+    Svc->>Handler: handle(employeeRequest)
+    Handler->>DB: INSERT concrete entity
+    Handler-->>Svc: concrete entity
+    Svc->>DB: UPDATE employee_requests { status: APPROVED, approved_by, approved_at, requestable_* }
+    API-->>UI: 200 OK
+```
+
 ### 6.4 Partial Leave Registration
 
 ```mermaid
@@ -1415,6 +1589,8 @@ sequenceDiagram
 | ----------------------- | ------------------------------------------------- | ------------------------------------------------------ |
 | `employees`             | UNIQUE(`code`)                                    | Employee code unique system-wide.                      |
 | `attendances`           | UNIQUE(`employee_id`, `date`)                     | One attendance record per employee per day.            |
+| `employee_requests`     | INDEX(`employee_id`, `status`)                    | Fast inbox queries by employee and status.             |
+| `employee_requests`     | INDEX(`requestable_type`, `requestable_id`)       | Polymorphic reverse lookup.                            |
 | `negotiated_extra_days` | UNIQUE(`employee_id`, `date`)                     | One extra day per employee per date.                   |
 | `schedule_days`         | UNIQUE(`employee_schedule_id`, `day_of_week`)     | One configuration per day of week per schedule.        |
 | `vacation_entitlements` | UNIQUE(`employee_id`, `year`)                     | One vacation entitlement record per employee per year. |
@@ -1484,8 +1660,10 @@ sequenceDiagram
 | 21  | PayPeriodEmployee     | `pay_period_employees`     | Payroll          |
 | 22  | PayPeriodLine         | `pay_period_lines`         | Payroll          |
 | 23  | AttendanceAuditLog    | `attendance_audit_logs`    | Audit            |
+| 24  | EmployeeRequest       | `employee_requests`        | Requests         |
 
 ---
 
 > **Traceability:** Each field in the dictionary references the FR/BR/DC that originated it.
 > **Conventions:** Table names in snake_case plural, models in PascalCase singular, FKs `{model}_id`, automatic timestamps, soft deletes where applicable, JSON `meta` for extensibility.
+> **v1.1 note:** Concrete request entities (`negotiated_extra_days`, `leaves`, `vacation_requests`) are semantically "approved" by their existence — no status filter needed on those tables.

--- a/doc/modules/attendance-payroll/attendance-payroll-domain-model.en.md
+++ b/doc/modules/attendance-payroll/attendance-payroll-domain-model.en.md
@@ -142,7 +142,7 @@ erDiagram
     Attendance ||--o{ OvertimeBankMovement : "attendance_id"
 
     NegotiatedExtraDay }|--|| Branch : "branch_id"
-    NegotiatedExtraDay }|--|| EmployeeRequest : "request_id"
+    NegotiatedExtraDay ||--|| EmployeeRequest : "request_id"
 
     Attendance {
         bigint id PK
@@ -217,8 +217,8 @@ erDiagram
     Employee ||--|{ VacationRequest : "employee_id"
 
     Leave }|--|| LeaveType : "leave_type_id"
-    Leave }|--|| EmployeeRequest : "request_id"
-    VacationRequest }|--|| EmployeeRequest : "request_id"
+    Leave ||--|| EmployeeRequest : "request_id"
+    VacationRequest ||--|| EmployeeRequest : "request_id"
 
     LeaveType {
         bigint id PK
@@ -402,7 +402,7 @@ Employee requests → EmployeeRequest{PENDING} → inbox → Manager approves �
 
 | type | payload fields |
 |---|---|
-| `EXTRA_DAY` | `date`, `branch_id`, `salary_pct`, `prima_pct`, `salary_day`, `prima_amount`, `seventh_day`, `total` |
+| `EXTRA_DAY` | `date`, `branch_id`, `salary_pct`, `prima_pct`, `salary_day`, `prima`, `seventh_day`, `total` |
 | `LEAVE` | `leave_type_id`, `start_date`, `end_date`, `pay_percentage`, `time_mode`, … |
 | `VACATION` | `start_date`, `end_date`, `days_count` |
 
@@ -837,7 +837,7 @@ total_pay = base_pay
 
 ---
 
-### 2.24 `employee_requests` — Employee Request & Approval Wrapper
+### 2.23 `employee_requests` — Employee Request & Approval Wrapper
 
 > Unified approval entity. Holds the request in pending state (payload JSON) until the manager approves or rejects. On approval, the concrete entity is created and `requestable_type / requestable_id` are assigned.
 
@@ -851,7 +851,7 @@ total_pay = base_pay
 | `requestable_id`   | bigint       | YES  | NULL      | FK to concrete entity. Set on approval.                                  | —     |
 | `payload`          | json         | NO   | —         | Type-specific data while pending. Consumed by handler on approval.       | —     |
 | `requested_by`     | bigint FK    | NO   | —         | User who created the request (→ `users`).                                | RF-38 |
-| `approved_by`      | bigint FK    | YES  | NULL      | User who approved or rejected (→ `users`). NULL = auto-approved by system. | RN-09 |
+| `approved_by`      | bigint FK    | YES  | NULL      | User who approved or rejected (→ `users`). On manager auto-approval, set to the manager's user id (= `requested_by`). | RN-09 |
 | `approved_at`      | datetime     | YES  | NULL      | When approved or rejected.                                               | —     |
 | `notes`            | text         | YES  | NULL      | Notes / justification.                                                   | —     |
 | `created_at`       | timestamp    | NO   | now       | —                                                                        | —     |
@@ -866,7 +866,7 @@ total_pay = base_pay
 
 ---
 
-### 2.23 `attendance_audit_logs` — Change Audit Log
+### 2.24 `attendance_audit_logs` — Change Audit Log
 
 | Field            | Type         | Null | Default | Description                                                  | FR    |
 | ---------------- | ------------ | ---- | ------- | ------------------------------------------------------------ | ----- |
@@ -1113,6 +1113,8 @@ classDiagram
     Employee "1" --> "*" OvertimeBankMovement
     Employee "1" --> "*" EmployeeRequest
     EmployeeRequest "1" --> "0..1" NegotiatedExtraDay : requestable
+    EmployeeRequest "1" --> "0..1" Leave : requestable
+    EmployeeRequest "1" --> "0..1" VacationRequest : requestable
 ```
 
 ### 4.3 Domain Classes — Payroll Close
@@ -1520,7 +1522,7 @@ sequenceDiagram
     API->>Svc: create(data, autoApprove: bool)
 
     alt autoApprove = true (Manager registers on behalf)
-        Svc->>DB: INSERT employee_requests { status: APPROVED, approved_by: manager }
+        Svc->>DB: INSERT employee_requests { status: APPROVED, approved_by: manager, approved_at: now() }
         Svc->>Handler: handle(employeeRequest)
         Handler->>Handler: Build entity from payload
         Handler->>DB: INSERT negotiated_extra_days (or Leave, etc.)

--- a/doc/modules/attendance-payroll/attendance-payroll-domain-model.en.md
+++ b/doc/modules/attendance-payroll/attendance-payroll-domain-model.en.md
@@ -558,7 +558,7 @@ Employee requests → EmployeeRequest{PENDING} → inbox → Manager approves �
 | `branch_id`   | bigint FK     | NO   | —       | Branch where they worked.                           | RF-39        |
 | `salary_day`  | decimal(10,2) | NO   | —       | Salary component (agreed daily wage).               | RF-39, RN-10 |
 | `prima`       | decimal(10,2) | NO   | —       | Rest-day premium component.                         | RF-39, RN-10 |
-| `seventh_day` | decimal(10,2) | NO   | —       | Seventh-day component (1/6 of salary_day).          | RF-39        |
+| `seventh_day` | decimal(10,2) | NO   | —       | Seventh-day component (séptimo día): 1/6 of weekly salary. For 6-day schedules this equals `salary_day` (weekly = salary_day × 6, so weekly / 6 = salary_day). | RF-39        |
 | `agreed_pay`  | decimal(10,2) | NO   | —       | Total agreed pay (= salary_day + prima + seventh_day). | RF-39, RN-10 |
 | `request_id`  | bigint FK     | NO   | —       | Originating request (→ `employee_requests`).        | RF-39, RN-09 |
 | `notes`       | text          | YES  | NULL    | Notes/observations.                                 | RF-39        |

--- a/doc/modules/attendance-payroll/attendance-payroll-domain-model.en.md
+++ b/doc/modules/attendance-payroll/attendance-payroll-domain-model.en.md
@@ -863,6 +863,7 @@ total_pay = base_pay
 - When `requested_by = manager` and `type = EXTRA_DAY`: status is set to `APPROVED` at creation (auto-approval). Concrete entity is created in the same transaction.
 - `requestable_type` and `requestable_id` are NULL while `status = PENDING` or `REJECTED`. Set only on `APPROVED`.
 - Rejecting a request never creates a concrete entity.
+- **Cancelling an APPROVED request deletes the associated concrete entity (requestable) and nullifies `requestable_type`/`requestable_id` in the same transaction.** This preserves the "existence = approved" invariant on concrete entity tables. An audit log entry must be created.
 
 ---
 
@@ -1506,7 +1507,7 @@ sequenceDiagram
     UI-->>M: Successful close confirmation
 ```
 
-### 6.5 EmployeeRequest — Creation and Approval
+### 6.4 EmployeeRequest — Creation and Approval
 
 ```mermaid
 sequenceDiagram
@@ -1547,7 +1548,7 @@ sequenceDiagram
     API-->>UI: 200 OK
 ```
 
-### 6.4 Partial Leave Registration
+### 6.5 Partial Leave Registration
 
 ```mermaid
 sequenceDiagram

--- a/doc/modules/attendance-payroll/attendance-payroll-domain-model.es.md
+++ b/doc/modules/attendance-payroll/attendance-payroll-domain-model.es.md
@@ -918,6 +918,7 @@ total_pay = base_pay
 - Cuando `requested_by = manager` y `type = EXTRA_DAY`: el status se establece como `APPROVED` al crear (auto-aprobación). La entidad concreta se crea en la misma transacción.
 - `requestable_type` y `requestable_id` son NULL mientras `status = PENDING` o `REJECTED`. Se asignan solo al `APPROVED`.
 - Rechazar una solicitud nunca crea una entidad concreta.
+- **Cancelar una solicitud en estado APPROVED elimina la entidad concreta asociada (requestable) y anula `requestable_type`/`requestable_id` en la misma transacción.** Esto preserva el invariante "existencia = aprobado" en las tablas de entidades concretas. Debe crearse una entrada en el log de auditoría.
 
 ---
 
@@ -1559,7 +1560,7 @@ sequenceDiagram
     UI-->>M: Confirmación de cierre exitoso
 ```
 
-### 6.5 EmployeeRequest — Creación y Aprobación
+### 6.4 EmployeeRequest — Creación y Aprobación
 
 ```mermaid
 sequenceDiagram
@@ -1600,7 +1601,7 @@ sequenceDiagram
     API-->>UI: 200 OK
 ```
 
-### 6.4 Registro de Permiso Parcial
+### 6.5 Registro de Permiso Parcial
 
 ```mermaid
 sequenceDiagram

--- a/doc/modules/attendance-payroll/attendance-payroll-domain-model.es.md
+++ b/doc/modules/attendance-payroll/attendance-payroll-domain-model.es.md
@@ -163,7 +163,7 @@ erDiagram
     Attendance ||--o{ OvertimeBankMovement : "attendance_id"
 
     NegotiatedExtraDay }|--|| Branch : "branch_id"
-    NegotiatedExtraDay }|--|| EmployeeRequest : "request_id"
+    NegotiatedExtraDay ||--|| EmployeeRequest : "request_id"
 
     Attendance {
         bigint id PK
@@ -262,8 +262,8 @@ erDiagram
     Employee ||--|{ VacationRequest : "employee_id"
 
     Leave }|--|| LeaveType : "leave_type_id"
-    Leave }|--|| EmployeeRequest : "request_id"
-    VacationRequest }|--|| EmployeeRequest : "request_id"
+    Leave ||--|| EmployeeRequest : "request_id"
+    VacationRequest ||--|| EmployeeRequest : "request_id"
 
     LeaveType {
         bigint id PK
@@ -463,7 +463,7 @@ Empleado solicita → EmployeeRequest{PENDING} → inbox → Manager aprueba →
 
 | type | campos del payload |
 |---|---|
-| `EXTRA_DAY` | `date`, `branch_id`, `salary_pct`, `prima_pct`, `salary_day`, `prima_amount`, `seventh_day`, `total` |
+| `EXTRA_DAY` | `date`, `branch_id`, `salary_pct`, `prima_pct`, `salary_day`, `prima`, `seventh_day`, `total` |
 | `LEAVE` | `leave_type_id`, `start_date`, `end_date`, `pay_percentage`, `time_mode`, … |
 | `VACATION` | `start_date`, `end_date`, `days_count` |
 
@@ -892,7 +892,7 @@ total_pay = base_pay
 
 ---
 
-### 2.24 `employee_requests` — Solicitud de Empleado (Wrapper de Aprobación)
+### 2.23 `employee_requests` — Solicitud de Empleado (Wrapper de Aprobación)
 
 > Entidad unificada de aprobación. Guarda la solicitud en estado pendiente (payload JSON) hasta que el manager aprueba o rechaza. Al aprobar, se crea la entidad concreta y se asignan `requestable_type / requestable_id`.
 
@@ -906,7 +906,7 @@ total_pay = base_pay
 | `requestable_id` | bigint | SÍ | NULL | FK a la entidad concreta. Se asigna al aprobar. | — |
 | `payload` | json | NO | — | Datos específicos del tipo mientras está pendiente. Los consume el handler al aprobar. | — |
 | `requested_by` | bigint FK | NO | — | Usuario que creó la solicitud (→ `users`). | RF-38 |
-| `approved_by` | bigint FK | SÍ | NULL | Usuario que aprobó o rechazó (→ `users`). NULL = auto-aprobado. | RN-09 |
+| `approved_by` | bigint FK | SÍ | NULL | Usuario que aprobó o rechazó (→ `users`). En auto-aprobación por manager, se asigna el id del manager (= `requested_by`). | RN-09 |
 | `approved_at` | datetime | SÍ | NULL | Cuándo se aprobó o rechazó. | — |
 | `notes` | text | SÍ | NULL | Notas / justificación. | — |
 | `created_at` | timestamp | NO | now | — | — |
@@ -921,7 +921,7 @@ total_pay = base_pay
 
 ---
 
-### 2.23 `attendance_audit_logs` — Auditoría de Cambios
+### 2.24 `attendance_audit_logs` — Auditoría de Cambios
 
 | Campo | Tipo | Null | Default | Descripción | RF |
 |-------|------|------|---------|-------------|-----|
@@ -1166,6 +1166,8 @@ classDiagram
     Employee "1" --> "*" OvertimeBankMovement
     Employee "1" --> "*" EmployeeRequest
     EmployeeRequest "1" --> "0..1" NegotiatedExtraDay : requestable
+    EmployeeRequest "1" --> "0..1" Leave : requestable
+    EmployeeRequest "1" --> "0..1" VacationRequest : requestable
 ```
 
 ### 4.3 Clases de Dominio — Cierre de Nómina
@@ -1573,7 +1575,7 @@ sequenceDiagram
     API->>Svc: create(data, autoApprove: bool)
 
     alt autoApprove = true (Manager registra en nombre del empleado)
-        Svc->>DB: INSERT employee_requests { status: APPROVED, approved_by: manager }
+        Svc->>DB: INSERT employee_requests { status: APPROVED, approved_by: manager, approved_at: now() }
         Svc->>Handler: handle(employeeRequest)
         Handler->>Handler: Construir entidad desde payload
         Handler->>DB: INSERT negotiated_extra_days (o Leave, etc.)

--- a/doc/modules/attendance-payroll/attendance-payroll-domain-model.es.md
+++ b/doc/modules/attendance-payroll/attendance-payroll-domain-model.es.md
@@ -1,9 +1,11 @@
 # 📐 Modelo de Dominio — Attendance & Payroll (SushiGo)
 
-**Versión:** 1.0
-**Fecha:** 2026-02-09
+**Versión:** 1.1
+**Fecha:** 2026-04-21
 **Base:** attendance-payroll-spec v0.8 + mvp-scope
-**Estado:** Contrato de dominio congelado
+**Estado:** Contrato de dominio activo
+
+**Changelog v1.1 (2026-04-21):** Se agrega `EmployeeRequest` como wrapper unificado de aprobación para todas las solicitudes de empleados. Las entidades concretas (`NegotiatedExtraDay`, `Leave`, `VacationRequest`) solo se crean al aprobarse — la DB queda semánticamente limpia. Los campos de ciclo de aprobación (`status`, `approved_by`, `approved_at`) se centralizan en `EmployeeRequest`. Se agrega subdominio 1.7 (ER Solicitudes), sección 2.24 (diccionario employee_requests) y secuencia 6.5 (ciclo de vida de solicitud).
 
 ---
 
@@ -161,6 +163,7 @@ erDiagram
     Attendance ||--o{ OvertimeBankMovement : "attendance_id"
 
     NegotiatedExtraDay }|--|| Branch : "branch_id"
+    NegotiatedExtraDay }|--|| EmployeeRequest : "request_id"
 
     Attendance {
         bigint id PK
@@ -205,8 +208,27 @@ erDiagram
         bigint employee_id FK
         date date
         bigint branch_id FK
-        decimal agreed_pay "10,2"
-        bigint approved_by FK "→ users"
+        decimal salary_day "10,2 salario del día"
+        decimal prima "10,2 prima por descanso"
+        decimal seventh_day "10,2 séptimo día 1/6"
+        decimal agreed_pay "10,2 total acordado"
+        bigint request_id FK "→ employee_requests"
+        text notes "nullable"
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    EmployeeRequest {
+        bigint id PK
+        bigint employee_id FK
+        enum type "EXTRA_DAY|LEAVE|VACATION|..."
+        enum status "PENDING|APPROVED|REJECTED|CANCELLED"
+        string requestable_type "nullable - se asigna al aprobar"
+        bigint requestable_id "nullable - se asigna al aprobar"
+        json payload "datos específicos mientras está pendiente"
+        bigint requested_by FK "→ users"
+        bigint approved_by FK "nullable → users"
+        datetime approved_at "nullable"
         text notes "nullable"
         timestamp created_at
         timestamp updated_at
@@ -240,6 +262,8 @@ erDiagram
     Employee ||--|{ VacationRequest : "employee_id"
 
     Leave }|--|| LeaveType : "leave_type_id"
+    Leave }|--|| EmployeeRequest : "request_id"
+    VacationRequest }|--|| EmployeeRequest : "request_id"
 
     LeaveType {
         bigint id PK
@@ -260,9 +284,7 @@ erDiagram
         bigint leave_type_id FK
         date start_date
         date end_date
-        enum status "PENDING|APPROVED|REJECTED|CANCELLED"
-        bigint approved_by FK "nullable → users"
-        datetime approved_at "nullable"
+        bigint request_id FK "→ employee_requests"
         text notes "nullable"
         timestamp created_at
         timestamp updated_at
@@ -294,9 +316,7 @@ erDiagram
         date start_date
         date end_date
         decimal days_count "5,2"
-        enum status "PENDING|APPROVED|REJECTED|CANCELLED"
-        bigint approved_by FK "nullable → users"
-        datetime approved_at "nullable"
+        bigint request_id FK "→ employee_requests"
         text notes "nullable"
         timestamp created_at
         timestamp updated_at
@@ -402,6 +422,50 @@ erDiagram
         timestamp created_at
     }
 ```
+
+### 1.7 Subdominio: Solicitudes (Employee Requests — Flujo de Aprobación)
+
+> **Decisión de diseño:** `EmployeeRequest` es el wrapper unificado de aprobación para todas las solicitudes. Las entidades concretas se crean **únicamente al aprobarse** — si un registro existe en `negotiated_extra_days`, `leaves` o `vacation_requests`, está aprobado por definición.
+
+```mermaid
+erDiagram
+    Employee ||--|{ EmployeeRequest : "employee_id"
+    EmployeeRequest ||--o| NegotiatedExtraDay : "requestable (EXTRA_DAY)"
+    EmployeeRequest ||--o| Leave : "requestable (LEAVE)"
+    EmployeeRequest ||--o| VacationRequest : "requestable (VACATION)"
+
+    EmployeeRequest {
+        bigint id PK
+        bigint employee_id FK
+        enum type "EXTRA_DAY|LEAVE|VACATION|SCHEDULE_CHANGE"
+        enum status "PENDING|APPROVED|REJECTED|CANCELLED"
+        string requestable_type "nullable - se asigna al aprobar"
+        bigint requestable_id "nullable - se asigna al aprobar"
+        json payload "datos específicos mientras pendiente"
+        bigint requested_by FK "→ users"
+        bigint approved_by FK "nullable → users"
+        datetime approved_at "nullable"
+        text notes "nullable"
+        timestamp created_at
+        timestamp updated_at
+    }
+```
+
+**Ciclo de vida:**
+
+```
+Manager registra → EmployeeRequest{APPROVED} → entidad concreta creada en la misma transacción
+Empleado solicita → EmployeeRequest{PENDING} → inbox → Manager aprueba → entidad concreta creada
+                                                       → Manager rechaza → no se crea entidad
+```
+
+**Estructura del payload por tipo:**
+
+| type | campos del payload |
+|---|---|
+| `EXTRA_DAY` | `date`, `branch_id`, `salary_pct`, `prima_pct`, `salary_day`, `prima_amount`, `seventh_day`, `total` |
+| `LEAVE` | `leave_type_id`, `start_date`, `end_date`, `pay_percentage`, `time_mode`, … |
+| `VACATION` | `start_date`, `end_date`, `days_count` |
 
 ---
 
@@ -560,7 +624,9 @@ erDiagram
 
 ---
 
-### 2.9 `negotiated_extra_days` — Días Extra Negociados
+### 2.9 `negotiated_extra_days` — Días Extra Negociados (Aprobados)
+
+> **v1.1:** Los registros solo existen en estado aprobado. El ciclo de aprobación (`status`, `approved_by`, `approved_at`) se gestiona en `EmployeeRequest`. `agreed_pay` se desglosa en tres componentes para las líneas de nómina.
 
 | Campo | Tipo | Null | Default | Descripción | RF |
 |-------|------|------|---------|-------------|-----|
@@ -568,13 +634,16 @@ erDiagram
 | `employee_id` | bigint FK | NO | — | Empleado. | RF-38 |
 | `date` | date | NO | — | Fecha del día extra. | RF-39 |
 | `branch_id` | bigint FK | NO | — | Sucursal donde trabajó. | RF-39 |
-| `agreed_pay` | decimal(10,2) | NO | — | Pago acordado. | RF-39, RN-10 |
-| `approved_by` | bigint FK | NO | — | Quién aprobó (→ `users`). | RF-39, RN-09 |
+| `salary_day` | decimal(10,2) | NO | — | Componente salario del día acordado. | RF-39, RN-10 |
+| `prima` | decimal(10,2) | NO | — | Componente prima por día de descanso. | RF-39, RN-10 |
+| `seventh_day` | decimal(10,2) | NO | — | Componente séptimo día (1/6 del salary_day). | RF-39 |
+| `agreed_pay` | decimal(10,2) | NO | — | Total acordado (= salary_day + prima + seventh_day). | RF-39, RN-10 |
+| `request_id` | bigint FK | NO | — | Solicitud de origen (→ `employee_requests`). | RF-39, RN-09 |
 | `notes` | text | SÍ | NULL | Notas/observaciones. | RF-39 |
 | `created_at` | timestamp | NO | now | — | — |
 | `updated_at` | timestamp | NO | now | — | — |
 
-**Constraints:** UNIQUE(`employee_id`, `date`).
+**Constraints:** UNIQUE(`employee_id`, `date`). INDEX(`request_id`).
 
 ---
 
@@ -619,7 +688,9 @@ erDiagram
 
 ---
 
-### 2.12 `leaves` — Permisos (Día Completo o Rango)
+### 2.12 `leaves` — Permisos Aprobados (Día Completo o Rango)
+
+> **v1.1:** Los registros solo existen en estado aprobado. El ciclo de aprobación se gestiona en `EmployeeRequest`. `request_id` da trazabilidad a la solicitud de origen.
 
 | Campo | Tipo | Null | Default | Descripción | RF |
 |-------|------|------|---------|-------------|-----|
@@ -628,9 +699,7 @@ erDiagram
 | `leave_type_id` | bigint FK | NO | — | Tipo de permiso del catálogo. | RF-25 |
 | `start_date` | date | NO | — | Fecha inicio. | RF-25 |
 | `end_date` | date | NO | — | Fecha fin (= start_date si un solo día). | RF-25 |
-| `status` | enum | NO | `PENDING` | `PENDING`, `APPROVED`, `REJECTED`, `CANCELLED`. | RF-25 |
-| `approved_by` | bigint FK | SÍ | NULL | Quién aprobó (→ `users`). | RF-25 |
-| `approved_at` | datetime | SÍ | NULL | Cuándo se aprobó. | RF-25 |
+| `request_id` | bigint FK | NO | — | Solicitud de origen (→ `employee_requests`). | RF-25 |
 | `notes` | text | SÍ | NULL | Notas. | RF-25 |
 | `created_at` | timestamp | NO | now | — | — |
 | `updated_at` | timestamp | NO | now | — | — |
@@ -671,7 +740,9 @@ erDiagram
 
 ---
 
-### 2.15 `vacation_requests` — Solicitudes de Vacaciones
+### 2.15 `vacation_requests` — Vacaciones Aprobadas
+
+> **v1.1:** Los registros solo existen en estado aprobado. El ciclo de aprobación se gestiona en `EmployeeRequest`. El nombre de tabla se mantiene por compatibilidad pero conceptualmente representa un periodo de vacaciones aprobado.
 
 | Campo | Tipo | Null | Default | Descripción | RF |
 |-------|------|------|---------|-------------|-----|
@@ -679,10 +750,8 @@ erDiagram
 | `employee_id` | bigint FK | NO | — | Empleado. | RF-27 |
 | `start_date` | date | NO | — | Fecha inicio. | RF-27 |
 | `end_date` | date | NO | — | Fecha fin. | RF-27 |
-| `days_count` | decimal(5,2) | NO | — | Días solicitados. | RF-27 |
-| `status` | enum | NO | `PENDING` | `PENDING`, `APPROVED`, `REJECTED`, `CANCELLED`. | RF-27 |
-| `approved_by` | bigint FK | SÍ | NULL | Quién aprobó (→ `users`). | RF-27 |
-| `approved_at` | datetime | SÍ | NULL | Cuándo. | RF-27 |
+| `days_count` | decimal(5,2) | NO | — | Días de vacaciones aprobados. | RF-27 |
+| `request_id` | bigint FK | NO | — | Solicitud de origen (→ `employee_requests`). | RF-27 |
 | `notes` | text | SÍ | NULL | Notas. | RF-27 |
 | `created_at` | timestamp | NO | now | — | — |
 | `updated_at` | timestamp | NO | now | — | — |
@@ -823,6 +892,35 @@ total_pay = base_pay
 
 ---
 
+### 2.24 `employee_requests` — Solicitud de Empleado (Wrapper de Aprobación)
+
+> Entidad unificada de aprobación. Guarda la solicitud en estado pendiente (payload JSON) hasta que el manager aprueba o rechaza. Al aprobar, se crea la entidad concreta y se asignan `requestable_type / requestable_id`.
+
+| Campo | Tipo | Null | Default | Descripción | RF |
+|-------|------|------|---------|-------------|-----|
+| `id` | bigint | NO | auto | PK | — |
+| `employee_id` | bigint FK | NO | — | Empleado al que corresponde la solicitud (→ `employees`). | RF-38 |
+| `type` | enum | NO | — | `EXTRA_DAY`, `LEAVE`, `VACATION`, `SCHEDULE_CHANGE`. | — |
+| `status` | enum | NO | `PENDING` | `PENDING`, `APPROVED`, `REJECTED`, `CANCELLED`. | RN-09 |
+| `requestable_type` | varchar(100) | SÍ | NULL | Clase del modelo polimórfico. Se asigna al aprobar (ej: `NegotiatedExtraDay`). | — |
+| `requestable_id` | bigint | SÍ | NULL | FK a la entidad concreta. Se asigna al aprobar. | — |
+| `payload` | json | NO | — | Datos específicos del tipo mientras está pendiente. Los consume el handler al aprobar. | — |
+| `requested_by` | bigint FK | NO | — | Usuario que creó la solicitud (→ `users`). | RF-38 |
+| `approved_by` | bigint FK | SÍ | NULL | Usuario que aprobó o rechazó (→ `users`). NULL = auto-aprobado. | RN-09 |
+| `approved_at` | datetime | SÍ | NULL | Cuándo se aprobó o rechazó. | — |
+| `notes` | text | SÍ | NULL | Notas / justificación. | — |
+| `created_at` | timestamp | NO | now | — | — |
+| `updated_at` | timestamp | NO | now | — | — |
+
+**Constraints:** INDEX(`employee_id`, `status`). INDEX(`requestable_type`, `requestable_id`). INDEX(`type`, `status`).
+
+**Reglas de negocio:**
+- Cuando `requested_by = manager` y `type = EXTRA_DAY`: el status se establece como `APPROVED` al crear (auto-aprobación). La entidad concreta se crea en la misma transacción.
+- `requestable_type` y `requestable_id` son NULL mientras `status = PENDING` o `REJECTED`. Se asignan solo al `APPROVED`.
+- Rechazar una solicitud nunca crea una entidad concreta.
+
+---
+
 ### 2.23 `attendance_audit_logs` — Auditoría de Cambios
 
 | Campo | Tipo | Null | Default | Descripción | RF |
@@ -848,11 +946,12 @@ total_pay = base_pay
 | **EmployeeRole** | `MANAGER`, `COOK`, `KITCHEN_ASSISTANT`, `DELIVERY_DRIVER` | `employees.role` |
 | **WorkdayType** | `FULL`, `PARTIAL` | `employee_schedules.workday_type` |
 | **DayStatus** | `WORKED`, `DAY_OFF`, `LEAVE`, `VACATION`, `HOLIDAY`, `ABSENCE`, `EXTRA` | `attendances.day_status` |
+| **RequestType** | `EXTRA_DAY`, `LEAVE`, `VACATION`, `SCHEDULE_CHANGE` | `employee_requests.type` |
+| **RequestStatus** | `PENDING`, `APPROVED`, `REJECTED`, `CANCELLED` | `employee_requests.status` |
 | **PartialLeaveType** | `ARRIVE_LATE`, `LEAVE_EARLY`, `TAKE_TIME` | `partial_leaves.type` |
 | **OvertimeMovementType** | `EARNED`, `USED`, `PAID`, `ADJUSTMENT` | `overtime_bank_movements.movement_type` |
 | **OvertimeOrigin** | `AUTO`, `MANUAL` | `overtime_bank_movements.origin` |
 | **OvertimeValuationMethod** | `LFT_PROPORTIONAL`, `AGREED_RATE` | `overtime_pay_configs.method`, `overtime_bank_movements.valuation_method` |
-| **LeaveStatus** | `PENDING`, `APPROVED`, `REJECTED`, `CANCELLED` | `leaves.status`, `vacation_requests.status` |
 | **PayPeriodStatus** | `OPEN`, `CLOSED`, `REOPENED` | `pay_periods.status` |
 | **PayConcept** | `BASE_PAY`, `LATE_DEDUCTION`, `UNPAID_LEAVE`, `OVERTIME`, `EXTRA_DAY`, `PUNCTUALITY_BONUS`, `HOLIDAY`, `OTHER` | `pay_period_lines.concept` |
 | **AuditAction** | `CREATE`, `UPDATE`, `DELETE` | `attendance_audit_logs.action` |
@@ -1012,11 +1111,33 @@ classDiagram
         +int employee_id
         +date date
         +int branch_id
+        +decimal salary_day
+        +decimal prima
+        +decimal seventh_day
         +decimal agreed_pay
-        +int approved_by
+        +int request_id
         +string notes
         --
+        +totalPay() decimal
+    }
+
+    class EmployeeRequest {
+        +int id
+        +int employee_id
+        +RequestType type
+        +RequestStatus status
+        +string requestable_type
+        +int requestable_id
+        +json payload
+        +int requested_by
+        +int approved_by
+        +datetime approved_at
+        --
+        +isPending() bool
         +isApproved() bool
+        +approve(userId) void
+        +reject(userId) void
+        +requestable() Model
     }
 
     class OvertimeBankMovement {
@@ -1043,6 +1164,8 @@ classDiagram
     Employee "1" --> "*" PartialLeave
     Employee "1" --> "*" NegotiatedExtraDay
     Employee "1" --> "*" OvertimeBankMovement
+    Employee "1" --> "*" EmployeeRequest
+    EmployeeRequest "1" --> "0..1" NegotiatedExtraDay : requestable
 ```
 
 ### 4.3 Clases de Dominio — Cierre de Nómina
@@ -1204,13 +1327,25 @@ stateDiagram-v2
     CLOSED --> [*] : Periodo finalizado
 ```
 
-### 5.2 Ciclo de vida de una Solicitud (Leave / VacationRequest)
+### 5.2 Ciclo de vida de EmployeeRequest
+
+> Aplica a todos los tipos: `EXTRA_DAY`, `LEAVE`, `VACATION`, `SCHEDULE_CHANGE`.
+> La entidad concreta (NegotiatedExtraDay, Leave, etc.) se crea **únicamente en APPROVED**.
 
 ```mermaid
 stateDiagram-v2
-    [*] --> PENDING : Empleado/Manager crea solicitud
+    [*] --> PENDING : Empleado envía solicitud
+    [*] --> APPROVED : Manager registra en nombre del empleado (auto-aprobación)
+    note right of APPROVED
+        Entidad concreta creada
+        en la misma transacción.
+    end note
 
     PENDING --> APPROVED : Manager/Admin aprueba
+    note right of PENDING
+        Aparece en el inbox del Manager.
+        payload guarda los datos.
+    end note
     PENDING --> REJECTED : Manager/Admin rechaza
     PENDING --> CANCELLED : Solicitante cancela
 
@@ -1422,6 +1557,47 @@ sequenceDiagram
     UI-->>M: Confirmación de cierre exitoso
 ```
 
+### 6.5 EmployeeRequest — Creación y Aprobación
+
+```mermaid
+sequenceDiagram
+    actor A as Actor (Empleado o Manager)
+    participant UI as Formulario de Solicitud
+    participant API as EmployeeRequestController
+    participant Svc as EmployeeRequestService
+    participant Handler as RequestHandler (ej: ExtraDayRequestHandler)
+    participant DB as Database
+
+    A->>UI: Llena formulario (fecha, salario%, prima%)
+    UI->>API: POST /employee-requests { type, employee_id, payload }
+    API->>Svc: create(data, autoApprove: bool)
+
+    alt autoApprove = true (Manager registra en nombre del empleado)
+        Svc->>DB: INSERT employee_requests { status: APPROVED, approved_by: manager }
+        Svc->>Handler: handle(employeeRequest)
+        Handler->>Handler: Construir entidad desde payload
+        Handler->>DB: INSERT negotiated_extra_days (o Leave, etc.)
+        Handler-->>Svc: entidad concreta
+        Svc->>DB: UPDATE employee_requests { requestable_type, requestable_id }
+        API-->>UI: 201 Created (aprobado + entidad creada)
+    else autoApprove = false (Empleado solicita)
+        Svc->>DB: INSERT employee_requests { status: PENDING }
+        API-->>UI: 201 Created (pendiente — en inbox del Manager)
+    end
+
+    note over API,DB: Flujo de aprobación separado (cuando está pendiente)
+
+    actor M as Manager
+    M->>UI: Abre inbox, aprueba solicitud
+    UI->>API: PATCH /employee-requests/{id}/approve
+    API->>Svc: approve(employeeRequest, manager)
+    Svc->>Handler: handle(employeeRequest)
+    Handler->>DB: INSERT entidad concreta
+    Handler-->>Svc: entidad concreta
+    Svc->>DB: UPDATE employee_requests { status: APPROVED, approved_by, approved_at, requestable_* }
+    API-->>UI: 200 OK
+```
+
 ### 6.4 Registro de Permiso Parcial
 
 ```mermaid
@@ -1466,6 +1642,8 @@ sequenceDiagram
 |-------|-----------|-------------|
 | `employees` | UNIQUE(`code`) | Código de empleado único en el sistema. |
 | `attendances` | UNIQUE(`employee_id`, `date`) | Un registro de asistencia por empleado por día. |
+| `employee_requests` | INDEX(`employee_id`, `status`) | Consultas rápidas de inbox por empleado y estado. |
+| `employee_requests` | INDEX(`requestable_type`, `requestable_id`) | Lookup polimórfico inverso. |
 | `negotiated_extra_days` | UNIQUE(`employee_id`, `date`) | Un día extra por empleado por fecha. |
 | `schedule_days` | UNIQUE(`employee_schedule_id`, `day_of_week`) | Una configuración por día de semana por horario. |
 | `vacation_entitlements` | UNIQUE(`employee_id`, `year`) | Un registro de derecho vacacional por empleado por año. |
@@ -1535,8 +1713,10 @@ sequenceDiagram
 | 21 | PayPeriodEmployee | `pay_period_employees` | Nómina |
 | 22 | PayPeriodLine | `pay_period_lines` | Nómina |
 | 23 | AttendanceAuditLog | `attendance_audit_logs` | Auditoría |
+| 24 | EmployeeRequest | `employee_requests` | Solicitudes |
 
 ---
 
 > **Trazabilidad:** Cada campo del diccionario referencia el RF/RN/DC que lo origina.
 > **Convenciones:** Nombres de tabla en snake_case plural, modelos PascalCase singular, FKs `{modelo}_id`, timestamps automáticos, soft deletes donde aplique, JSON `meta` para extensibilidad.
+> **Nota v1.1:** Las entidades concretas de solicitud (`negotiated_extra_days`, `leaves`, `vacation_requests`) son semánticamente "aprobadas" por su existencia — no se necesita filtrar por estado en esas tablas.

--- a/doc/modules/attendance-payroll/attendance-payroll-domain-model.es.md
+++ b/doc/modules/attendance-payroll/attendance-payroll-domain-model.es.md
@@ -636,7 +636,7 @@ Empleado solicita → EmployeeRequest{PENDING} → inbox → Manager aprueba →
 | `branch_id` | bigint FK | NO | — | Sucursal donde trabajó. | RF-39 |
 | `salary_day` | decimal(10,2) | NO | — | Componente salario del día acordado. | RF-39, RN-10 |
 | `prima` | decimal(10,2) | NO | — | Componente prima por día de descanso. | RF-39, RN-10 |
-| `seventh_day` | decimal(10,2) | NO | — | Componente séptimo día (1/6 del salary_day). | RF-39 |
+| `seventh_day` | decimal(10,2) | NO | — | Componente séptimo día: 1/6 del salario semanal. Para jornadas de 6 días equivale a `salary_day` (semanal = salary_day × 6, por tanto semanal / 6 = salary_day). | RF-39 |
 | `agreed_pay` | decimal(10,2) | NO | — | Total acordado (= salary_day + prima + seventh_day). | RF-39, RN-10 |
 | `request_id` | bigint FK | NO | — | Solicitud de origen (→ `employee_requests`). | RF-39, RN-09 |
 | `notes` | text | SÍ | NULL | Notas/observaciones. | RF-39 |

--- a/doc/tasks/backlog/123-extra-day-manager-advance.md
+++ b/doc/tasks/backlog/123-extra-day-manager-advance.md
@@ -88,8 +88,16 @@ Después de guardar aparece un chip con el día acordado:
 
 ---
 
-## 🔗 Referencias
+## 🔗 Dependencias
 
+### Requiere (debe completarse antes)
+- [ ] **#126** — EmployeeRequest base entity (API + modelo base)
+- [ ] **#127** — Solicitudes navegación y shell (punto de entrada del formulario)
+
+### Desbloquea (puede iniciarse después)
+> Sin dependencias directas — el check-in automático (#059) ya existe.
+
+### Referencias
 - **Viene de:** #059
 - **Relacionado:** #122 (exprés), #124 (empleado solicita), #125 (inbox aprobaciones)
 

--- a/doc/tasks/backlog/124-extra-day-employee-request.md
+++ b/doc/tasks/backlog/124-extra-day-employee-request.md
@@ -98,10 +98,17 @@ En la vista personal del empleado su horario semanal muestra los días de descan
 
 ---
 
-## 🔗 Referencias
+## 🔗 Dependencias
 
+### Requiere (debe completarse antes)
+- [ ] **#126** — EmployeeRequest base entity (API + modelo base)
+- [ ] **#127** — Solicitudes navegación y shell (punto de entrada del formulario)
+
+### Desbloquea (puede iniciarse después)
+- [ ] **#125** — Solicitudes listado + filtros (necesita solicitudes reales para mostrar)
+
+### Referencias
 - **Viene de:** #059
-- **Depende de:** Vista del empleado con rol reducido en la webapp
 - **Relacionado:** #122 (exprés), #123 (Manager anticipa), #125 (inbox aprobaciones)
 
 ---

--- a/doc/tasks/backlog/125-extra-day-approval-inbox.md
+++ b/doc/tasks/backlog/125-extra-day-approval-inbox.md
@@ -119,10 +119,18 @@ Este inbox es el **punto central de aprobaciones** — en el futuro también rec
 
 ---
 
-## 🔗 Referencias
+## 🔗 Dependencias
 
+### Requiere (debe completarse antes)
+- [ ] **#126** — EmployeeRequest base entity (API + listado de solicitudes)
+- [ ] **#127** — Solicitudes navegación y shell (la página donde vive el listado)
+- [ ] **#124** — Extra day employee request (necesita solicitudes reales que mostrar)
+
+### Desbloquea (puede iniciarse después)
+> Es el último eslabón de este flujo — no bloquea otras tareas.
+
+### Referencias
 - **Viene de:** #059
-- **Depende de:** #124 (solicitud del empleado)
 - **Relacionado:** #122 (exprés), #123 (Manager anticipa)
 
 ---

--- a/doc/tasks/backlog/126-employee-request-base-entity.md
+++ b/doc/tasks/backlog/126-employee-request-base-entity.md
@@ -60,7 +60,7 @@ NegotiatedExtraDay / Leave / VacationRequest / ...
   "prima_pct": 100,
   "salary_day": 200.00,
   "prima": 200.00,
-  "seventh_day": 200.00,
+  "seventh_day": 200.00,    // 1/6 of weekly salary = salary_day (for 6-day schedules)
   "total": 600.00,
   "branch_id": 1
 }

--- a/doc/tasks/backlog/126-employee-request-base-entity.md
+++ b/doc/tasks/backlog/126-employee-request-base-entity.md
@@ -36,7 +36,7 @@ requested_by · approved_by (nullable) · approved_at (nullable) · notes
 ```
 EmployeeRequest{pending}
         ↓  al aprobar
-NegotiatedExtraDay / Leave / VacationPeriod / ...
+NegotiatedExtraDay / Leave / VacationRequest / ...
   ← requestable_type + requestable_id se asignan aquí
   ← la entidad concreta guarda request_id para trazabilidad
 ```
@@ -47,7 +47,7 @@ NegotiatedExtraDay / Leave / VacationPeriod / ...
 |---|---|
 | `EXTRA_DAY` | `NegotiatedExtraDay` |
 | `LEAVE` | `Leave` |
-| `VACATION` | `VacationPeriod` |
+| `VACATION` | `VacationRequest` |
 | `SCHEDULE_CHANGE` | `ScheduleChangeRequest` (futuro) |
 
 ### Estructura del `payload` JSON por tipo
@@ -59,7 +59,7 @@ NegotiatedExtraDay / Leave / VacationPeriod / ...
   "salary_pct": 100,
   "prima_pct": 100,
   "salary_day": 200.00,
-  "prima_amount": 200.00,
+  "prima": 200.00,
   "seventh_day": 200.00,
   "total": 600.00,
   "branch_id": 1

--- a/doc/tasks/backlog/126-employee-request-base-entity.md
+++ b/doc/tasks/backlog/126-employee-request-base-entity.md
@@ -1,0 +1,142 @@
+# 🔀 Task #126: EmployeeRequest — Base Entity for Approval Workflow
+
+## 📖 Story
+
+**English:**
+As a system architect, I need a unified `EmployeeRequest` entity that acts as the approval wrapper for all employee requests (extra days, leaves, vacations, schedule changes), so that the authorization workflow, manager inbox, and employee self-service are unified across all request types.
+
+**Español:**
+Como arquitecto del sistema, necesito una entidad unificada `EmployeeRequest` que funcione como wrapper de aprobación para todas las solicitudes de empleados (días extra, permisos, vacaciones, cambios de horario), para que el flujo de autorización, el inbox del manager y el autoservicio del empleado estén unificados en todos los tipos de solicitud.
+
+---
+
+## 🧠 Contexto
+
+Diseñado durante el análisis del #123. Todas las solicitudes de empleados siguen el mismo ciclo de vida:
+
+- El empleado solicita **O** el Manager registra en nombre del empleado
+- Cuando el **Manager registra** → auto-aprobado (mismo request, status=approved de inmediato)
+- Cuando el **Empleado solicita** → status=pending, el Manager debe aprobar
+- La entidad concreta (`NegotiatedExtraDay`, `Leave`, etc.) se crea **únicamente al aprobarse** — la DB queda semánticamente limpia: si existe el registro, está aprobado
+
+---
+
+## 🏗️ Arquitectura
+
+### Tabla `employee_requests`
+
+```
+id · employee_id · type (enum) · status
+requestable_type (nullable) · requestable_id (nullable) · payload (JSON)
+requested_by · approved_by (nullable) · approved_at (nullable) · notes
+```
+
+### Relación con entidades concretas
+
+```
+EmployeeRequest{pending}
+        ↓  al aprobar
+NegotiatedExtraDay / Leave / VacationPeriod / ...
+  ← requestable_type + requestable_id se asignan aquí
+  ← la entidad concreta guarda request_id para trazabilidad
+```
+
+### Enum `type`
+
+| Valor | Entidad concreta |
+|---|---|
+| `EXTRA_DAY` | `NegotiatedExtraDay` |
+| `LEAVE` | `Leave` |
+| `VACATION` | `VacationPeriod` |
+| `SCHEDULE_CHANGE` | `ScheduleChangeRequest` (futuro) |
+
+### Estructura del `payload` JSON por tipo
+
+```json
+// EXTRA_DAY
+{
+  "date": "2026-04-22",
+  "salary_pct": 100,
+  "prima_pct": 100,
+  "salary_day": 200.00,
+  "prima_amount": 200.00,
+  "seventh_day": 200.00,
+  "total": 600.00,
+  "branch_id": 1
+}
+```
+
+### Patrones de creación
+
+| Actor | Flujo |
+|---|---|
+| Manager registra (anticipado) | Crea `EmployeeRequest` + aprueba inmediatamente → crea `NegotiatedExtraDay` |
+| Empleado solicita | Crea `EmployeeRequest{pending}` → aparece en inbox del Manager |
+| Manager aprueba | Aprueba `EmployeeRequest` → crea entidad concreta desde payload |
+
+---
+
+## 🔨 Implementación
+
+### Backend (Laravel)
+
+- Migración `employee_requests` table
+- Modelo `EmployeeRequest` con relación polimórfica `requestable()` (morphTo)
+- Interface `RequestHandler` con método `handle(EmployeeRequest): Model` — una implementación por tipo
+  - `ExtraDayRequestHandler`
+  - `LeaveRequestHandler` (futuro)
+- `EmployeeRequestService`:
+  - `create(data, autoApprove: bool)` — crea el request y opcionalmente auto-aprueba
+  - `approve(EmployeeRequest, User)` — aprueba, crea entidad concreta, asigna requestable
+  - `reject(EmployeeRequest, User, reason)` — rechaza
+- Endpoints:
+  - `POST /employee-requests` — crear solicitud
+  - `PATCH /employee-requests/{id}/approve` — aprobar
+  - `PATCH /employee-requests/{id}/reject` — rechazar
+  - `GET /employee-requests` — listar (con filtros de tipo/status/empleado)
+
+### Permisos necesarios
+
+- `employee-requests.view`
+- `employee-requests.create`
+- `employee-requests.approve`
+
+---
+
+## ✅ Criterios de Aceptación
+
+- [ ] Migración crea la tabla `employee_requests` con todos sus campos
+- [ ] Modelo `EmployeeRequest` con morphTo `requestable()` y campos tipados
+- [ ] `RequestHandler` interface + `ExtraDayRequestHandler` implementado
+- [ ] `EmployeeRequestService` maneja creación, auto-aprobación y aprobación manual
+- [ ] Al aprobar se crea la entidad concreta desde el payload y se asigna `requestable_type/id`
+- [ ] Al rechazar solo cambia el status — no se crea ninguna entidad concreta
+- [ ] API endpoints documentados en Swagger
+- [ ] PHPUnit: happy path (crear + aprobar), rechazo, duplicado, permisos
+- [ ] SonarCloud ≥ 80% en código nuevo
+
+---
+
+## 🔗 Dependencias
+
+### Requiere (debe completarse antes)
+> Sin dependencias — es la base del sistema de solicitudes.
+
+### Desbloquea (puede iniciarse después)
+- [ ] **#127** — Solicitudes navegación y shell
+- [ ] **#123** — Extra day manager advance
+- [ ] **#124** — Extra day employee request
+- [ ] **#125** — Solicitudes listado + filtros
+
+### Referencias
+- **Introduce patrón para:** Leave, Vacation, ScheduleChange
+
+---
+
+## ⏱️ Estimado
+- **Optimista:** `3h` · **Pesimista:** `5h`
+
+## ⏱️ Sessions
+```json
+[]
+```

--- a/doc/tasks/backlog/127-solicitudes-navigation-shell.md
+++ b/doc/tasks/backlog/127-solicitudes-navigation-shell.md
@@ -1,0 +1,114 @@
+# 📋 Task #127: Solicitudes — Navegación y Shell de Página
+
+## 📖 Story
+
+**English:**
+As a user (Manager or Employee), I want a dedicated "Solicitudes" section in the navigation so I can see and submit all types of requests from a single place, with role-aware content depending on who is logged in.
+
+**Español:**
+Como usuario (Manager o Empleado), quiero una sección dedicada "Solicitudes" en la navegación para poder ver y enviar todos los tipos de solicitudes desde un solo lugar, con contenido adaptado según el rol del usuario.
+
+---
+
+## 🧠 Contexto
+
+Esta tarea establece la **estructura navegable** de la sección de solicitudes. No implementa los formularios ni el listado completo — eso viene en tareas posteriores. El objetivo es que al hacer merge la sección exista y sea accesible.
+
+**Comportamiento por rol:**
+- **Empleado:** ve sus propias solicitudes + botonera con las solicitudes que puede hacer
+- **Manager/Admin:** ve todas las solicitudes de su sucursal + botonera para crear en nombre de un empleado + badge con pendientes de aprobación
+
+---
+
+## 🎨 UI
+
+### Menú lateral
+
+```
+  🏠 Inicio
+  👥 Empleados
+  📋 Solicitudes  ← nueva entrada
+     └─ badge (3) cuando hay pendientes de aprobación (solo Manager/Admin)
+  📦 Inventario
+  💰 Caja
+```
+
+### Página `/solicitudes`
+
+```
+┌─ Solicitudes ──────────────────────────────────────────┐
+│                                                          │
+│  Nueva solicitud                                         │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐   │
+│  │ ➕ Día extra │  │ 📅 Permiso   │  │ 🌴 Vacaciones│   │
+│  │              │  │  (próximo)   │  │  (próximo)   │   │
+│  └──────────────┘  └──────────────┘  └──────────────┘   │
+│                                                          │
+│  ── Solicitudes ─────────────────────────────────────   │
+│                                                          │
+│  [Vista del listado — implementado en #125]              │
+│                                                          │
+└──────────────────────────────────────────────────────────┘
+```
+
+**Vista Manager/Admin — tabs adicionales:**
+
+```
+  [ Mis solicitudes ]  [ Pendientes de aprobación (3) ]
+```
+
+### Estados de botones de la botonera
+
+- `➕ Día extra` — **activo** al completar #123 / #124
+- `📅 Permiso` — deshabilitado con tooltip "Próximamente"
+- `🌴 Vacaciones` — deshabilitado con tooltip "Próximamente"
+
+---
+
+## 🔧 Implementación
+
+### Ruta nueva
+- `/solicitudes` — página principal de solicitudes
+
+### Componentes
+- `SolicitudesPage` — página raíz, carga el contexto de rol
+- `RequestTypeBar` — botonera de tipos de solicitud (renderiza botones por config)
+- `SolicitudesLayout` — layout con tabs para Manager (mis solicitudes / pendientes)
+
+### Navegación
+- Agregar entrada al menú lateral con badge reactivo
+- Badge muestra `GET /employee-requests?status=pending&branch_id=X` count (solo manager)
+- Permisos de vista: `employee-requests.view`
+
+---
+
+## ✅ Criterios de Aceptación
+
+- [ ] Entrada "Solicitudes" visible en el menú lateral para roles autorizados
+- [ ] Badge en el menú muestra conteo de pendientes (solo Manager/Admin)
+- [ ] Ruta `/solicitudes` es accesible y renderiza el shell de la página
+- [ ] Botonera visible con `+ Día extra` (activo — sin form aún) y demás opciones deshabilitadas con "Próximamente"
+- [ ] Layout con tabs en vista Manager (mis solicitudes / pendientes de aprobación)
+- [ ] Sin errores de lint ni typecheck
+
+---
+
+## 🔗 Dependencias
+
+### Requiere (debe completarse antes)
+- [ ] **#126** — EmployeeRequest base entity (API + modelo base)
+
+### Desbloquea (puede iniciarse después)
+- [ ] **#123** — Extra day manager advance (conecta botón + form en botonera)
+- [ ] **#124** — Extra day employee request (conecta botón + form en botonera)
+- [ ] **#125** — Solicitudes listado + filtros (llena el grid de la página)
+
+---
+
+## ⏱️ Estimado
+- **Optimista:** `1.5h` · **Pesimista:** `2.5h`
+
+## ⏱️ Sessions
+```json
+[]
+```


### PR DESCRIPTION
## Summary

- Introduce `EmployeeRequest` as the unified approval wrapper for all employee requests (extra days, leaves, vacations, schedule changes)
- Concrete entities (`NegotiatedExtraDay`, `Leave`, `VacationRequest`) are now created **only upon approval** — DB is semantically clean by design
- Domain model bumped to v1.1 with full changelog, new subdomain, updated ER/UML/State/Sequence diagrams (EN + ES)
- Two new tasks created (#126 base entity, #127 navigation shell) with dependency chains defined

## Changes

**Domain model (EN + ES):**
- New subdomain 1.7: Requests ER + lifecycle + payload spec
- `NegotiatedExtraDay`: removed `approved_by`, added `request_id` + `salary_day / prima / seventh_day` breakdown
- `Leave` + `VacationRequest`: removed status/approval fields, added `request_id`
- New Dict 2.24 `employee_requests` with business rules
- New enums `RequestType` + `RequestStatus`
- State diagram 5.2 updated to `EmployeeRequest` lifecycle
- New sequence 6.5: request creation + approval flow

**Tasks:**
- `#126` — EmployeeRequest base entity (backend: migration, model, service, API, handlers)
- `#127` — Solicitudes navigation shell (menu item, role-aware page, button bar)
- `#123 / #124 / #125` — dependency sections updated with correct sequence

## Dependency sequence

```
#126 → #127 → #123 (manager form)
             → #124 (employee form) → #125 (list + filters)
```

## Test plan
- [ ] Review domain model diagrams for correctness (ER, UML, state, sequence)
- [ ] Verify task dependency chains are complete and accurate
- [ ] Confirm no existing task references are broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pakodiazdev/sushigo/pull/127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
