### PR TITLE
[#126] EmployeeRequest — Base Entity for Approval Workflow

### DIFF
--- a/code/api/app/Enums/EmployeeRequestStatus.php
+++ b/code/api/app/Enums/EmployeeRequestStatus.php
@@ -7,4 +7,5 @@ enum EmployeeRequestStatus: string
     case PENDING = 'PENDING';
     case APPROVED = 'APPROVED';
     case REJECTED = 'REJECTED';
+    case CANCELLED = 'CANCELLED';
 }

--- a/code/api/app/Http/Controllers/Api/V1/EmployeeRequests/CancelEmployeeRequestController.php
+++ b/code/api/app/Http/Controllers/Api/V1/EmployeeRequests/CancelEmployeeRequestController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\EmployeeRequests;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\EmployeeRequest\EmployeeRequestResource;
+use App\Models\EmployeeRequest;
+use App\Models\User;
+use App\Services\EmployeeRequests\EmployeeRequestService;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * @OA\Patch(
+ *   path="/api/v1/employee-requests/{id}/cancel",
+ *   summary="Cancel Employee Request",
+ *   description="Cancels a PENDING or APPROVED employee request. Only the original requester can cancel. Cancelling an APPROVED request also deletes the concrete entity.",
+ *   tags={"EmployeeRequests"},
+ *   security={{"passport": {}}},
+ *
+ *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="string"), description="EmployeeRequest public_id (ULID)"),
+ *
+ *   @OA\Response(
+ *       response=200,
+ *       description="Employee request cancelled",
+ *
+ *       @OA\JsonContent(
+ *           allOf={
+ *
+ *              @OA\Schema(ref="#/components/schemas/ResponseEntity"),
+ *              @OA\Schema(@OA\Property(property="data", ref="#/components/schemas/EmployeeRequestResponse"))
+ *           }
+ *       )
+ *   ),
+ *
+ *   @OA\Response(response=401, description="Unauthenticated"),
+ *   @OA\Response(response=403, description="Forbidden — not the original requester"),
+ *   @OA\Response(response=404, description="Not Found", @OA\JsonContent(ref="#/components/schemas/ResponseError")),
+ *   @OA\Response(response=422, description="Validation Error — request is not in a cancellable state", @OA\JsonContent(ref="#/components/schemas/ResponseError"))
+ * )
+ *
+ * @throws ValidationException
+ */
+class CancelEmployeeRequestController extends Controller
+{
+    public function __invoke(
+        Request $request,
+        string $id,
+        EmployeeRequestService $service,
+    ): EmployeeRequestResource {
+        $employeeRequest = EmployeeRequest::query()->where('public_id', $id)->firstOrFail();
+
+        $user = $request->user();
+        assert($user instanceof User);
+
+        $employeeRequest = $service->cancel($employeeRequest, $user);
+
+        return new EmployeeRequestResource($employeeRequest);
+    }
+}

--- a/code/api/app/Http/Resources/EmployeeRequest/EmployeeRequestResource.php
+++ b/code/api/app/Http/Resources/EmployeeRequest/EmployeeRequestResource.php
@@ -15,7 +15,7 @@ use App\Models\EmployeeRequest;
  *     @OA\Property(property="id", type="string", example="01JKXYZ1234567890ABCDEFGH", description="ULID public identifier"),
  *     @OA\Property(property="employee_id", type="string", example="01JKABC0987654321ZYXWVUTS", description="Employee public_id (ULID)"),
  *     @OA\Property(property="type", type="string", enum={"EXTRA_DAY", "LEAVE", "VACATION", "SCHEDULE_CHANGE"}, example="EXTRA_DAY"),
