### PR TITLE
🐛 [#154] - Fix frontend-backend integration: parametric HMR and webapp .env

### DIFF
--- a/code/webapp/.env.example
+++ b/code/webapp/.env.example
@@ -59,5 +59,12 @@ VITE_APP_ENV=production
 # Agent Label (local dev only)
 # ----------------
 # Shown in the browser tab title to distinguish between local dev agents.
-# e.g. ' [A]' shows 'SushiGo [A]' in the tab. Leave empty for production.
+# e.g. '[A] ' shows 'SushiGo [A]' in the tab. Leave empty for production.
 VITE_AGENT_LABEL=
+
+# Environment Badge (local dev / QA only)
+# ----------------------------------------
+# Emoji prefix in the browser tab to indicate the environment at a glance.
+# Mirrors the envBadge pattern from atreyu-library.
+# 🟢 = local dev | 🟠 = QA/staging | (empty) = production
+VITE_ENV_BADGE=

--- a/code/webapp/.env.example
+++ b/code/webapp/.env.example
@@ -55,3 +55,9 @@ VITE_DEV_DEBUGGER_START_HIDDEN=false
 VITE_LOGIN_WITH_DEVDEBUG=false
 VITE_DEV_LOGIN_ALLOWED_ENVIRONMENTS=dev,devtest
 VITE_APP_ENV=production
+
+# Agent Label (local dev only)
+# ----------------
+# Shown in the browser tab title to distinguish between local dev agents.
+# e.g. ' [A]' shows 'SushiGo [A]' in the tab. Leave empty for production.
+VITE_AGENT_LABEL=

--- a/code/webapp/.env.example
+++ b/code/webapp/.env.example
@@ -5,7 +5,7 @@
 # API Configuration
 # -----------------
 # Base URL for the backend API
-# Default: http://localhost:8080/api/v1
+# Local dev (sushigo-dev-lab): http://localhost:<APP_PORT>/api/v1  e.g. http://localhost:8001/api/v1
 # Production: Set to your production API URL
 VITE_API_URL=https://api.sushigo.local/api/v1
 
@@ -14,6 +14,15 @@ VITE_API_URL=https://api.sushigo.local/api/v1
 # - All API calls use this base URL automatically
 # - For production, update to your production backend URL
 # - Must start with http:// or https://
+
+# HMR (Hot Module Replacement) Configuration
+# -------------------------------------------
+# Controls Vite's WebSocket connection for live reload.
+# Leave UNSET for direct local dev (Vite auto-detects host and port).
+# Set for Docker/nginx environments where a proxy handles the WebSocket.
+# VITE_HMR_HOST=sushigo.local       ← nginx proxy hostname
+# VITE_HMR_PROTOCOL=wss             ← 'ws' or 'wss' (default: wss)
+# VITE_HMR_PORT=443                 ← port the browser connects to (default: 443)
 
 # E2E Testing Configuration
 # --------------------------

--- a/code/webapp/index.html
+++ b/code/webapp/index.html
@@ -11,7 +11,7 @@
   <meta name="googlebot" content="noindex, nofollow, noarchive, nosnippet, noimageindex" />
   <meta name="bingbot" content="noindex, nofollow, noarchive, nosnippet, noimageindex" />
 
-  <title>%VITE_AGENT_LABEL%SushiGo</title>
+  <title>%VITE_ENV_BADGE%%VITE_AGENT_LABEL%SushiGo</title>
 </head>
 
 <body>

--- a/code/webapp/index.html
+++ b/code/webapp/index.html
@@ -11,7 +11,7 @@
   <meta name="googlebot" content="noindex, nofollow, noarchive, nosnippet, noimageindex" />
   <meta name="bingbot" content="noindex, nofollow, noarchive, nosnippet, noimageindex" />
 
-  <title>SushiGo</title>
+  <title>SushiGo%VITE_AGENT_LABEL%</title>
 </head>
 
 <body>

--- a/code/webapp/index.html
+++ b/code/webapp/index.html
@@ -11,7 +11,7 @@
   <meta name="googlebot" content="noindex, nofollow, noarchive, nosnippet, noimageindex" />
   <meta name="bingbot" content="noindex, nofollow, noarchive, nosnippet, noimageindex" />
 
-  <title>SushiGo%VITE_AGENT_LABEL%</title>
+  <title>%VITE_AGENT_LABEL%SushiGo</title>
 </head>
 
 <body>

--- a/code/webapp/vite.config.ts
+++ b/code/webapp/vite.config.ts
@@ -29,14 +29,15 @@ export default defineConfig({
       usePolling: true,
       ignored: ['**/routeTree.gen.ts'],
     },
-    hmr: {
-      // Usar el protocolo del cliente (wss:// cuando se accede por HTTPS)
-      protocol: 'wss',
-      // Usar el host desde variable de entorno o default a sushigo.local
-      host: process.env.VITE_HMR_HOST || 'sushigo.local',
-      // Puerto 443 (HTTPS por defecto) - nginx proxy redirigirá el WebSocket
-      clientPort: 443,
-    },
+    // When VITE_HMR_HOST is set (Docker/nginx environments), use explicit config.
+    // When unset (direct local dev), let Vite auto-detect (default behavior).
+    hmr: process.env.VITE_HMR_HOST
+      ? {
+          protocol: (process.env.VITE_HMR_PROTOCOL as 'ws' | 'wss') || 'wss',
+          host: process.env.VITE_HMR_HOST,
+          clientPort: parseInt(process.env.VITE_HMR_PORT || '443'),
+        }
+      : true,
   },
   test: {
     environment: 'node',

--- a/code/webapp/vite.config.ts
+++ b/code/webapp/vite.config.ts
@@ -1,63 +1,69 @@
 /// <reference types="vitest/config" />
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react-swc'
 import { TanStackRouterVite } from '@tanstack/router-vite-plugin'
 import path from 'path'
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [
-    react(),
-    TanStackRouterVite({
-      routesDirectory: './src/pages',
-      generatedRouteTree: './src/routeTree.gen.ts',
-      routeFilePrefix: '',
-      routeFileIgnorePrefix: '-',
-    }),
-  ],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
+export default defineConfig(({ mode }) => {
+  // Vite does not expose .env vars in process.env when evaluating vite.config.ts,
+  // so we load them explicitly with loadEnv before branching on any VITE_* value.
+  const env = loadEnv(mode, process.cwd(), '')
+
+  return {
+    plugins: [
+      react(),
+      TanStackRouterVite({
+        routesDirectory: './src/pages',
+        generatedRouteTree: './src/routeTree.gen.ts',
+        routeFilePrefix: '',
+        routeFileIgnorePrefix: '-',
+      }),
+    ],
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+      },
     },
-  },
-  server: {
-    host: '0.0.0.0',
-    port: parseInt(process.env.VITE_PORT || '5173'),
-    allowedHosts: ['.localhost', '.dev', '.local', 'cypress-ui', 'sushigo.local', 'devtest.sushigo.local'],
-    strictPort: true,
-    watch: {
-      usePolling: true,
-      ignored: ['**/routeTree.gen.ts'],
+    server: {
+      host: '0.0.0.0',
+      port: parseInt(env.VITE_PORT || '5173'),
+      allowedHosts: ['.localhost', '.dev', '.local', 'cypress-ui', 'sushigo.local', 'devtest.sushigo.local'],
+      strictPort: true,
+      watch: {
+        usePolling: true,
+        ignored: ['**/routeTree.gen.ts'],
+      },
+      // When VITE_HMR_HOST is set (Docker/nginx environments), use explicit config.
+      // When unset (direct local dev), let Vite auto-detect (default behavior).
+      hmr: env.VITE_HMR_HOST
+        ? {
+            protocol: (env.VITE_HMR_PROTOCOL as 'ws' | 'wss') || 'wss',
+            host: env.VITE_HMR_HOST,
+            clientPort: parseInt(env.VITE_HMR_PORT || '443'),
+          }
+        : true,
     },
-    // When VITE_HMR_HOST is set (Docker/nginx environments), use explicit config.
-    // When unset (direct local dev), let Vite auto-detect (default behavior).
-    hmr: process.env.VITE_HMR_HOST
-      ? {
-          protocol: (process.env.VITE_HMR_PROTOCOL as 'ws' | 'wss') || 'wss',
-          host: process.env.VITE_HMR_HOST,
-          clientPort: parseInt(process.env.VITE_HMR_PORT || '443'),
-        }
-      : true,
-  },
-  test: {
-    environment: 'node',
-    pool: 'threads',
-    testTimeout: 30000,
-    hookTimeout: 30000,
-    teardownTimeout: 5000,
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'lcov', 'json-summary'],
-      include: ['src/**/*.{ts,tsx}'],
-      exclude: [
-        'src/routeTree.gen.ts',
-        'src/main.tsx',
-        'src/**/*.d.ts',
-        'src/pages/**',
-        'src/**/__tests__/**',
-        'src/**/*.test.{ts,tsx}',
-        'src/**/*.spec.{ts,tsx}',
-      ],
+    test: {
+      environment: 'node',
+      pool: 'threads',
+      testTimeout: 30000,
+      hookTimeout: 30000,
+      teardownTimeout: 5000,
+      coverage: {
+        provider: 'v8',
+        reporter: ['text', 'lcov', 'json-summary'],
+        include: ['src/**/*.{ts,tsx}'],
+        exclude: [
+          'src/routeTree.gen.ts',
+          'src/main.tsx',
+          'src/**/*.d.ts',
+          'src/pages/**',
+          'src/**/__tests__/**',
+          'src/**/*.test.{ts,tsx}',
+          'src/**/*.spec.{ts,tsx}',
+        ],
+      },
     },
-  },
+  }
 })


