### PR TITLE
✨ [#063] - Add Punctuality Ranges config endpoint and UI 🎛️

### DIFF
--- a/code/api/app/Console/Commands/TestReset.php
+++ b/code/api/app/Console/Commands/TestReset.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands;
 
 use App\Contracts\PasswordResetTokenRecorder;
 use Database\Seeders\Fakes\FakeEmployeesSeeder;
+use Database\Seeders\PunctualityRangeSeeder;
 use Database\Seeders\Testing\AttendanceTestSeeder;
 use Database\Seeders\Testing\AttendanceTodayLeaveSeeder;
 use Database\Seeders\Testing\CloseDayHappyPathSeeder;
@@ -31,6 +32,7 @@ class TestReset extends Command
     private array $seederGroups = [
         'core' => [
             CoreTestSeeder::class,
+            PunctualityRangeSeeder::class,
         ],
         'attendance' => [
             AttendanceTestSeeder::class,

--- a/code/api/app/Http/Controllers/Api/V1/Punctuality/ListPunctualityRangesController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Punctuality/ListPunctualityRangesController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Punctuality;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Punctuality\PunctualityRangeResource;
+use App\Http\Responses\Common\ResponseEntity;
+use App\Models\PunctualityRange;
+
+/**
+ * @OA\Get(
+ *   path="/api/v1/punctuality/ranges",
+ *   summary="List Punctuality Ranges",
+ *   description="Returns all punctuality bonus ranges ordered by sort_order.",
+ *   tags={"Punctuality"},
+ *   security={{"passport": {}}},
+ *
+ *   @OA\Response(
+ *       response=200,
+ *       description="Ranges retrieved successfully",
+ *
+ *       @OA\JsonContent(
+ *           allOf={
+ *
+ *              @OA\Schema(ref="#/components/schemas/ResponseEntity"),
+ *              @OA\Schema(@OA\Property(property="data", type="array", @OA\Items(ref="#/components/schemas/PunctualityRangeResponse")))
+ *           }
+ *       )
+ *   ),
+ *
+ *   @OA\Response(response=401, description="Unauthenticated"),
+ *   @OA\Response(response=403, description="Forbidden")
+ * )
+ */
+class ListPunctualityRangesController extends Controller
+{
+    public function __invoke(): ResponseEntity
+    {
+        $ranges = PunctualityRange::orderBy('sort_order')->get();
+
+        $data = $ranges
+            ->map(fn (PunctualityRange $r) => (new PunctualityRangeResource($r))->resolve())
+            ->values()
+            ->all();
+
+        return new ResponseEntity(data: $data);
+    }
+}

--- a/code/api/app/Http/Controllers/Api/V1/Punctuality/UpdatePunctualityRangesController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Punctuality/UpdatePunctualityRangesController.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Punctuality;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Punctuality\UpdatePunctualityRangesRequest;
+use App\Http\Resources\Punctuality\PunctualityRangeResource;
+use App\Http\Responses\Common\ResponseEntity;
+use App\Models\PunctualityRange;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * @OA\Put(
+ *   path="/api/v1/punctuality/ranges",
+ *   summary="Replace Punctuality Ranges",
+ *   description="Atomically replaces all punctuality ranges with the provided list. The backend computes max_seconds and sort_order automatically. The first range must start at min_seconds=0. The last range will be open-ended (max_seconds=null).",
+ *   tags={"Punctuality"},
+ *   security={{"passport": {}}},
+ *
+ *   @OA\RequestBody(required=true, @OA\JsonContent(ref="#/components/schemas/UpdatePunctualityRangesRequest")),
+ *
+ *   @OA\Response(
+ *       response=200,
+ *       description="Ranges replaced successfully",
+ *
+ *       @OA\JsonContent(
+ *           allOf={
+ *
+ *              @OA\Schema(ref="#/components/schemas/ResponseEntity"),
+ *              @OA\Schema(@OA\Property(property="data", type="array", @OA\Items(ref="#/components/schemas/PunctualityRangeResponse")))
+ *           }
+ *       )
+ *   ),
+ *
+ *   @OA\Response(response=401, description="Unauthenticated"),
+ *   @OA\Response(response=403, description="Forbidden"),
+ *   @OA\Response(response=422, description="Validation Error", @OA\JsonContent(ref="#/components/schemas/ResponseError"))
+ * )
+ */
+class UpdatePunctualityRangesController extends Controller
+{
+    public function __invoke(UpdatePunctualityRangesRequest $request): ResponseEntity
+    {
+        $sorted = collect($request->input('ranges'))
+            ->sortBy('min_seconds')
+            ->values();
+
+        DB::transaction(function () use ($sorted) {
+            PunctualityRange::query()->delete();
+
+            $sorted->each(function (array $item, int $index) use ($sorted) {
+                $isLast = $index === $sorted->count() - 1;
+                $maxSeconds = $isLast
+                    ? null
+                    : $sorted->get($index + 1)['min_seconds'] - 1;
+
+                PunctualityRange::create([
+                    'min_seconds' => $item['min_seconds'],
+                    'max_seconds' => $maxSeconds,
+                    'bonus_percentage' => $item['bonus_percentage'],
+                    'sort_order' => $index + 1,
+                ]);
+            });
+        });
+
+        $ranges = PunctualityRange::orderBy('sort_order')->get();
+
+        $data = $ranges
+            ->map(fn (PunctualityRange $r) => (new PunctualityRangeResource($r))->resolve())
+            ->values()
+            ->all();
+
+        return new ResponseEntity(data: $data);
+    }
+}

--- a/code/api/app/Http/Requests/Punctuality/UpdatePunctualityRangesRequest.php
+++ b/code/api/app/Http/Requests/Punctuality/UpdatePunctualityRangesRequest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Requests\Punctuality;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Validator;
+
+/**
+ * Full-replacement bulk update.
+ * The caller sends the complete desired list; the backend replaces all ranges atomically.
+ *
+ * @OA\Schema(
+ *     schema="UpdatePunctualityRangesRequest",
+ *     title="Update Punctuality Ranges Request",
+ *     required={"ranges"},
+ *
+ *     @OA\Property(
+ *         property="ranges",
+ *         type="array",
+ *         minItems=1,
+ *
+ *         @OA\Items(
+ *
+ *             @OA\Property(property="min_seconds", type="integer", minimum=0, example=0),
+ *             @OA\Property(property="bonus_percentage", type="number", format="float", minimum=0, maximum=100, example=100.0)
+ *         )
+ *     )
+ * )
+ */
+class UpdatePunctualityRangesRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()->can('punctuality.manage');
+    }
+
+    public function rules(): array
+    {
+        return [
+            'ranges' => ['required', 'array', 'min:1'],
+            'ranges.*.min_seconds' => ['required', 'integer', 'min:0'],
+            'ranges.*.bonus_percentage' => ['required', 'numeric', 'min:0', 'max:100'],
+        ];
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $v) {
+            $ranges = collect($this->input('ranges', []))
+                ->pluck('min_seconds')
+                ->filter(fn ($s) => is_numeric($s))
+                ->map(fn ($s) => (int) $s)
+                ->sort()
+                ->values();
+
+            if ($ranges->isEmpty()) {
+                return;
+            }
+
+            if ($ranges->first() !== 0) {
+                $v->errors()->add('ranges.0.min_seconds', 'El primer rango debe comenzar en 0 segundos.');
+            }
+
+            $dupes = $ranges->duplicates();
+            if ($dupes->isNotEmpty()) {
+                $v->errors()->add('ranges', 'Los valores de min_seconds deben ser únicos.');
+            }
+        });
+    }
+}

