### PR TITLE
📚 [#163] - Document init-agent-workspace.sh as dev-lab startup method in CLAUDE.md 📚

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,20 @@ SushiGo is a full-stack tenant platform within the ComandaFlow ecosystem. **This
 
 ## Development Commands
 
+### Dev-Lab (multi-agent local development)
+
+When working inside [sushigo-dev-lab](https://github.com/pakodiazdev/sushigo-dev-lab), each workspace clone starts with:
+
+```bash
+./init-agent-workspace.sh   # starts Laravel (php artisan serve) + Vite via Overmind
+```
+
+This script lives at the root of this repo and is the **only startup method** when using the dev-lab.
+Shared services (PostgreSQL, Redis, Mailpit) are managed by the dev-lab's `docker compose up -d`.
+Do **not** run `docker compose up` from inside a workspace — that starts the full heavyweight stack.
+
+---
+
 ### Docker Development (Recommended)
 
 This monorepo runs inside `dev_container`. Each sub-project maps to a path inside the container:

--- a/doc/tasks/2026-06/163-document-dev-lab-startup-in-claude-md.md
+++ b/doc/tasks/2026-06/163-document-dev-lab-startup-in-claude-md.md
@@ -1,0 +1,45 @@
+# 🔧 Task #163: Document init-agent-workspace.sh in CLAUDE.md as dev-lab startup method
+
+## 📖 Story
+
+**English:**
+As an AI agent or developer working inside a `sushigo-dev-lab` workspace, I need `CLAUDE.md` to document the correct startup method (`init-agent-workspace.sh`) so I don't accidentally run the full heavyweight Docker stack inside a workspace clone.
+
+**Español:**
+Como agente o desarrollador trabajando dentro de un workspace de `sushigo-dev-lab`, necesito que `CLAUDE.md` documente el método de arranque correcto (`init-agent-workspace.sh`) para no ejecutar accidentalmente el stack Docker completo dentro de un clon de workspace.
+
+---
+
+## ✅ Technical Tasks
+
+- [x] 📝 Add `### Dev-Lab (multi-agent local development)` section to `CLAUDE.md`
+- [x] 📝 Document `./init-agent-workspace.sh` as the startup method when using dev-lab
+- [x] 📝 Clarify that shared services (PostgreSQL, Redis, Mailpit) come from dev-lab's `docker compose up -d`
+- [x] 📝 Add warning: do NOT run `docker compose up` from inside a workspace when using dev-lab
+- [x] 📝 Add link to `sushigo-dev-lab` repo
+
+---
+
+## 🎯 Acceptance Criteria
+
+- [x] `CLAUDE.md` has a `### Dev-Lab (multi-agent local development)` section before the Docker section
+- [x] Section explains `init-agent-workspace.sh` purpose and usage
+- [x] Section warns against running `docker compose up` from workspace
+- [x] Section links to `sushigo-dev-lab` repo
+
+---
+
+## 🔗 References
+
+- **GitHub Issue:** [#163](https://github.com/pakodiazdev/sushigo/issues/163)
+- **dev-lab repo:** [pakodiazdev/sushigo-dev-lab](https://github.com/pakodiazdev/sushigo-dev-lab)
+- Related: pakodiazdev/sushigo-dev-lab #1
+
+---
+
+## ⏱️ Estimates
+
+- **Optimistic:** `15m`
+- **Pessimistic:** `30m`
+- **Tracked:** `~15m`
+- **Closed:** `2026-06-05`


### PR DESCRIPTION
## Summary

Closes #163

Adds a **Dev-Lab** section to `CLAUDE.md` documenting the correct startup method when working inside a `sushigo-dev-lab` workspace clone.

## Changes

- `CLAUDE.md`: new `### Dev-Lab (multi-agent local development)` section placed before the Docker Development section
- `doc/tasks/2026-06/163-document-dev-lab-startup-in-claude-md.md`: task file (Done)

## Why

Without this documentation, an AI agent or developer opening a workspace inside sushigo-dev-lab has no guidance in `CLAUDE.md` and may incorrectly run `docker compose up` — starting the full heavyweight 9-container stack instead of the lightweight Overmind-based setup.

## Type

📚 docs — no functional code changes