### PR DESCRIPTION
## Summary

Fixes #154 — The frontend was unable to reach the backend and the HMR WebSocket was broken in local dev.

### Root causes

1. **Missing `code/webapp/.env`** — No `.env` file existed for the webapp, causing `VITE_API_URL` to fall back to the hardcoded default `http://localhost:8080/api/v1` (wrong port).
2. **Hardcoded HMR config** — `vite.config.ts` always set `hmr.host = 'sushigo.local'` and `clientPort = 443`, breaking the WebSocket connection in direct local dev (outside nginx proxy).

### Changes

- **`code/webapp/vite.config.ts`**: HMR config is now conditional on `VITE_HMR_HOST`:
  - When unset (local dev) → `hmr: true` → Vite auto-detects host/port ✅
  - When set (Docker/nginx) → uses `VITE_HMR_HOST`, `VITE_HMR_PROTOCOL`, `VITE_HMR_PORT` explicitly
- **`code/webapp/.env.example`**: Documented `VITE_API_URL` local dev pattern and the new optional HMR env vars.

### Local setup

The `code/webapp/.env` file (gitignored) must be created per agent. The `sushigo-dev-lab` scripts (`setup.sh`, `create-agent.sh`) now handle this automatically for new setups.

For existing agents, `code/webapp/.env` was already created manually with the correct `VITE_API_URL` per agent port.