--- a/code/api/app/Http/Resources/Punctuality/PunctualityRangeResource.php
+++ b/code/api/app/Http/Resources/Punctuality/PunctualityRangeResource.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Resources\Punctuality;
+
+use App\Http\Resources\BaseResource;
+use App\Models\PunctualityRange;
+
+/**
+ * @mixin PunctualityRange
+ *
+ * @OA\Schema(
+ *     schema="PunctualityRangeResponse",
+ *     title="Punctuality Range Response",
+ *
+ *     @OA\Property(property="id", type="string", example="01HXYZ"),
+ *     @OA\Property(property="min_seconds", type="integer", example=0),
+ *     @OA\Property(property="max_seconds", type="integer", nullable=true, example=599),
+ *     @OA\Property(property="bonus_percentage", type="number", format="float", example=100.0),
+ *     @OA\Property(property="sort_order", type="integer", example=1)
+ * )
+ */
+class PunctualityRangeResource extends BaseResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->public_id,
+            'min_seconds' => $this->min_seconds,
+            'max_seconds' => $this->max_seconds,
+            'bonus_percentage' => (float) $this->bonus_percentage,
+            'sort_order' => $this->sort_order,
+        ];
+    }
+}

--- a/code/api/app/Models/PunctualityRange.php
+++ b/code/api/app/Models/PunctualityRange.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use App\Support\Traits\HasPublicId;
+use Illuminate\Database\Eloquent\Model;
+
+class PunctualityRange extends Model
+{
+    use HasPublicId;
+
+    protected $fillable = [
+        'min_seconds',
+        'max_seconds',
+        'bonus_percentage',
+        'sort_order',
+    ];
+
+    protected $casts = [
+        'min_seconds' => 'integer',
+        'max_seconds' => 'integer',
+        'bonus_percentage' => 'decimal:2',
+        'sort_order' => 'integer',
+    ];
+
+    /**
+     * Returns true if the given lateness in seconds falls within this range.
+     * A null max_seconds means the range is open-ended (≥ min_seconds).
+     */
+    public function matches(int $lateSeconds): bool
+    {
+        if ($lateSeconds < $this->min_seconds) {
+            return false;
+        }
+
+        if ($this->max_seconds !== null && $lateSeconds > $this->max_seconds) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/code/api/database/migrations/2026_04_28_000001_create_punctuality_ranges_table.php
+++ b/code/api/database/migrations/2026_04_28_000001_create_punctuality_ranges_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('punctuality_ranges', function (Blueprint $table) {
+            $table->id();
+            $table->string('public_id', 26)->unique();
+            $table->unsignedInteger('min_seconds')->unique();
+            $table->unsignedInteger('max_seconds')->nullable();
+            $table->decimal('bonus_percentage', 5, 2);
+            $table->unsignedSmallInteger('sort_order')->unique();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('punctuality_ranges');
+    }
+};

--- a/code/api/database/seeders/Development/DevelopmentSeeder.php
+++ b/code/api/database/seeders/Development/DevelopmentSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders\Development;
 
+use Database\Seeders\PunctualityRangeSeeder;
 use Illuminate\Database\Seeder;
 
 class DevelopmentSeeder extends Seeder
@@ -31,6 +32,7 @@ class DevelopmentSeeder extends Seeder
             \Database\Seeders\UomConversionSeeder::class,
             AttendanceAuditLogSeeder::class,
             \Database\Seeders\LeaveTypeSeeder::class,
+            PunctualityRangeSeeder::class,
         ];
 
         foreach ($seeders as $seederClass) {

--- a/code/api/database/seeders/Development/PermissionSeeder.php
+++ b/code/api/database/seeders/Development/PermissionSeeder.php
@@ -119,6 +119,9 @@ class PermissionSeeder extends LockedSeeder
             // Inventario — Stock y movimientos
             'stock.view' => ['label' => 'Ver stock y movimientos',   'group' => self::GROUP_INVENTARIO],
             'stock.manage' => ['label' => 'Registrar movimientos de stock', 'group' => self::GROUP_INVENTARIO],
+
+            // Asistencia — configuración
+            'punctuality.manage' => ['label' => 'Gestionar rangos de puntualidad', 'group' => 'Asistencia'],
         ];
 
         foreach ($permissions as $name => $meta) {
@@ -146,7 +149,8 @@ class PermissionSeeder extends LockedSeeder
                             ->orWhere('name', 'like', self::EMPLOYEE_REQUESTS_PATTERN)
                             ->orWhere('name', 'like', self::ITEMS_PATTERN)
                             ->orWhere('name', 'like', self::INVENTORY_LOCATIONS_PATTERN)
-                            ->orWhere('name', 'like', self::STOCK_PATTERN);
+                            ->orWhere('name', 'like', self::STOCK_PATTERN)
+                            ->orWhereIn('name', ['punctuality.manage']);
                     })
                     ->get()
             );

--- a/code/api/database/seeders/Production/PermissionSeeder.php
+++ b/code/api/database/seeders/Production/PermissionSeeder.php
@@ -83,6 +83,9 @@ class PermissionSeeder extends LockedSeeder
             'attendances.view',
             'attendances.create',
 
+            // Asistencia — configuración
+            'punctuality.manage',
+
             // Inventario — Ítems y variantes
             'items.view',
             'items.create',
@@ -140,7 +143,8 @@ class PermissionSeeder extends LockedSeeder
                             ->orWhere('name', 'like', 'attendances.%')
                             ->orWhere('name', 'like', 'items.%')
                             ->orWhere('name', 'like', 'inventory_locations.%')
-                            ->orWhere('name', 'like', 'stock.%');
+                            ->orWhere('name', 'like', 'stock.%')
+                            ->orWhereIn('name', ['punctuality.manage']);
                     })
                     ->get()
             );

--- a/code/api/database/seeders/Production/ProductionSeeder.php
+++ b/code/api/database/seeders/Production/ProductionSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders\Production;
 
+use Database\Seeders\PunctualityRangeSeeder;
 use Illuminate\Database\Seeder;
 
 class ProductionSeeder extends Seeder
@@ -24,6 +25,7 @@ class ProductionSeeder extends Seeder
             \Database\Seeders\CashRegisterSeeder::class,
             \Database\Seeders\UnitOfMeasureSeeder::class,
             \Database\Seeders\UomConversionSeeder::class,
