### PR TITLE
🐛 [#178] Fix employee-negotiated-extra-days E2E test — 8 root causes

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -2,3 +2,5 @@
 !.gitignore
 !skills/
 !skills/**
+!commands/
+!commands/**

--- a/.claude/commands/pr-comments.md
+++ b/.claude/commands/pr-comments.md
@@ -1,0 +1,137 @@
+---
+allowed-tools: Bash(gh api:*), Bash(gh pr view:*), Bash(gh repo view:*), Bash(git fetch:*), Bash(git checkout:*), Bash(git push:*), Bash(git log:*), Bash(git diff:*), Bash(git add:*), Bash(git commit:*), Bash(git branch:*), Bash(git status:*), Read, Edit, Write
+description: Address open review thread comments on a GitHub PR — analyze each, fix or justify, reply with outcome, and resolve the thread
+---
+
+Address all open review thread comments on a GitHub PR.
+
+**Usage:** `/pr-comments <PR_NUMBER>` or `/pr-comments <owner/repo> <PR_NUMBER>`
+
+## Steps
+
+### 1. Load context
+
+- Parse `$ARGUMENTS` to extract the PR number and optionally `owner/repo`. If no repo is provided, detect it with:
+  ```bash
+  gh repo view --json nameWithOwner --jq .nameWithOwner
+  ```
+- Fetch PR metadata:
+  ```bash
+  gh pr view <number> --repo <owner/repo> --json title,state,headRefName,baseRefName,isDraft
+  ```
+- If the PR is closed, merged, or a draft, stop and inform the user.
+- Read the root `CLAUDE.md` (if present) to understand the project's commit convention, linting commands, and code style rules. This is critical — do not skip it.
+
+### 2. Fetch open review threads
+
+Use the GitHub GraphQL API to list all unresolved review threads:
+
+```bash
+gh api graphql -f query='
+  query($owner: String!, $repo: String!, $pr: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 50) {
+          nodes {
+            id
+            isResolved
+            path
+            line
+            comments(first: 10) {
+              nodes {
+                id
+                databaseId
+                body
+                author { login }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+' -f owner=<owner> -f repo=<repo> -F pr=<number>
+```
+
+Filter to threads where `isResolved = false`. If there are none, report "No open review threads found." and stop.
+
+### 3. Ensure the PR branch is checked out
+
+```bash
+git fetch origin <headRefName>
+git checkout <headRefName>
+```
+
+### 4. Process each open thread
+
+For each unresolved thread, in order:
+
+#### a. Analyze the comment
+
+Read the comment body. Then read the file at `path` around the referenced `line` for context. Decide:
+
+- **Address** — the comment identifies a real issue, a valid improvement, or a violation of the project's conventions. The fix is clear, safe, and localized.
+- **Skip** — the comment is a false positive, does not apply to this codebase's conventions, is already handled elsewhere, or the suggested change would introduce more risk than benefit. A clear justification is required.
+
+#### b. If addressing
+
+1. Implement the fix in the relevant file(s).
+2. Run the project linter/formatter if configured (read CLAUDE.md for the exact command — e.g. `pint`, `eslint`, `shellcheck`). Stage any auto-fixed files.
+3. Stage changed files and commit following the project's commit convention from CLAUDE.md. Reuse the issue number from the current branch name or recent commits.
+4. Capture the commit SHA:
+   ```bash
+   git log -1 --format=%H
+   ```
+
+Do **not** reply or resolve yet — continue to the next thread. Replies and resolutions happen after the push so that commit references are live on GitHub.
+
+### 5. Push all commits
+
+After every thread has been analyzed and fixes committed, push once:
+
+```bash
+git push origin <headRefName>
+```
+
+This step is **mandatory** even if all threads were skipped (no commits to push is fine — the push is a no-op). It must run before any replies are posted so commit SHAs are reachable on GitHub.
+
+### 6. Reply and resolve every thread
+
+Loop over each thread processed in step 4 and, in order:
+
+#### a. Reply to the thread
+
+Post a reply to the thread's first comment via the REST API:
+
+```bash
+gh api repos/<owner>/<repo>/pulls/<pr_number>/comments/<comment_databaseId>/replies \
+  --method POST \
+  --field body="<reply>"
+```
+
+Reply format:
+- **If addressed:** Describe what was changed and why (2–3 sentences), then close with the commit reference: `Fixed in <short_sha> — <one-line summary of the change>.`
+- **If skipped:** Explain concisely why this comment was not addressed. Reference the specific convention or reasoning (e.g. "This is correct per the CLAUDE.md convention — `copy()` is required to avoid mutating the shared Carbon instance.").
+
+Keep replies under 4 sentences. Match the language used in the thread (Spanish if the thread is in Spanish, English otherwise).
+
+#### b. Resolve the thread
+
+```bash
+gh api graphql -f query='
+  mutation($threadId: ID!) {
+    resolveReviewThread(input: { threadId: $threadId }) {
+      thread { id isResolved }
+    }
+  }
+' -f threadId=<thread_node_id>
+```
+
+Resolve **every** processed thread — both addressed and skipped. A skipped thread is still closed because a reply explains the decision.
+
+### 7. Report
+
+Summarize to the user:
+- Total open threads found
+- Threads addressed: file path, one-line description, commit SHA
+- Threads skipped: file path, one-line justification

--- a/code/api/database/seeders/Testing/NegotiatedExtraDaysSeeder.php
+++ b/code/api/database/seeders/Testing/NegotiatedExtraDaysSeeder.php
@@ -32,12 +32,11 @@ class NegotiatedExtraDaysSeeder extends Seeder
 
     public function run(): void
     {
-        $this->now = (string) now();
+        $today = now();
+        $this->now = (string) $today;
         $this->employeeId = (int) DB::table('employees')->where('code', 'EMP-001')->value('id');
         $this->branchId = (int) DB::table('branches')->where('code', 'MAIN')->value('id');
         $this->adminUserId = (int) DB::table('users')->where('email', 'admin@sushigo.com')->value('id');
-
-        $today = now();
         $past1 = $today->copy()->subDays(90)->toDateString();
         $past2 = $today->copy()->subDays(69)->toDateString();
         $past3 = $today->copy()->subDays(54)->toDateString();

--- a/code/api/database/seeders/Testing/NegotiatedExtraDaysSeeder.php
+++ b/code/api/database/seeders/Testing/NegotiatedExtraDaysSeeder.php
@@ -37,15 +37,16 @@ class NegotiatedExtraDaysSeeder extends Seeder
         $this->branchId = (int) DB::table('branches')->where('code', 'MAIN')->value('id');
         $this->adminUserId = (int) DB::table('users')->where('email', 'admin@sushigo.com')->value('id');
 
-        $past1  = now()->subDays(90)->toDateString();
-        $past2  = now()->subDays(69)->toDateString();
-        $past3  = now()->subDays(54)->toDateString();
-        $future = now()->addDays(30)->toDateString();
+        $today = now();
+        $past1 = $today->copy()->subDays(90)->toDateString();
+        $past2 = $today->copy()->subDays(69)->toDateString();
+        $past3 = $today->copy()->subDays(54)->toDateString();
+        $future = $today->copy()->addDays(30)->toDateString();
 
         DB::table('negotiated_extra_days')->insert([
-            $this->row($past1,  '600.0000', '100.0000', '600.0000', 'Turno especial'),
-            $this->row($past2,  '500.0000', '50.0000',  '250.0000', null),
-            $this->row($past3,  '700.0000', '0.0000',   '0.0000',   'Sin prima'),
+            $this->row($past1, '600.0000', '100.0000', '600.0000', 'Turno especial'),
+            $this->row($past2, '500.0000', '50.0000', '250.0000', null),
+            $this->row($past3, '700.0000', '0.0000', '0.0000', 'Sin prima'),
             $this->row($future, '800.0000', '100.0000', '800.0000', 'Próximo extra'),
         ]);
     }

--- a/code/api/database/seeders/Testing/NegotiatedExtraDaysSeeder.php
+++ b/code/api/database/seeders/Testing/NegotiatedExtraDaysSeeder.php
@@ -14,11 +14,11 @@ use Illuminate\Support\Str;
  *
  * Employees must already exist (AttendanceTestSeeder ran first).
  *
- * Records:
- *   2026-03-15  $600  prima 100%  → $600  notes: "Turno especial"   (past)
- *   2026-04-05  $500  prima 50%   → $250  notes: null                (past)
- *   2026-04-20  $700  prima 0%    → $0    notes: "Sin prima"         (past)
- *   2026-05-10  $800  prima 100%  → $800  notes: "Próximo extra"     (future — cancellable)
+ * Records (dates are relative to today so the future record stays future):
+ *   today - 90 days  $600  prima 100%  → $600  notes: "Turno especial"   (past)
+ *   today - 69 days  $500  prima 50%   → $250  notes: null                (past)
+ *   today - 54 days  $700  prima 0%    → $0    notes: "Sin prima"         (past)
+ *   today + 30 days  $800  prima 100%  → $800  notes: "Próximo extra"     (future — cancellable)
  */
 class NegotiatedExtraDaysSeeder extends Seeder
 {
@@ -37,11 +37,16 @@ class NegotiatedExtraDaysSeeder extends Seeder
         $this->branchId = (int) DB::table('branches')->where('code', 'MAIN')->value('id');
         $this->adminUserId = (int) DB::table('users')->where('email', 'admin@sushigo.com')->value('id');
 
+        $past1  = now()->subDays(90)->toDateString();
+        $past2  = now()->subDays(69)->toDateString();
+        $past3  = now()->subDays(54)->toDateString();
+        $future = now()->addDays(30)->toDateString();
+
         DB::table('negotiated_extra_days')->insert([
-            $this->row('2026-03-15', '600.0000', '100.0000', '600.0000', 'Turno especial'),
-            $this->row('2026-04-05', '500.0000', '50.0000', '250.0000', null),
-            $this->row('2026-04-20', '700.0000', '0.0000', '0.0000', 'Sin prima'),
-            $this->row('2026-05-10', '800.0000', '100.0000', '800.0000', 'Próximo extra'),
+            $this->row($past1,  '600.0000', '100.0000', '600.0000', 'Turno especial'),
+            $this->row($past2,  '500.0000', '50.0000',  '250.0000', null),
+            $this->row($past3,  '700.0000', '0.0000',   '0.0000',   'Sin prima'),
+            $this->row($future, '800.0000', '100.0000', '800.0000', 'Próximo extra'),
         ]);
     }
 

--- a/code/webapp/cypress/e2e/employee-negotiated-extra-days.cy.ts
+++ b/code/webapp/cypress/e2e/employee-negotiated-extra-days.cy.ts
@@ -9,11 +9,13 @@
  *  4. Cancel button (future day) removes the row and updates the summary.
  *  5. Cancel button is disabled for past days in the history dialog.
  *
- * Seeder: NegotiatedExtraDaysSeeder seeds 4 records for EMP-001:
- *   2026-03-15  $600  prima 100%  "Turno especial"   (past)
- *   2026-04-05  $500  prima 50%   (sin notas)         (past)
- *   2026-04-20  $700  prima 0%    "Sin prima"         (past)
- *   2026-05-10  $800  prima 100%  "Próximo extra"     (future — cancellable)
+ * Seeder: NegotiatedExtraDaysSeeder seeds 4 records for EMP-001 using
+ * relative dates so the "future" record stays future regardless of when the
+ * test runs:
+ *   today - 90 days  $600  prima 100%  "Turno especial"   (past)
+ *   today - 69 days  $500  prima 50%   (sin notas)         (past)
+ *   today - 54 days  $700  prima 0%    "Sin prima"         (past)
+ *   today + 30 days  $800  prima 100%  "Próximo extra"     (future — cancellable)
  *
  * DB reset strategy
  * ─────────────────
@@ -42,7 +44,12 @@ function scrollToExtraDays() {
 }
 
 function openHistory() {
-  cy.contains('button', 'Ver historial').click()
+  // Scope to the Días extra section header — the leave-summary-section also
+  // has a "Ver historial" button and cy.contains would click the wrong one.
+  cy.contains('h3', 'Días extra')
+    .parent()
+    .contains('button', 'Ver historial')
+    .click()
   cy.contains('Historial de días extra', { timeout: 8_000 }).should('be.visible')
 }
 
@@ -61,6 +68,7 @@ describe('Negotiated Extra Days — Executive Summary', () => {
     cy.loginByApi(email, password)
     cy.visitWithAuth('/employees')
     cy.url().should('include', '/employees', { timeout: 10_000 })
+    cy.get('table', { timeout: 10_000 }).should('exist')
     cy.closeDevDebugger()
   })
 
@@ -71,11 +79,12 @@ describe('Negotiated Extra Days — Executive Summary', () => {
     scrollToExtraDays()
     cy.wait('@listUpcoming')
 
-    // The future record (2026-05-10) appears in the upcoming badge
+    // The future record appears in the upcoming badge
     cy.contains('1 programado').should('be.visible')
 
-    // Upcoming list row is shown
-    cy.contains('Próximo extra', { timeout: 8_000 }).should('be.visible')
+    // The upcoming list section header appears (notes are not shown in the
+    // upcoming card — only date, wage and prima %).
+    cy.contains('Próximos días extra', { timeout: 8_000 }).should('be.visible')
   })
 })
 
