### PR TITLE
🐛 [#157] - Fix spacing in browser tab title between env badge and agent label

### DIFF
--- a/code/webapp/index.html
+++ b/code/webapp/index.html
@@ -11,7 +11,7 @@
   <meta name="googlebot" content="noindex, nofollow, noarchive, nosnippet, noimageindex" />
   <meta name="bingbot" content="noindex, nofollow, noarchive, nosnippet, noimageindex" />
 
-  <title>%VITE_ENV_BADGE%%VITE_AGENT_LABEL%SushiGo</title>
+  <title>%VITE_ENV_BADGE% %VITE_AGENT_LABEL% SushiGo</title>
 </head>
 
 <body>


### PR DESCRIPTION
## Summary

Fixes #157

The browser tab title placeholders were concatenated without spaces, rendering as `🟢[A]SushiGo` instead of the readable `🟢 [A] SushiGo`.

## Change

**`code/webapp/index.html`**

```diff
- <title>%VITE_ENV_BADGE%%VITE_AGENT_LABEL%SushiGo</title>
+ <title>%VITE_ENV_BADGE% %VITE_AGENT_LABEL% SushiGo</title>
```

## Testing

Verified locally on agent-a (port 5171). Browser tab shows `🟢 [A] SushiGo` correctly.