### PR TITLE
✨ [#123] - Add manager advance extra-day registration from employee d…

### DIFF
--- a/code/webapp/src/components/employees/__tests__/employee-detail-view.test.tsx
+++ b/code/webapp/src/components/employees/__tests__/employee-detail-view.test.tsx
@@ -52,6 +52,10 @@ vi.mock('@/components/employees/leave-summary-section', () => ({
   LeaveSummarySection: () => <div>LeaveSummarySection</div>,
 }))
 
+vi.mock('@/components/employees/extra-day-section', () => ({
+  ExtraDaySection: () => <div>ExtraDaySection</div>,
+}))
+
 vi.mock('@/components/employees/permission-manager-dialog', () => ({
   PermissionManagerDialog: ({ isOpen }: { isOpen: boolean }) => isOpen ? <div>PermissionManagerDialog</div> : null,
 }))

--- a/code/webapp/src/components/employees/__tests__/extra-day-form.test.tsx
+++ b/code/webapp/src/components/employees/__tests__/extra-day-form.test.tsx
@@ -1,0 +1,268 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import React from 'react'
+import type { Employee } from '@/types/employee'
+
+// ── UI mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock('@/components/ui/slide-panel', () => ({
+  SlidePanel: ({ isOpen, children, title }: { isOpen: boolean; children: React.ReactNode; title: string }) =>
+    isOpen ? <div data-testid="slide-panel"><div data-testid="panel-title">{title}</div>{children}</div> : null,
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, onClick, disabled, type, className }: {
+    children: React.ReactNode
+    onClick?: () => void
+    disabled?: boolean
+    type?: string
+    className?: string
+  }) => (
+    <button
+      type={(type ?? 'button') as 'button' | 'submit' | 'reset'}
+      onClick={onClick}
+      disabled={disabled}
+      className={className}
+      data-testid={type === 'submit' ? 'submit-btn' : 'cancel-btn'}
+    >
+      {children}
+    </button>
+  ),
+}))
+
+vi.mock('@/components/ui/input', () => ({
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}))
+
+vi.mock('@/components/ui/form-fields', () => ({
+  FormField: ({ children, label, error }: { children: React.ReactNode; label: string; error?: string }) => (
+    <div>
+      <label>{label}</label>
+      {children}
+      {error && <p data-testid="field-error">{error}</p>}
+    </div>
+  ),
+  Textarea: (props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) => <textarea {...props} />,
+}))
+
+// ── Hook mock ─────────────────────────────────────────────────────────────────
+
+const mockSetValue = vi.fn()
+const mockRegister = vi.fn((name: string) => ({ name, onChange: vi.fn(), onBlur: vi.fn(), ref: vi.fn() }))
+const mockHandleSubmit = vi.fn()
+
+const defaultHookReturn = {
+  form: {
+    register: mockRegister,
+    watch: vi.fn((field: string) => field === 'salary_type' ? 'registered' : 'legal'),
+    setValue: mockSetValue,
+    handleSubmit: vi.fn(),
+    formState: { errors: {} },
+  },
+  isLoadingWages: false,
+  hasNoWage: false,
+  registeredDailyWage: 800,
+  salaryDay: 800,
+  seventhDay: 800,
+  prima: 800,
+  total: 2400,
+  handleSubmit: mockHandleSubmit,
+  isPending: false,
+}
+
+vi.mock('../use-extra-day-form', () => ({
+  useExtraDayForm: () => mockUseExtraDayFormReturn,
+}))
+
+let mockUseExtraDayFormReturn = { ...defaultHookReturn }
+
+import { ExtraDayForm } from '../extra-day-form'
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const employee = {
+  id: 'emp-1',
+  first_name: 'Ana',
+  last_name: 'López',
+} as unknown as Employee
+
+const baseProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  employee,
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('ExtraDayForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseExtraDayFormReturn = {
+      ...defaultHookReturn,
+      form: {
+        register: vi.fn((name: string) => ({ name, onChange: vi.fn(), onBlur: vi.fn(), ref: vi.fn() })),
+        watch: vi.fn((field: string) => field === 'salary_type' ? 'registered' : 'legal'),
+        setValue: mockSetValue,
+        handleSubmit: vi.fn(),
+        formState: { errors: {} },
+      },
+      handleSubmit: mockHandleSubmit,
+    }
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('does not render when isOpen=false', () => {
+    render(<ExtraDayForm {...baseProps} isOpen={false} />)
+    expect(screen.queryByTestId('slide-panel')).toBeNull()
+  })
+
+  it('renders panel with employee name in title', () => {
+    render(<ExtraDayForm {...baseProps} />)
+    expect(screen.getByTestId('panel-title').textContent).toContain('Ana López')
+  })
+
+  it('shows registered daily wage label', () => {
+    render(<ExtraDayForm {...baseProps} />)
+    expect(screen.getByText('Salario registrado')).toBeTruthy()
+  })
+
+  it('shows salary custom input only when salary_type is custom', () => {
+    mockUseExtraDayFormReturn = {
+      ...mockUseExtraDayFormReturn,
+      form: {
+        ...mockUseExtraDayFormReturn.form,
+        watch: vi.fn((field: string) => field === 'salary_type' ? 'custom' : 'legal'),
+      },
+    }
+
+    render(<ExtraDayForm {...baseProps} />)
+
+    // salary_pct input is rendered when salary_type=custom
+    const numberInputs = screen.getAllByRole('spinbutton')
+    expect(numberInputs.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('does not show salary_pct input when salary_type is registered', () => {
+    render(<ExtraDayForm {...baseProps} />)
+    // With salary_type=registered and prima_type=legal, no number inputs for pct
+    const numberInputs = screen.queryAllByRole('spinbutton')
+    expect(numberInputs).toHaveLength(0)
+  })
+
+  it('shows prima custom input only when prima_type is custom', () => {
+    mockUseExtraDayFormReturn = {
+      ...mockUseExtraDayFormReturn,
+      form: {
+        ...mockUseExtraDayFormReturn.form,
+        watch: vi.fn((field: string) => field === 'salary_type' ? 'registered' : 'custom'),
+      },
+    }
+
+    render(<ExtraDayForm {...baseProps} />)
+
+    const numberInputs = screen.getAllByRole('spinbutton')
+    expect(numberInputs.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('shows summary section with Total label', () => {
+    render(<ExtraDayForm {...baseProps} />)
+    expect(screen.getByText('Total')).toBeTruthy()
+    expect(screen.getByText('Resumen del día')).toBeTruthy()
+  })
+
+  it('shows no-wage error when hasNoWage=true', () => {
+    mockUseExtraDayFormReturn = { ...mockUseExtraDayFormReturn, hasNoWage: true }
+
+    render(<ExtraDayForm {...baseProps} />)
+
+    expect(screen.getByText(/no tiene historial de salario/)).toBeTruthy()
+  })
+
+  it('hides no-wage error when hasNoWage=false', () => {
+    render(<ExtraDayForm {...baseProps} />)
+    expect(screen.queryByText(/no tiene historial de salario/)).toBeNull()
+  })
+
+  it('disables submit button when hasNoWage=true', () => {
+    mockUseExtraDayFormReturn = { ...mockUseExtraDayFormReturn, hasNoWage: true }
+
+    render(<ExtraDayForm {...baseProps} />)
+
+    expect((screen.getByTestId('submit-btn') as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('disables submit button when isPending=true', () => {
+    mockUseExtraDayFormReturn = { ...mockUseExtraDayFormReturn, isPending: true }
+
+    render(<ExtraDayForm {...baseProps} />)
+
+    expect((screen.getByTestId('submit-btn') as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('disables submit button while wages are loading', () => {
+    mockUseExtraDayFormReturn = { ...mockUseExtraDayFormReturn, isLoadingWages: true }
+
+    render(<ExtraDayForm {...baseProps} />)
+
+    expect((screen.getByTestId('submit-btn') as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('enables submit button when ready', () => {
+    render(<ExtraDayForm {...baseProps} />)
+    expect((screen.getByTestId('submit-btn') as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('calls onClose when cancel button is clicked', () => {
+    const onClose = vi.fn()
+    render(<ExtraDayForm {...baseProps} onClose={onClose} />)
+
+    fireEvent.click(screen.getByTestId('cancel-btn'))
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('resets salary_pct to 100 when salary_type radio changes to registered', () => {
+    mockUseExtraDayFormReturn = {
+      ...mockUseExtraDayFormReturn,
+      form: {
+        ...mockUseExtraDayFormReturn.form,
+        watch: vi.fn((field: string) => field === 'salary_type' ? 'custom' : 'legal'),
+      },
+    }
+    const setValueSpy = vi.fn()
+    mockUseExtraDayFormReturn.form.setValue = setValueSpy
+
+    render(<ExtraDayForm {...baseProps} />)
+
+    // Click the "registered" radio
+    const registeredRadio = screen.getByDisplayValue('registered')
+    fireEvent.click(registeredRadio)
+
+    expect(setValueSpy).toHaveBeenCalledWith('salary_type', 'registered')
+    expect(setValueSpy).toHaveBeenCalledWith('salary_pct', 100)
+  })
+
+  it('resets prima_pct to 100 when prima_type radio changes to legal', () => {
+    mockUseExtraDayFormReturn = {
+      ...mockUseExtraDayFormReturn,
+      form: {
+        ...mockUseExtraDayFormReturn.form,
+        watch: vi.fn((field: string) => field === 'salary_type' ? 'registered' : 'custom'),
+      },
+    }
+    const setValueSpy = vi.fn()
+    mockUseExtraDayFormReturn.form.setValue = setValueSpy
+
+    render(<ExtraDayForm {...baseProps} />)
+
+    const legalRadio = screen.getByDisplayValue('legal')
+    fireEvent.click(legalRadio)
+
+    expect(setValueSpy).toHaveBeenCalledWith('prima_type', 'legal')
+    expect(setValueSpy).toHaveBeenCalledWith('prima_pct', 100)
+  })
+})

--- a/code/webapp/src/components/employees/__tests__/extra-day-form.test.tsx
+++ b/code/webapp/src/components/employees/__tests__/extra-day-form.test.tsx
@@ -48,18 +48,43 @@ vi.mock('@/components/ui/form-fields', () => ({
 
 // ── Hook mock ─────────────────────────────────────────────────────────────────
 
-const mockSetValue = vi.fn()
-const mockRegister = vi.fn((name: string) => ({ name, onChange: vi.fn(), onBlur: vi.fn(), ref: vi.fn() }))
-const mockHandleSubmit = vi.fn()
+interface MockForm {
+  register: (name: string) => object
+  watch: (field: string) => string
+  setValue: (...args: unknown[]) => void
+  handleSubmit: (...args: unknown[]) => unknown
+  formState: { errors: Record<string, unknown> }
+}
 
-const defaultHookReturn = {
-  form: {
-    register: mockRegister,
-    watch: vi.fn((field: string) => field === 'salary_type' ? 'registered' : 'legal'),
-    setValue: mockSetValue,
+interface MockHookReturn {
+  form: MockForm
+  isLoadingWages: boolean
+  hasNoWage: boolean
+  registeredDailyWage: number
+  salaryDay: number
+  seventhDay: number
+  prima: number
+  total: number
+  handleSubmit: (...args: unknown[]) => unknown
+  isPending: boolean
+}
+
+function makeForm(watchImpl: (field: string) => string): MockForm {
+  return {
+    register: vi.fn((name: string) => ({ name, onChange: vi.fn(), onBlur: vi.fn(), ref: vi.fn() })),
+    watch: vi.fn(watchImpl),
+    setValue: vi.fn(),
     handleSubmit: vi.fn(),
     formState: { errors: {} },
-  },
+  }
+}
+
+vi.mock('../use-extra-day-form', () => ({
+  useExtraDayForm: () => mockUseExtraDayFormReturn,
+}))
+
+let mockUseExtraDayFormReturn: MockHookReturn = {
+  form: makeForm((field) => field === 'salary_type' ? 'registered' : 'legal'),
   isLoadingWages: false,
   hasNoWage: false,
   registeredDailyWage: 800,
@@ -67,15 +92,9 @@ const defaultHookReturn = {
   seventhDay: 800,
   prima: 800,
   total: 2400,
-  handleSubmit: mockHandleSubmit,
+  handleSubmit: vi.fn(),
   isPending: false,
 }
-
-vi.mock('../use-extra-day-form', () => ({
-  useExtraDayForm: () => mockUseExtraDayFormReturn,
-}))
-
-let mockUseExtraDayFormReturn = { ...defaultHookReturn }
 
 import { ExtraDayForm } from '../extra-day-form'
 
@@ -99,15 +118,16 @@ describe('ExtraDayForm', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockUseExtraDayFormReturn = {
-      ...defaultHookReturn,
-      form: {
-        register: vi.fn((name: string) => ({ name, onChange: vi.fn(), onBlur: vi.fn(), ref: vi.fn() })),
-        watch: vi.fn((field: string) => field === 'salary_type' ? 'registered' : 'legal'),
-        setValue: mockSetValue,
-        handleSubmit: vi.fn(),
-        formState: { errors: {} },
-      },
-      handleSubmit: mockHandleSubmit,
+      form: makeForm((field) => field === 'salary_type' ? 'registered' : 'legal'),
+      isLoadingWages: false,
+      hasNoWage: false,
+      registeredDailyWage: 800,
+      salaryDay: 800,
+      seventhDay: 800,
+      prima: 800,
+      total: 2400,
+      handleSubmit: vi.fn(),
+      isPending: false,
     }
   })
 
@@ -133,10 +153,7 @@ describe('ExtraDayForm', () => {
   it('shows salary custom input only when salary_type is custom', () => {
     mockUseExtraDayFormReturn = {
       ...mockUseExtraDayFormReturn,
-      form: {
-        ...mockUseExtraDayFormReturn.form,
-        watch: vi.fn((field: string) => field === 'salary_type' ? 'custom' : 'legal'),
-      },
+      form: makeForm((field) => field === 'salary_type' ? 'custom' : 'legal'),
     }
 
     render(<ExtraDayForm {...baseProps} />)
@@ -156,10 +173,7 @@ describe('ExtraDayForm', () => {
   it('shows prima custom input only when prima_type is custom', () => {
     mockUseExtraDayFormReturn = {
       ...mockUseExtraDayFormReturn,
-      form: {
-        ...mockUseExtraDayFormReturn.form,
-        watch: vi.fn((field: string) => field === 'salary_type' ? 'registered' : 'custom'),
-      },
+      form: makeForm((field) => field === 'salary_type' ? 'registered' : 'custom'),
     }
 
     render(<ExtraDayForm {...baseProps} />)
@@ -226,19 +240,13 @@ describe('ExtraDayForm', () => {
   })
 
   it('resets salary_pct to 100 when salary_type radio changes to registered', () => {
-    mockUseExtraDayFormReturn = {
-      ...mockUseExtraDayFormReturn,
-      form: {
-        ...mockUseExtraDayFormReturn.form,
-        watch: vi.fn((field: string) => field === 'salary_type' ? 'custom' : 'legal'),
-      },
-    }
     const setValueSpy = vi.fn()
-    mockUseExtraDayFormReturn.form.setValue = setValueSpy
+    const form = makeForm((field) => field === 'salary_type' ? 'custom' : 'legal')
+    form.setValue = setValueSpy
+    mockUseExtraDayFormReturn = { ...mockUseExtraDayFormReturn, form }
 
     render(<ExtraDayForm {...baseProps} />)
 
-    // Click the "registered" radio
     const registeredRadio = screen.getByDisplayValue('registered')
     fireEvent.click(registeredRadio)
 
@@ -247,15 +255,10 @@ describe('ExtraDayForm', () => {
   })
 
   it('resets prima_pct to 100 when prima_type radio changes to legal', () => {
-    mockUseExtraDayFormReturn = {
-      ...mockUseExtraDayFormReturn,
-      form: {
-        ...mockUseExtraDayFormReturn.form,
-        watch: vi.fn((field: string) => field === 'salary_type' ? 'registered' : 'custom'),
-      },
-    }
     const setValueSpy = vi.fn()
-    mockUseExtraDayFormReturn.form.setValue = setValueSpy
+    const form = makeForm((field) => field === 'salary_type' ? 'registered' : 'custom')
+    form.setValue = setValueSpy
+    mockUseExtraDayFormReturn = { ...mockUseExtraDayFormReturn, form }
 
     render(<ExtraDayForm {...baseProps} />)
 

--- a/code/webapp/src/components/employees/__tests__/extra-day-section.test.tsx
+++ b/code/webapp/src/components/employees/__tests__/extra-day-section.test.tsx
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { fireEvent } from '@testing-library/react'
+import React from 'react'
+import type { Employee } from '@/types/employee'
+import type { EmployeeRequest } from '@/types/employee-request'
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, onClick, type }: { children: React.ReactNode; onClick?: () => void; type?: string }) => (
+    <button type={(type ?? 'button') as 'button' | 'submit' | 'reset'} onClick={onClick}>{children}</button>
+  ),
+}))
+
+vi.mock('@/components/employees/extra-day-form', () => ({
+  ExtraDayForm: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="extra-day-form">ExtraDayForm</div> : null,
+}))
+
+const mockCan = vi.fn()
+vi.mock('@/stores/auth.store', () => ({
+  useAuthStore: (selector: (state: { can: (p: string) => boolean }) => unknown) =>
+    selector({ can: (p: string) => mockCan(p) }),
+}))
+
+const mockUseApprovedExtraDays = vi.fn()
+vi.mock('@/services/employee-request-hooks', () => ({
+  useApprovedExtraDays: (...args: unknown[]) => mockUseApprovedExtraDays(...args),
+}))
+
+import { ExtraDaySection } from '../extra-day-section'
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const employee = {
+  id: 'emp-1',
+  first_name: 'Ana',
+  last_name: 'López',
+} as unknown as Employee
+
+function makeRequest(overrides: Partial<EmployeeRequest> = {}): EmployeeRequest {
+  return {
+    id: 'req-1',
+    employee_id: 'emp-1',
+    type: 'EXTRA_DAY',
+    status: 'APPROVED',
+    payload: { date: '2026-04-25', prima_pct: 100 },
+    requestable: null,
+    requested_by: 'emp-1',
+    approved_by: null,
+    approved_at: null,
+    notes: null,
+    rejection_reason: null,
+    created_at: '2026-04-25T00:00:00Z',
+    ...overrides,
+  }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('ExtraDaySection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('hides empty-state text while data is loading', () => {
+    mockCan.mockReturnValue(false)
+    mockUseApprovedExtraDays.mockReturnValue({ data: undefined, isLoading: true })
+
+    render(<ExtraDaySection employee={employee} />)
+
+    expect(screen.queryByText('No hay días extra acordados')).toBeNull()
+  })
+
+  it('shows empty state when no extra days and not loading', () => {
+    mockCan.mockReturnValue(false)
+    mockUseApprovedExtraDays.mockReturnValue({ data: [], isLoading: false })
+
+    render(<ExtraDaySection employee={employee} />)
+
+    expect(screen.getByText('No hay días extra acordados')).toBeTruthy()
+  })
+
+  it('hides the "+ Día extra" button when user lacks approve permission', () => {
+    mockCan.mockReturnValue(false)
+    mockUseApprovedExtraDays.mockReturnValue({ data: [], isLoading: false })
+
+    render(<ExtraDaySection employee={employee} />)
+
+    expect(screen.queryByText('Día extra')).toBeNull()
+  })
+
+  it('shows the "+ Día extra" button when user has approve permission', () => {
+    mockCan.mockImplementation((p: string) => p === 'employee-requests.approve')
+    mockUseApprovedExtraDays.mockReturnValue({ data: [], isLoading: false })
+
+    render(<ExtraDaySection employee={employee} />)
+
+    expect(screen.getByText('Día extra')).toBeTruthy()
+  })
+
+  it('opens ExtraDayForm when button is clicked', () => {
+    mockCan.mockImplementation((p: string) => p === 'employee-requests.approve')
+    mockUseApprovedExtraDays.mockReturnValue({ data: [], isLoading: false })
+
+    render(<ExtraDaySection employee={employee} />)
+
+    expect(screen.queryByTestId('extra-day-form')).toBeNull()
+
+    fireEvent.click(screen.getByText('Día extra'))
+
+    expect(screen.getByTestId('extra-day-form')).toBeTruthy()
+  })
+
+  it('renders approved extra-day chips with date and prima_pct', () => {
+    mockCan.mockReturnValue(false)
+    mockUseApprovedExtraDays.mockReturnValue({
+      data: [makeRequest({ payload: { date: '2026-04-25', prima_pct: 75 } })],
+      isLoading: false,
+    })
+
+    render(<ExtraDaySection employee={employee} />)
+
+    expect(screen.getByText('Día extra acordado')).toBeTruthy()
+    expect(screen.getByText('Prima: 75%')).toBeTruthy()
+  })
+
+  it('renders chip without prima when prima_pct is absent', () => {
+    mockCan.mockReturnValue(false)
+    mockUseApprovedExtraDays.mockReturnValue({
+      data: [makeRequest({ payload: { date: '2026-04-25' } })],
+      isLoading: false,
+    })
+
+    render(<ExtraDaySection employee={employee} />)
+
+    expect(screen.queryByText(/Prima:/)).toBeNull()
+  })
+
+  it('passes employeeId to useApprovedExtraDays', () => {
+    mockCan.mockReturnValue(false)
+    mockUseApprovedExtraDays.mockReturnValue({ data: [], isLoading: false })
+
+    render(<ExtraDaySection employee={employee} />)
+
+    expect(mockUseApprovedExtraDays).toHaveBeenCalledWith('emp-1')
+  })
+})

--- a/code/webapp/src/components/employees/__tests__/use-extra-day-form.test.ts
+++ b/code/webapp/src/components/employees/__tests__/use-extra-day-form.test.ts
@@ -1,0 +1,245 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import React from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockMutateAsync = vi.fn()
+const mockUseCreateEmployeeRequest = vi.fn()
+const mockUseWageHistory = vi.fn()
+
+vi.mock('@/services/employee-hooks', () => ({
+  useWageHistory: (...args: unknown[]) => mockUseWageHistory(...args),
+}))
+
+vi.mock('@/services/employee-request-hooks', () => ({
+  useCreateEmployeeRequest: () => mockUseCreateEmployeeRequest(),
+}))
+
+import { useExtraDayForm } from '../use-extra-day-form'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeWage(hourlyRate: string, weeklyHours: number) {
+  return { hourly_rate: hourlyRate, weekly_scheduled_hours: weeklyHours }
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('useExtraDayForm — wage calculations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCreateEmployeeRequest.mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    })
+  })
+
+  it('computes registeredDailyWage from hourly_rate × (weeklyHours / 6)', () => {
+    // 100/hr × (48h/6) = 100 × 8 = 800
+    mockUseWageHistory.mockReturnValue({ data: [makeWage('100', 48)], isLoading: false })
+
+    const { result } = renderHook(() => useExtraDayForm('emp-1', vi.fn()), { wrapper: createWrapper() })
+
+    expect(result.current.registeredDailyWage).toBeCloseTo(800)
+  })
+
+  it('sets registeredDailyWage to 0 when no wage history', () => {
+    mockUseWageHistory.mockReturnValue({ data: [], isLoading: false })
+
+    const { result } = renderHook(() => useExtraDayForm('emp-1', vi.fn()), { wrapper: createWrapper() })
+
+    expect(result.current.registeredDailyWage).toBe(0)
+  })
+
+  it('sets hasNoWage=true when no wage and not loading', () => {
+    mockUseWageHistory.mockReturnValue({ data: [], isLoading: false })
+
+    const { result } = renderHook(() => useExtraDayForm('emp-1', vi.fn()), { wrapper: createWrapper() })
+
+    expect(result.current.hasNoWage).toBe(true)
+  })
+
+  it('sets hasNoWage=false when wage exists', () => {
+    mockUseWageHistory.mockReturnValue({ data: [makeWage('100', 48)], isLoading: false })
+
+    const { result } = renderHook(() => useExtraDayForm('emp-1', vi.fn()), { wrapper: createWrapper() })
+
+    expect(result.current.hasNoWage).toBe(false)
+  })
+
+  it('sets hasNoWage=false while wages are loading', () => {
+    mockUseWageHistory.mockReturnValue({ data: undefined, isLoading: true })
+
+    const { result } = renderHook(() => useExtraDayForm('emp-1', vi.fn()), { wrapper: createWrapper() })
+
+    expect(result.current.hasNoWage).toBe(false)
+  })
+
+  it('computes total = salaryDay + seventhDay + prima (registered, legal)', () => {
+    // dailyWage = 100 × (48/6) = 800
+    // salaryDay = 800, seventhDay = 800, prima = 800 (100%), total = 2400
+    mockUseWageHistory.mockReturnValue({ data: [makeWage('100', 48)], isLoading: false })
+
+    const { result } = renderHook(() => useExtraDayForm('emp-1', vi.fn()), { wrapper: createWrapper() })
+
+    expect(result.current.salaryDay).toBeCloseTo(800)
+    expect(result.current.seventhDay).toBeCloseTo(800)
+    expect(result.current.prima).toBeCloseTo(800)
+    expect(result.current.total).toBeCloseTo(2400)
+  })
+
+  it('uses custom salary_pct when salary_type is custom', async () => {
+    // dailyWage = 800, salary_pct=50 → salaryDay = 400
+    mockUseWageHistory.mockReturnValue({ data: [makeWage('100', 48)], isLoading: false })
+
+    const { result } = renderHook(() => useExtraDayForm('emp-1', vi.fn()), { wrapper: createWrapper() })
+
+    act(() => {
+      result.current.form.setValue('salary_type', 'custom')
+      result.current.form.setValue('salary_pct', 50)
+    })
+
+    await waitFor(() => expect(result.current.salaryDay).toBeCloseTo(400))
+  })
+
+  it('uses custom prima_pct when prima_type is custom', async () => {
+    // dailyWage = 800, prima_pct=50 → prima = 400
+    mockUseWageHistory.mockReturnValue({ data: [makeWage('100', 48)], isLoading: false })
+
+    const { result } = renderHook(() => useExtraDayForm('emp-1', vi.fn()), { wrapper: createWrapper() })
+
+    act(() => {
+      result.current.form.setValue('prima_type', 'custom')
+      result.current.form.setValue('prima_pct', 50)
+    })
+
+    await waitFor(() => expect(result.current.prima).toBeCloseTo(400))
+  })
+})
+
+describe('useExtraDayForm — submission', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseWageHistory.mockReturnValue({ data: [makeWage('100', 48)], isLoading: false })
+    mockUseCreateEmployeeRequest.mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    })
+  })
+
+  it('calls mutateAsync with correct payload on submit', async () => {
+    mockMutateAsync.mockResolvedValue({})
+    const onSuccess = vi.fn()
+
+    const { result } = renderHook(() => useExtraDayForm('emp-1', onSuccess), { wrapper: createWrapper() })
+
+    act(() => {
+      result.current.form.setValue('date', '2026-04-25')
+    })
+
+    await act(async () => {
+      await result.current.handleSubmit({ preventDefault: () => {} } as unknown as React.FormEvent)
+    })
+
+    expect(mockMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        employee_id: 'emp-1',
+        type: 'EXTRA_DAY',
+        auto_approve: true,
+        payload: expect.objectContaining({
+          date: '2026-04-25',
+          salary_pct: 100,
+          prima_pct: 100,
+        }),
+      }),
+    )
+  })
+
+  it('calls onSuccess and resets form after successful submission', async () => {
+    mockMutateAsync.mockResolvedValue({})
+    const onSuccess = vi.fn()
+
+    const { result } = renderHook(() => useExtraDayForm('emp-1', onSuccess), { wrapper: createWrapper() })
+
+    act(() => {
+      result.current.form.setValue('date', '2026-04-25')
+      result.current.form.setValue('notes', 'Acuerdo verbal')
+    })
+
+    await act(async () => {
+      await result.current.handleSubmit({ preventDefault: () => {} } as unknown as React.FormEvent)
+    })
+
+    expect(onSuccess).toHaveBeenCalledTimes(1)
+    // form should be reset — notes back to default
+    expect(result.current.form.getValues('notes')).toBe('')
+  })
+
+  it('does not call onSuccess when mutation rejects', async () => {
+    mockMutateAsync.mockRejectedValue(new Error('Network error'))
+    const onSuccess = vi.fn()
+
+    const { result } = renderHook(() => useExtraDayForm('emp-1', onSuccess), { wrapper: createWrapper() })
+
+    act(() => {
+      result.current.form.setValue('date', '2026-04-25')
+    })
+
+    await act(async () => {
+      await result.current.handleSubmit({ preventDefault: () => {} } as unknown as React.FormEvent)
+    })
+
+    expect(onSuccess).not.toHaveBeenCalled()
+  })
+
+  it('uses effectiveSalaryPct=100 when salary_type=registered regardless of salary_pct value', async () => {
+    mockMutateAsync.mockResolvedValue({})
+
+    const { result } = renderHook(() => useExtraDayForm('emp-1', vi.fn()), { wrapper: createWrapper() })
+
+    act(() => {
+      result.current.form.setValue('date', '2026-04-25')
+      result.current.form.setValue('salary_type', 'registered')
+      result.current.form.setValue('salary_pct', 50) // stale hidden value
+    })
+
+    await act(async () => {
+      await result.current.handleSubmit({ preventDefault: () => {} } as unknown as React.FormEvent)
+    })
+
+    expect(mockMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ payload: expect.objectContaining({ salary_pct: 100 }) }),
+    )
+  })
+
+  it('uses effectivePrimaPct=100 when prima_type=legal regardless of prima_pct value', async () => {
+    mockMutateAsync.mockResolvedValue({})
+
+    const { result } = renderHook(() => useExtraDayForm('emp-1', vi.fn()), { wrapper: createWrapper() })
+
+    act(() => {
+      result.current.form.setValue('date', '2026-04-25')
+      result.current.form.setValue('prima_type', 'legal')
+      result.current.form.setValue('prima_pct', 75) // stale hidden value
+    })
+
+    await act(async () => {
+      await result.current.handleSubmit({ preventDefault: () => {} } as unknown as React.FormEvent)
+    })
+
+    expect(mockMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ payload: expect.objectContaining({ prima_pct: 100 }) }),
+    )
+  })
+})

--- a/code/webapp/src/components/employees/__tests__/use-extra-day-form.test.ts
+++ b/code/webapp/src/components/employees/__tests__/use-extra-day-form.test.ts
@@ -99,6 +99,38 @@ describe('useExtraDayForm — wage calculations', () => {
     expect(result.current.total).toBeCloseTo(2400)
   })
 
+  it('falls back to 0 instead of NaN when salary_pct is cleared (NaN)', async () => {
+    mockUseWageHistory.mockReturnValue({ data: [makeWage('100', 48)], isLoading: false })
+
+    const { result } = renderHook(() => useExtraDayForm('emp-1', vi.fn()), { wrapper: createWrapper() })
+
+    act(() => {
+      result.current.form.setValue('salary_type', 'custom')
+      result.current.form.setValue('salary_pct', NaN)
+    })
+
+    await waitFor(() => {
+      expect(result.current.salaryDay).toBe(0)
+      expect(Number.isNaN(result.current.total)).toBe(false)
+    })
+  })
+
+  it('falls back to 0 instead of NaN when prima_pct is cleared (NaN)', async () => {
+    mockUseWageHistory.mockReturnValue({ data: [makeWage('100', 48)], isLoading: false })
+
+    const { result } = renderHook(() => useExtraDayForm('emp-1', vi.fn()), { wrapper: createWrapper() })
+
+    act(() => {
+      result.current.form.setValue('prima_type', 'custom')
+      result.current.form.setValue('prima_pct', NaN)
+    })
+
+    await waitFor(() => {
+      expect(result.current.prima).toBe(0)
+      expect(Number.isNaN(result.current.total)).toBe(false)
+    })
+  })
+
   it('uses custom salary_pct when salary_type is custom', async () => {
     // dailyWage = 800, salary_pct=50 → salaryDay = 400
     mockUseWageHistory.mockReturnValue({ data: [makeWage('100', 48)], isLoading: false })

--- a/code/webapp/src/components/employees/employee-detail-view.tsx
+++ b/code/webapp/src/components/employees/employee-detail-view.tsx
@@ -11,6 +11,7 @@ import { RehireForm } from './rehire-form'
 import { useEmployeeDetailActions } from './use-employee-detail-actions'
 import { ScheduleSection } from './schedule-section'
 import { LeaveSummarySection } from './leave-summary-section'
+import { ExtraDaySection } from './extra-day-section'
 import { usePermissionManager } from './use-permission-manager'
 import { PermissionManagerDialog } from './permission-manager-dialog'
 
@@ -81,6 +82,11 @@ export function EmployeeDetailView({
         employeeId={employee.id}
         employee={employee}
       />
+
+      <hr className="border-border" />
+
+      {/* Extra days — approved agreements + manager registration */}
+      <ExtraDaySection employee={employee} />
 
       <hr className="border-border" />
 

--- a/code/webapp/src/components/employees/extra-day-form.tsx
+++ b/code/webapp/src/components/employees/extra-day-form.tsx
@@ -7,9 +7,9 @@ import { useExtraDayForm } from './use-extra-day-form'
 import type { Employee } from '@/types/employee'
 
 interface ExtraDayFormProps {
-  isOpen: boolean
-  onClose: () => void
-  employee: Employee
+  readonly isOpen: boolean
+  readonly onClose: () => void
+  readonly employee: Employee
 }
 
 function formatCurrency(value: number): string {

--- a/code/webapp/src/components/employees/extra-day-form.tsx
+++ b/code/webapp/src/components/employees/extra-day-form.tsx
@@ -1,0 +1,205 @@
+import { Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { FormField, Textarea } from '@/components/ui/form-fields'
+import { SlidePanel } from '@/components/ui/slide-panel'
+import { useExtraDayForm } from './use-extra-day-form'
+import type { Employee } from '@/types/employee'
+
+interface ExtraDayFormProps {
+  isOpen: boolean
+  onClose: () => void
+  employee: Employee
+}
+
+function formatCurrency(value: number): string {
+  return value.toLocaleString('es-MX', { style: 'currency', currency: 'MXN', minimumFractionDigits: 2 })
+}
+
+export function ExtraDayForm({ isOpen, onClose, employee }: ExtraDayFormProps) {
+  const employeeName = `${employee.first_name} ${employee.last_name}`
+
+  const {
+    form,
+    isLoadingWages,
+    registeredDailyWage,
+    salaryDay,
+    seventhDay,
+    prima,
+    total,
+    handleSubmit,
+    isPending,
+  } = useExtraDayForm(employee.id, onClose)
+
+  const { register, watch, setValue, formState: { errors } } = form
+  const salaryType = watch('salary_type')
+  const primaType = watch('prima_type')
+
+  return (
+    <SlidePanel
+      isOpen={isOpen}
+      onClose={onClose}
+      title={`Registrar día extra — ${employeeName}`}
+      size="sm"
+    >
+      <form onSubmit={handleSubmit} className="space-y-6">
+        {/* Date */}
+        <FormField label="Fecha" required error={errors.date?.message}>
+          <Input type="date" {...register('date')} />
+        </FormField>
+
+        {/* Salary */}
+        <div className="space-y-3">
+          <p className="text-sm font-medium text-foreground">Salario del día</p>
+
+          <label className="flex items-center gap-3 cursor-pointer">
+            <input
+              type="radio"
+              value="registered"
+              checked={salaryType === 'registered'}
+              onChange={() => setValue('salary_type', 'registered')}
+              className="h-4 w-4 text-primary"
+            />
+            <span className="flex-1 text-sm">Salario registrado</span>
+            {isLoadingWages ? (
+              <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+            ) : (
+              <span className="text-sm font-medium">{formatCurrency(registeredDailyWage)}</span>
+            )}
+          </label>
+
+          <label className="flex items-start gap-3 cursor-pointer">
+            <input
+              type="radio"
+              value="custom"
+              checked={salaryType === 'custom'}
+              onChange={() => setValue('salary_type', 'custom')}
+              className="h-4 w-4 mt-0.5 text-primary"
+            />
+            <div className="flex-1 space-y-2">
+              <span className="text-sm">Salario acordado</span>
+              {salaryType === 'custom' && (
+                <div className="flex items-center gap-2">
+                  <Input
+                    type="number"
+                    min="0"
+                    max="200"
+                    step="0.01"
+                    className="w-24"
+                    {...register('salary_pct', { valueAsNumber: true })}
+                  />
+                  <span className="text-sm text-muted-foreground">%</span>
+                  <span className="text-sm text-muted-foreground">=</span>
+                  <span className="text-sm font-medium w-24 text-right">{formatCurrency(salaryDay)}</span>
+                  {errors.salary_pct && (
+                    <p className="text-xs text-red-600">{errors.salary_pct.message}</p>
+                  )}
+                </div>
+              )}
+            </div>
+          </label>
+        </div>
+
+        {/* Prima */}
+        <div className="space-y-3">
+          <p className="text-sm font-medium text-foreground">Prima por día de descanso trabajado</p>
+
+          <label className="flex items-center gap-3 cursor-pointer">
+            <input
+              type="radio"
+              value="legal"
+              checked={primaType === 'legal'}
+              onChange={() => setValue('prima_type', 'legal')}
+              className="h-4 w-4 text-primary"
+            />
+            <span className="flex-1 text-sm">Prima legal &nbsp; 100%</span>
+            <span className="text-sm font-medium">{formatCurrency(salaryDay)}</span>
+          </label>
+
+          <label className="flex items-start gap-3 cursor-pointer">
+            <input
+              type="radio"
+              value="custom"
+              checked={primaType === 'custom'}
+              onChange={() => setValue('prima_type', 'custom')}
+              className="h-4 w-4 mt-0.5 text-primary"
+            />
+            <div className="flex-1 space-y-2">
+              <span className="text-sm">Prima acordada</span>
+              {primaType === 'custom' && (
+                <div className="flex items-center gap-2">
+                  <Input
+                    type="number"
+                    min="0"
+                    max="200"
+                    step="0.01"
+                    className="w-24"
+                    {...register('prima_pct', { valueAsNumber: true })}
+                  />
+                  <span className="text-sm text-muted-foreground">%</span>
+                  <span className="text-sm text-muted-foreground">=</span>
+                  <span className="text-sm font-medium w-24 text-right">{formatCurrency(prima)}</span>
+                  {errors.prima_pct && (
+                    <p className="text-xs text-red-600">{errors.prima_pct.message}</p>
+                  )}
+                </div>
+              )}
+              <p className="text-xs text-muted-foreground">0% mínimo · 200% máximo</p>
+            </div>
+          </label>
+        </div>
+
+        {/* Summary */}
+        <div className="rounded-md border border-border bg-muted/40 p-4 space-y-1.5">
+          <p className="text-sm font-semibold text-foreground mb-2">Resumen del día</p>
+          <div className="flex justify-between text-sm">
+            <span className="text-muted-foreground">Salario del día</span>
+            <span>{formatCurrency(salaryDay)}</span>
+          </div>
+          <div className="flex justify-between text-sm">
+            <span className="text-muted-foreground">Séptimo día (1/6)</span>
+            <span>{formatCurrency(seventhDay)}</span>
+          </div>
+          <div className="flex justify-between text-sm">
+            <span className="text-muted-foreground">Prima</span>
+            <span>{formatCurrency(prima)}</span>
+          </div>
+          <hr className="border-border my-1" />
+          <div className="flex justify-between text-sm font-semibold">
+            <span>Total</span>
+            <span>{formatCurrency(total)}</span>
+          </div>
+        </div>
+
+        {/* Notes */}
+        <FormField label="Notas (opcional)" error={errors.notes?.message}>
+          <Textarea
+            placeholder="Ej. Acuerdo verbal del lunes"
+            rows={3}
+            {...register('notes')}
+          />
+        </FormField>
+
+        {/* Actions */}
+        <div className="flex gap-3 justify-end pt-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onClose}
+            disabled={isPending}
+          >
+            Cancelar
+          </Button>
+          <Button
+            type="submit"
+            disabled={isPending || isLoadingWages}
+            className="bg-emerald-600 text-white hover:bg-emerald-700"
+          >
+            {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Registrar acuerdo
+          </Button>
+        </div>
+      </form>
+    </SlidePanel>
+  )
+}

--- a/code/webapp/src/components/employees/extra-day-form.tsx
+++ b/code/webapp/src/components/employees/extra-day-form.tsx
@@ -22,6 +22,7 @@ export function ExtraDayForm({ isOpen, onClose, employee }: ExtraDayFormProps) {
   const {
     form,
     isLoadingWages,
+    hasNoWage,
     registeredDailyWage,
     salaryDay,
     seventhDay,
@@ -57,7 +58,7 @@ export function ExtraDayForm({ isOpen, onClose, employee }: ExtraDayFormProps) {
               type="radio"
               value="registered"
               checked={salaryType === 'registered'}
-              onChange={() => setValue('salary_type', 'registered')}
+              onChange={() => { setValue('salary_type', 'registered'); setValue('salary_pct', 100) }}
               className="h-4 w-4 text-primary"
             />
             <span className="flex-1 text-sm">Salario registrado</span>
@@ -109,7 +110,7 @@ export function ExtraDayForm({ isOpen, onClose, employee }: ExtraDayFormProps) {
               type="radio"
               value="legal"
               checked={primaType === 'legal'}
-              onChange={() => setValue('prima_type', 'legal')}
+              onChange={() => { setValue('prima_type', 'legal'); setValue('prima_pct', 100) }}
               className="h-4 w-4 text-primary"
             />
             <span className="flex-1 text-sm">Prima legal &nbsp; 100%</span>
@@ -180,6 +181,13 @@ export function ExtraDayForm({ isOpen, onClose, employee }: ExtraDayFormProps) {
           />
         </FormField>
 
+        {/* No wage warning */}
+        {hasNoWage && (
+          <p className="text-sm text-red-600">
+            Este empleado no tiene historial de salario registrado. No es posible registrar un día extra.
+          </p>
+        )}
+
         {/* Actions */}
         <div className="flex gap-3 justify-end pt-2">
           <Button
@@ -192,7 +200,7 @@ export function ExtraDayForm({ isOpen, onClose, employee }: ExtraDayFormProps) {
           </Button>
           <Button
             type="submit"
-            disabled={isPending || isLoadingWages}
+            disabled={isPending || isLoadingWages || hasNoWage}
             className="bg-emerald-600 text-white hover:bg-emerald-700"
           >
             {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}

--- a/code/webapp/src/components/employees/extra-day-section.tsx
+++ b/code/webapp/src/components/employees/extra-day-section.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react'
+import { Plus, Loader2, CalendarDays } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useAuthStore } from '@/stores/auth.store'
+import { useApprovedExtraDays } from '@/services/employee-request-hooks'
+import { ExtraDayForm } from './extra-day-form'
+import type { Employee } from '@/types/employee'
+
+interface ExtraDaySectionProps {
+  employee: Employee
+}
+
+function formatExtraDayDate(dateStr: string): string {
+  const date = new Date(`${dateStr}T12:00:00`)
+  return date.toLocaleDateString('es-MX', { weekday: 'short', day: '2-digit', month: 'short' })
+}
+
+export function ExtraDaySection({ employee }: ExtraDaySectionProps) {
+  const [showForm, setShowForm] = useState(false)
+  const canApprove = useAuthStore((s) => s.can('employee-requests.approve'))
+
+  const { data: extraDays, isLoading } = useApprovedExtraDays(employee.id)
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-foreground">Días extra</h3>
+        {canApprove && (
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => setShowForm(true)}
+          >
+            <Plus className="mr-1 h-4 w-4" />
+            Día extra
+          </Button>
+        )}
+      </div>
+
+      {isLoading && (
+        <div className="flex items-center justify-center py-4">
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+        </div>
+      )}
+
+      {!isLoading && (!extraDays || extraDays.length === 0) && (
+        <div className="flex flex-col items-center justify-center py-6 text-muted-foreground">
+          <CalendarDays className="h-7 w-7 mb-2" />
+          <p className="text-sm">No hay días extra acordados</p>
+        </div>
+      )}
+
+      {!isLoading && extraDays && extraDays.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {extraDays.map((req) => {
+            const date = req.payload?.date as string | undefined
+            const primaPct = req.payload?.prima_pct as number | undefined
+            return (
+              <div
+                key={req.id}
+                className="inline-flex items-center gap-1.5 rounded-full bg-emerald-50 border border-emerald-200 px-3 py-1 text-xs text-emerald-800 dark:bg-emerald-900/20 dark:border-emerald-800 dark:text-emerald-300"
+              >
+                <span>✅</span>
+                <span>Día extra acordado</span>
+                {date && (
+                  <>
+                    <span className="text-emerald-500">·</span>
+                    <span>{formatExtraDayDate(date)}</span>
+                  </>
+                )}
+                {primaPct !== undefined && (
+                  <>
+                    <span className="text-emerald-500">·</span>
+                    <span>Prima: {primaPct}%</span>
+                  </>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      <ExtraDayForm
+        isOpen={showForm}
+        onClose={() => setShowForm(false)}
+        employee={employee}
+      />
+    </div>
+  )
+}

--- a/code/webapp/src/components/employees/extra-day-section.tsx
+++ b/code/webapp/src/components/employees/extra-day-section.tsx
@@ -7,7 +7,7 @@ import { ExtraDayForm } from './extra-day-form'
 import type { Employee } from '@/types/employee'
 
 interface ExtraDaySectionProps {
-  employee: Employee
+  readonly employee: Employee
 }
 
 function formatExtraDayDate(dateStr: string): string {

--- a/code/webapp/src/components/employees/use-extra-day-form.ts
+++ b/code/webapp/src/components/employees/use-extra-day-form.ts
@@ -41,15 +41,16 @@ export function useExtraDayForm(employeeId: string, onSuccess: () => void) {
   const primaType = form.watch('prima_type')
   const primaPct = form.watch('prima_pct')
 
+  const safeSalaryPct = Number.isNaN(salaryPct) ? 0 : salaryPct
   const salaryDay =
     salaryType === 'registered'
       ? registeredDailyWage
-      : (salaryPct / 100) * registeredDailyWage
+      : (safeSalaryPct / 100) * registeredDailyWage
 
   // seventh day = 1/6 of weekly wage = 1 daily wage (for 6-day schedule)
   const seventhDay = salaryDay
-  const effectivePrimaPct = primaType === 'legal' ? 100 : primaPct
-  const prima = (effectivePrimaPct / 100) * salaryDay
+  const safePrimaPct = primaType === 'legal' ? 100 : (Number.isNaN(primaPct) ? 0 : primaPct)
+  const prima = (safePrimaPct / 100) * salaryDay
   const total = salaryDay + seventhDay + prima
 
   const hasNoWage = !isLoadingWages && !currentWage

--- a/code/webapp/src/components/employees/use-extra-day-form.ts
+++ b/code/webapp/src/components/employees/use-extra-day-form.ts
@@ -49,7 +49,8 @@ export function useExtraDayForm(employeeId: string, onSuccess: () => void) {
 
   // seventh day = 1/6 of weekly wage = 1 daily wage (for 6-day schedule)
   const seventhDay = salaryDay
-  const safePrimaPct = primaType === 'legal' ? 100 : (Number.isNaN(primaPct) ? 0 : primaPct)
+  const cleanPrimaPct = Number.isNaN(primaPct) ? 0 : primaPct
+  const safePrimaPct = primaType === 'legal' ? 100 : cleanPrimaPct
   const prima = (safePrimaPct / 100) * salaryDay
   const total = salaryDay + seventhDay + prima
 

--- a/code/webapp/src/components/employees/use-extra-day-form.ts
+++ b/code/webapp/src/components/employees/use-extra-day-form.ts
@@ -52,34 +52,42 @@ export function useExtraDayForm(employeeId: string, onSuccess: () => void) {
   const prima = (effectivePrimaPct / 100) * salaryDay
   const total = salaryDay + seventhDay + prima
 
+  const hasNoWage = !isLoadingWages && !currentWage
+
   const mutation = useCreateEmployeeRequest()
 
   const handleSubmit = form.handleSubmit(async (values) => {
     const effectiveSalaryPct = values.salary_type === 'registered' ? 100 : values.salary_pct
     const effectivePrimaPctValue = values.prima_type === 'legal' ? 100 : values.prima_pct
 
-    await mutation.mutateAsync({
-      employee_id: employeeId,
-      type: 'EXTRA_DAY',
-      auto_approve: true,
-      notes: values.notes || undefined,
-      payload: {
-        date: values.date,
-        salary_pct: effectiveSalaryPct,
-        prima_pct: effectivePrimaPctValue,
-        salary_day: salaryDay,
-        prima,
-        seventh_day: seventhDay,
-        total,
-      },
-    })
+    try {
+      await mutation.mutateAsync({
+        employee_id: employeeId,
+        type: 'EXTRA_DAY',
+        auto_approve: true,
+        notes: values.notes || undefined,
+        payload: {
+          date: values.date,
+          salary_pct: effectiveSalaryPct,
+          prima_pct: effectivePrimaPctValue,
+          salary_day: salaryDay,
+          prima,
+          seventh_day: seventhDay,
+          total,
+        },
+      })
 
-    onSuccess()
+      form.reset()
+      onSuccess()
+    } catch {
+      // error handled by mutation.onError toast
+    }
   })
 
   return {
     form,
     isLoadingWages,
+    hasNoWage,
     registeredDailyWage,
     salaryDay,
     seventhDay,

--- a/code/webapp/src/components/employees/use-extra-day-form.ts
+++ b/code/webapp/src/components/employees/use-extra-day-form.ts
@@ -1,0 +1,91 @@
+import { z } from 'zod'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useWageHistory } from '@/services/employee-hooks'
+import { useCreateEmployeeRequest } from '@/services/employee-request-hooks'
+
+const extraDaySchema = z.object({
+  date: z.string().min(1, 'La fecha es requerida'),
+  salary_type: z.enum(['registered', 'custom']),
+  salary_pct: z.number().min(0, 'Mínimo 0%').max(200, 'Máximo 200%'),
+  prima_type: z.enum(['legal', 'custom']),
+  prima_pct: z.number().min(0, 'Mínimo 0%').max(200, 'Máximo 200%'),
+  notes: z.string().max(1000).optional(),
+})
+
+export type ExtraDayFormValues = z.infer<typeof extraDaySchema>
+
+export function useExtraDayForm(employeeId: string, onSuccess: () => void) {
+  const { data: wages, isLoading: isLoadingWages } = useWageHistory(employeeId)
+  const currentWage = wages?.[0]
+
+  // daily wage = hourly_rate × (weekly_scheduled_hours / 6 days)
+  const registeredDailyWage = currentWage
+    ? parseFloat(currentWage.hourly_rate) * (currentWage.weekly_scheduled_hours / 6)
+    : 0
+
+  const form = useForm<ExtraDayFormValues>({
+    resolver: zodResolver(extraDaySchema),
+    defaultValues: {
+      date: '',
+      salary_type: 'registered',
+      salary_pct: 100,
+      prima_type: 'legal',
+      prima_pct: 100,
+      notes: '',
+    },
+  })
+
+  const salaryType = form.watch('salary_type')
+  const salaryPct = form.watch('salary_pct')
+  const primaType = form.watch('prima_type')
+  const primaPct = form.watch('prima_pct')
+
+  const salaryDay =
+    salaryType === 'registered'
+      ? registeredDailyWage
+      : (salaryPct / 100) * registeredDailyWage
+
+  // seventh day = 1/6 of weekly wage = 1 daily wage (for 6-day schedule)
+  const seventhDay = salaryDay
+  const effectivePrimaPct = primaType === 'legal' ? 100 : primaPct
+  const prima = (effectivePrimaPct / 100) * salaryDay
+  const total = salaryDay + seventhDay + prima
+
+  const mutation = useCreateEmployeeRequest()
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    const effectiveSalaryPct = values.salary_type === 'registered' ? 100 : values.salary_pct
+    const effectivePrimaPctValue = values.prima_type === 'legal' ? 100 : values.prima_pct
+
+    await mutation.mutateAsync({
+      employee_id: employeeId,
+      type: 'EXTRA_DAY',
+      auto_approve: true,
+      notes: values.notes || undefined,
+      payload: {
+        date: values.date,
+        salary_pct: effectiveSalaryPct,
+        prima_pct: effectivePrimaPctValue,
+        salary_day: salaryDay,
+        prima,
+        seventh_day: seventhDay,
+        total,
+      },
+    })
+
+    onSuccess()
+  })
+
+  return {
+    form,
+    isLoadingWages,
+    registeredDailyWage,
+    salaryDay,
+    seventhDay,
+    prima,
+    total,
+    handleSubmit,
+    isPending: mutation.isPending,
+  }
+}

--- a/code/webapp/src/components/employees/use-extra-day-form.ts
+++ b/code/webapp/src/components/employees/use-extra-day-form.ts
@@ -21,7 +21,7 @@ export function useExtraDayForm(employeeId: string, onSuccess: () => void) {
 
   // daily wage = hourly_rate × (weekly_scheduled_hours / 6 days)
   const registeredDailyWage = currentWage
-    ? parseFloat(currentWage.hourly_rate) * (currentWage.weekly_scheduled_hours / 6)
+    ? Number.parseFloat(currentWage.hourly_rate) * (currentWage.weekly_scheduled_hours / 6)
     : 0
 
   const form = useForm<ExtraDayFormValues>({

--- a/code/webapp/src/services/__tests__/employee-request-api.test.ts
+++ b/code/webapp/src/services/__tests__/employee-request-api.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 vi.mock('@/lib/api-client', () => ({
     apiClient: {
         get: vi.fn(),
+        post: vi.fn(),
     },
 }))
 
@@ -53,6 +54,33 @@ describe('employeeRequestApi', () => {
             await employeeRequestApi.list({ per_page: 1 })
 
             expect(apiClient.get).toHaveBeenCalledWith('/employee-requests', { params: { per_page: 1 } })
+        })
+    })
+
+    describe('create', () => {
+        it('calls POST /employee-requests with the given data', async () => {
+            const mockResponse = { data: { status: 201, data: { id: 'req-1' } } }
+            vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
+
+            const payload = {
+                employee_id: 'emp-1',
+                type: 'EXTRA_DAY' as const,
+                auto_approve: true,
+                payload: {
+                    date: '2026-04-25',
+                    salary_pct: 100,
+                    prima_pct: 100,
+                    salary_day: 800,
+                    prima: 800,
+                    seventh_day: 800,
+                    total: 2400,
+                },
+            }
+
+            const result = await employeeRequestApi.create(payload)
+
+            expect(apiClient.post).toHaveBeenCalledWith('/employee-requests', payload)
+            expect(result).toEqual(mockResponse)
         })
     })
 })

--- a/code/webapp/src/services/__tests__/employee-request-hooks.test.tsx
+++ b/code/webapp/src/services/__tests__/employee-request-hooks.test.tsx
@@ -1,20 +1,33 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { renderHook, waitFor } from '@testing-library/react'
+import { renderHook, waitFor, act } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
 const mockList = vi.fn()
+const mockCreate = vi.fn()
+const mockShowSuccess = vi.fn()
+const mockShowError = vi.fn()
 
 vi.mock('@/services/employee-request-api', () => ({
     employeeRequestApi: {
         list: (...args: unknown[]) => mockList(...args),
+        create: (...args: unknown[]) => mockCreate(...args),
     },
 }))
 
-import { useEmployeeRequests, usePendingRequestsCount } from '../employee-request-hooks'
+vi.mock('@/components/ui/toast-provider', () => ({
+    useToast: () => ({ showSuccess: mockShowSuccess, showError: mockShowError }),
+}))
+
+import {
+    useEmployeeRequests,
+    usePendingRequestsCount,
+    useApprovedExtraDays,
+    useCreateEmployeeRequest,
+} from '../employee-request-hooks'
 
 // ── Wrapper ───────────────────────────────────────────────────────────────────
 
@@ -122,5 +135,137 @@ describe('usePendingRequestsCount', () => {
 
         await waitFor(() => expect(result.current.isSuccess).toBe(true))
         expect(mockList).toHaveBeenCalledTimes(1)
+    })
+})
+
+describe('useApprovedExtraDays', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('uses a distinct query key that does not collide with useEmployeeRequests', () => {
+        mockList.mockReturnValue(new Promise(() => {}))
+
+        const { result } = renderHook(
+            () => useApprovedExtraDays('emp-1'),
+            { wrapper: createWrapper() },
+        )
+
+        // Query fires (not idle), confirming enabled=true with a non-empty employeeId
+        expect(result.current.fetchStatus).toBe('fetching')
+        expect(mockList).toHaveBeenCalledWith(
+            expect.objectContaining({ employee_id: 'emp-1', type: 'EXTRA_DAY', status: 'APPROVED' }),
+        )
+    })
+
+    it('does not fire when employeeId is empty', () => {
+        const { result } = renderHook(
+            () => useApprovedExtraDays(''),
+            { wrapper: createWrapper() },
+        )
+
+        expect(result.current.fetchStatus).toBe('idle')
+        expect(mockList).not.toHaveBeenCalled()
+    })
+
+    it('returns the data array from response.data.data', async () => {
+        const extraDays = [{ id: 'req-1', type: 'EXTRA_DAY', status: 'APPROVED' }]
+        mockList.mockResolvedValue({ data: { data: extraDays, meta: null } })
+
+        const { result } = renderHook(
+            () => useApprovedExtraDays('emp-1'),
+            { wrapper: createWrapper() },
+        )
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true))
+        expect(result.current.data).toEqual(extraDays)
+    })
+})
+
+describe('useCreateEmployeeRequest', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('calls employeeRequestApi.create with the given data', async () => {
+        mockCreate.mockResolvedValue({ data: { data: { id: 'req-new' } } })
+
+        const { result } = renderHook(() => useCreateEmployeeRequest(), { wrapper: createWrapper() })
+
+        const payload = {
+            employee_id: 'emp-1',
+            type: 'EXTRA_DAY' as const,
+            auto_approve: true,
+            payload: {
+                date: '2026-04-25',
+                salary_pct: 100,
+                prima_pct: 100,
+                salary_day: 800,
+                prima: 800,
+                seventh_day: 800,
+                total: 2400,
+            },
+        }
+
+        await act(async () => {
+            await result.current.mutateAsync(payload)
+        })
+
+        expect(mockCreate).toHaveBeenCalledWith(payload)
+    })
+
+    it('shows success toast on successful mutation', async () => {
+        mockCreate.mockResolvedValue({ data: { data: { id: 'req-new' } } })
+
+        const { result } = renderHook(() => useCreateEmployeeRequest(), { wrapper: createWrapper() })
+
+        await act(async () => {
+            await result.current.mutateAsync({
+                employee_id: 'emp-1',
+                type: 'EXTRA_DAY',
+                payload: {
+                    date: '2026-04-25',
+                    salary_pct: 100,
+                    prima_pct: 100,
+                    salary_day: 800,
+                    prima: 800,
+                    seventh_day: 800,
+                    total: 2400,
+                },
+            })
+        })
+
+        expect(mockShowSuccess).toHaveBeenCalledWith(
+            expect.stringContaining('día extra'),
+            expect.any(String),
+        )
+    })
+
+    it('shows error toast when mutation rejects', async () => {
+        mockCreate.mockRejectedValue(new Error('Server error'))
+
+        const { result } = renderHook(() => useCreateEmployeeRequest(), { wrapper: createWrapper() })
+
+        await act(async () => {
+            try {
+                await result.current.mutateAsync({
+                    employee_id: 'emp-1',
+                    type: 'EXTRA_DAY',
+                    payload: {
+                        date: '2026-04-25',
+                        salary_pct: 100,
+                        prima_pct: 100,
+                        salary_day: 800,
+                        prima: 800,
+                        seventh_day: 800,
+                        total: 2400,
+                    },
+                })
+            } catch {
+                // expected
+            }
+        })
+
+        await waitFor(() => expect(mockShowError).toHaveBeenCalled())
     })
 })

--- a/code/webapp/src/services/employee-request-api.ts
+++ b/code/webapp/src/services/employee-request-api.ts
@@ -1,8 +1,15 @@
 import { apiClient } from '@/lib/api-client'
-import type { PaginatedResponse } from '@/types/employee'
-import type { EmployeeRequest, EmployeeRequestFilters } from '@/types/employee-request'
+import type { PaginatedResponse, EntityResponse } from '@/types/employee'
+import type {
+  EmployeeRequest,
+  EmployeeRequestFilters,
+  CreateEmployeeRequestData,
+} from '@/types/employee-request'
 
 export const employeeRequestApi = {
   list: (params?: EmployeeRequestFilters) =>
     apiClient.get<PaginatedResponse<EmployeeRequest>>('/employee-requests', { params }),
+
+  create: (data: CreateEmployeeRequestData) =>
+    apiClient.post<EntityResponse<EmployeeRequest>>('/employee-requests', data),
 }

--- a/code/webapp/src/services/employee-request-hooks.ts
+++ b/code/webapp/src/services/employee-request-hooks.ts
@@ -31,7 +31,7 @@ export function usePendingRequestsCount({ enabled = true }: { enabled?: boolean 
 
 export function useApprovedExtraDays(employeeId: string) {
   return useQuery({
-    queryKey: ['employee-requests', { employee_id: employeeId, type: 'EXTRA_DAY', status: 'APPROVED' }],
+    queryKey: ['employee-requests', 'approved-extra-days', employeeId],
     queryFn: async () => {
       const response = await employeeRequestApi.list({
         employee_id: employeeId,

--- a/code/webapp/src/services/employee-request-hooks.ts
+++ b/code/webapp/src/services/employee-request-hooks.ts
@@ -1,6 +1,11 @@
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useToast } from '@/components/ui/toast-provider'
+import { getApiErrorMessage } from '@/lib/api-error'
 import { employeeRequestApi } from './employee-request-api'
-import type { EmployeeRequestFilters } from '@/types/employee-request'
+import type {
+  EmployeeRequestFilters,
+  CreateEmployeeRequestData,
+} from '@/types/employee-request'
 
 export function useEmployeeRequests(filters?: EmployeeRequestFilters) {
   return useQuery({
@@ -21,5 +26,37 @@ export function usePendingRequestsCount({ enabled = true }: { enabled?: boolean 
     },
     refetchInterval: 60_000,
     enabled,
+  })
+}
+
+export function useApprovedExtraDays(employeeId: string) {
+  return useQuery({
+    queryKey: ['employee-requests', { employee_id: employeeId, type: 'EXTRA_DAY', status: 'APPROVED' }],
+    queryFn: async () => {
+      const response = await employeeRequestApi.list({
+        employee_id: employeeId,
+        type: 'EXTRA_DAY',
+        status: 'APPROVED',
+        per_page: 10,
+      })
+      return response.data.data
+    },
+    enabled: !!employeeId,
+  })
+}
+
+export function useCreateEmployeeRequest() {
+  const queryClient = useQueryClient()
+  const { showSuccess, showError } = useToast()
+
+  return useMutation({
+    mutationFn: (data: CreateEmployeeRequestData) => employeeRequestApi.create(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['employee-requests'] })
+      showSuccess('El día extra ha sido registrado y aprobado.', 'Día extra acordado')
+    },
+    onError: (error: unknown) => {
+      showError(getApiErrorMessage(error, 'No se pudo registrar el día extra.'), 'Error')
+    },
   })
 }

--- a/code/webapp/src/types/employee-request.ts
+++ b/code/webapp/src/types/employee-request.ts
@@ -23,3 +23,21 @@ export interface EmployeeRequestFilters {
   per_page?: number
   sort?: string[]
 }
+
+export interface ExtraDayPayload {
+  date: string
+  salary_pct: number
+  prima_pct: number
+  salary_day: number
+  prima: number
+  seventh_day: number
+  total: number
+}
+
+export interface CreateEmployeeRequestData {
+  employee_id: string
+  type: EmployeeRequestType
+  auto_approve?: boolean
+  notes?: string
+  payload: ExtraDayPayload
+}

--- a/code/webapp/src/types/employee-request.ts
+++ b/code/webapp/src/types/employee-request.ts
@@ -36,7 +36,7 @@ export interface ExtraDayPayload {
 
 export interface CreateEmployeeRequestData {
   employee_id: string
-  type: EmployeeRequestType
+  type: 'EXTRA_DAY'
   auto_approve?: boolean
   notes?: string
   payload: ExtraDayPayload


### PR DESCRIPTION
…etail ➕

- ✨ Created ExtraDaySection component — shows approved extra-day chips + "+ Día extra" button (managers only)
- ✨ Created ExtraDayForm SlidePanel — date, salary config, prima config, live summary, notes
- ✨ Created useExtraDayForm hook — wage-based daily salary calculation, auto_approve=true submission
- ✨ Added useCreateEmployeeRequest mutation and useApprovedExtraDays query hooks
- ✨ Added create() to employeeRequestApi and CreateEmployeeRequestData / ExtraDayPayload types
- 🔨 Wired ExtraDaySection into employee-detail-view between leave summary and schedule sections
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pakodiazdev/sushigo/pull/132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
