### PR TITLE
📚 [#163] Document dev-lab startup method in CLAUDE.md and add backlog task files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ SushiGo is a full-stack tenant platform within the ComandaFlow ecosystem. **This
 When working inside [sushigo-dev-lab](https://github.com/pakodiazdev/sushigo-dev-lab), each workspace clone starts with:
 
 ```bash
-./init-agent-workspace.sh   # starts Laravel (php artisan serve) + Vite via Overmind
+./init-agent-workspace.sh   # starts Laravel (php -S built-in server) + Vite via Overmind
 ```
 
 This script lives at the root of this repo and is the **only startup method** when using the dev-lab.

--- a/doc/tasks/backlog/096-leave-request.md
+++ b/doc/tasks/backlog/096-leave-request.md
@@ -1,0 +1,46 @@
+# 📝 Task #096: Leave Request — Solicitud Anticipada + Express + Aprobar/Rechazar
+
+## 📖 Story
+
+**Español:**
+Como empleado (registrado por el manager en su nombre), quiero solicitar un permiso con anticipación para que el manager pueda aprobarlo o rechazarlo. Para situaciones del mismo día, el manager usa un flujo de aprobación exprés. Al aprobar, los registros de asistencia se ajustan y la vista de Hoy refleja el contexto del permiso.
+
+---
+
+## ✅ Backend Tasks
+
+- [ ] 🔧 `POST /api/v1/leaves` — soporte para `submit_as_request = true` (crea PENDING, sin registros de asistencia)
+- [ ] 🔧 `PATCH /api/v1/leaves/{id}/approve` — `ApproveLeaveController` (ya existe estructura base)
+- [ ] 🔧 `PATCH /api/v1/leaves/{id}/reject` — `RejectLeaveController` con nota opcional (ya existe estructura base)
+- [ ] 🧪 PHPUnit: submit PENDING, aprobar OPEN_ENDED, aprobar SCHEDULED parcial, rechazar, doble-aprobación 422
+
+## ✅ Frontend Tasks
+
+- [ ] 🔧 Toggle "Guardar como solicitud" en `RegisterLeaveForm` (#78)
+- [ ] 🔧 Botones Aprobar/Rechazar en filas PENDING del tab Ausencias (#78) con `AlertDialog`
+- [ ] 🔧 `useLeaveActions(employeeId)` hook — mutations de approve/reject
+- [ ] 🧪 Cypress E2E: flujo anticipado (PENDING → APPROVED) + flujo exprés parcial (→ chip en tarjeta de Hoy)
+
+---
+
+## 🎯 Acceptance Criteria
+
+- [ ] Toggle "Guardar como solicitud" crea PENDING sin impacto en asistencia
+- [ ] Botón Aprobar solo visible en filas PENDING; crea registros LEAVE para OPEN_ENDED
+- [ ] Botón Rechazar solo visible en filas PENDING; cambia estado a REJECTED
+- [ ] Permiso parcial exprés (PROPORTIONAL_HOURS, aprobado directo) aparece como chip en vista de Hoy (#98)
+- [ ] No se puede aprobar un permiso ya aprobado (UI oculta botón + API retorna 422)
+
+---
+
+## 🔗 References
+
+- **GitHub Issue:** [#096](https://github.com/pakodiazdev/sushigo/issues/96)
+- Depende de: #77 (Leave model), #78 (pestaña Ausencias), #55 (CloseDayAction fix), #98 (leave context en tarjetas)
+- Código existente: `Actions/Leaves/`, `Controllers/Api/V1/Leaves/`, `Services/EmployeeRequests/`
+
+---
+
+## ⏱️ Estimates
+
+- **Optimistic:** `4h` · **Pessimistic:** `8h`

--- a/doc/tasks/backlog/135-filter-requests-by-manager-branch.md
+++ b/doc/tasks/backlog/135-filter-requests-by-manager-branch.md
@@ -1,0 +1,46 @@
+# 🔒 Task #135: Filtrar solicitudes pendientes por sucursal del Manager
+
+## 📖 Story
+
+**Español:**
+Como Manager, quiero ver únicamente las solicitudes pendientes de los empleados de mi sucursal, para no mezclar solicitudes de otras sucursales al momento de aprobar o rechazar.
+
+**English:**
+As a Manager, I need the pending requests list to be filtered by my branch so I only act on requests from employees I manage.
+
+---
+
+## ✅ Backend Tasks
+
+- [ ] 🔧 Definir cómo el Manager está vinculado a su sucursal (vía `EmploymentPeriod` activo o rol asignado)
+- [ ] 🔧 `ListEmployeeRequestsController` — agregar filtro `branch_id` del Manager autenticado cuando el rol es Manager
+- [ ] 🔧 `EmployeeRequestService::approve()` — validar que el Manager solo pueda aprobar solicitudes de su propia sucursal (403 si no coincide)
+- [ ] 🧪 Feature test: Manager solo ve y puede aprobar solicitudes de su sucursal; Admin ve todas
+
+## ✅ Frontend Tasks
+
+- [ ] 🔧 `usePendingRequests()` — pasar `branch_id` del Manager autenticado en los filtros de la query
+- [ ] 🧪 Verificar que la lista no muestra solicitudes de otras sucursales al loguear como Manager
+
+---
+
+## 🎯 Acceptance Criteria
+
+- [ ] Manager autenticado ve únicamente solicitudes PENDING de empleados de su sucursal
+- [ ] Manager no puede aprobar solicitudes de otras sucursales (API retorna 403)
+- [ ] Admin sigue viendo todas las solicitudes sin filtro de sucursal
+- [ ] En MVP (sucursal única) el comportamiento visible es idéntico al actual
+
+---
+
+## 🔗 References
+
+- **GitHub Issue:** [#135](https://github.com/pakodiazdev/sushigo/issues/135)
+- Detectado en PR #134 por Copilot review
+- Tarea relacionada: #125 (spec original)
+
+---
+
+## ⏱️ Estimates
+
+- **Optimistic:** `2h` · **Pessimistic:** `4h`

--- a/doc/tasks/backlog/135-filter-requests-by-manager-branch.md
+++ b/doc/tasks/backlog/135-filter-requests-by-manager-branch.md
@@ -2,11 +2,11 @@
 
 ## 📖 Story
 
-**Español:**
-Como Manager, quiero ver únicamente las solicitudes pendientes de los empleados de mi sucursal, para no mezclar solicitudes de otras sucursales al momento de aprobar o rechazar.
-
 **English:**
 As a Manager, I need the pending requests list to be filtered by my branch so I only act on requests from employees I manage.
+
+**Español:**
+Como Manager, quiero ver únicamente las solicitudes pendientes de los empleados de mi sucursal, para no mezclar solicitudes de otras sucursales al momento de aprobar o rechazar.
 
 ---
 

--- a/doc/tasks/backlog/147-skip-ci-on-doc-only-prs.md
+++ b/doc/tasks/backlog/147-skip-ci-on-doc-only-prs.md
@@ -1,0 +1,44 @@
+# 🔧 Task #147: Skip CI Workflows on Documentation-Only Pull Requests
+
+## 📖 Story
+
+**English:**
+As a developer merging documentation-only PRs (licensing docs, task files, README, architecture docs), I need CI workflows to skip entirely so that merge is not blocked by queued checks that have nothing to test.
+
+**Español:**
+Como desarrollador al mergear PRs de solo documentación, necesito que los CI workflows no corran para que el merge no quede bloqueado por checks en cola que no tienen nada que probar.
+
+---
+
+## ✅ Technical Tasks
+
+- [ ] 🔧 Add `paths: ['code/api/**']` to `on: pull_request:` trigger in `.github/workflows/api-lint.yml`
+- [ ] 🔧 Add `paths: ['code/api/**']` to `on: pull_request:` trigger in `.github/workflows/api-tests.yml`
+- [ ] 🔧 Add `paths: ['code/webapp/**']` to `on: pull_request:` trigger in `.github/workflows/webapp-lint.yml`
+- [ ] 🔧 Add `paths: ['code/webapp/**']` to `on: pull_request:` trigger in `.github/workflows/webapp-tests.yml`
+- [ ] 🧪 Verify: doc-only PR → zero CI checks appear → merge unblocked
+- [ ] 🧪 Verify: code PR → CI checks appear and run correctly
+- [ ] 🧪 Verify: mixed PR (code + docs) → only relevant suite runs
+
+---
+
+## 🎯 Acceptance Criteria
+
+- [ ] A PR changing only `doc/**`, `*.md`, or `LICENSE` triggers zero CI workflows
+- [ ] A PR changing `code/api/**` triggers `api-lint` and `api-tests`
+- [ ] A PR changing `code/webapp/**` triggers `webapp-lint` and `webapp-tests`
+- [ ] Branch protection required checks continue to work for code PRs
+- [ ] No changes required to branch protection rules
+
+---
+
+## 🔗 References
+
+- **GitHub Issue:** [#147](https://github.com/pakodiazdev/sushigo/issues/147)
+- Triggered by: PR #146 (doc-only PR blocked by pending api-sonar check)
+
+---
+
+## ⏱️ Estimates
+
+- **Optimistic:** `1h` · **Pessimistic:** `2h`


### PR DESCRIPTION
## Summary

- Documents `init-agent-workspace.sh` as the recommended startup method when using `sushigo-dev-lab`, so Claude Code and developers know the correct boot flow without reading external docs
- Adds three backlog task files for issues #096, #135 and #147

## Test plan

- [ ] Verify `CLAUDE.md` describes the dev-lab startup flow accurately
- [ ] Verify task files for #096, #135 and #147 are present in `doc/tasks/backlog/`

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)