### PR TITLE
✨ [#144] - Add Procfile.dev and init-agent-workspace.sh for dev-lab support

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web:    php -S 0.0.0.0:${APP_PORT:-8000} -t public
+vite:   npm --prefix ../webapp run dev -- --port ${VITE_PORT:-5173} --host 0.0.0.0

--- a/init-agent-workspace.sh
+++ b/init-agent-workspace.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+
+# Load agent-specific env vars (APP_PORT, VITE_PORT, DB_DATABASE, etc.)
+if [ -f .env ]; then
+  set -o allexport
+  # shellcheck source=/dev/null
+  source .env
+  set +o allexport
+fi
+
+APP_PORT="${APP_PORT:-8000}"
+VITE_PORT="${VITE_PORT:-5173}"
+
+if ! command -v overmind &>/dev/null; then
+  echo "❌ Overmind not found. Install with: brew install overmind"
+  exit 1
+fi
+
+if [ ! -f Procfile.dev ]; then
+  echo "❌ Procfile.dev not found. Make sure you are inside the sushigo repo root."
+  exit 1
+fi
+
+echo ""
+echo "🚀 Starting agent workspace"
+echo "   Backend  → http://127.0.0.1:${APP_PORT}"
+echo "   Frontend → http://localhost:${VITE_PORT}"
+echo ""
+
+overmind start -f Procfile.dev


### PR DESCRIPTION
## Summary

Adds two files to the sushigo root so that the [sushigo-dev-lab](https://github.com/pakodiazdev/sushigo-dev-lab) can boot any clone without knowing Laravel or Vite internals.

- **`Procfile.dev`** — defines the two named processes Overmind will manage:
  - `web`: `php -S 0.0.0.0:${APP_PORT:-8000} -t public`
  - `vite`: `npm --prefix ../webapp run dev -- --port ${VITE_PORT:-5173} --host 0.0.0.0`
  
- **`init-agent-workspace.sh`** — boot script called by dev-lab's `init.sh`:
  - Sources the agent-level `.env` (sets `APP_PORT`, `VITE_PORT`)
  - Guards against missing `overmind` or `Procfile.dev`
  - Prints the backend and frontend URLs before starting
  - Calls `overmind start -f Procfile.dev` (foreground by default)

**Key design decision:** sushigo knows how to boot itself. The dev-lab only clones and orchestrates — it never hardcodes Laravel or Vite command details.

## Test plan

- [ ] `bash init-agent-workspace.sh` — starts both `web` and `vite` via Overmind with default ports
- [ ] Agent with custom `.env` (`APP_PORT=8002`, `VITE_PORT=5172`) — ports are picked up correctly
- [ ] `overmind restart web` — web process restarts independently
- [ ] `overmind stop` — both processes stop cleanly

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)