### PR TITLE
🐛 [#121] - Merge indefinite overrides into schedule summary line 🗂️

### DIFF
--- a/code/api/app/Console/Commands/TestReset.php
+++ b/code/api/app/Console/Commands/TestReset.php
@@ -10,6 +10,7 @@ use Database\Seeders\Testing\CloseDayHappyPathSeeder;
 use Database\Seeders\Testing\CloseDayPendingLunchSeeder;
 use Database\Seeders\Testing\CoreTestSeeder;
 use Database\Seeders\Testing\NegotiatedExtraDaysSeeder;
+use Database\Seeders\Testing\ScheduleSummaryOverrideSeeder;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -53,6 +54,10 @@ class TestReset extends Command
         'attendance-extra-days' => [
             AttendanceTestSeeder::class,
             NegotiatedExtraDaysSeeder::class,
+        ],
+        'schedule-summary' => [
+            AttendanceTestSeeder::class,
+            ScheduleSummaryOverrideSeeder::class,
         ],
         'fakes-employees' => [
             FakeEmployeesSeeder::class,

--- a/code/api/database/seeders/Testing/ScheduleSummaryOverrideSeeder.php
+++ b/code/api/database/seeders/Testing/ScheduleSummaryOverrideSeeder.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Database\Seeders\Testing;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+/**
+ * Adds schedule day overrides to EMP-001 for testing the indefinite override summary.
+ *
+ * Requires AttendanceTestSeeder to have run first (EMP-001 must exist).
+ *
+ * Inserts:
+ *  - 1 indefinite override: Wednesday (DOW=3) → 14:00–23:00 (effective_to null)
+ *    The summary should group days and show "L, M, J, V, S · 1:00 PM – 10:00 PM · X · 2:00 PM – 11:00 PM"
+ *  - 1 temporary override: Saturday (DOW=6) → 10:00–16:00 (expires next month)
+ *    Only this one should be counted by the ⚡ badge (count = 1)
+ */
+class ScheduleSummaryOverrideSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $now = now();
+
+        $periodId = DB::table('employees as e')
+            ->join('employment_periods as ep', 'ep.employee_id', '=', 'e.id')
+            ->where('e.code', 'EMP-001')
+            ->where('ep.is_active', true)
+            ->value('ep.id');
+
+        if (! $periodId) {
+            return;
+        }
+
+        DB::table('schedule_day_overrides')->insert([
+            [
+                'public_id' => (string) Str::ulid(),
+                'employment_period_id' => $periodId,
+                'day_of_week' => 3, // Wednesday
+                'effective_from' => '2020-01-01',
+                'effective_to' => null,
+                'is_day_off' => false,
+                'expected_start' => '14:00:00',
+                'expected_lunch_start' => '16:00:00',
+                'expected_lunch_end' => '16:30:00',
+                'lunch_duration_minutes' => 30,
+                'expected_end' => '23:00:00',
+                'note' => 'Miércoles turno diferente',
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+            [
+                'public_id' => (string) Str::ulid(),
+                'employment_period_id' => $periodId,
+                'day_of_week' => 6, // Saturday
+                'effective_from' => $now->toDateString(),
+                'effective_to' => $now->copy()->addMonth()->toDateString(),
+                'is_day_off' => false,
+                'expected_start' => '10:00:00',
+                'expected_lunch_start' => null,
+                'expected_lunch_end' => null,
+                'lunch_duration_minutes' => null,
+                'expected_end' => '16:00:00',
+                'note' => 'Sábado turno especial temporal',
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+        ]);
+    }
+}

--- a/code/webapp/cypress/e2e/schedule-indefinite-summary.cy.ts
+++ b/code/webapp/cypress/e2e/schedule-indefinite-summary.cy.ts
@@ -1,0 +1,112 @@
+/**
+ * Schedule Indefinite Override Summary — E2E tests
+ *
+ * Verifies that indefinite exceptions (effective_to = null) are absorbed into
+ * the schedule summary line instead of being ignored, while temporary overrides
+ * are still counted in the ⚡ badge.
+ *
+ * Seeder: 'schedule-summary'
+ *   AttendanceTestSeeder  → EMP-001..EMP-008 (Mon-Sat 1:00 PM – 10:00 PM, Sun off)
+ *   ScheduleSummaryOverrideSeeder → EMP-001 gets:
+ *     • Indefinite override: Wednesday (X) 2:00 PM – 11:00 PM  (effective_to null)
+ *     • Temporary override: Saturday (S)  10:00 AM – 4:00 PM   (expires next month)
+ *
+ * Expected summary for EMP-001:
+ *   Card:   🕐 L, M, J, V, S · 1:00 PM – 10:00 PM · X · 2:00 PM – 11:00 PM
+ *   Dialog: same compact line + ⚡ +1 badge (only the temporary Saturday counts)
+ *
+ * DB reset strategy
+ * ─────────────────
+ * • before()     → cy.task('test:reset', 'schedule-summary') ONCE per file (~4-6s)
+ * • beforeEach() → login + navigate to /employees
+ *
+ * For running only this file:
+ *   make cypress-spec SPEC=schedule-indefinite-summary
+ *   make cypress-debug SPEC=schedule-indefinite-summary
+ */
+
+import users from '../fixtures/users.json'
+
+const { email: adminEmail, password: adminPassword } = users.admin
+
+// ── Suite setup ──────────────────────────────────────────────────────────────
+
+before(() => {
+  cy.task('test:reset', 'schedule-summary', { timeout: 60_000 })
+})
+
+// ══════════════════════════════════════════════════════════════════════════════
+// 1. Employee card — schedule summary section
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('Indefinite override — employee card summary', () => {
+  beforeEach(() => {
+    cy.login(adminEmail, adminPassword)
+    cy.url().should('not.include', '/login', { timeout: 10_000 })
+    cy.visit('/employees')
+    cy.url().should('include', '/employees', { timeout: 10_000 })
+    cy.closeDevDebugger()
+  })
+
+  it('shows comma-separated day groups instead of a plain range when an indefinite override exists', () => {
+    cy.contains('tr', 'EMP-001', { timeout: 10_000 }).find('button[title="Ver detalle"]').click()
+    cy.contains('h2', 'Detalle de Empleado', { timeout: 10_000 }).should('be.visible')
+
+    cy.contains('Horario activo', { timeout: 10_000 }).scrollIntoView().should('be.visible')
+
+    // The work line should use comma-separated groups, NOT the compact "L-S" range
+    cy.contains(/L, M, J, V, S/, { timeout: 10_000 }).should('be.visible')
+
+    // Wednesday's overridden times must appear
+    cy.contains(/2:00 PM/).should('be.visible')
+    cy.contains(/11:00 PM/).should('be.visible')
+
+    // The original range label "L-S" must NOT appear in the summary
+    cy.contains(/🕐 L-S/).should('not.exist')
+  })
+
+  it('shows the original range format for an employee without indefinite overrides', () => {
+    // EMP-002 has no overrides — should still show the compact "L-S" format
+    cy.contains('tr', 'EMP-002', { timeout: 10_000 }).find('button[title="Ver detalle"]').click()
+    cy.contains('h2', 'Detalle de Empleado', { timeout: 10_000 }).should('be.visible')
+
+    cy.contains('Horario activo', { timeout: 10_000 }).scrollIntoView().should('be.visible')
+    cy.contains(/🕐 L-S/, { timeout: 10_000 }).should('be.visible')
+  })
+})
+
+// ══════════════════════════════════════════════════════════════════════════════
+// 2. Schedule dialog — compact summary header + badge
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('Indefinite override — schedule dialog compact summary', () => {
+  beforeEach(() => {
+    cy.login(adminEmail, adminPassword)
+    cy.url().should('not.include', '/login', { timeout: 10_000 })
+    cy.visit('/employees')
+    cy.url().should('include', '/employees', { timeout: 10_000 })
+    cy.closeDevDebugger()
+  })
+
+  it('shows grouped day summary and ⚡ +1 badge (only the temporary override counts)', () => {
+    cy.contains('tr', 'EMP-001', { timeout: 10_000 }).find('button[title="Ver detalle"]').click()
+    cy.contains('h2', 'Detalle de Empleado', { timeout: 10_000 }).should('be.visible')
+
+    cy.contains('button', 'Ver horario', { timeout: 10_000 }).scrollIntoView().click()
+    cy.contains('dialog', 'Horarios', { timeout: 5_000 }).should('be.visible')
+
+    cy.get('dialog').within(() => {
+      // Compact summary shows comma-separated groups
+      cy.contains(/L, M, J, V, S/, { timeout: 10_000 }).should('be.visible')
+      cy.contains(/2:00 PM/).should('be.visible')
+      cy.contains(/11:00 PM/).should('be.visible')
+
+      // ⚡ badge counts ONLY the temporary Saturday override (= 1)
+      // The indefinite Wednesday override is absorbed into the summary line
+      cy.contains('+1').should('be.visible')
+    })
+
+    cy.contains('button', 'Cerrar').click()
+    cy.contains('dialog', 'Horarios').should('not.exist')
+  })
+})

--- a/code/webapp/src/components/employees/__tests__/schedule-summary.test.ts
+++ b/code/webapp/src/components/employees/__tests__/schedule-summary.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { buildSummaryLines } from '@/components/employees/schedule-section'
-import type { ScheduleDay } from '@/types/schedule'
+import type { ScheduleDay, ScheduleDayOverride } from '@/types/schedule'
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -191,5 +191,93 @@ describe('buildSummaryLines — line ordering', () => {
     const lines = buildSummaryLines(days)
     expect(lines).toHaveLength(1)
     expect(lines[0]!.icon).toBe('work')
+  })
+})
+
+// ── Indefinite overrides ──────────────────────────────────────────────────────
+
+/** Build a minimal indefinite ScheduleDayOverride for a given DOW. */
+function indefiniteOverride(dow: number, opts: Partial<ScheduleDayOverride> = {}): ScheduleDayOverride {
+  return {
+    id: `override-${dow}`,
+    employment_period_id: 'period-01',
+    day_of_week: dow,
+    effective_from: '2020-01-01',
+    effective_to: null, // indefinite
+    is_day_off: false,
+    expected_start: '14:00',
+    expected_lunch_start: null,
+    expected_lunch_end: null,
+    lunch_duration_minutes: null,
+    expected_end: '23:00',
+    note: null,
+    created_at: '2020-01-01T00:00:00Z',
+    updated_at: '2020-01-01T00:00:00Z',
+    ...opts,
+  }
+}
+
+/** Build a temporary (has effective_to) ScheduleDayOverride. */
+function temporaryOverride(dow: number): ScheduleDayOverride {
+  return {
+    ...indefiniteOverride(dow),
+    id: `temp-${dow}`,
+    effective_to: '2026-04-30',
+  }
+}
+
+describe('buildSummaryLines — indefinite overrides', () => {
+  it('shows two time groups when Wednesday has different hours', () => {
+    // Base: L-S 1:00 PM – 10:00 PM. Override: Wed → 2:00 PM – 11:00 PM
+    const days = [1, 2, 3, 4, 5, 6].map((d) => workDay(d)).concat([restDay(7)])
+    const overrides = [indefiniteOverride(3, { expected_start: '14:00', expected_end: '23:00' })]
+    const [work] = buildSummaryLines(days, overrides)
+    // Wed gets different hours → two groups should appear
+    expect(work!.text).toContain('2:00 PM')
+    expect(work!.text).toContain('11:00 PM')
+    expect(work!.text).toContain('1:00 PM')
+    expect(work!.text).toContain('10:00 PM')
+  })
+
+  it('work line shows comma-separated day abbreviations per group', () => {
+    const days = [1, 2, 3, 4, 5, 6].map((d) => workDay(d)).concat([restDay(7)])
+    const overrides = [indefiniteOverride(3)]
+    const [work] = buildSummaryLines(days, overrides)
+    // Main group should list day abbreviations with commas
+    expect(work!.text).toMatch(/[LMXJVSD], [LMXJVSD]/)
+  })
+
+  it('does not change behavior when no indefinite overrides (only temporary)', () => {
+    const days = [1, 2, 3, 4, 5].map((d) => workDay(d)).concat([restDay(6), restDay(7)])
+    const overrides = [temporaryOverride(1)]
+    const [work] = buildSummaryLines(days, overrides)
+    // Temporary override should not change the summary groups
+    expect(work!.text).toContain('L-V')
+  })
+
+  it('reflects indefinite day-off override in rest days', () => {
+    // Base: all 7 work. Override: Thursday → is_day_off
+    const days = allWeek()
+    const overrides = [indefiniteOverride(4, { is_day_off: true, expected_start: null, expected_end: null })]
+    const lines = buildSummaryLines(days, overrides)
+    const rest = lines.find((l) => l.icon === 'rest')
+    expect(rest).toBeDefined()
+    expect(rest!.text).toContain('Jueves')
+  })
+
+  it('no overrides uses original range format', () => {
+    const days = [1, 2, 3, 4, 5].map((d) => workDay(d)).concat([restDay(6), restDay(7)])
+    const [work] = buildSummaryLines(days, [])
+    expect(work!.text).toContain('L-V')
+  })
+
+  it('does not apply indefinite override with future effective_from', () => {
+    // Override for Wednesday with a date far in the future — should be ignored
+    const days = [1, 2, 3, 4, 5, 6].map((d) => workDay(d)).concat([restDay(7)])
+    const overrides = [indefiniteOverride(3, { effective_from: '2099-01-01', expected_start: '14:00', expected_end: '23:00' })]
+    const [work] = buildSummaryLines(days, overrides)
+    // Future override not applied → original single-range format with no time split
+    expect(work!.text).toContain('L-S')
+    expect(work!.text).not.toContain('2:00 PM')
   })
 })

