### PR TITLE
✨ [#159] - Add dynamic workspace label to DevDebugger panel

### DIFF
--- a/code/webapp/.env.example
+++ b/code/webapp/.env.example
@@ -60,7 +60,14 @@ VITE_APP_ENV=production
 # ----------------
 # Shown in the browser tab title to distinguish between local dev agents.
 # e.g. '[A] ' shows 'SushiGo [A]' in the tab. Leave empty for production.
+# init.sh auto-injects '[A:#065]' format (slot + issue number) on every startup.
 VITE_AGENT_LABEL=
+
+# Git Branch (local dev only)
+# ---------------------------
+# Full git branch name, shown in the Dev Debugger header.
+# Injected automatically by init.sh on every startup. Leave empty for production.
+VITE_GIT_BRANCH=
 
 # Environment Badge (local dev / QA only)
 # ----------------------------------------

--- a/code/webapp/src/components/dev/DevDebugger.tsx
+++ b/code/webapp/src/components/dev/DevDebugger.tsx
@@ -127,11 +127,11 @@ export function DevDebugger() {
                 </div>
             </div>
 
-            {import.meta.env.VITE_GIT_BRANCH && (
+            {import.meta.env.VITE_GIT_BRANCH?.trim() && (
                 <div className="bg-gray-950 px-4 py-1.5 flex items-center gap-2 text-xs font-mono border-b border-gray-700">
                     <GitBranch className="h-3 w-3 text-yellow-400 shrink-0" />
-                    <span className="text-yellow-300 truncate">{import.meta.env.VITE_GIT_BRANCH}</span>
-                    {import.meta.env.VITE_AGENT_LABEL && (
+                    <span className="text-yellow-300 truncate">{import.meta.env.VITE_GIT_BRANCH.trim()}</span>
+                    {import.meta.env.VITE_AGENT_LABEL?.trim() && (
                         <span className="ml-auto text-gray-500 shrink-0">{import.meta.env.VITE_AGENT_LABEL.trim()}</span>
                     )}
                 </div>

--- a/code/webapp/src/components/dev/DevDebugger.tsx
+++ b/code/webapp/src/components/dev/DevDebugger.tsx
@@ -11,6 +11,7 @@ import {
     LogIn,
     Search,
     Loader2,
+    GitBranch,
     type LucideIcon,
 } from 'lucide-react'
 import { useDevDebugger } from './use-dev-debugger'
@@ -125,6 +126,16 @@ export function DevDebugger() {
                     </button>
                 </div>
             </div>
+
+            {import.meta.env.VITE_GIT_BRANCH && (
+                <div className="bg-gray-950 px-4 py-1.5 flex items-center gap-2 text-xs font-mono border-b border-gray-700">
+                    <GitBranch className="h-3 w-3 text-yellow-400 shrink-0" />
+                    <span className="text-yellow-300 truncate">{import.meta.env.VITE_GIT_BRANCH}</span>
+                    {import.meta.env.VITE_AGENT_LABEL && (
+                        <span className="ml-auto text-gray-500 shrink-0">{import.meta.env.VITE_AGENT_LABEL.trim()}</span>
+                    )}
+                </div>
+            )}
 
             <div className="flex-1 overflow-y-auto p-4 space-y-3 text-sm">
                 <Section

--- a/code/webapp/src/vite-env.d.ts
+++ b/code/webapp/src/vite-env.d.ts
@@ -30,6 +30,18 @@ interface ImportMetaEnv {
      * @see doc/tasks/backlog/101-dev-debug-login.md
      */
     readonly VITE_APP_ENV?: string
+    /**
+     * Agent label shown in the browser tab title — slot letter + git issue number.
+     * Injected by init.sh on every startup. Example: '[A:#065] '
+     * Corresponds to VITE_AGENT_LABEL in code/webapp/.env
+     */
+    readonly VITE_AGENT_LABEL?: string
+    /**
+     * Full git branch name of the workspace at the time of startup.
+     * Injected by init.sh on every startup. Example: 'feature/065-my-feature'
+     * Shown in the Dev Debugger header for multi-branch dev work.
+     */
+    readonly VITE_GIT_BRANCH?: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
Closes #159

## Summary

Surfaces workspace identity (slot letter + active issue number) and the current git branch directly in the frontend dev panel, eliminating workspace confusion during multi-agent parallel development sessions.

## Changes

### `src/components/dev/DevDebugger.tsx`
- Added `GitBranch` import from `lucide-react`
- Added a branch info bar between the blue header and the scrollable content:
  - Branch name in yellow (`VITE_GIT_BRANCH`) with branch icon
  - Slot label right-aligned in gray (`VITE_AGENT_LABEL`, e.g. `[A:#065]`)
  - Only renders when `VITE_GIT_BRANCH` is set (dev only — no production impact)

### `src/vite-env.d.ts`
- Added typed declarations for `VITE_AGENT_LABEL` and `VITE_GIT_BRANCH`

### `code/webapp/.env.example`
- Added `VITE_GIT_BRANCH=` with documentation comment explaining it is auto-injected by `init.sh`

## How it works

Both variables are injected by `init.sh` (in `sushigo-dev-lab`) on every workspace startup — no manual `.env` edits required. The label auto-updates on each `init.sh` run to reflect the current branch.

## Companion change

- `pakodiazdev/sushigo-dev-lab` — [#003 Add dynamic workspace label system and ADR documentation](https://github.com/pakodiazdev/sushigo-dev-lab/pull/4)