### PR TITLE
🐛 [#176] Fix employee-bonus-config E2E test — four root causes

### DIFF
--- a/code/webapp/cypress/e2e/employee-bonus-config.cy.ts
+++ b/code/webapp/cypress/e2e/employee-bonus-config.cy.ts
@@ -35,13 +35,18 @@ describe('Employee Bonus Config — admin happy path', () => {
     cy.url().should('not.include', '/login', { timeout: 10_000 })
     cy.visit('/employees')
     cy.url().should('include', '/employees', { timeout: 10_000 })
+    // Wait for the employee table to render before closing the DevDebugger.
+    // cy.closeDevDebugger uses a synchronous DOM check — React must be
+    // hydrated first or the DevDebugger won't be found and stays open.
+    cy.get('table', { timeout: 10_000 }).should('exist')
     cy.closeDevDebugger()
   })
 
   it('shows no bonus group assigned initially and allows assigning one', () => {
     // Open the employee detail panel for María García
     cy.contains(EMPLOYEE_NAME).closest('tr').find('button[aria-label="Ver detalle"]').click()
-    cy.contains('Grupo de Bono de Puntualidad').should('be.visible')
+    // BonusConfigSection is deep in the panel — scroll it into view before asserting
+    cy.contains('Grupo de Bono de Puntualidad').scrollIntoView().should('be.visible')
 
     // No group assigned yet
     cy.contains('Sin grupo de bono asignado').should('be.visible')
@@ -49,8 +54,19 @@ describe('Employee Bonus Config — admin happy path', () => {
     // Open the assignment form
     cy.contains('button', 'Asignar grupo').click()
 
-    // Select a group from the dropdown
-    cy.get('select#bonus_group_id').should('be.visible').select(1)
+    // Wait for groups to load (select is disabled while loading).
+    // Use native DOM + ownerDocument.defaultView.Event so React's event
+    // delegation catches the change. cy.trigger uses jQuery synthetic events
+    // which React 17+ does not pick up. Avoids Cypress visibility checks on
+    // <option> elements (they are always 0x0 and cannot be forced).
+    cy.get('select#bonus_group_id').should('be.visible').should('not.be.disabled').then(($select) => {
+      const select = $select[0] as HTMLSelectElement
+      const win = select.ownerDocument.defaultView as Window
+      const firstRealOption = Array.from(select.options).find((o) => o.value !== '')
+      if (!firstRealOption) throw new Error('No bonus group options loaded')
+      select.value = firstRealOption.value
+      select.dispatchEvent(new win.Event('change', { bubbles: true }))
+    })
 
     // Set effective date
     const today = new Date().toISOString().slice(0, 10)
@@ -62,8 +78,10 @@ describe('Employee Bonus Config — admin happy path', () => {
     // Toast should appear
     cy.contains('Grupo de bono asignado').should('be.visible')
 
-    // The current assignment card is now shown
-    cy.contains('Activo').should('be.visible')
+    // The current assignment card is now shown. Use data-testid to avoid
+    // accidentally matching the <option value="active">Activos</option> in
+    // the employee status filter select (which has 0x0 dimensions).
+    cy.get('[data-testid="current-bonus-assignment"]').scrollIntoView().should('be.visible')
     cy.contains('Sin grupo de bono asignado').should('not.exist')
   })
 })

--- a/code/webapp/cypress/e2e/employee-bonus-config.cy.ts
+++ b/code/webapp/cypress/e2e/employee-bonus-config.cy.ts
@@ -82,6 +82,7 @@ describe('Employee Bonus Config — admin happy path', () => {
     // accidentally matching the <option value="active">Activos</option> in
     // the employee status filter select (which has 0x0 dimensions).
     cy.get('[data-testid="current-bonus-assignment"]').scrollIntoView().should('be.visible')
+    cy.get('[data-testid="current-bonus-assignment"]').contains('Activo').should('be.visible')
     cy.contains('Sin grupo de bono asignado').should('not.exist')
   })
 })

--- a/code/webapp/cypress/support/commands.ts
+++ b/code/webapp/cypress/support/commands.ts
@@ -84,20 +84,23 @@ Cypress.Commands.add('logout', () => {
 });
 
 /**
- * Minimiza el Dev Debugger flotante si está visible.
- * Solo aparece en entorno devtest — no hace nada en producción.
+ * Oculta completamente el Dev Debugger (sets isHidden=true → component returns null).
+ * Uses Ctrl+Shift+D — the same shortcut the component listens to — so the element
+ * is removed from the DOM entirely, not just minimized.
+ *
+ * A minimized DevDebugger keeps a fixed-position badge on screen (z-9999) that
+ * can cover panel content in tests. Full hide avoids that.
+ *
+ * IMPORTANT: call this only after waiting for page content to be rendered
+ * (e.g. cy.get('table').should('exist')).  The inner check is a synchronous
+ * jQuery snapshot — if React hasn't hydrated yet the DevDebugger won't be in
+ * the DOM and the command silently no-ops.
  */
 Cypress.Commands.add('closeDevDebugger', () => {
   cy.get('body').then(($body) => {
-    if ($body.find('span:contains("Dev Debugger")').length > 0) {
-      cy.log('🔧 Minimizando Dev Debugger...');
-      // span → div.flex → div.bg-blue-600 (header) → último button = MinusCircle
-      cy.contains('span', 'Dev Debugger')
-        .parent()
-        .parent()
-        .find('button')
-        .last()
-        .click({ force: true });
+    if ($body.find('[data-testid="dev-debugger"]').length > 0) {
+      cy.log('🔧 Hiding Dev Debugger (Ctrl+Shift+D)...');
+      cy.get('body').type('{ctrl}{shift}d');
     }
   });
 });

--- a/code/webapp/cypress/support/commands.ts
+++ b/code/webapp/cypress/support/commands.ts
@@ -101,6 +101,9 @@ Cypress.Commands.add('closeDevDebugger', () => {
     if ($body.find('[data-testid="dev-debugger"]').length > 0) {
       cy.log('🔧 Hiding Dev Debugger (Ctrl+Shift+D)...');
       cy.get('body').type('{ctrl}{shift}d');
+      // Verify the element was actually removed from the DOM so tests cannot
+      // proceed while the overlay is still covering page content.
+      cy.get('[data-testid="dev-debugger"]').should('not.exist');
     }
   });
 });

