### PR TITLE
✨ [#170] Add cypress-devlab make target for interactive E2E

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help e2e-ui cypress-ui cypress-run cypress-run-headed cypress-spec cypress-debug cypress-build chrome-clear-hsts ssl-info hosts-setup db-seed e2e-up e2e-down e2e-logs e2e-restart cypress-devlab
+.PHONY: help e2e-ui cypress-ui cypress-run cypress-run-headed cypress-spec cypress-debug cypress-build chrome-clear-hsts ssl-info hosts-setup db-seed e2e-up e2e-down e2e-logs e2e-restart cypress-devlab cypress-devlab-spec
 
 # Colores para output
 GREEN  := \033[0;32m
@@ -84,6 +84,27 @@ cypress-devlab: ## Open Cypress GUI against the sushigo-dev-lab E2E stack (run m
 	echo "  API URL   : http://localhost:$$API_PORT/api/v1"; \
 	E2E_CONTAINER="$$CONTAINER" VITE_PORT="$$VITE_PORT" E2E_API_PORT="$$API_PORT" \
 		npm --prefix code/webapp run cypress:open:devlab
+
+cypress-devlab-spec: ## Run a specific spec headed against dev-lab stack: make cypress-devlab-spec SPEC=login [GREP="text"]
+	@if [ -z "$(SPEC)" ]; then echo "$(RED)Usage: make cypress-devlab-spec SPEC=<name> [GREP='text']$(NC)"; exit 1; fi
+	@LETTER="$$(basename $$(pwd) | sed 's/sushigo-//')"; \
+	CONTAINER="$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1)"; \
+	if [ -z "$$CONTAINER" ]; then \
+		echo "$(RED)❌ Dev-lab E2E stack not running.$(NC)"; \
+		echo "   Start it with: $(YELLOW)make e2e WORKSPACE=sushigo-$$LETTER$(NC)  (from sushigo-dev-lab)"; \
+		exit 1; \
+	fi; \
+	OFFSET=$$(echo "$$LETTER" | tr 'a-h' '12345678'); \
+	VITE_PORT=$$((5180 + OFFSET)); \
+	API_PORT=$$((8900 + OFFSET)); \
+	echo "$(GREEN)Running spec (devlab): $(SPEC).cy.ts$(if $(GREP), [grep: $(GREP)])$(NC)"; \
+	echo "  Container : $$CONTAINER"; \
+	echo "  Base URL  : http://localhost:$$VITE_PORT"; \
+	E2E_CONTAINER="$$CONTAINER" VITE_PORT="$$VITE_PORT" E2E_API_PORT="$$API_PORT" \
+		npm --prefix code/webapp run cypress:run:devlab -- \
+		--headed --browser chrome \
+		--spec "cypress/e2e/$(SPEC).cy.ts" \
+		$(if $(GREP),--env grep="$(GREP)")
 
 cypress-run-headed: cypress-up ## Ejecutar TODOS los tests con navegador visible (ver en VNC http://localhost:6080)
 	@echo "$(GREEN)Ejecutando todos los tests en modo headed (VNC: http://localhost:6080)...$(NC)"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help e2e-ui cypress-ui cypress-run cypress-run-headed cypress-spec cypress-debug cypress-build chrome-clear-hsts ssl-info hosts-setup db-seed e2e-up e2e-down e2e-logs e2e-restart cypress-devlab cypress-devlab-spec
+.PHONY: help e2e-ui cypress-ui cypress-run cypress-run-headed cypress-spec cypress-debug cypress-build chrome-clear-hsts ssl-info hosts-setup db-seed e2e-up e2e-down e2e-logs e2e-restart cypress-devlab cypress-devlab-spec cypress-devlab-headed cypress-devlab-run cypress-devlab-run-spec
 
 # Colores para output
 GREEN  := \033[0;32m
@@ -103,6 +103,61 @@ cypress-devlab-spec: ## Run a specific spec headed against dev-lab stack: make c
 	E2E_CONTAINER="$$CONTAINER" VITE_PORT="$$VITE_PORT" E2E_API_PORT="$$API_PORT" \
 		npm --prefix code/webapp run cypress:run:devlab -- \
 		--headed --browser chrome \
+		--spec "cypress/e2e/$(SPEC).cy.ts" \
+		$(if $(GREP),--env grep="$(GREP)")
+
+cypress-devlab-headed: ## Run ALL specs headed (browser visible) against dev-lab stack
+	@LETTER="$$(basename $$(pwd) | sed 's/sushigo-//')"; \
+	CONTAINER="$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1)"; \
+	if [ -z "$$CONTAINER" ]; then \
+		echo "$(RED)❌ Dev-lab E2E stack not running.$(NC)"; \
+		echo "   Start it with: $(YELLOW)make e2e WORKSPACE=sushigo-$$LETTER$(NC)  (from sushigo-dev-lab)"; \
+		exit 1; \
+	fi; \
+	OFFSET=$$(echo "$$LETTER" | tr 'a-h' '12345678'); \
+	VITE_PORT=$$((5180 + OFFSET)); \
+	API_PORT=$$((8900 + OFFSET)); \
+	echo "$(GREEN)Running ALL specs headed (devlab)$(NC)"; \
+	echo "  Container : $$CONTAINER"; \
+	echo "  Base URL  : http://localhost:$$VITE_PORT"; \
+	E2E_CONTAINER="$$CONTAINER" VITE_PORT="$$VITE_PORT" E2E_API_PORT="$$API_PORT" \
+		npm --prefix code/webapp run cypress:run:devlab -- \
+		--headed --browser chrome
+
+cypress-devlab-run: ## Run ALL specs headless against dev-lab stack
+	@LETTER="$$(basename $$(pwd) | sed 's/sushigo-//')"; \
+	CONTAINER="$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1)"; \
+	if [ -z "$$CONTAINER" ]; then \
+		echo "$(RED)❌ Dev-lab E2E stack not running.$(NC)"; \
+		echo "   Start it with: $(YELLOW)make e2e WORKSPACE=sushigo-$$LETTER$(NC)  (from sushigo-dev-lab)"; \
+		exit 1; \
+	fi; \
+	OFFSET=$$(echo "$$LETTER" | tr 'a-h' '12345678'); \
+	VITE_PORT=$$((5180 + OFFSET)); \
+	API_PORT=$$((8900 + OFFSET)); \
+	echo "$(GREEN)Running ALL specs headless (devlab)$(NC)"; \
+	echo "  Container : $$CONTAINER"; \
+	echo "  Base URL  : http://localhost:$$VITE_PORT"; \
+	E2E_CONTAINER="$$CONTAINER" VITE_PORT="$$VITE_PORT" E2E_API_PORT="$$API_PORT" \
+		npm --prefix code/webapp run cypress:run:devlab
+
+cypress-devlab-run-spec: ## Run a specific spec headless against dev-lab stack: make cypress-devlab-run-spec SPEC=login [GREP="text"]
+	@if [ -z "$(SPEC)" ]; then echo "$(RED)Usage: make cypress-devlab-run-spec SPEC=<name> [GREP='text']$(NC)"; exit 1; fi
+	@LETTER="$$(basename $$(pwd) | sed 's/sushigo-//')"; \
+	CONTAINER="$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1)"; \
+	if [ -z "$$CONTAINER" ]; then \
+		echo "$(RED)❌ Dev-lab E2E stack not running.$(NC)"; \
+		echo "   Start it with: $(YELLOW)make e2e WORKSPACE=sushigo-$$LETTER$(NC)  (from sushigo-dev-lab)"; \
+		exit 1; \
+	fi; \
+	OFFSET=$$(echo "$$LETTER" | tr 'a-h' '12345678'); \
+	VITE_PORT=$$((5180 + OFFSET)); \
+	API_PORT=$$((8900 + OFFSET)); \
+	echo "$(GREEN)Running spec headless (devlab): $(SPEC).cy.ts$(if $(GREP), [grep: $(GREP)])$(NC)"; \
+	echo "  Container : $$CONTAINER"; \
+	echo "  Base URL  : http://localhost:$$VITE_PORT"; \
+	E2E_CONTAINER="$$CONTAINER" VITE_PORT="$$VITE_PORT" E2E_API_PORT="$$API_PORT" \
+		npm --prefix code/webapp run cypress:run:devlab -- \
 		--spec "cypress/e2e/$(SPEC).cy.ts" \
 		$(if $(GREP),--env grep="$(GREP)")
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help e2e-ui cypress-ui cypress-run cypress-run-headed cypress-spec cypress-debug cypress-build chrome-clear-hsts ssl-info hosts-setup db-seed e2e-up e2e-down e2e-logs e2e-restart
+.PHONY: help e2e-ui cypress-ui cypress-run cypress-run-headed cypress-spec cypress-debug cypress-build chrome-clear-hsts ssl-info hosts-setup db-seed e2e-up e2e-down e2e-logs e2e-restart cypress-devlab
 
 # Colores para output
 GREEN  := \033[0;32m
@@ -66,6 +66,24 @@ cypress-debug: ## Abrir spec en modo interactivo (navegador queda abierto): make
 cypress-run: ## Ejecutar tests de Cypress en modo headless
 	@echo "$(GREEN)Ejecutando tests de Cypress...$(NC)"
 	@docker compose -f docker-compose.yml -f docker-compose.e2e.yml run --rm cypress
+
+cypress-devlab: ## Open Cypress GUI against the sushigo-dev-lab E2E stack (run make e2e WORKSPACE=... first)
+	@LETTER="$$(basename $$(pwd) | sed 's/sushigo-//')"; \
+	CONTAINER="$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1)"; \
+	if [ -z "$$CONTAINER" ]; then \
+		echo "$(RED)❌ Dev-lab E2E stack not running.$(NC)"; \
+		echo "   Start it with: $(YELLOW)make e2e WORKSPACE=sushigo-$$LETTER$(NC)  (from sushigo-dev-lab)"; \
+		exit 1; \
+	fi; \
+	OFFSET=$$(echo "$$LETTER" | tr 'a-h' '12345678'); \
+	VITE_PORT=$$((5180 + OFFSET)); \
+	API_PORT=$$((8900 + OFFSET)); \
+	echo "$(GREEN)Opening Cypress (devlab)$(NC)"; \
+	echo "  Container : $$CONTAINER"; \
+	echo "  Base URL  : http://localhost:$$VITE_PORT"; \
+	echo "  API URL   : http://localhost:$$API_PORT/api/v1"; \
+	E2E_CONTAINER="$$CONTAINER" VITE_PORT="$$VITE_PORT" E2E_API_PORT="$$API_PORT" \
+		npm --prefix code/webapp run cypress:open:devlab
 
 cypress-run-headed: cypress-up ## Ejecutar TODOS los tests con navegador visible (ver en VNC http://localhost:6080)
 	@echo "$(GREEN)Ejecutando todos los tests en modo headed (VNC: http://localhost:6080)...$(NC)"

--- a/README.md
+++ b/README.md
@@ -85,6 +85,55 @@ npm run build       # production build into dist/
 
 The webapp relies on the API base URL configured in `src/lib/api-client.ts`.
 
+## Make commands
+
+Run `make help` for the full list. Common commands grouped by purpose:
+
+### E2E testing — dev-lab stack
+
+Requires the dev-lab E2E stack to be running first (`make e2e WORKSPACE=sushigo-a` from `sushigo-dev-lab`).
+
+| Command | Description |
+|---|---|
+| `make cypress-devlab` | Open Cypress GUI — pick and run specs interactively |
+| `make cypress-devlab-spec SPEC=login` | Run one spec with browser visible |
+| `make cypress-devlab-spec SPEC=login GREP="logs in"` | Same, filtered by test name |
+| `make cypress-devlab-headed` | Run all specs with browser visible |
+| `make cypress-devlab-run` | Run all specs headless |
+| `make cypress-devlab-run-spec SPEC=login` | Run one spec headless |
+| `make cypress-devlab-run-spec SPEC=login GREP="logs in"` | Same, filtered by test name |
+
+`SPEC` is the filename without path or `.cy.ts` extension (e.g. `attendance-checkin`).
+`GREP` filters by test description substring — useful to run a single `it()` inside a spec.
+
+### E2E testing — devtest Docker stack
+
+Uses the workspace's own `docker-compose.e2e.yml` with a Cypress container.
+
+| Command | Description |
+|---|---|
+| `make e2e-up` | Start the E2E PHP container |
+| `make e2e-down` | Stop it |
+| `make e2e-restart` | Restart it |
+| `make e2e-logs` | Tail its logs |
+| `make cypress-run` | Run all specs headless inside Docker |
+| `make cypress-spec SPEC=login` | Run one spec headed (browser via VNC) |
+| `make cypress-ui` | Open Cypress GUI inside Docker (VNC at http://localhost:6080) |
+
+### Database
+
+| Command | Description |
+|---|---|
+| `make db-seed` | Run all seeders inside `dev_container` |
+
+### Local setup
+
+| Command | Description |
+|---|---|
+| `make hosts-setup` | Print the `/etc/hosts` line needed for `sushigo.local` |
+| `make ssl-info` | Show SSL certificate status and install instructions |
+| `make chrome-clear-hsts` | Instructions to clear Chrome HSTS cache for `localhost` |
+
 ## Architecture & domain documentation
 
 - [Inventory Architecture & Design (modelos, diagramas y flujos)](doc/architecture/inventory-architecture.md)

--- a/code/webapp/.env.example
+++ b/code/webapp/.env.example
@@ -33,6 +33,11 @@ VITE_API_URL=https://api.sushigo.local/api/v1
 # You can override it here for local development outside Docker
 CYPRESS_baseUrl=https://sushigo.local
 
+# Cypress Cloud record key — upload run results to cloud.cypress.io
+# Get your key at: https://cloud.cypress.io → Project Settings → Record Key
+# Leave empty to run without recording.
+CYPRESS_RECORD_KEY=
+
 # Time Display Format
 # -------------------
 # Controls how times are displayed across the UI (schedule, attendance, etc.)

--- a/code/webapp/cypress.config.devlab.ts
+++ b/code/webapp/cypress.config.devlab.ts
@@ -2,12 +2,14 @@ import { defineConfig } from 'cypress'
 import { execSync } from 'child_process'
 import * as http from 'http'
 
-// Container name set by sushigo-dev-lab's start-e2e.sh.
-// Example: E2E_CONTAINER=e2e-api-a npm run cypress:open:devlab
+// Container name set by sushigo-dev-lab's cypress.sh.
 const E2E_CONTAINER = process.env.E2E_CONTAINER || 'e2e-api-a'
 
-// Vite E2E port set by start-e2e.sh (5181–5188 per slot).
+// Vite E2E port set by cypress.sh (5181–5188 per workspace slot).
 const VITE_PORT = process.env.VITE_PORT || '5181'
+
+// API container port set by cypress.sh (8901–8908 per workspace slot).
+const E2E_API_PORT = process.env.E2E_API_PORT || '8901'
 
 // Mailpit (shared Docker service) exposes the same HTTP API as Mailhog.
 const MAILPIT_HOST = process.env.CYPRESS_mailpitHost || 'localhost'
@@ -25,6 +27,9 @@ export default defineConfig({
   projectId: 'phbcj4',
   e2e: {
     baseUrl: process.env.CYPRESS_baseUrl || `http://localhost:${VITE_PORT}`,
+    env: {
+      apiUrl: `http://localhost:${E2E_API_PORT}/api/v1`,
+    },
     supportFile: 'cypress/support/e2e.ts',
     specPattern: 'cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
     setupNodeEvents(on, config) {

--- a/code/webapp/cypress.config.devlab.ts
+++ b/code/webapp/cypress.config.devlab.ts
@@ -13,8 +13,10 @@ const VITE_PORT = process.env.VITE_PORT || '5181'
 const MAILPIT_HOST = process.env.CYPRESS_mailpitHost || 'localhost'
 const MAILPIT_PORT = parseInt(process.env.CYPRESS_mailpitPort || '8025', 10)
 
+// /app/artisan is the absolute path inside the e2e container
+// (volume maps workspaces/sushigo-x/code/api → /app, WORKDIR /app in Dockerfile)
 const artisan = (cmd: string, opts: { timeout?: number } = {}) =>
-  execSync(`docker exec ${E2E_CONTAINER} php artisan ${cmd}`, {
+  execSync(`docker exec ${E2E_CONTAINER} php /app/artisan ${cmd}`, {
     timeout: opts.timeout ?? 60_000,
     stdio: 'inherit',
   })
@@ -81,7 +83,7 @@ export default defineConfig({
           console.log(`[test:getResetLink] Fetching reset link for ${email}...`)
           try {
             const result = execSync(
-              `docker exec ${E2E_CONTAINER} php artisan tinker --execute="echo app(App\\\\Contracts\\\\PasswordResetTokenRecorder::class)->retrieve('${email}') ?? 'NULL';"`,
+              `docker exec ${E2E_CONTAINER} php /app/artisan tinker --execute="echo app(App\\\\Contracts\\\\PasswordResetTokenRecorder::class)->retrieve('${email}') ?? 'NULL';"`,
               { timeout: 10_000, encoding: 'utf-8' }
             ).trim()
             if (result === 'NULL' || !result) {

--- a/code/webapp/cypress.config.devlab.ts
+++ b/code/webapp/cypress.config.devlab.ts
@@ -1,0 +1,178 @@
+import { defineConfig } from 'cypress'
+import { execSync } from 'child_process'
+import * as http from 'http'
+
+// Container name set by sushigo-dev-lab's start-e2e.sh.
+// Example: E2E_CONTAINER=e2e-api-a npm run cypress:open:devlab
+const E2E_CONTAINER = process.env.E2E_CONTAINER || 'e2e-api-a'
+
+// Vite E2E port set by start-e2e.sh (5181–5188 per slot).
+const VITE_PORT = process.env.VITE_PORT || '5181'
+
+// Mailpit (shared Docker service) exposes the same HTTP API as Mailhog.
+const MAILPIT_HOST = process.env.CYPRESS_mailpitHost || 'localhost'
+const MAILPIT_PORT = parseInt(process.env.CYPRESS_mailpitPort || '8025', 10)
+
+const artisan = (cmd: string, opts: { timeout?: number } = {}) =>
+  execSync(`docker exec ${E2E_CONTAINER} php artisan ${cmd}`, {
+    timeout: opts.timeout ?? 60_000,
+    stdio: 'inherit',
+  })
+
+export default defineConfig({
+  projectId: 'phbcj4',
+  e2e: {
+    baseUrl: process.env.CYPRESS_baseUrl || `http://localhost:${VITE_PORT}`,
+    supportFile: 'cypress/support/e2e.ts',
+    specPattern: 'cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
+    setupNodeEvents(on, config) {
+      on('task', {
+        log(message) {
+          console.log(message)
+          return null
+        },
+
+        /**
+         * Full reset: migrate:fresh + seed.
+         * Slow (~30s). Use only when schema has changed.
+         * Usage: cy.task('db:reset')
+         */
+        'db:reset': () => {
+          console.log(`[db:reset] Running migrate:fresh --seed on ${E2E_CONTAINER}...`)
+          artisan('migrate:fresh --seed', { timeout: 180_000 })
+          return null
+        },
+
+        /**
+         * Fast reset: truncate + selective seed (no migration). ~3–5s.
+         * Usage:
+         *   cy.task('test:reset')                    → core only
+         *   cy.task('test:reset', 'attendance')      → core + attendance
+         *   cy.task('test:reset', 'attendance,cash') → core + attendance + cash
+         */
+        'test:reset': (seeders: string | null) => {
+          const flag = seeders ? ` --seeders=${seeders}` : ''
+          console.log(`[test:reset] Running test:reset${flag} on ${E2E_CONTAINER}...`)
+          artisan(`test:reset${flag}`, { timeout: 120_000 })
+          return null
+        },
+
+        /**
+         * Seed only (no migration).
+         * Usage: cy.task('db:seed')
+         */
+        'db:seed': () => {
+          console.log(`[db:seed] Running db:seed on ${E2E_CONTAINER}...`)
+          artisan('db:seed', { timeout: 60_000 })
+          return null
+        },
+
+        /**
+         * Get password reset link via artisan tinker inside the E2E container.
+         * No Mailpit dependency — instant and deterministic.
+         * Usage: cy.task('test:getResetLink', 'user@example.com')
+         */
+        'test:getResetLink': (email: string) => {
+          const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/
+          if (!emailRegex.test(email)) {
+            console.error(`[test:getResetLink] Invalid email format: ${email}`)
+            return null
+          }
+          console.log(`[test:getResetLink] Fetching reset link for ${email}...`)
+          try {
+            const result = execSync(
+              `docker exec ${E2E_CONTAINER} php artisan tinker --execute="echo app(App\\\\Contracts\\\\PasswordResetTokenRecorder::class)->retrieve('${email}') ?? 'NULL';"`,
+              { timeout: 10_000, encoding: 'utf-8' }
+            ).trim()
+            if (result === 'NULL' || !result) {
+              console.log(`[test:getResetLink] No reset link found for ${email}`)
+              return null
+            }
+            console.log(`[test:getResetLink] Reset link found`)
+            return result
+          } catch {
+            console.error(`[test:getResetLink] Error fetching reset link`)
+            return null
+          }
+        },
+
+        /**
+         * Get password reset link from Mailpit.
+         * Mailpit exposes the same /api/v2/messages endpoint as Mailhog.
+         * Usage: cy.task('mailhog:getResetLink', 'user@example.com')
+         */
+        'mailhog:getResetLink': (email: string) => {
+          const decodeQuotedPrintable = (str: string) =>
+            str
+              .replace(/=\r?\n/g, '')
+              .replace(/=([0-9A-Fa-f]{2})/g, (_, hex) =>
+                String.fromCharCode(parseInt(hex, 16))
+              )
+
+          return new Promise((resolve, reject) => {
+            const req = http.request(
+              { hostname: MAILPIT_HOST, port: MAILPIT_PORT, path: '/api/v2/messages', method: 'GET' },
+              (res) => {
+                let data = ''
+                res.on('data', (chunk) => (data += chunk))
+                res.on('end', () => {
+                  try {
+                    const json = JSON.parse(data)
+                    for (const msg of json.items || []) {
+                      const to = msg.Content?.Headers?.To?.[0] || ''
+                      if (to.includes(email)) {
+                        const body = decodeQuotedPrintable(msg.Content?.Body || '')
+                        const match = body.match(
+                          /https?:\/\/[^\s"<>]+\/reset-password\?t=[A-Za-z0-9.]+/
+                        )
+                        if (match) {
+                          console.log(`[mailpit] Found reset link for ${email}`)
+                          resolve(match[0])
+                          return
+                        }
+                      }
+                    }
+                    console.log(`[mailpit] No reset link found for ${email}`)
+                    resolve(null)
+                  } catch (e) {
+                    reject(e)
+                  }
+                })
+              }
+            )
+            req.on('error', reject)
+            req.end()
+          })
+        },
+
+        /**
+         * Clear all emails from Mailpit.
+         * Usage: cy.task('mailhog:clear')
+         */
+        'mailhog:clear': () => {
+          return new Promise((resolve, reject) => {
+            const req = http.request(
+              { hostname: MAILPIT_HOST, port: MAILPIT_PORT, path: '/api/v1/messages', method: 'DELETE' },
+              (res) => {
+                res.on('data', () => {})
+                res.on('end', () => {
+                  console.log('[mailpit] Cleared all messages')
+                  resolve(null)
+                })
+              }
+            )
+            req.on('error', reject)
+            req.end()
+          })
+        },
+      })
+
+      return config
+    },
+  },
+  chromeWebSecurity: false,
+  video: false,
+  screenshotOnRunFailure: true,
+  viewportWidth: 1280,
+  viewportHeight: 720,
+})

--- a/code/webapp/eslint.config.js
+++ b/code/webapp/eslint.config.js
@@ -7,7 +7,7 @@ import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
   // Ignore build output and Cypress suite (tested separately via cypress workflow)
-  globalIgnores(['dist', 'cypress/**', 'cypress.config.ts']),
+  globalIgnores(['dist', 'cypress/**', 'cypress.config.ts', 'cypress.config.devlab.ts']),
 
   // JS / JSX
   {

--- a/code/webapp/package.json
+++ b/code/webapp/package.json
@@ -13,7 +13,9 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "cypress:open": "cypress open",
-    "cypress:run": "cypress run"
+    "cypress:run": "cypress run",
+    "cypress:open:devlab": "cypress open --config-file cypress.config.devlab.ts",
+    "cypress:run:devlab": "cypress run --config-file cypress.config.devlab.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",


### PR DESCRIPTION
## Summary

- Adds `make cypress-devlab` to the workspace `Makefile` for opening Cypress GUI against the sushigo-dev-lab E2E stack
- Auto-detects workspace letter from directory name (`sushigo-a` → `a`)
- Resolves the running `e2e-api-<letter>` container via `docker ps`
- Derives ports dynamically (Vite: 5181–5188, API: 8901–8908 per workspace slot)
- Exits with a clear error if the dev-lab E2E stack is not running

## Usage

```bash
# From workspaces/sushigo-a/
make cypress-devlab
```

## Test plan

- [ ] `make cypress-devlab` with E2E stack running → Cypress GUI opens with correct baseUrl and apiUrl
- [ ] `make cypress-devlab` with E2E stack stopped → shows error with the start command
- [ ] Works from `sushigo-b` (detects letter `b`, uses ports 5182/8902)

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)