### PR TITLE
✨ [#159] - Dynamic workspace label in DevDebugger (live branch tracking)

### DIFF
--- a/code/webapp/.env.example
+++ b/code/webapp/.env.example
@@ -63,12 +63,6 @@ VITE_APP_ENV=production
 # init.sh auto-injects '[A:#065]' format (slot + issue number) on every startup.
 VITE_AGENT_LABEL=
 
-# Git Branch (local dev only)
-# ---------------------------
-# Full git branch name, shown in the Dev Debugger header.
-# Injected automatically by init.sh on every startup. Leave empty for production.
-VITE_GIT_BRANCH=
-
 # Environment Badge (local dev / QA only)
 # ----------------------------------------
 # Emoji prefix in the browser tab to indicate the environment at a glance.

--- a/code/webapp/src/components/dev/DevDebugger.tsx
+++ b/code/webapp/src/components/dev/DevDebugger.tsx
@@ -14,6 +14,7 @@ import {
     GitBranch,
     type LucideIcon,
 } from 'lucide-react'
+import { gitBranch } from 'virtual:git-branch'
 import { useDevDebugger } from './use-dev-debugger'
 
 export function DevDebugger() {
@@ -127,10 +128,10 @@ export function DevDebugger() {
                 </div>
             </div>
 
-            {import.meta.env.VITE_GIT_BRANCH?.trim() && (
+            {gitBranch && (
                 <div className="bg-gray-950 px-4 py-1.5 flex items-center gap-2 text-xs font-mono border-b border-gray-700">
                     <GitBranch className="h-3 w-3 text-yellow-400 shrink-0" />
-                    <span className="text-yellow-300 truncate">{import.meta.env.VITE_GIT_BRANCH.trim()}</span>
+                    <span className="text-yellow-300 truncate">{gitBranch}</span>
                     {import.meta.env.VITE_AGENT_LABEL?.trim() && (
                         <span className="ml-auto text-gray-500 shrink-0">{import.meta.env.VITE_AGENT_LABEL.trim()}</span>
                     )}

--- a/code/webapp/src/vite-env.d.ts
+++ b/code/webapp/src/vite-env.d.ts
@@ -36,12 +36,6 @@ interface ImportMetaEnv {
      * Corresponds to VITE_AGENT_LABEL in code/webapp/.env
      */
     readonly VITE_AGENT_LABEL?: string
-    /**
-     * Full git branch name of the workspace at the time of startup.
-     * Injected by init.sh on every startup. Example: 'feature/065-my-feature'
-     * Shown in the Dev Debugger header for multi-branch dev work.
-     */
-    readonly VITE_GIT_BRANCH?: string
 }
 
 interface ImportMeta {
@@ -51,6 +45,10 @@ interface ImportMeta {
 declare module '*.png' {
     const value: string
     export default value
+}
+
+declare module 'virtual:git-branch' {
+    export const gitBranch: string
 }
 
 declare module '*.jpg' {

--- a/code/webapp/vite.config.ts
+++ b/code/webapp/vite.config.ts
@@ -1,8 +1,45 @@
 /// <reference types="vitest/config" />
-import { defineConfig, loadEnv } from 'vite'
+import { defineConfig, loadEnv, type Plugin } from 'vite'
 import react from '@vitejs/plugin-react-swc'
 import { TanStackRouterVite } from '@tanstack/router-vite-plugin'
 import path from 'path'
+import { execSync } from 'child_process'
+
+const VIRTUAL_GIT_BRANCH_ID = 'virtual:git-branch'
+const RESOLVED_GIT_BRANCH_ID = '\0' + VIRTUAL_GIT_BRANCH_ID
+
+function getCurrentBranch(): string {
+    try {
+        return execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf-8' }).trim()
+    } catch {
+        return ''
+    }
+}
+
+function gitBranchPlugin(): Plugin {
+    return {
+        name: 'git-branch',
+        resolveId(id) {
+            if (id === VIRTUAL_GIT_BRANCH_ID) return RESOLVED_GIT_BRANCH_ID
+        },
+        load(id) {
+            if (id === RESOLVED_GIT_BRANCH_ID) {
+                return `export const gitBranch = ${JSON.stringify(getCurrentBranch())}`
+            }
+        },
+        configureServer(server) {
+            const gitHeadPath = path.resolve(process.cwd(), '.git/HEAD')
+            server.watcher.add(gitHeadPath)
+            server.watcher.on('change', (file) => {
+                if (file === gitHeadPath) {
+                    const mod = server.moduleGraph.getModuleById(RESOLVED_GIT_BRANCH_ID)
+                    if (mod) server.moduleGraph.invalidateModule(mod)
+                    server.hot.send({ type: 'full-reload' })
+                }
+            })
+        },
+    }
+}
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
@@ -13,6 +50,7 @@ export default defineConfig(({ mode }) => {
   return {
     plugins: [
       react(),
+      gitBranchPlugin(),
       TanStackRouterVite({
         routesDirectory: './src/pages',
         generatedRouteTree: './src/routeTree.gen.ts',


### PR DESCRIPTION
## Summary

Adds a branch identity bar to the **DevDebugger** panel that shows the current git branch and agent label. The branch label updates automatically on `git checkout` — no dev server restart required.

## Changes

### `code/webapp/src/components/dev/DevDebugger.tsx`
- Imports `GitBranch` icon from `lucide-react`
- Imports `gitBranch` from `virtual:git-branch` (Vite virtual module)
- Renders a dark bar between the header and content showing branch name + agent label

### `code/webapp/vite.config.ts`
- Added `gitBranchPlugin()` — Vite plugin that:
  - Exposes `virtual:git-branch` module returning `export const gitBranch = "..."` read via `execSync git rev-parse --abbrev-ref HEAD`
  - Watches `.git/HEAD` during dev server — invalidates the module and emits `full-reload` on `git checkout`

### `code/webapp/src/vite-env.d.ts`
- Removed `VITE_GIT_BRANCH` from `ImportMetaEnv` (no longer an env var)
- Added `declare module 'virtual:git-branch'` type declaration

### `code/webapp/.env.example`
- Removed `VITE_GIT_BRANCH` entry (no longer injected by scripts)

## Behavior

| Action | Result |
|---|---|
| Start dev server | Branch bar shows current branch immediately |
| `git checkout other-branch` | Browser reloads (~200ms), bar updates — server keeps running |
| `VITE_GIT_BRANCH` unset/missing | No regression — var is no longer used |

## Related

- Closes #159
- Companion PR (scripts cleanup): [pakodiazdev/sushigo-dev-lab#6](https://github.com/pakodiazdev/sushigo-dev-lab/pull/6)