--- a/code/webapp/src/components/dev/DevDebugger.tsx
+++ b/code/webapp/src/components/dev/DevDebugger.tsx
@@ -74,6 +74,7 @@ export function DevDebugger() {
                     top: state.position.y,
                 }}
                 className="fixed z-[9999] cursor-move"
+                data-testid="dev-debugger"
                 onMouseDown={handleMouseDown}
             >
                 <div className="bg-gray-900 text-white rounded-lg shadow-2xl p-3 flex items-center gap-2 border-2 border-blue-500">
@@ -101,6 +102,7 @@ export function DevDebugger() {
                 maxHeight: '80vh',
             }}
             className="fixed z-[9999] bg-gray-900 text-white rounded-lg shadow-2xl border-2 border-blue-500 overflow-hidden flex flex-col"
+            data-testid="dev-debugger"
         >
             <div
                 className="bg-blue-600 px-4 py-2 flex items-center justify-between cursor-move"
@@ -122,6 +124,7 @@ export function DevDebugger() {
                         onClick={toggleMinimized}
                         className="p-1 hover:bg-blue-700 rounded"
                         title="Minimize debugger"
+                        aria-label="Minimize debugger"
                     >
                         <MinusCircle className="h-4 w-4" />
                     </button>

--- a/code/webapp/src/components/employees/bonus-config-section.tsx
+++ b/code/webapp/src/components/employees/bonus-config-section.tsx
@@ -55,7 +55,7 @@ export function BonusConfigSection({ employeeId }: BonusConfigSectionProps) {
 
       {/* Current assignment */}
       {current ? (
-        <div className="rounded-md border border-border p-3 space-y-1">
+        <div className="rounded-md border border-border p-3 space-y-1" data-testid="current-bonus-assignment">
           <div className="flex items-center gap-2">
             <Award className="h-4 w-4 text-amber-500" />
             <span className="text-sm font-medium">{current.bonus_group_name}</span>

--- a/code/webapp/src/components/employees/employee-columns.tsx
+++ b/code/webapp/src/components/employees/employee-columns.tsx
@@ -123,6 +123,7 @@ export function getEmployeeColumns(onEdit: (item: Employee) => void): Column<Emp
           }}
           className="h-8 w-8 p-0"
           title="Ver detalle"
+          aria-label="Ver detalle"
         >
           <Eye className="h-4 w-4" />
         </Button>


### PR DESCRIPTION
## Summary

Fixes the broken `employee-bonus-config.cy.ts` E2E test. Four distinct root causes were identified and fixed:

- **Missing `aria-label` on Ver detalle button** — `employee-columns.tsx` button had `title="Ver detalle"` but no `aria-label`, making `button[aria-label="Ver detalle"]` selector fail
- **`closeDevDebugger` race condition** — the synchronous jQuery DOM check fired before React hydrated, so the DevDebugger was never found and stayed open, covering panel content
- **DevDebugger minimize vs. hide** — minimized state keeps a `fixed z-9999` badge that covers `BonusConfigSection`; updated to use `Ctrl+Shift+D` for full hide (`isHidden=true` → component returns `null`)
- **`cy.contains('Activo')` false match** — matched `<option value="active">Activos</option>` in the employee status filter select (0×0 px) instead of the assignment badge; fixed with `data-testid="current-bonus-assignment"`

## Test plan

- [x] Run `make cypress-devlab-spec SPEC=employee-bonus-config` — 1 passing (9s)
- [x] TypeScript typecheck passes (`npm run typecheck` — 0 errors)
- [x] ESLint passes (0 errors, warnings are pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)