- *     @OA\Property(property="status", type="string", enum={"PENDING", "APPROVED", "REJECTED"}, example="PENDING"),
+ *     @OA\Property(property="status", type="string", enum={"PENDING", "APPROVED", "REJECTED", "CANCELLED"}, example="PENDING"),
  *     @OA\Property(property="payload", type="object"),
  *     @OA\Property(property="requestable", type="object", nullable=true,
  *        @OA\Property(property="id", type="string", example="01JKXYZ1234567890ABCDEFGH", description="ULID public_id of the concrete entity"),

--- a/code/api/app/Services/EmployeeRequests/EmployeeRequestService.php
+++ b/code/api/app/Services/EmployeeRequests/EmployeeRequestService.php
@@ -109,6 +109,38 @@ class EmployeeRequestService
     /**
      * @throws ValidationException
      */
+    public function cancel(EmployeeRequest $employeeRequest, User $requester): EmployeeRequest
+    {
+        return DB::transaction(function () use ($employeeRequest, $requester): EmployeeRequest {
+            $employeeRequest = EmployeeRequest::query()->lockForUpdate()->findOrFail($employeeRequest->id);
+
+            if ($employeeRequest->requested_by !== $requester->id) {
+                abort(403, 'Solo el solicitante puede cancelar esta solicitud.');
+            }
+
+            if (! in_array($employeeRequest->status, [EmployeeRequestStatus::PENDING, EmployeeRequestStatus::APPROVED], true)) {
+                throw ValidationException::withMessages([
+                    'status' => 'Solo se pueden cancelar solicitudes en estado PENDING o APPROVED.',
+                ]);
+            }
+
+            if ($employeeRequest->status === EmployeeRequestStatus::APPROVED && $employeeRequest->requestable !== null) {
+                $employeeRequest->requestable->forceDelete();
+            }
+
+            $employeeRequest->update([
+                'status' => EmployeeRequestStatus::CANCELLED,
+                'requestable_type' => null,
+                'requestable_id' => null,
+            ]);
+
+            return $employeeRequest->load(['employee', 'requestable', 'requestedBy', 'approvedBy']);
+        });
+    }
+
+    /**
+     * @throws ValidationException
+     */
     private function resolveHandler(EmployeeRequest $employeeRequest): RequestHandler
     {
         return match ($employeeRequest->type) {

--- a/code/api/app/Services/EmployeeRequests/EmployeeRequestService.php
+++ b/code/api/app/Services/EmployeeRequests/EmployeeRequestService.php
@@ -7,6 +7,7 @@ use App\Enums\EmployeeRequestType;
 use App\Models\Employee;
 use App\Models\EmployeeRequest;
 use App\Models\User;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
@@ -30,7 +31,7 @@ class EmployeeRequestService
         }
 
         if ($autoApprove && ! $requestedBy->can('employee-requests.approve')) {
-            abort(403, 'No tienes permiso para auto-aprobar solicitudes.');
+            throw new AuthorizationException('No tienes permiso para auto-aprobar solicitudes.');
         }
 
         return DB::transaction(function () use ($data, $autoApprove, $requestedBy): EmployeeRequest {
@@ -115,7 +116,7 @@ class EmployeeRequestService
             $employeeRequest = EmployeeRequest::query()->lockForUpdate()->findOrFail($employeeRequest->id);
 
             if ($employeeRequest->requested_by !== $requester->id) {
-                abort(403, 'Solo el solicitante puede cancelar esta solicitud.');
+                throw new AuthorizationException('Solo el solicitante puede cancelar esta solicitud.');
             }
 
             if (! in_array($employeeRequest->status, [EmployeeRequestStatus::PENDING, EmployeeRequestStatus::APPROVED], true)) {

--- a/code/api/database/migrations/2026_04_21_000001_create_employee_requests_table.php
+++ b/code/api/database/migrations/2026_04_21_000001_create_employee_requests_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
             $table->string('public_id', 26)->unique();
             $table->foreignId('employee_id')->constrained('employees');
             $table->enum('type', ['EXTRA_DAY', 'LEAVE', 'VACATION', 'SCHEDULE_CHANGE']);
-            $table->enum('status', ['PENDING', 'APPROVED', 'REJECTED'])->default('PENDING');
+            $table->enum('status', ['PENDING', 'APPROVED', 'REJECTED', 'CANCELLED'])->default('PENDING');
             $table->nullableMorphs('requestable');
             $table->json('payload');
             $table->foreignId('requested_by')->constrained('users');

--- a/code/api/database/seeders/Production/PermissionSeeder.php
+++ b/code/api/database/seeders/Production/PermissionSeeder.php
@@ -77,6 +77,7 @@ class PermissionSeeder extends LockedSeeder
             'employee-requests.view',
             'employee-requests.create',
             'employee-requests.approve',
+            'employee-requests.cancel',
 
             // Attendances
             'attendances.view',

--- a/code/api/database/seeders/Testing/CoreTestSeeder.php
+++ b/code/api/database/seeders/Testing/CoreTestSeeder.php
@@ -82,6 +82,7 @@ class CoreTestSeeder extends Seeder
         'employee-requests.view',
         'employee-requests.create',
         'employee-requests.approve',
+        'employee-requests.cancel',
         'items.view',
         'items.create',
         'items.update',

--- a/code/api/routes/api.php
+++ b/code/api/routes/api.php
@@ -23,6 +23,7 @@ use App\Http\Controllers\Api\V1\Devtools\ResetClockController;
 use App\Http\Controllers\Api\V1\Devtools\SetClockController;
 use App\Http\Controllers\Api\V1\Devtools\ShiftClockController;
 use App\Http\Controllers\Api\V1\EmployeeRequests\ApproveEmployeeRequestController;
+use App\Http\Controllers\Api\V1\EmployeeRequests\CancelEmployeeRequestController;
 use App\Http\Controllers\Api\V1\EmployeeRequests\CreateEmployeeRequestController;
 use App\Http\Controllers\Api\V1\EmployeeRequests\ListEmployeeRequestsController;
 use App\Http\Controllers\Api\V1\EmployeeRequests\RejectEmployeeRequestController;
@@ -298,6 +299,7 @@ Route::prefix('v1')->group(function () {
         Route::post('/', CreateEmployeeRequestController::class)->name('store')->middleware('permission:employee-requests.create');
         Route::patch('/{id}/approve', ApproveEmployeeRequestController::class)->name('approve')->middleware('permission:employee-requests.approve');
         Route::patch('/{id}/reject', RejectEmployeeRequestController::class)->name('reject')->middleware('permission:employee-requests.approve');
+        Route::patch('/{id}/cancel', CancelEmployeeRequestController::class)->name('cancel')->middleware('permission:employee-requests.cancel');
     });
 
     // Attendances Module (All Protected)

--- a/code/api/tests/Feature/AttendancePayroll/EmployeeRequestApiTest.php
+++ b/code/api/tests/Feature/AttendancePayroll/EmployeeRequestApiTest.php
@@ -34,11 +34,13 @@ class EmployeeRequestApiTest extends TestCase
         Permission::create(['name' => 'employee-requests.view', 'guard_name' => 'api']);
         Permission::create(['name' => 'employee-requests.create', 'guard_name' => 'api']);
         Permission::create(['name' => 'employee-requests.approve', 'guard_name' => 'api']);
+        Permission::create(['name' => 'employee-requests.cancel', 'guard_name' => 'api']);
 
         $managerRole = Role::create(['name' => 'manager', 'guard_name' => 'api']);
         $managerRole->givePermissionTo('employee-requests.view');
         $managerRole->givePermissionTo('employee-requests.create');
         $managerRole->givePermissionTo('employee-requests.approve');
+        $managerRole->givePermissionTo('employee-requests.cancel');
 
         Role::firstOrCreate(['name' => 'employee', 'guard_name' => 'api']);
         foreach (Employee::POSITION_ROLES as $roleName) {
@@ -456,6 +458,121 @@ class EmployeeRequestApiTest extends TestCase
         ]);
 
         $response->assertStatus(422);
+    }
+
+    #[Test]
+    public function it_cancels_a_pending_request_without_creating_concrete_entity(): void
+    {
+        $employee = $this->makeEmployeeWithActivePeriod();
+
+        $createResponse = $this->postJson('/api/v1/employee-requests', [
+            'employee_id' => $employee->public_id,
+            'type' => EmployeeRequestType::EXTRA_DAY->value,
+            'payload' => $this->extraDayPayload(),
+        ])->assertStatus(201);
+
+        $requestId = $createResponse->json('data.id');
+
+        $cancelResponse = $this->patchJson("/api/v1/employee-requests/{$requestId}/cancel");
+
+        $cancelResponse->assertOk()
+            ->assertJsonPath('data.status', EmployeeRequestStatus::CANCELLED->value)
+            ->assertJsonPath('data.requestable', null);
+
+        $this->assertDatabaseHas('employee_requests', [
+            'public_id' => $requestId,
+            'status' => EmployeeRequestStatus::CANCELLED->value,
+        ]);
+
+        $this->assertDatabaseMissing('negotiated_extra_days', [
+            'employee_id' => $employee->id,
+            'date' => self::DATE,
+        ]);
+    }
+
+    #[Test]
+    public function it_cancels_an_approved_request_and_deletes_concrete_entity(): void
+    {
+        $employee = $this->makeEmployeeWithActivePeriod();
+
+        $createResponse = $this->postJson('/api/v1/employee-requests', [
+            'employee_id' => $employee->public_id,
+            'type' => EmployeeRequestType::EXTRA_DAY->value,
+            'payload' => $this->extraDayPayload(),
+        ])->assertStatus(201);
+
+        $requestId = $createResponse->json('data.id');
+
+        $this->patchJson("/api/v1/employee-requests/{$requestId}/approve")->assertOk();
+
+        $this->assertDatabaseHas('negotiated_extra_days', [
+            'employee_id' => $employee->id,
+            'date' => self::DATE,
+        ]);
+
+        $cancelResponse = $this->patchJson("/api/v1/employee-requests/{$requestId}/cancel");
+
+        $cancelResponse->assertOk()
+            ->assertJsonPath('data.status', EmployeeRequestStatus::CANCELLED->value)
+            ->assertJsonPath('data.requestable', null);
+
+        $this->assertDatabaseMissing('negotiated_extra_days', [
+            'employee_id' => $employee->id,
+            'date' => self::DATE,
+        ]);
+    }
+
+    #[Test]
+    public function it_prevents_cancel_by_non_requester(): void
+    {
+        $employee = $this->makeEmployeeWithActivePeriod();
+
+        $createResponse = $this->postJson('/api/v1/employee-requests', [
+            'employee_id' => $employee->public_id,
+            'type' => EmployeeRequestType::EXTRA_DAY->value,
+            'payload' => $this->extraDayPayload(),
+        ])->assertStatus(201);
+
+        $requestId = $createResponse->json('data.id');
+
+        $otherUser = User::factory()->createOne();
+        assert($otherUser instanceof User);
+
+        $cancelOnlyRole = Role::create(['name' => 'cancel-only', 'guard_name' => 'api']);
+        $cancelOnlyRole->givePermissionTo('employee-requests.cancel');
+        $otherUser->assignRole('cancel-only');
+
+        Passport::actingAs($otherUser);
+
+        $this->patchJson("/api/v1/employee-requests/{$requestId}/cancel")
+            ->assertStatus(403);
+
+        $this->assertDatabaseHas('employee_requests', [
+            'public_id' => $requestId,
+            'status' => EmployeeRequestStatus::PENDING->value,
+        ]);
+    }
+
+    #[Test]
+    public function it_prevents_cancelling_a_rejected_request(): void
+    {
+        $employee = $this->makeEmployeeWithActivePeriod();
+
+        $createResponse = $this->postJson('/api/v1/employee-requests', [
+            'employee_id' => $employee->public_id,
+            'type' => EmployeeRequestType::EXTRA_DAY->value,
+            'payload' => $this->extraDayPayload(),
+        ])->assertStatus(201);
+
+        $requestId = $createResponse->json('data.id');
+
+        $this->patchJson("/api/v1/employee-requests/{$requestId}/reject", [
+            'reason' => 'No aplica.',
+        ])->assertOk();
+
+        $cancelResponse = $this->patchJson("/api/v1/employee-requests/{$requestId}/cancel");
+
+        $cancelResponse->assertStatus(422);
     }
 
     private function extraDayPayload(): array

--- a/doc/modules/attendance-payroll/attendance-payroll-domain-model.en.md
+++ b/doc/modules/attendance-payroll/attendance-payroll-domain-model.en.md
@@ -5,7 +5,7 @@
 **Base:** attendance-payroll-spec v0.8 + mvp-scope
 **Status:** Active domain contract
 
-**Changelog v1.2 (2026-04-21):** Added `rejection_reason` column to `employee_requests` to separate the manager's rejection note from the requester's original `notes`. Fixed `status` enum to `PENDING`, `APPROVED`, `REJECTED` only — `CANCELLED` is deferred. Added permission guard: `auto_approve=true` requires `employee-requests.approve` in addition to `employee-requests.create`.
+**Changelog v1.2 (2026-04-21):** Added `rejection_reason` column to `employee_requests` to separate the manager's rejection note from the requester's original `notes`. The `status` enum is `PENDING`, `APPROVED`, `REJECTED`, `CANCELLED` — cancellation is available to the requester for requests in PENDING or APPROVED state. Added permission guard: `auto_approve=true` requires `employee-requests.approve` in addition to `employee-requests.create`.
 
 **Changelog v1.1 (2026-04-21):** Added `EmployeeRequest` as the unified approval wrapper for all employee requests. Concrete entities (`NegotiatedExtraDay`, `Leave`, `VacationRequest`) are now created only upon approval — keeping the DB semantically clean. Approval lifecycle fields (`status`, `approved_by`, `approved_at`) removed from concrete entities and centralized in `EmployeeRequest`. Added subdomain 1.7 (Requests ER), section 2.23 (employee_requests dict), and sequence 6.4 (request lifecycle).
 
@@ -183,7 +183,7 @@ erDiagram
         bigint id PK
         bigint employee_id FK
         enum type "EXTRA_DAY|LEAVE|VACATION|..."
-        enum status "PENDING|APPROVED|REJECTED"
+        enum status "PENDING|APPROVED|REJECTED|CANCELLED"
         string requestable_type "nullable - set on approval"
         bigint requestable_id "nullable - set on approval"
         json payload "type-specific data"
@@ -379,7 +379,7 @@ erDiagram
         bigint id PK
         bigint employee_id FK
         enum type "EXTRA_DAY|LEAVE|VACATION|SCHEDULE_CHANGE"
-        enum status "PENDING|APPROVED|REJECTED"
+        enum status "PENDING|APPROVED|REJECTED|CANCELLED"
         string requestable_type "nullable - set on approval"
         bigint requestable_id "nullable - set on approval"
         json payload "type-specific data while pending"

--- a/doc/modules/attendance-payroll/attendance-payroll-domain-model.es.md
+++ b/doc/modules/attendance-payroll/attendance-payroll-domain-model.es.md
@@ -5,7 +5,7 @@
 **Base:** attendance-payroll-spec v0.8 + mvp-scope
 **Estado:** Contrato de dominio activo
 
-**Changelog v1.2 (2026-04-21):** Se agrega columna `rejection_reason` a `employee_requests` para separar el motivo de rechazo del manager de las `notes` originales del solicitante. Se corrige el enum `status` a `PENDING`, `APPROVED`, `REJECTED` únicamente — `CANCELLED` queda diferido. Se agrega guardia de permiso: `auto_approve=true` requiere `employee-requests.approve` además de `employee-requests.create`.
+**Changelog v1.2 (2026-04-21):** Se agrega columna `rejection_reason` a `employee_requests` para separar el motivo de rechazo del manager de las `notes` originales del solicitante. El enum `status` es `PENDING`, `APPROVED`, `REJECTED`, `CANCELLED` — cancelación disponible para el solicitante en estado PENDING o APPROVED. Se agrega guardia de permiso: `auto_approve=true` requiere `employee-requests.approve` además de `employee-requests.create`.
 
 **Changelog v1.1 (2026-04-21):** Se agrega `EmployeeRequest` como wrapper unificado de aprobación para todas las solicitudes de empleados. Las entidades concretas (`NegotiatedExtraDay`, `Leave`, `VacationRequest`) solo se crean al aprobarse — la DB queda semánticamente limpia. Los campos de ciclo de aprobación (`status`, `approved_by`, `approved_at`) se centralizan en `EmployeeRequest`. Se agrega subdominio 1.7 (ER Solicitudes), sección 2.23 (diccionario employee_requests) y secuencia 6.4 (ciclo de vida de solicitud).
 
@@ -224,7 +224,7 @@ erDiagram
         bigint id PK
         bigint employee_id FK
         enum type "EXTRA_DAY|LEAVE|VACATION|..."
-        enum status "PENDING|APPROVED|REJECTED"
+        enum status "PENDING|APPROVED|REJECTED|CANCELLED"
         string requestable_type "nullable - se asigna al aprobar"
         bigint requestable_id "nullable - se asigna al aprobar"
         json payload "datos específicos mientras está pendiente"
@@ -440,7 +440,7 @@ erDiagram
         bigint id PK
         bigint employee_id FK
         enum type "EXTRA_DAY|LEAVE|VACATION|SCHEDULE_CHANGE"
-        enum status "PENDING|APPROVED|REJECTED"
+        enum status "PENDING|APPROVED|REJECTED|CANCELLED"
         string requestable_type "nullable - se asigna al aprobar"
         bigint requestable_id "nullable - se asigna al aprobar"
         json payload "datos específicos mientras pendiente"


### PR DESCRIPTION
## Summary

- Unified `EmployeeRequest` entity as approval wrapper for all employee requests (extra days, leaves, vacations)
- Full lifecycle: `PENDING → APPROVED → CANCELLED` or `PENDING → REJECTED`
- Polymorphic `requestable` link: concrete entity (e.g. `NegotiatedExtraDay`) is created **only on approval** — existencia = aprobado
- Cancel APPROVED also force-deletes the concrete entity in the same transaction, preserving the invariant
- Auto-approve flow: Manager creates + approves in one call (requires `employee-requests.approve` permission)
- 5 endpoints: `POST`, `PATCH approve`, `PATCH reject`, `PATCH cancel`, `GET list` (filterable by status/type/employee)

## Endpoints

| Method | Path | Permission |
|---|---|---|
| POST | `/api/v1/employee-requests` | `employee-requests.create` |
| PATCH | `/api/v1/employee-requests/{id}/approve` | `employee-requests.approve` |
| PATCH | `/api/v1/employee-requests/{id}/reject` | `employee-requests.approve` |
| PATCH | `/api/v1/employee-requests/{id}/cancel` | `employee-requests.cancel` |
| GET | `/api/v1/employee-requests` | `employee-requests.view` |

## Test plan

- [x] PHPUnit: create + approve happy path, rejection, cancel PENDING, cancel APPROVED (deletes entity), duplicate guard, permission checks, validation errors
- [x] 23 tests, all green (`php artisan test --filter=EmployeeRequest`)
- [x] Pint: 0 errors (527 files pass)
- [ ] Cypress: happy path — Manager creates request, employee can view/cancel (tracked in #127)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pakodiazdev/sushigo/pull/129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