+            PunctualityRangeSeeder::class,
         ];
 
         foreach ($seeders as $seederClass) {

--- a/code/api/database/seeders/PunctualityRangeSeeder.php
+++ b/code/api/database/seeders/PunctualityRangeSeeder.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\PunctualityRange;
+use Database\Seeders\Base\RepeatableSeeder;
+
+/**
+ * Default SushiGo punctuality bonus percentage ranges.
+ *
+ * Ranges (in seconds):
+ *   0 – 599    → 100%   (on time or up to 9 min 59 s late)
+ *   600 – 899  →  50%   (10 – 14 min 59 s)
+ *   900 – 1259 →  25%   (15 – 20 min 59 s)
+ *   1260 – 1559 → 10%   (21 – 25 min 59 s)
+ *   1560 +     →   0%   (26 min or more)
+ */
+class PunctualityRangeSeeder extends RepeatableSeeder
+{
+    private const RANGES = [
+        ['min_seconds' => 0,    'max_seconds' => 599,  'bonus_percentage' => '100.00', 'sort_order' => 1],
+        ['min_seconds' => 600,  'max_seconds' => 899,  'bonus_percentage' => '50.00',  'sort_order' => 2],
+        ['min_seconds' => 900,  'max_seconds' => 1259, 'bonus_percentage' => '25.00',  'sort_order' => 3],
+        ['min_seconds' => 1260, 'max_seconds' => 1559, 'bonus_percentage' => '10.00',  'sort_order' => 4],
+        ['min_seconds' => 1560, 'max_seconds' => null,  'bonus_percentage' => '0.00',   'sort_order' => 5],
+    ];
+
+    public function run(): void
+    {
+        foreach (self::RANGES as $range) {
+            PunctualityRange::updateOrCreate(
+                ['sort_order' => $range['sort_order']],
+                $range,
+            );
+        }
+    }
+}

--- a/code/api/database/seeders/Testing/CoreTestSeeder.php
+++ b/code/api/database/seeders/Testing/CoreTestSeeder.php
@@ -93,6 +93,7 @@ class CoreTestSeeder extends Seeder
         'stock.manage',
         'attendances.view',
         'attendances.create',
+        'punctuality.manage',
     ];
 
     /** Basic view-only user permissions shared by most roles */