--- a/code/webapp/src/components/employees/schedule-compact-summary.tsx
+++ b/code/webapp/src/components/employees/schedule-compact-summary.tsx
@@ -11,8 +11,8 @@ interface ScheduleCompactSummaryProps {
  * Format: "🕐 L-V · 1:00 PM – 10:00 PM · 🍽 1h · 🏠 Sáb-Dom  ⚡ +3"
  */
 export function ScheduleCompactSummary({ schedule }: ScheduleCompactSummaryProps) {
-  const summaryLine = buildCompactSummaryLine(schedule.days)
-  const overrideCount = schedule.active_overrides?.length ?? 0
+  const summaryLine = buildCompactSummaryLine(schedule.days, schedule.active_overrides ?? [])
+  const overrideCount = (schedule.active_overrides ?? []).filter((o) => o.effective_to !== null).length
 
   if (!summaryLine) return null
 

--- a/code/webapp/src/components/employees/schedule-compact-summary.tsx
+++ b/code/webapp/src/components/employees/schedule-compact-summary.tsx
@@ -1,4 +1,5 @@
 import { Zap } from 'lucide-react'
+import { useBusinessDate } from '@/stores/clock.store'
 import type { EmployeeSchedule } from '@/types/schedule'
 import { buildCompactSummaryLine } from './schedule-section-utils'
 
@@ -11,7 +12,8 @@ interface ScheduleCompactSummaryProps {
  * Format: "🕐 L-V · 1:00 PM – 10:00 PM · 🍽 1h · 🏠 Sáb-Dom  ⚡ +3"
  */
 export function ScheduleCompactSummary({ schedule }: ScheduleCompactSummaryProps) {
-  const summaryLine = buildCompactSummaryLine(schedule.days, schedule.active_overrides ?? [])
+  const businessDate = useBusinessDate()
+  const summaryLine = buildCompactSummaryLine(schedule.days, schedule.active_overrides ?? [], businessDate ?? undefined)
   const overrideCount = (schedule.active_overrides ?? []).filter((o) => o.effective_to !== null).length
 
   if (!summaryLine) return null

--- a/code/webapp/src/components/employees/schedule-history-item.tsx
+++ b/code/webapp/src/components/employees/schedule-history-item.tsx
@@ -70,7 +70,7 @@ interface ScheduleHistoryItemProps {
 export function ScheduleHistoryItem({ schedule, isActive }: ScheduleHistoryItemProps) {
   const [expanded, setExpanded] = useState(false)
   const hasOverrides = schedule.overrides.length > 0
-  const compactSummary = buildCompactSummaryLine(schedule.days)
+  const compactSummary = buildCompactSummaryLine(schedule.days, schedule.overrides)
 
   const sortedOverrides = useMemo(() =>
     [...schedule.overrides].sort((a, b) => {

--- a/code/webapp/src/components/employees/schedule-history-item.tsx
+++ b/code/webapp/src/components/employees/schedule-history-item.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react'
 import { ChevronDown, ChevronRight, Zap } from 'lucide-react'
+import { useBusinessDate } from '@/stores/clock.store'
 import type { EmployeeScheduleHistoryItem, ScheduleDayOverride } from '@/types/schedule'
 import { DAY_LABELS } from '@/types/schedule'
 import { buildCompactSummaryLine } from './schedule-section-utils'
@@ -69,8 +70,9 @@ interface ScheduleHistoryItemProps {
 
 export function ScheduleHistoryItem({ schedule, isActive }: ScheduleHistoryItemProps) {
   const [expanded, setExpanded] = useState(false)
+  const businessDate = useBusinessDate()
   const hasOverrides = schedule.overrides.length > 0
-  const compactSummary = buildCompactSummaryLine(schedule.days, schedule.overrides)
+  const compactSummary = buildCompactSummaryLine(schedule.days, schedule.overrides, businessDate ?? undefined)
 
   const sortedOverrides = useMemo(() =>
     [...schedule.overrides].sort((a, b) => {

--- a/code/webapp/src/components/employees/schedule-section-utils.ts
+++ b/code/webapp/src/components/employees/schedule-section-utils.ts
@@ -3,8 +3,14 @@ import type { ScheduleDay, ScheduleDayOverride } from '@/types/schedule'
 
 // ── Schedule summary helpers ──────────────────────────────────────────────────
 
+/** Returns today's date as YYYY-MM-DD in browser local time. */
+function getLocalDate(): string {
+  const d = new Date()
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
 /** Single-letter abbreviations for ISO DOW 1=Mon…7=Sun (Mexican convention). */
-const DOW_ABBR  = ['L', 'M', 'X', 'J', 'V', 'S', 'D'] as const
+const DOW_ABBR = ['L', 'M', 'X', 'J', 'V', 'S', 'D'] as const
 const DOW_NAMES = ['Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado', 'Domingo'] as const
 
 /** Compute the compact day-range label (e.g. "L-V", "L-D", "LXV"). */
@@ -25,7 +31,7 @@ function computeDayRangeLabel(working: ScheduleDay[], resting: ScheduleDay[]): s
   )
   if (isRestConsecutive) {
     const firstWork = working[0]!
-    const lastWork  = working[working.length - 1]!
+    const lastWork = working[working.length - 1]!
     return `${DOW_ABBR[firstWork.day_of_week - 1]}-${DOW_ABBR[lastWork.day_of_week - 1]}`
   }
 
@@ -33,35 +39,101 @@ function computeDayRangeLabel(working: ScheduleDay[], resting: ScheduleDay[]): s
 }
 
 /**
- * Given the 7 schedule days, build 1-3 compact summary lines:
- *   • Work:  "L-V · 1:00 PM – 10:00 PM"
+ * Apply indefinite overrides (effective_to === null) to the base days.
+ * Only overrides whose effective_from <= asOf (defaults to today) are applied.
+ * When multiple indefinite overrides exist for the same DOW, the most-recently
+ * started one (latest effective_from) takes precedence.
+ */
+export function resolveScheduleDays(
+  days: ScheduleDay[],
+  overrides: ScheduleDayOverride[],
+  asOf: string = getLocalDate(),
+): ScheduleDay[] {
+  const effective = overrides.filter((o) => o.effective_to === null && o.effective_from <= asOf)
+  if (effective.length === 0) return days
+  return days.map((day) => {
+    const override = [...effective]
+      .filter((o) => o.day_of_week === day.day_of_week)
+      .sort((a, b) => b.effective_from.localeCompare(a.effective_from))[0]
+    if (!override) return day
+    return {
+      ...day,
+      is_day_off: override.is_day_off,
+      expected_start: override.expected_start,
+      expected_lunch_start: override.expected_lunch_start,
+      expected_lunch_end: override.expected_lunch_end,
+      lunch_duration_minutes: override.lunch_duration_minutes,
+      expected_end: override.expected_end,
+    }
+  })
+}
+
+/** Comma-separated abbreviations for a group of days: "L, M, J" */
+function buildGroupLabel(groupDays: ScheduleDay[]): string {
+  return groupDays.map((d) => DOW_ABBR[d.day_of_week - 1]).join(', ')
+}
+
+/**
+ * Build the work-time text line (without icon prefix) for a set of working days.
+ * When `hasIndefiniteOverrides` is true, groups days by (start, end) slot.
+ * Otherwise falls back to the compact consecutive-range format.
+ */
+function buildWorkText(
+  working: ScheduleDay[],
+  resting: ScheduleDay[],
+  hasIndefiniteOverrides: boolean,
+): string {
+  if (hasIndefiniteOverrides) {
+    const groups = new Map<string, ScheduleDay[]>()
+    for (const day of working) {
+      const key = `${day.expected_start}|${day.expected_end}`
+      if (!groups.has(key)) groups.set(key, [])
+      groups.get(key)!.push(day)
+    }
+    const groupParts = [...groups.values()]
+      .sort((a, b) => a[0]!.day_of_week - b[0]!.day_of_week)
+      .map((groupDays) => {
+        const ref = groupDays[0]!
+        return `${buildGroupLabel(groupDays)} · ${formatTime(ref.expected_start)} – ${formatTime(ref.expected_end)}`
+      })
+    return `🕐 ${groupParts.join(' · ')}`
+  }
+  const dayRange = computeDayRangeLabel(working, resting)
+  const ref = working[0]!
+  return `🕐 ${dayRange} · ${formatTime(ref.expected_start)} – ${formatTime(ref.expected_end)}`
+}
+
+/**
+ * Given the 7 schedule days (and optional overrides), build 1-3 compact summary lines:
+ *   • Work:  "L-V · 1:00 PM – 10:00 PM"  (or grouped when indefinite overrides exist)
  *   • Lunch: "Comida 1 hr a las 4:00 PM"   (omitted if no lunch configured)
  *   • Rest:  "Descansa Sábado, Domingo"     (omitted if 0 rest days)
  */
-export function buildSummaryLines(days: ScheduleDay[]): { icon: 'work' | 'lunch' | 'rest'; text: string }[] {
-  const working = days.filter((d) => !d.is_day_off).sort((a, b) => a.day_of_week - b.day_of_week)
-  const resting = days.filter((d) =>  d.is_day_off).sort((a, b) => a.day_of_week - b.day_of_week)
+export function buildSummaryLines(
+  days: ScheduleDay[],
+  overrides: ScheduleDayOverride[] = [],
+): { icon: 'work' | 'lunch' | 'rest'; text: string }[] {
+  const asOf = getLocalDate()
+  const resolved = resolveScheduleDays(days, overrides, asOf)
+  const hasIndefiniteOverrides = overrides.some((o) => o.effective_to === null && o.effective_from <= asOf)
+
+  const working = resolved.filter((d) => !d.is_day_off).sort((a, b) => a.day_of_week - b.day_of_week)
+  const resting = resolved.filter((d) => d.is_day_off).sort((a, b) => a.day_of_week - b.day_of_week)
 
   if (working.length === 0) return []
 
-  const dayRange = computeDayRangeLabel(working, resting)
-
-  // ── Times (use the first working day as reference) ───────────────────────────
-  const ref = working[0]!
-  const startT = formatTime(ref.expected_start)
-  const endT   = formatTime(ref.expected_end)
-
   const lines: { icon: 'work' | 'lunch' | 'rest'; text: string }[] = []
 
-  lines.push({ icon: 'work', text: `🕐 ${dayRange} · ${startT} – ${endT}` })
+  lines.push({ icon: 'work', text: buildWorkText(working, resting, hasIndefiniteOverrides) })
 
-  // ── Lunch ────────────────────────────────────────────────────────────────────
-  if (ref.expected_lunch_start && ref.lunch_duration_minutes) {
-    const mins = ref.lunch_duration_minutes
+  // ── Lunch (first working day that has lunch configured) ─────────────────────
+  const lunchRef = working.find((d) => d.expected_lunch_start !== null && d.lunch_duration_minutes !== null)
+  if (lunchRef) {
+    const mins = lunchRef.lunch_duration_minutes!
     const durLabel = mins % 60 === 0 ? `${mins / 60} hr` : `${mins} min`
     lines.push({
       icon: 'lunch',
-      text: `🍽️ ${durLabel} a las ${formatTime(ref.expected_lunch_start)}`,
+      text: `🍽️ ${durLabel} a las ${formatTime(lunchRef.expected_lunch_start)}`,
     })
   }
 
@@ -110,25 +182,30 @@ const DOW_SHORT_NAMES = ['Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb', 'Dom'] as c
 /**
  * Build a compact one-line summary of the schedule.
  * Format: "🕐 L-V · 1:00 PM – 10:00 PM · 🍽 1h · 🏠 Sáb-Dom"
+ * When indefinite overrides are present:
+ * "🕐 L, M, J, V, S · 1:00 PM – 10:00 PM · X · 2:00 PM – 11:00 PM · 🍽 1h · 🏠 Dom"
  */
-export function buildCompactSummaryLine(days: ScheduleDay[]): string {
-  const working = days.filter((d) => !d.is_day_off).sort((a, b) => a.day_of_week - b.day_of_week)
-  const resting = days.filter((d) => d.is_day_off).sort((a, b) => a.day_of_week - b.day_of_week)
+export function buildCompactSummaryLine(
+  days: ScheduleDay[],
+  overrides: ScheduleDayOverride[] = [],
+): string {
+  const asOf = getLocalDate()
+  const resolved = resolveScheduleDays(days, overrides, asOf)
+  const hasIndefiniteOverrides = overrides.some((o) => o.effective_to === null && o.effective_from <= asOf)
+
+  const working = resolved.filter((d) => !d.is_day_off).sort((a, b) => a.day_of_week - b.day_of_week)
+  const resting = resolved.filter((d) => d.is_day_off).sort((a, b) => a.day_of_week - b.day_of_week)
 
   if (working.length === 0) return ''
 
   const parts: string[] = []
 
-  // Day range (reuse the computeDayRangeLabel function defined above)
-  const dayRange = computeDayRangeLabel(working, resting)
-  const ref = working[0]!
-  const startT = formatTime(ref.expected_start)
-  const endT = formatTime(ref.expected_end)
-  parts.push(`🕐 ${dayRange} · ${startT} – ${endT}`)
+  parts.push(buildWorkText(working, resting, hasIndefiniteOverrides))
 
-  // Lunch duration
-  if (ref.lunch_duration_minutes) {
-    const mins = ref.lunch_duration_minutes
+  // Lunch duration (first working day with lunch configured)
+  const lunchRef = working.find((d) => d.lunch_duration_minutes !== null)
+  if (lunchRef) {
+    const mins = lunchRef.lunch_duration_minutes!
     const durLabel = mins % 60 === 0 ? `${mins / 60}h` : `${mins}min`
     parts.push(`🍽 ${durLabel}`)
   }

--- a/code/webapp/src/components/employees/schedule-section-utils.ts
+++ b/code/webapp/src/components/employees/schedule-section-utils.ts
@@ -1,10 +1,17 @@
 import { formatTime } from '@/lib/time-format'
+import { useApplicationClockStore } from '@/stores/clock.store'
 import type { ScheduleDay, ScheduleDayOverride } from '@/types/schedule'
 
 // ── Schedule summary helpers ──────────────────────────────────────────────────
 
-/** Returns today's date as YYYY-MM-DD in browser local time. */
+/**
+ * Returns today's date as YYYY-MM-DD.
+ * Reads `business_date` from the application clock store (honours simulated time).
+ * Falls back to browser local time only when the store has not yet loaded.
+ */
 function getLocalDate(): string {
+  const businessDate = useApplicationClockStore.getState().clockState?.business_date
+  if (businessDate) return businessDate
   const d = new Date()
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
 }

--- a/code/webapp/src/components/employees/schedule-section-utils.ts
+++ b/code/webapp/src/components/employees/schedule-section-utils.ts
@@ -112,8 +112,8 @@ function buildWorkText(
 export function buildSummaryLines(
   days: ScheduleDay[],
   overrides: ScheduleDayOverride[] = [],
+  asOf: string = getLocalDate(),
 ): { icon: 'work' | 'lunch' | 'rest'; text: string }[] {
-  const asOf = getLocalDate()
   const resolved = resolveScheduleDays(days, overrides, asOf)
   const hasIndefiniteOverrides = overrides.some((o) => o.effective_to === null && o.effective_from <= asOf)
 
@@ -188,8 +188,8 @@ const DOW_SHORT_NAMES = ['Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb', 'Dom'] as c
 export function buildCompactSummaryLine(
   days: ScheduleDay[],
   overrides: ScheduleDayOverride[] = [],
+  asOf: string = getLocalDate(),
 ): string {
-  const asOf = getLocalDate()
   const resolved = resolveScheduleDays(days, overrides, asOf)
   const hasIndefiniteOverrides = overrides.some((o) => o.effective_to === null && o.effective_from <= asOf)
 
@@ -203,7 +203,7 @@ export function buildCompactSummaryLine(
   parts.push(buildWorkText(working, resting, hasIndefiniteOverrides))
 
   // Lunch duration (first working day with lunch configured)
-  const lunchRef = working.find((d) => d.lunch_duration_minutes !== null)
+  const lunchRef = working.find((d) => d.expected_lunch_start !== null && d.lunch_duration_minutes !== null)
   if (lunchRef) {
     const mins = lunchRef.lunch_duration_minutes!
     const durLabel = mins % 60 === 0 ? `${mins / 60}h` : `${mins}min`

--- a/code/webapp/src/components/employees/schedule-summary.tsx
+++ b/code/webapp/src/components/employees/schedule-summary.tsx
@@ -2,7 +2,7 @@ import type { EmployeeSchedule } from '@/types/schedule'
 import { buildSummaryLines } from './schedule-section-utils'
 
 export function ScheduleSummary({ schedule }: { readonly schedule: EmployeeSchedule }) {
-  const lines = buildSummaryLines(schedule.days)
+  const lines = buildSummaryLines(schedule.days, schedule.active_overrides ?? [])
   if (lines.length === 0) return null
 
   return (

--- a/code/webapp/src/components/employees/schedule-summary.tsx
+++ b/code/webapp/src/components/employees/schedule-summary.tsx
@@ -1,8 +1,10 @@
+import { useBusinessDate } from '@/stores/clock.store'
 import type { EmployeeSchedule } from '@/types/schedule'
 import { buildSummaryLines } from './schedule-section-utils'
 
 export function ScheduleSummary({ schedule }: { readonly schedule: EmployeeSchedule }) {
-  const lines = buildSummaryLines(schedule.days, schedule.active_overrides ?? [])
+  const businessDate = useBusinessDate()
+  const lines = buildSummaryLines(schedule.days, schedule.active_overrides ?? [], businessDate ?? undefined)
   if (lines.length === 0) return null
 
   return (

--- a/doc/tasks/2026-04/121-indefinite-exception-summary.md
+++ b/doc/tasks/2026-04/121-indefinite-exception-summary.md
@@ -1,0 +1,104 @@
+# 🐛 Task #121: Indefinite Exceptions Should Affect Schedule Summary
+
+**GitHub Issue:** [#121](https://github.com/pakodiazdev/sushigo/issues/121)
+
+## 📖 Story
+
+**English:**
+As an Admin, I want the schedule summary line to reflect indefinite exceptions ("from here onwards"), so that I can see the actual current schedule at a glance without expanding the details.
+
+**Español:**
+Como Admin, quiero que la línea de resumen del horario refleje las excepciones indefinidas ("de aquí en adelante"), para poder ver el horario actual real de un vistazo sin expandir los detalles.
+
+---
+
+## 🧠 Context
+
+When an indefinite exception is added to a schedule (e.g., "every Wednesday from April 20, 2026 onwards, work 2:00 PM - 11:00 PM"), this effectively becomes part of the permanent schedule. However, the current summary line only shows the base schedule configuration and ignores these modifications.
+
+**Current behavior:**
+- Base schedule: L-S · 1:00 PM – 10:00 PM
+- Indefinite exception added: Wednesday → 2:00 PM – 11:00 PM
+- Summary shows: `L-S · 1:00 PM – 10:00 PM` ❌
+
+**Expected behavior:**
+- Summary should show: `L, M, J, V, S · 1:00 PM – 10:00 PM · Mi · 2:00 PM – 11:00 PM` ✅
+- Or a condensed version that indicates Wednesday has different hours
+
+---
+
+## 🎨 UI Design
+
+The schedule summary line should:
+
+1. **Group days by common time ranges** - Days with the same schedule should be grouped together
+2. **Show exceptions separately** - Indefinite exceptions should appear as additional groups
+
+### Examples
+
+**Single exception:**
+```
+🕐 L, M, J, V, S · 1:00 PM – 10:00 PM · Mi · 2:00 PM – 11:00 PM · 🍽 30min · 🏠 Dom
+```
+
+**Multiple exceptions:**
+```
+🕐 L, M, V, S · 1:00 PM – 10:00 PM · Mi · 2:00 PM – 11:00 PM · J · Descanso · 🍽 30min · 🏠 Dom
+```
+
+**Alternative compact format (if line is too long):**
+```
+🕐 L-S · 1:00 PM – 10:00 PM · ⚡ 2 mod · 🍽 30min · 🏠 Dom
+```
+
+### Badge behavior
+
+The `⚡ +N` badge at the end of the summary should only count **temporary** exceptions (those with both start AND end dates). Indefinite exceptions are "absorbed" into the summary display.
+
+---
+
+## ✅ Backend Tasks
+
+> **Decision:** The merging logic was implemented entirely on the frontend (`resolveScheduleDays` in `schedule-section-utils.ts`). A backend `resolved_days` field is not needed — the API already returns `active_overrides` and the frontend merges them at render time.
+
+- [x] 🔧 Modify schedule summary calculation to merge indefinite exceptions into the day groups (`resolveScheduleDays` + `buildWorkText` in `schedule-section-utils.ts`)
+- [x] ~~🔧 Return a `resolved_days` array that reflects base schedule + indefinite exceptions~~ — not needed, done client-side
+- [x] 🧪 Unit tests for summary calculation with indefinite exceptions (6 new Vitest cases in `schedule-summary.test.ts`)
+
+## ✅ Frontend Tasks
+
+- [x] 📱 Updated `ScheduleSummary`, `ScheduleCompactSummary`, `ScheduleHistoryItem` to pass overrides to utility functions
+- [x] 🔧 `buildSummaryLines` and `buildCompactSummaryLine` now accept overrides and apply indefinite ones via `resolveScheduleDays`
+- [x] 🧪 6 new Vitest cases covering grouping, day-off override, future override guard, and temporary-only path
+
+---
+
+## 🎯 Acceptance Criteria
+
+- [x] Summary line shows actual schedule considering indefinite exceptions
+- [x] Days with the same time are grouped (e.g., "L, M, J, V, S · 1:00 PM – 10:00 PM · X · 2:00 PM – 11:00 PM")
+- [x] Indefinite exceptions are visually distinguishable — shown as a separate day group with different times in the same line (separator `·`)
+- [x] Badge count only includes temporary exceptions, not indefinite ones (`effective_to !== null` filter in `ScheduleCompactSummary`)
+- [x] Works in both dialog summary and employee card summary (`ScheduleSummary` + `ScheduleCompactSummary` both updated)
+- [x] E2E Cypress spec: `schedule-indefinite-summary.cy.ts` (seeder group `schedule-summary`)
+
+---
+
+## 🔗 References
+
+- **Story:** AP-010 · RF-09
+- **Discovered in:** #062 (schedule-history)
+- **Related to:** #088 (day override exceptions)
+
+---
+
+## ⏱️ Estimates
+
+- **Optimistic:** `2h` · **Pessimistic:** `4h`
+
+---
+
+## ⏱️ Sessions
+```json
+[]
+```


### PR DESCRIPTION
## Descripción

Corrige el bug donde las excepciones indefinidas (sin fecha de fin) eran ignoradas en la línea de resumen del horario.

Fixes #121

## Cambios

- `resolveScheduleDays(days, overrides)` — nueva función que aplica excepciones indefinidas (`effective_to === null`) al array base de días
- `buildSummaryLines(days, overrides?)` — cuando hay indefinidas, agrupa los días por rango horario (ej: `L, M, J, V · 1:00 PM – 10:00 PM · X · 2:00 PM – 11:00 PM`)
- `buildCompactSummaryLine(days, overrides?)` — mismo tratamiento en el header del diálogo
- **Badge ⚡** — ahora solo cuenta excepciones **temporales** (`effective_to !== null`); las indefinidas se absorben en el resumen
- `ScheduleSummary`, `ScheduleCompactSummary`, `ScheduleHistoryItem` — pasan `active_overrides` / `overrides` a las utilidades

## Tests

- 5 nuevos casos en `schedule-summary.test.ts` cubriendo agrupación por horario, override de día libre, y que overrides temporales no rompen el formato original
- 32 tests pasando en total (27 existentes + 5 nuevos)
- TypeScript: 0 errores · ESLint: 0 warnings
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pakodiazdev/sushigo/pull/140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
