### PR TITLE
🐛 [#159] - Fix git HEAD watcher path (resolves from wrong cwd)

### DIFF
--- a/code/webapp/vite.config.ts
+++ b/code/webapp/vite.config.ts
@@ -8,6 +8,14 @@ import { execSync } from 'child_process'
 const VIRTUAL_GIT_BRANCH_ID = 'virtual:git-branch'
 const RESOLVED_GIT_BRANCH_ID = '\0' + VIRTUAL_GIT_BRANCH_ID
 
+function getGitDir(): string {
+    try {
+        return execSync('git rev-parse --git-dir', { encoding: 'utf-8' }).trim()
+    } catch {
+        return '.git'
+    }
+}
+
 function getCurrentBranch(): string {
     try {
         return execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf-8' }).trim()
@@ -28,7 +36,7 @@ function gitBranchPlugin(): Plugin {
             }
         },
         configureServer(server) {
-            const gitHeadPath = path.resolve(process.cwd(), '.git/HEAD')
+            const gitHeadPath = path.resolve(getGitDir(), 'HEAD')
             server.watcher.add(gitHeadPath)
             server.watcher.on('change', (file) => {
                 if (file === gitHeadPath) {


### PR DESCRIPTION
## Problem

`gitBranchPlugin` registered a watcher on `path.resolve(process.cwd(), '.git/HEAD')`, assuming Vite's cwd contains a `.git` directory. But Vite runs from `code/webapp/` while the actual git repo root is two levels up at `workspaces/sushigo-a/`. The watcher path didn't exist, so `git checkout` never triggered the HMR reload.

## Fix

Replaced `process.cwd() + '/.git/HEAD'` with `git rev-parse --git-dir` which returns the absolute path to the git directory regardless of where the process is running from. Extracted to a `getGitDir()` helper.

```ts
// Before (broken — points to code/webapp/.git/HEAD which doesn't exist)
const gitHeadPath = path.resolve(process.cwd(), '.git/HEAD')

// After (correct — resolves to workspaces/sushigo-a/.git/HEAD)
const gitHeadPath = path.resolve(getGitDir(), 'HEAD')
```

## Related

- Fixes behavior introduced in #159 / PR #161