@@ -101,7 +102,7 @@ class CoreTestSeeder extends Seeder
     /** role name => permission name prefixes or exact names */
     private const ROLE_PERMISSIONS = [
         'super-admin' => '*',  // all permissions
-        'admin' => ['users.', 'employees.', 'leaves.', 'employee-requests.', 'items.', 'inventory_locations.', 'stock.', 'attendances.'],
+        'admin' => ['users.', 'employees.', 'leaves.', 'employee-requests.', 'items.', 'inventory_locations.', 'stock.', 'attendances.', 'punctuality.'],
         'inventory-manager' => ['items.', 'inventory_locations.', 'stock.'],
         'manager' => [...self::BASIC_USER_VIEW, 'employees.', 'leaves.', 'employee-requests.', 'attendances.'],
         'cook' => self::BASIC_USER_VIEW,

--- a/code/api/routes/api.php
+++ b/code/api/routes/api.php
@@ -75,6 +75,8 @@ use App\Http\Controllers\Api\V1\OperatingUnit\UpdateOperatingUnitController;
 use App\Http\Controllers\Api\V1\OperatingUnitUser\AddUserToOperatingUnitController;
 use App\Http\Controllers\Api\V1\OperatingUnitUser\ListOperatingUnitUsersController;
 use App\Http\Controllers\Api\V1\OperatingUnitUser\RemoveUserFromOperatingUnitController;
+use App\Http\Controllers\Api\V1\Punctuality\ListPunctualityRangesController;
+use App\Http\Controllers\Api\V1\Punctuality\UpdatePunctualityRangesController;
 use App\Http\Controllers\Api\V1\Schedules\CreateScheduleController;
 use App\Http\Controllers\Api\V1\Schedules\CreateScheduleDayOverrideController;
 use App\Http\Controllers\Api\V1\Schedules\CurrentScheduleController;
@@ -329,6 +331,12 @@ Route::prefix('v1')->group(function () {
 
     Route::middleware('auth:api')->prefix('negotiated-extra-days')->group(function () {
         Route::delete('/{id}', CancelNegotiatedExtraDayController::class)->name('negotiated-extra-days.destroy');
+    });
+
+    // Punctuality config
+    Route::middleware('auth:api')->prefix('punctuality')->name('punctuality.')->group(function () {
+        Route::get('/ranges', ListPunctualityRangesController::class)->name('ranges.index')->middleware('permission:punctuality.manage');
+        Route::put('/ranges', UpdatePunctualityRangesController::class)->name('ranges.update')->middleware('permission:punctuality.manage');
     });
 
     // Cash Adjustments Module (All Protected)

--- a/code/api/tests/Feature/Punctuality/PunctualityRangesTest.php
+++ b/code/api/tests/Feature/Punctuality/PunctualityRangesTest.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace Tests\Feature\Punctuality;
+
+use App\Models\PunctualityRange;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+class PunctualityRangesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        app()[PermissionRegistrar::class]->forgetCachedPermissions();
+
+        Permission::create(['name' => 'punctuality.manage', 'guard_name' => 'api']);
+        $admin = Role::create(['name' => 'admin', 'guard_name' => 'api']);
+        $admin->givePermissionTo('punctuality.manage');
+
+        PunctualityRange::insert([
+            ['public_id' => '01A', 'min_seconds' => 0,    'max_seconds' => 599,  'bonus_percentage' => '100.00', 'sort_order' => 1, 'created_at' => now(), 'updated_at' => now()],
+            ['public_id' => '01B', 'min_seconds' => 600,  'max_seconds' => 899,  'bonus_percentage' => '50.00',  'sort_order' => 2, 'created_at' => now(), 'updated_at' => now()],
+            ['public_id' => '01C', 'min_seconds' => 900,  'max_seconds' => 1259, 'bonus_percentage' => '25.00',  'sort_order' => 3, 'created_at' => now(), 'updated_at' => now()],
+            ['public_id' => '01D', 'min_seconds' => 1260, 'max_seconds' => 1559, 'bonus_percentage' => '10.00',  'sort_order' => 4, 'created_at' => now(), 'updated_at' => now()],
+            ['public_id' => '01E', 'min_seconds' => 1560, 'max_seconds' => null,  'bonus_percentage' => '0.00',   'sort_order' => 5, 'created_at' => now(), 'updated_at' => now()],
+        ]);
+    }
+
+    private function adminUser(): User
+    {
+        $user = User::factory()->create();
+        $user->assignRole('admin');
+
+        return $user;
+    }
+
+    // ── GET /api/v1/punctuality/ranges ──────────────────────────────────────────
+
+    #[Test]
+    public function admin_can_list_ranges(): void
+    {
+        Passport::actingAs($this->adminUser());
+
+        $response = $this->getJson('/api/v1/punctuality/ranges');
+
+        $response->assertOk()
+            ->assertJsonCount(5, 'data')
+            ->assertJsonPath('data.0.sort_order', 1)
+            ->assertJsonPath('data.0.bonus_percentage', 100)
+            ->assertJsonPath('data.4.max_seconds', null);
+    }
+
+    #[Test]
+    public function unauthenticated_cannot_list_ranges(): void
+    {
+        $this->getJson('/api/v1/punctuality/ranges')->assertUnauthorized();
+    }
+
+    #[Test]
+    public function user_without_permission_cannot_list_ranges(): void
+    {
+        Passport::actingAs(User::factory()->create());
+        $this->getJson('/api/v1/punctuality/ranges')->assertForbidden();
+    }
+
+    // ── PUT /api/v1/punctuality/ranges — happy path ─────────────────────────────
+
+    #[Test]
+    public function admin_can_replace_all_ranges(): void
+    {
+        Passport::actingAs($this->adminUser());
+
+        $response = $this->putJson('/api/v1/punctuality/ranges', [
+            'ranges' => [
+                ['min_seconds' => 0,   'bonus_percentage' => 100],
+                ['min_seconds' => 900, 'bonus_percentage' => 50],
+                ['min_seconds' => 1800, 'bonus_percentage' => 0],
+            ],
+        ]);
+
+        $response->assertOk()->assertJsonCount(3, 'data');
+
+        $this->assertDatabaseCount('punctuality_ranges', 3);
+        $this->assertDatabaseHas('punctuality_ranges', ['min_seconds' => 0,    'max_seconds' => 899,  'sort_order' => 1]);
+        $this->assertDatabaseHas('punctuality_ranges', ['min_seconds' => 900,  'max_seconds' => 1799, 'sort_order' => 2]);
+        $this->assertDatabaseHas('punctuality_ranges', ['min_seconds' => 1800, 'max_seconds' => null,  'sort_order' => 3]);
+    }
+
+    #[Test]
+    public function server_computes_max_seconds_from_next_min(): void
+    {
+        Passport::actingAs($this->adminUser());
+
+        $this->putJson('/api/v1/punctuality/ranges', [
+            'ranges' => [
+                ['min_seconds' => 0,   'bonus_percentage' => 100],
+                ['min_seconds' => 600, 'bonus_percentage' => 0],
+            ],
+        ])->assertOk();
+
+        $this->assertDatabaseHas('punctuality_ranges', ['min_seconds' => 0,   'max_seconds' => 599]);
+        $this->assertDatabaseHas('punctuality_ranges', ['min_seconds' => 600, 'max_seconds' => null]);
+    }
+
+    #[Test]
+    public function admin_can_simplify_to_a_single_range(): void
+    {
+        Passport::actingAs($this->adminUser());
+
+        $this->putJson('/api/v1/punctuality/ranges', [
+            'ranges' => [['min_seconds' => 0, 'bonus_percentage' => 100]],
+        ])->assertOk()->assertJsonCount(1, 'data');
+
+        $this->assertDatabaseCount('punctuality_ranges', 1);
+        $this->assertDatabaseHas('punctuality_ranges', ['min_seconds' => 0, 'max_seconds' => null, 'bonus_percentage' => 100]);
+    }
+
+    #[Test]
+    public function request_is_sorted_server_side_regardless_of_input_order(): void
+    {
+        Passport::actingAs($this->adminUser());
+
+        $response = $this->putJson('/api/v1/punctuality/ranges', [
+            'ranges' => [
+                ['min_seconds' => 1800, 'bonus_percentage' => 0],
+                ['min_seconds' => 0,    'bonus_percentage' => 100],
+                ['min_seconds' => 900,  'bonus_percentage' => 50],
+            ],
+        ])->assertOk();
+
+        $data = $response->json('data');
+        $this->assertSame([0, 900, 1800], array_column($data, 'min_seconds'));
+        $this->assertSame([1, 2, 3], array_column($data, 'sort_order'));
+    }
+
+    #[Test]
+    public function response_returns_all_ranges_ordered_by_sort_order(): void
+    {
+        Passport::actingAs($this->adminUser());
+
+        $response = $this->putJson('/api/v1/punctuality/ranges', [
+            'ranges' => [
+                ['min_seconds' => 0,   'bonus_percentage' => 100],
+                ['min_seconds' => 600, 'bonus_percentage' => 50],
+                ['min_seconds' => 900, 'bonus_percentage' => 0],
+            ],
+        ])->assertOk();
+
+        $data = $response->json('data');
+        $this->assertSame([1, 2, 3], array_column($data, 'sort_order'));
+    }
+
+    // ── PUT — validation ────────────────────────────────────────────────────────
+
+    #[Test]
+    public function update_rejects_missing_ranges_array(): void
+    {
+        Passport::actingAs($this->adminUser());
+        $this->putJson('/api/v1/punctuality/ranges', [])->assertUnprocessable();
+    }
+
+    #[Test]
+    public function update_rejects_empty_ranges_array(): void
+    {
+        Passport::actingAs($this->adminUser());
+        $this->putJson('/api/v1/punctuality/ranges', ['ranges' => []])->assertUnprocessable();
+    }
+
+    #[Test]
+    public function update_rejects_when_first_range_does_not_start_at_zero(): void
+    {
+        Passport::actingAs($this->adminUser());
+
+        $this->putJson('/api/v1/punctuality/ranges', [
+            'ranges' => [['min_seconds' => 600, 'bonus_percentage' => 50]],
+        ])->assertUnprocessable();
+    }
+
+    #[Test]
+    public function update_rejects_duplicate_min_seconds(): void
+    {
+        Passport::actingAs($this->adminUser());
+
+        $this->putJson('/api/v1/punctuality/ranges', [
+            'ranges' => [
+                ['min_seconds' => 0,   'bonus_percentage' => 100],
+                ['min_seconds' => 600, 'bonus_percentage' => 50],
+                ['min_seconds' => 600, 'bonus_percentage' => 25],
+            ],
+        ])->assertUnprocessable();
+    }
+
+    #[Test]
+    public function update_rejects_bonus_above_100(): void
+    {
+        Passport::actingAs($this->adminUser());
+
+        $this->putJson('/api/v1/punctuality/ranges', [
+            'ranges' => [['min_seconds' => 0, 'bonus_percentage' => 101]],
+        ])->assertUnprocessable();
+    }
+
+    #[Test]
+    public function update_rejects_negative_bonus(): void
+    {
+        Passport::actingAs($this->adminUser());
+
+        $this->putJson('/api/v1/punctuality/ranges', [
+            'ranges' => [['min_seconds' => 0, 'bonus_percentage' => -1]],
+        ])->assertUnprocessable();
+    }
+
+    #[Test]
+    public function unauthenticated_cannot_update_ranges(): void
+    {
+        $this->putJson('/api/v1/punctuality/ranges', [
+            'ranges' => [['min_seconds' => 0, 'bonus_percentage' => 100]],
+        ])->assertUnauthorized();
+    }
+
+    #[Test]
+    public function user_without_permission_cannot_update_ranges(): void
+    {
+        Passport::actingAs(User::factory()->create());
+
+        $this->putJson('/api/v1/punctuality/ranges', [
+            'ranges' => [['min_seconds' => 0, 'bonus_percentage' => 100]],
+        ])->assertForbidden();
+    }
+}

--- a/code/api/tests/Unit/Models/PunctualityRangeMatchesTest.php
+++ b/code/api/tests/Unit/Models/PunctualityRangeMatchesTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\PunctualityRange;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class PunctualityRangeMatchesTest extends TestCase
+{
+    private static function range(int $min, ?int $max): PunctualityRange
+    {
+        $r = new PunctualityRange;
+        $r->min_seconds = $min;
+        $r->max_seconds = $max;
+
+        return $r;
+    }
+
+    public static function boundaryProvider(): array
+    {
+        return [
+            // [min, max, lateSeconds, expected]
+            'below min returns false' => [600, 899, 599, false],
+            'at min returns true' => [600, 899, 600, true],
+            'within range returns true' => [600, 899, 750, true],
+            'at max returns true' => [600, 899, 899, true],
+            'above max returns false' => [600, 899, 900, false],
+            'open-ended: at min returns true' => [1560, null, 1560, true],
+            'open-ended: above min true' => [1560, null, 9999, true],
+            'open-ended: below min false' => [1560, null, 1559, false],
+            'zero min: zero seconds true' => [0, 599, 0, true],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('boundaryProvider')]
+    public function matches_boundary_cases(int $min, ?int $max, int $lateSeconds, bool $expected): void
+    {
+        $range = self::range($min, $max);
+        $this->assertSame($expected, $range->matches($lateSeconds));
+    }
+}

--- a/code/webapp/cypress/e2e/punctuality-ranges-config.cy.ts
+++ b/code/webapp/cypress/e2e/punctuality-ranges-config.cy.ts
@@ -1,0 +1,102 @@
+/**
+ * Punctuality Ranges Config — E2E happy path
+ *
+ * Verifies that an admin can view, edit, add, and remove punctuality bonus ranges.
+ *
+ * Seeder group: 'core' (always included — seeds PunctualityRangeSeeder with 5 default ranges)
+ *
+ * Happy path:
+ *   1. Admin navigates to /attendance/punctuality-config via the sidebar.
+ *   2. All 5 default ranges are rendered.
+ *   3. Admin edits the first range bonus (100% → 95%) and saves — toast appears.
+ *   4. Persisted value survives a page reload.
+ *   5. Admin adds a new level — row count increases.
+ *   6. Admin removes a level — row count decreases.
+ *
+ * For running only this file:
+ *   make cypress-spec SPEC=punctuality-ranges-config
+ *   make cypress-debug SPEC=punctuality-ranges-config
+ */
+
+import users from '../fixtures/users.json'
+
+const { email: adminEmail, password: adminPassword } = users.admin
+
+before(() => {
+  cy.task('test:reset', null, { timeout: 60_000 })
+})
+
+describe('Punctuality Ranges Config — admin happy path', () => {
+  beforeEach(() => {
+    cy.loginByApi(adminEmail, adminPassword)
+  })
+
+  it('navigates to the config page via the Asistencia sidebar', () => {
+    cy.visitWithAuth('/')
+    cy.closeDevDebugger()
+    cy.contains('Asistencia').click()
+    cy.contains('Puntualidad').click()
+    cy.url().should('include', '/attendance/punctuality-config', { timeout: 10_000 })
+    cy.contains('Rangos de Puntualidad', { timeout: 10_000 }).should('be.visible')
+  })
+
+  it('displays all 5 default ranges', () => {
+    cy.visitWithAuth('/attendance/punctuality-config')
+    cy.closeDevDebugger()
+    cy.contains('Rangos de Puntualidad', { timeout: 10_000 }).should('be.visible')
+
+    cy.get('form').find('[type="number"]').should('have.length', 10) // 5 rows × 2 inputs (threshold + bonus)
+
+    // First bonus = 100, last bonus = 0
+    cy.get('form').find('[type="number"]').eq(1).should('have.value', '100')
+    cy.get('form').find('[type="number"]').last().should('have.value', '0')
+  })
+
+  it('saves an updated bonus percentage and shows a success toast', () => {
+    cy.visitWithAuth('/attendance/punctuality-config')
+    cy.closeDevDebugger()
+    cy.contains('Rangos de Puntualidad', { timeout: 10_000 }).should('be.visible')
+
+    // Edit first row's bonus (second input, index 1)
+    cy.get('form').find('[type="number"]').eq(1).clear().type('95')
+    cy.contains('button', 'Guardar cambios').click()
+
+    cy.contains('Rangos de puntualidad actualizados', { timeout: 10_000 }).should('be.visible')
+  })
+
+  it('persists the saved bonus after a page reload', () => {
+    cy.visitWithAuth('/attendance/punctuality-config')
+    cy.closeDevDebugger()
+    cy.contains('Rangos de Puntualidad', { timeout: 10_000 }).should('be.visible')
+
+    cy.get('form').find('[type="number"]').eq(1).should('have.value', '95')
+  })
+
+  it('adds a new level and shows one more row', () => {
+    cy.visitWithAuth('/attendance/punctuality-config')
+    cy.closeDevDebugger()
+    cy.contains('Rangos de Puntualidad', { timeout: 10_000 }).should('be.visible')
+
+    // Count initial rows (5 default ranges = 10 number inputs)
+    cy.get('form').find('[type="number"]').should('have.length', 10)
+
+    cy.contains('button', 'Agregar nivel').click()
+
+    // Now 6 rows = 12 number inputs
+    cy.get('form').find('[type="number"]').should('have.length', 12)
+  })
+
+  it('removes a level and shows one fewer row', () => {
+    cy.visitWithAuth('/attendance/punctuality-config')
+    cy.closeDevDebugger()
+    cy.contains('Rangos de Puntualidad', { timeout: 10_000 }).should('be.visible')
+
+    cy.get('form').find('[type="number"]').should('have.length', 10)
+
+    // Click delete on the second row (index 1)
+    cy.get('form').find('button[title="Eliminar nivel"]').eq(1).click()
+
+    // 4 rows = 8 number inputs
+    cy.get('form').find('[type="number"]').should('have.length', 8)
+  })
+})

--- a/code/webapp/src/components/layout/Sidebar.tsx
+++ b/code/webapp/src/components/layout/Sidebar.tsx
@@ -31,6 +31,8 @@ import { usePendingRequestsCount } from '@/services/employee-request-hooks';
 interface SubMenuItem {
     label: string;
     path: string;
+    /** When set, the sub-item is hidden unless the user has this permission. */
+    requiredPermission?: string;
 }
 
 interface MenuItem {
@@ -66,6 +68,7 @@ const menuItems: MenuItem[] = [
         accessMode: 'hidden',
         subItems: [
             { label: 'Hoy', path: '/attendance/today' },
+            { label: 'Puntualidad', path: '/attendance/punctuality-config', requiredPermission: 'punctuality.manage' },
         ]
     },
     {
@@ -229,7 +232,9 @@ export default function Sidebar() {
 
                         {hasSubItems && !isCollapsed && isExpanded && (
                             <ul className="mt-1 ml-8 space-y-1">
-                                {item.subItems!.map((subItem) => {
+                                {item.subItems!.filter((subItem) =>
+                                    !subItem.requiredPermission || can(subItem.requiredPermission)
+                                ).map((subItem) => {
                                     const isSubActive = currentPath === subItem.path;
                                     return (
                                         <li key={subItem.path}>

--- a/code/webapp/src/pages/attendance/punctuality-config.tsx
+++ b/code/webapp/src/pages/attendance/punctuality-config.tsx
@@ -1,0 +1,159 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { Trash2, Plus } from 'lucide-react'
+import { requirePermission } from '@/lib/route-guards'
+import { PageContainer } from '@/components/ui/page-container'
+import { PageHeader } from '@/components/ui/page-header'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { usePunctualityConfigPage } from './use-punctuality-config-page'
+
+export const Route = createFileRoute('/attendance/punctuality-config')({
+  beforeLoad: requirePermission('punctuality.manage'),
+  component: PunctualityConfigPage,
+})
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function rangeLabel(minSeconds: number, maxSeconds: number | null): string {
+  const minMin = Math.floor(minSeconds / 60)
+  if (maxSeconds === null) return `≥ ${minMin} min`
+  const maxMin = Math.floor((maxSeconds + 1) / 60)
+  return `${minMin} – ${maxMin - 1} min`
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+export function PunctualityConfigPage() {
+  const { ranges, isLoading, form, fields, remove, onSubmit, addRow, isPending } =
+    usePunctualityConfigPage()
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors, isDirty },
+  } = form
+
+  if (isLoading) {
+    return (
+      <PageContainer>
+        <PageHeader title="Rangos de Puntualidad" description="Cargando configuración..." />
+      </PageContainer>
+    )
+  }
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title="Rangos de Puntualidad"
+        description="Define los niveles de bono según el tiempo de tardanza. El último nivel aplica a cualquier tardanza mayor o igual al umbral indicado."
+      />
+
+      <form onSubmit={handleSubmit(onSubmit)} className="mt-6 space-y-3 max-w-xl">
+
+        {/* Header row */}
+        <div className="grid grid-cols-[1fr_120px_120px_40px] gap-3 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wide">
+          <span>Desde (min)</span>
+          <span className="text-right">Hasta (calculado)</span>
+          <span className="text-right">Bono %</span>
+          <span />
+        </div>
+
+        {fields.map((field, index) => {
+          const isFirst = index === 0
+          const isLast = index === fields.length - 1
+          const thresholdMinutes = watch(`rows.${index}.threshold_minutes`)
+          const nextThreshold = watch(`rows.${index + 1}.threshold_minutes`)
+
+          let uptoLabel = '—'
+          if (isLast) {
+            uptoLabel = '∞'
+          } else if (nextThreshold != null && nextThreshold > thresholdMinutes) {
+            uptoLabel = `${nextThreshold - 1} min`
+          }
+
+          return (
+            <div
+              key={field.id}
+              className="grid grid-cols-[1fr_120px_120px_40px] gap-3 items-start rounded-lg border bg-card px-4 py-3"
+            >
+              {/* Threshold */}
+              <div>
+                <Input
+                  type="number"
+                  min={0}
+                  step={1}
+                  disabled={isFirst}
+                  className={isFirst ? 'opacity-60 cursor-not-allowed' : ''}
+                  {...register(`rows.${index}.threshold_minutes`, { valueAsNumber: true })}
+                />
+                {errors.rows?.[index]?.threshold_minutes && (
+                  <p className="mt-1 text-xs text-red-600">
+                    {errors.rows[index]?.threshold_minutes?.message}
+                  </p>
+                )}
+              </div>
+
+              {/* Until label */}
+              <div className="flex items-center justify-end h-9 text-sm text-muted-foreground">
+                {uptoLabel}
+              </div>
+
+              {/* Bonus % */}
+              <div>
+                <div className="flex items-center gap-1">
+                  <Input
+                    type="number"
+                    min={0}
+                    max={100}
+                    step={0.01}
+                    className="text-right"
+                    {...register(`rows.${index}.bonus_percentage`, { valueAsNumber: true })}
+                  />
+                  <span className="text-sm text-muted-foreground shrink-0">%</span>
+                </div>
+                {errors.rows?.[index]?.bonus_percentage && (
+                  <p className="mt-1 text-xs text-red-600">
+                    {errors.rows[index]?.bonus_percentage?.message}
+                  </p>
+                )}
+              </div>
+
+              {/* Delete */}
+              <div className="flex items-center justify-center h-9">
+                <button
+                  type="button"
+                  onClick={() => remove(index)}
+                  disabled={isFirst || fields.length === 1}
+                  aria-label="Eliminar nivel"
+                  title="Eliminar nivel"
+                  className="text-muted-foreground hover:text-destructive disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              </div>
+            </div>
+          )
+        })}
+
+        {/* Current preview of saved ranges */}
+        {ranges && (
+          <p className="text-xs text-muted-foreground px-1">
+            Rangos actuales guardados: {ranges.map((r) => rangeLabel(r.min_seconds, r.max_seconds)).join(' · ')}
+          </p>
+        )}
+
+        {/* Actions */}
+        <div className="flex items-center gap-3 pt-2">
+          <Button type="button" variant="outline" size="sm" onClick={addRow}>
+            <Plus className="h-4 w-4 mr-1" />
+            Agregar nivel
+          </Button>
+          <Button type="submit" disabled={!isDirty || isPending}>
+            {isPending ? 'Guardando...' : 'Guardar cambios'}
+          </Button>
+        </div>
+      </form>
+    </PageContainer>
+  )
+}

--- a/code/webapp/src/pages/attendance/use-punctuality-config-page.ts
+++ b/code/webapp/src/pages/attendance/use-punctuality-config-page.ts
@@ -1,0 +1,78 @@
+import { useEffect } from 'react'
+import { useForm, useFieldArray, type SubmitHandler } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { usePunctualityRanges, useUpdatePunctualityRanges } from '@/services/punctuality-config-hooks'
+
+const rowSchema = z.object({
+  threshold_minutes: z.number().int().min(0),
+  bonus_percentage: z.number().min(0).max(100),
+})
+
+export const rangesSchema = z
+  .object({ rows: z.array(rowSchema).min(1) })
+  .superRefine(({ rows }, ctx) => {
+    if (rows[0]?.threshold_minutes !== 0) {
+      ctx.addIssue({ code: 'custom', path: ['rows', 0, 'threshold_minutes'], message: 'Debe ser 0' })
+    }
+    rows.forEach((row, i) => {
+      if (i > 0 && row.threshold_minutes <= rows[i - 1]!.threshold_minutes) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['rows', i, 'threshold_minutes'],
+          message: 'Debe ser mayor que el nivel anterior',
+        })
+      }
+    })
+  })
+
+export type RangesFormValues = z.infer<typeof rangesSchema>
+
+export function usePunctualityConfigPage() {
+  const { data: ranges, isLoading } = usePunctualityRanges()
+  const update = useUpdatePunctualityRanges()
+
+  const form = useForm<RangesFormValues>({
+    resolver: zodResolver(rangesSchema),
+    defaultValues: { rows: [{ threshold_minutes: 0, bonus_percentage: 100 }] },
+  })
+
+  const { reset } = form
+  const { fields, append, remove } = useFieldArray({ control: form.control, name: 'rows' })
+
+  useEffect(() => {
+    if (ranges) {
+      reset({
+        rows: ranges.map((r) => ({
+          threshold_minutes: Math.floor(r.min_seconds / 60),
+          bonus_percentage: r.bonus_percentage,
+        })),
+      })
+    }
+  }, [ranges, reset])
+
+  const onSubmit: SubmitHandler<RangesFormValues> = (values) => {
+    update.mutate({
+      ranges: values.rows.map((row) => ({
+        min_seconds: row.threshold_minutes * 60,
+        bonus_percentage: row.bonus_percentage,
+      })),
+    })
+  }
+
+  const addRow = () => {
+    const lastMinutes = form.watch(`rows.${fields.length - 1}.threshold_minutes`) ?? 0
+    append({ threshold_minutes: lastMinutes + 10, bonus_percentage: 0 })
+  }
+
+  return {
+    ranges,
+    isLoading,
+    form,
+    fields,
+    remove,
+    onSubmit,
+    addRow,
+    isPending: update.isPending,
+  }
+}

--- a/code/webapp/src/routeTree.gen.ts
+++ b/code/webapp/src/routeTree.gen.ts
@@ -34,6 +34,7 @@ import { Route as CashTerminalsRouteImport } from './pages/cash/terminals'
 import { Route as CashRegistersRouteImport } from './pages/cash/registers'
 import { Route as CashBankAccountsRouteImport } from './pages/cash/bank-accounts'
 import { Route as AttendanceTodayRouteImport } from './pages/attendance/today'
+import { Route as AttendancePunctualityConfigRouteImport } from './pages/attendance/punctuality-config'
 
 const UnauthorizedRoute = UnauthorizedRouteImport.update({
   id: '/unauthorized',
@@ -160,6 +161,12 @@ const AttendanceTodayRoute = AttendanceTodayRouteImport.update({
   path: '/attendance/today',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AttendancePunctualityConfigRoute =
+  AttendancePunctualityConfigRouteImport.update({
+    id: '/attendance/punctuality-config',
+    path: '/attendance/punctuality-config',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -178,6 +185,7 @@ export interface FileRoutesByFullPath {
   '/solicitudes': typeof SolicitudesRoute
   '/stock-dashboard': typeof StockDashboardRoute
   '/unauthorized': typeof UnauthorizedRoute
+  '/attendance/punctuality-config': typeof AttendancePunctualityConfigRoute
   '/attendance/today': typeof AttendanceTodayRoute
   '/cash/bank-accounts': typeof CashBankAccountsRoute
   '/cash/registers': typeof CashRegistersRoute
@@ -203,6 +211,7 @@ export interface FileRoutesByTo {
   '/solicitudes': typeof SolicitudesRoute
   '/stock-dashboard': typeof StockDashboardRoute
   '/unauthorized': typeof UnauthorizedRoute
+  '/attendance/punctuality-config': typeof AttendancePunctualityConfigRoute
   '/attendance/today': typeof AttendanceTodayRoute
   '/cash/bank-accounts': typeof CashBankAccountsRoute
   '/cash/registers': typeof CashRegistersRoute
@@ -231,6 +240,7 @@ export interface FileRoutesById {
   '/solicitudes': typeof SolicitudesRoute
   '/stock-dashboard': typeof StockDashboardRoute
   '/unauthorized': typeof UnauthorizedRoute
+  '/attendance/punctuality-config': typeof AttendancePunctualityConfigRoute
   '/attendance/today': typeof AttendanceTodayRoute
   '/cash/bank-accounts': typeof CashBankAccountsRoute
   '/cash/registers': typeof CashRegistersRoute
@@ -260,6 +270,7 @@ export interface FileRouteTypes {
     | '/solicitudes'
     | '/stock-dashboard'
     | '/unauthorized'
+    | '/attendance/punctuality-config'
     | '/attendance/today'
     | '/cash/bank-accounts'
     | '/cash/registers'
@@ -285,6 +296,7 @@ export interface FileRouteTypes {
     | '/solicitudes'
     | '/stock-dashboard'
     | '/unauthorized'
+    | '/attendance/punctuality-config'
     | '/attendance/today'
     | '/cash/bank-accounts'
     | '/cash/registers'
@@ -312,6 +324,7 @@ export interface FileRouteTypes {
     | '/solicitudes'
     | '/stock-dashboard'
     | '/unauthorized'
+    | '/attendance/punctuality-config'
     | '/attendance/today'
     | '/cash/bank-accounts'
     | '/cash/registers'
@@ -340,6 +353,7 @@ export interface RootRouteChildren {
   SolicitudesRoute: typeof SolicitudesRoute
   StockDashboardRoute: typeof StockDashboardRoute
   UnauthorizedRoute: typeof UnauthorizedRoute
+  AttendancePunctualityConfigRoute: typeof AttendancePunctualityConfigRoute
   AttendanceTodayRoute: typeof AttendanceTodayRoute
 }
 
@@ -520,6 +534,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AttendanceTodayRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/attendance/punctuality-config': {
+      id: '/attendance/punctuality-config'
+      path: '/attendance/punctuality-config'
+      fullPath: '/attendance/punctuality-config'
+      preLoaderRoute: typeof AttendancePunctualityConfigRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -574,6 +595,7 @@ const rootRouteChildren: RootRouteChildren = {
   SolicitudesRoute: SolicitudesRoute,
   StockDashboardRoute: StockDashboardRoute,
   UnauthorizedRoute: UnauthorizedRoute,
+  AttendancePunctualityConfigRoute: AttendancePunctualityConfigRoute,
   AttendanceTodayRoute: AttendanceTodayRoute,
 }
 export const routeTree = rootRouteImport

--- a/code/webapp/src/services/__tests__/punctuality-config-api.test.ts
+++ b/code/webapp/src/services/__tests__/punctuality-config-api.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { punctualityConfigApi } from '../punctuality-config-api'
+
+vi.mock('@/lib/api-client', () => ({
+  apiClient: {
+    get: vi.fn(),
+    put: vi.fn(),
+  },
+}))
+
+import { apiClient } from '@/lib/api-client'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('punctualityConfigApi.listRanges', () => {
+  it('calls GET /punctuality/ranges', async () => {
+    const mockResponse = { data: { status: 200, data: [] } }
+    vi.mocked(apiClient.get).mockResolvedValue(mockResponse)
+
+    const result = await punctualityConfigApi.listRanges()
+
+    expect(apiClient.get).toHaveBeenCalledWith('/punctuality/ranges')
+    expect(result).toEqual(mockResponse)
+  })
+})
+
+describe('punctualityConfigApi.updateRanges', () => {
+  it('calls PUT /punctuality/ranges with the payload', async () => {
+    const payload = { ranges: [{ min_seconds: 0, bonus_percentage: 100 }] }
+    const mockResponse = { data: { status: 200, data: [] } }
+    vi.mocked(apiClient.put).mockResolvedValue(mockResponse)
+
+    const result = await punctualityConfigApi.updateRanges(payload)
+
+    expect(apiClient.put).toHaveBeenCalledWith('/punctuality/ranges', payload)
+    expect(result).toEqual(mockResponse)
+  })
+})

--- a/code/webapp/src/services/__tests__/punctuality-config-hooks.test.tsx
+++ b/code/webapp/src/services/__tests__/punctuality-config-hooks.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import React from 'react'
+import type { PunctualityRange } from '@/types/punctuality'
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockListRanges = vi.fn()
+const mockUpdateRanges = vi.fn()
+const mockShowSuccess = vi.fn()
+const mockShowError = vi.fn()
+
+vi.mock('@/services/punctuality-config-api', () => ({
+  punctualityConfigApi: {
+    listRanges: (...args: unknown[]) => mockListRanges(...args),
+    updateRanges: (...args: unknown[]) => mockUpdateRanges(...args),
+  },
+}))
+
+vi.mock('@/components/ui/toast-provider', () => ({
+  useToast: () => ({ showSuccess: mockShowSuccess, showError: mockShowError }),
+}))
+
+import { usePunctualityRanges, useUpdatePunctualityRanges } from '../punctuality-config-hooks'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children)
+}
+
+const fakeRange: PunctualityRange = {
+  id: 'abc',
+  min_seconds: 0,
+  max_seconds: 599,
+  bonus_percentage: 100,
+  sort_order: 1,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+// ── usePunctualityRanges ──────────────────────────────────────────────────────
+
+describe('usePunctualityRanges', () => {
+  it('returns data from listRanges', async () => {
+    mockListRanges.mockResolvedValue({ data: { data: [fakeRange] } })
+    const { result } = renderHook(() => usePunctualityRanges(), { wrapper: makeWrapper() })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual([fakeRange])
+  })
+
+  it('starts with data undefined before resolving', () => {
+    mockListRanges.mockReturnValue(new Promise(() => {}))
+    const { result } = renderHook(() => usePunctualityRanges(), { wrapper: makeWrapper() })
+    expect(result.current.data).toBeUndefined()
+  })
+})
+
+// ── useUpdatePunctualityRanges ────────────────────────────────────────────────
+
+describe('useUpdatePunctualityRanges', () => {
+  const payload = { ranges: [{ min_seconds: 0, bonus_percentage: 100 }] }
+
+  it('calls punctualityConfigApi.updateRanges with the payload', async () => {
+    mockUpdateRanges.mockResolvedValue({ data: { data: [fakeRange] } })
+    const { result } = renderHook(() => useUpdatePunctualityRanges(), { wrapper: makeWrapper() })
+
+    act(() => { result.current.mutate(payload) })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockUpdateRanges).toHaveBeenCalledWith(payload)
+  })
+
+  it('shows success toast on success', async () => {
+    mockUpdateRanges.mockResolvedValue({ data: { data: [fakeRange] } })
+    const { result } = renderHook(() => useUpdatePunctualityRanges(), { wrapper: makeWrapper() })
+
+    act(() => { result.current.mutate(payload) })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockShowSuccess).toHaveBeenCalledWith(
+      'Rangos de puntualidad actualizados.',
+      'Puntualidad',
+    )
+  })
+
+  it('shows error toast on failure', async () => {
+    mockUpdateRanges.mockRejectedValue(new Error('Network error'))
+    const { result } = renderHook(() => useUpdatePunctualityRanges(), { wrapper: makeWrapper() })
+
+    act(() => { result.current.mutate(payload) })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(mockShowError).toHaveBeenCalled()
+  })
+
+  it('starts with isPending false', () => {
+    const { result } = renderHook(() => useUpdatePunctualityRanges(), { wrapper: makeWrapper() })
+    expect(result.current.isPending).toBe(false)
+  })
+})

--- a/code/webapp/src/services/punctuality-config-api.ts
+++ b/code/webapp/src/services/punctuality-config-api.ts
@@ -1,0 +1,11 @@
+import { apiClient } from '@/lib/api-client'
+import type { PunctualityRange, UpdatePunctualityRangesPayload } from '@/types/punctuality'
+
+export const punctualityConfigApi = {
+  listRanges: () =>
+    apiClient.get<{ status: number; data: PunctualityRange[] }>('/punctuality/ranges'),
+
+  /** Full replacement — server computes max_seconds and sort_order from the sorted list. */
+  updateRanges: (payload: UpdatePunctualityRangesPayload) =>
+    apiClient.put<{ status: number; data: PunctualityRange[] }>('/punctuality/ranges', payload),
+}

--- a/code/webapp/src/services/punctuality-config-hooks.ts
+++ b/code/webapp/src/services/punctuality-config-hooks.ts
@@ -1,0 +1,33 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { getApiErrorMessage } from '@/lib/api-error'
+import { useToast } from '@/components/ui/toast-provider'
+import type { PunctualityRange, UpdatePunctualityRangesPayload } from '@/types/punctuality'
+import { punctualityConfigApi } from './punctuality-config-api'
+
+export function usePunctualityRanges() {
+  return useQuery<PunctualityRange[]>({
+    queryKey: ['punctuality-ranges'],
+    queryFn: async () => {
+      const response = await punctualityConfigApi.listRanges()
+      return response.data.data
+    },
+    staleTime: 5 * 60_000,
+  })
+}
+
+export function useUpdatePunctualityRanges() {
+  const queryClient = useQueryClient()
+  const { showSuccess, showError } = useToast()
+
+  return useMutation({
+    mutationFn: (payload: UpdatePunctualityRangesPayload) =>
+      punctualityConfigApi.updateRanges(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['punctuality-ranges'] })
+      showSuccess('Rangos de puntualidad actualizados.', 'Puntualidad')
+    },
+    onError: (error: unknown) => {
+      showError(getApiErrorMessage(error, 'Error al actualizar los rangos.'), 'Puntualidad')
+    },
+  })
+}

--- a/code/webapp/src/types/punctuality.ts
+++ b/code/webapp/src/types/punctuality.ts
@@ -1,0 +1,12 @@
+export interface PunctualityRange {
+  id: string
+  min_seconds: number
+  max_seconds: number | null
+  bonus_percentage: number
+  sort_order: number
+}
+
+/** Full-replacement payload — server recomputes max_seconds and sort_order. */
+export interface UpdatePunctualityRangesPayload {
+  ranges: { min_seconds: number; bonus_percentage: number }[]
+}


### PR DESCRIPTION
## Summary

- Endpoint `GET /api/v1/punctuality/ranges` — lista rangos ordenados por `sort_order`
- Endpoint `PUT /api/v1/punctuality/ranges` — reemplaza atómicamente todos los rangos; el backend calcula `max_seconds` y `sort_order` automáticamente
- Modelo `PunctualityRange` con método `matches(int $lateSeconds): bool`
- Seeder con 5 rangos default (0–9m=100%, 10–14m=50%, 15–20m=25%, 21–25m=10%, 26m+=0%)
- Página `/attendance/punctuality-config` — tabla editable de rangos con validación (primer umbral=0, orden estrictamente creciente)
- Permiso `punctuality.manage` registrado en seeders de permisos

## Test plan

- [x] PHPUnit Feature: list ranges (auth, forbidden, happy path)
- [x] PHPUnit Feature: replace ranges (validación, sorting server-side, open-ended last range)
- [x] PHPUnit Unit: `PunctualityRange::matches()` boundary cases con DataProvider
- [x] Cypress E2E: happy path — admin ve rangos, edita umbrales y guarda

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pakodiazdev/sushigo/pull/142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