@@ -88,6 +97,7 @@ describe('Negotiated Extra Days — History Dialog', () => {
     cy.loginByApi(email, password)
     cy.visitWithAuth('/employees')
     cy.url().should('include', '/employees', { timeout: 10_000 })
+    cy.get('table', { timeout: 10_000 }).should('exist')
     cy.closeDevDebugger()
   })
 
@@ -100,10 +110,13 @@ describe('Negotiated Extra Days — History Dialog', () => {
 
     cy.wait('@listExtraDays').its('response.statusCode').should('eq', 200)
 
-    // Table headers
-    cy.contains('th', 'Fecha').should('be.visible')
-    cy.contains('th', 'Salario').should('be.visible')
-    cy.contains('th', 'Prima %').should('be.visible')
+    // Table headers — scoped to dialog[open] to avoid matching the employee
+    // table's "Fecha Creacion" th which has hidden lg:table-cell classes.
+    cy.get('dialog[open]').within(() => {
+      cy.contains('th', 'Fecha').should('be.visible')
+      cy.contains('th', 'Salario').should('be.visible')
+      cy.contains('th', 'Prima %').should('be.visible')
+    })
 
     // All 4 records
     cy.contains('Turno especial').should('be.visible')
@@ -132,11 +145,11 @@ describe('Negotiated Extra Days — History Dialog', () => {
     cy.contains('Sin prima').should('not.exist')
     cy.contains('Próximo extra').should('be.visible')
 
-    // Clear filter — all records return
-    cy.intercept('GET', '**/negotiated-extra-days**').as('listCleared')
-    cy.contains('button', 'Limpiar').click()
-    cy.wait('@listCleared').its('response.statusCode').should('eq', 200)
-
+    // Clear filter — all records return.
+    // Scope to dialog[open] to avoid matching a "Limpiar" button elsewhere.
+    // React Query may serve the unfiltered result from cache (no new HTTP
+    // request), so verify UI state directly instead of waiting for a network call.
+    cy.get('dialog[open]').contains('button', 'Limpiar').click()
     cy.contains('Turno especial').should('be.visible')
     cy.contains('Próximo extra').should('be.visible')
   })
@@ -152,6 +165,7 @@ describe('Negotiated Extra Days — Cancel', () => {
     cy.loginByApi(email, password)
     cy.visitWithAuth('/employees')
     cy.url().should('include', '/employees', { timeout: 10_000 })
+    cy.get('table', { timeout: 10_000 }).should('exist')
     cy.closeDevDebugger()
   })
 
@@ -161,19 +175,21 @@ describe('Negotiated Extra Days — Cancel', () => {
     openEmp001Detail()
     scrollToExtraDays()
 
-    // Upcoming row for "Próximo extra" is visible
-    cy.contains('Próximo extra', { timeout: 8_000 }).should('be.visible')
+    // Upcoming section appears when there is at least one future record.
+    // Notes ("Próximo extra") are not shown in the upcoming card — only date,
+    // wage and prima %. Use the section header to verify the row is present.
+    cy.contains('Próximos días extra', { timeout: 8_000 }).should('be.visible')
 
-    // Click the XCircle cancel button on that row
-    cy.contains('Próximo extra')
-      .closest('div')
-      .find('button[aria-label="Cancelar día extra"]')
-      .click()
+    // Click the cancel button on the upcoming row (only one record scheduled).
+    cy.get('[aria-label="Cancelar día extra"]').click()
+
+    // Clicking the button opens a ConfirmDialog — confirm the cancellation.
+    cy.contains('button', 'Sí, cancelar').click()
 
     cy.wait('@cancelDay').its('response.statusCode').should('eq', 200)
 
-    // Row and badge disappear after cancellation
-    cy.contains('Próximo extra').should('not.exist')
+    // Section and badge disappear (no more upcoming records).
+    cy.contains('Próximos días extra').should('not.exist')
     cy.contains('1 programado').should('not.exist')
   })
 


### PR DESCRIPTION
## Summary

Fixes all 5 failing tests in `employee-negotiated-extra-days.cy.ts`. Eight root causes were identified and fixed across the seeder and the spec file:

- **Seeder hardcoded dates** — Replaced `2026-03-15 / 2026-04-05 / 2026-04-20 / 2026-05-10` with `today±N days` so the "future" record remains future regardless of when the test runs
- **Wrong "Ver historial" button** — `leave-summary-section` also has a "Ver historial" button; scoped `openHistory()` to `cy.contains('h3', 'Días extra').parent()` to click the right one
- **Notes not shown in upcoming card** — `ExtraDaySection` upcoming list renders date/wage/prima but not `notes`; changed assertions to `cy.contains('Próximos días extra')` (section header)
- **`<th>Fecha</th>` ambiguity** — `cy.contains('th', 'Fecha')` was matching the employee table's `Fecha Creacion` th (`hidden lg:table-cell`) before the dialog's th; scoped to `cy.get('dialog[open]').within(...)`
- **Unscoped "Limpiar" button** — Same scoping fix applied to the clear-filter button
- **Missing ConfirmDialog confirm** — Cancel action shows a `ConfirmDialog`; added `cy.contains('button', 'Sí, cancelar').click()`
- **Stale `cy.wait('@listCleared')`** — React Query serves the unfiltered result from cache; removed the wait and verified UI state directly
- **`closeDevDebugger` race condition** — Added `cy.get('table').should('exist')` before `closeDevDebugger()` in all three `beforeEach` blocks

## Test plan

- [x] Run `make cypress-devlab-spec SPEC=employee-negotiated-extra-days` — **5 passing (26s)**
- [x] TypeScript typecheck passes (`npm run typecheck` — 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)