### PR TITLE
✨ [#180] Auto-start dev-lab E2E stack from cypress-devlab targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,13 +69,17 @@ cypress-run: ## Ejecutar tests de Cypress en modo headless
 
 cypress-devlab: ## Open Cypress GUI against the sushigo-dev-lab E2E stack (run make e2e WORKSPACE=... first)
 	@LETTER="$$(basename $$(pwd) | sed 's/sushigo-//')"; \
-	CONTAINER="$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1)"; \
+	CONTAINER=$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1); \
 	if [ -z "$$CONTAINER" ]; then \
 		DEVLAB_START="$$(pwd)/../../scripts/start-e2e.sh"; \
 		if [ -x "$$DEVLAB_START" ]; then \
 			echo "$(YELLOW)⚡ Dev-lab E2E stack not running — auto-starting for sushigo-$$LETTER...$(NC)"; \
-			"$$DEVLAB_START" "sushigo-$$LETTER"; \
-			CONTAINER="$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1)"; \
+			"$$DEVLAB_START" "sushigo-$$LETTER" || exit 1; \
+			CONTAINER=$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1); \
+			if [ -z "$$CONTAINER" ]; then \
+				echo "$(RED)❌ Container e2e-api-$$LETTER not found after auto-start$(NC)"; \
+				exit 1; \
+			fi; \
 		else \
 			echo "$(RED)❌ Dev-lab E2E stack not running.$(NC)"; \
 			echo "   Start it with: $(YELLOW)make e2e WORKSPACE=sushigo-$$LETTER$(NC)  (from sushigo-dev-lab)"; \
@@ -95,13 +99,17 @@ cypress-devlab: ## Open Cypress GUI against the sushigo-dev-lab E2E stack (run m
 cypress-devlab-spec: ## Run a specific spec headed against dev-lab stack: make cypress-devlab-spec SPEC=login [GREP="text"]
 	@if [ -z "$(SPEC)" ]; then echo "$(RED)Usage: make cypress-devlab-spec SPEC=<name> [GREP='text']$(NC)"; exit 1; fi
 	@LETTER="$$(basename $$(pwd) | sed 's/sushigo-//')"; \
-	CONTAINER="$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1)"; \
+	CONTAINER=$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1); \
 	if [ -z "$$CONTAINER" ]; then \
 		DEVLAB_START="$$(pwd)/../../scripts/start-e2e.sh"; \
 		if [ -x "$$DEVLAB_START" ]; then \
 			echo "$(YELLOW)⚡ Dev-lab E2E stack not running — auto-starting for sushigo-$$LETTER...$(NC)"; \
-			"$$DEVLAB_START" "sushigo-$$LETTER"; \
-			CONTAINER="$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1)"; \
+			"$$DEVLAB_START" "sushigo-$$LETTER" || exit 1; \
+			CONTAINER=$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1); \
+			if [ -z "$$CONTAINER" ]; then \
+				echo "$(RED)❌ Container e2e-api-$$LETTER not found after auto-start$(NC)"; \
+				exit 1; \
+			fi; \
 		else \
 			echo "$(RED)❌ Dev-lab E2E stack not running.$(NC)"; \
 			echo "   Start it with: $(YELLOW)make e2e WORKSPACE=sushigo-$$LETTER$(NC)  (from sushigo-dev-lab)"; \
@@ -126,13 +134,17 @@ cypress-devlab-spec: ## Run a specific spec headed against dev-lab stack: make c
 
 cypress-devlab-headed: ## Run ALL specs headed (browser visible) against dev-lab stack
 	@LETTER="$$(basename $$(pwd) | sed 's/sushigo-//')"; \
-	CONTAINER="$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1)"; \
+	CONTAINER=$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1); \
 	if [ -z "$$CONTAINER" ]; then \
 		DEVLAB_START="$$(pwd)/../../scripts/start-e2e.sh"; \
 		if [ -x "$$DEVLAB_START" ]; then \
 			echo "$(YELLOW)⚡ Dev-lab E2E stack not running — auto-starting for sushigo-$$LETTER...$(NC)"; \
-			"$$DEVLAB_START" "sushigo-$$LETTER"; \
-			CONTAINER="$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1)"; \
+			"$$DEVLAB_START" "sushigo-$$LETTER" || exit 1; \
+			CONTAINER=$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1); \
+			if [ -z "$$CONTAINER" ]; then \
+				echo "$(RED)❌ Container e2e-api-$$LETTER not found after auto-start$(NC)"; \
+				exit 1; \
+			fi; \
 		else \
 			echo "$(RED)❌ Dev-lab E2E stack not running.$(NC)"; \
 			echo "   Start it with: $(YELLOW)make e2e WORKSPACE=sushigo-$$LETTER$(NC)  (from sushigo-dev-lab)"; \
@@ -155,13 +167,17 @@ cypress-devlab-headed: ## Run ALL specs headed (browser visible) against dev-lab
 
 cypress-devlab-run: ## Run ALL specs headless against dev-lab stack
 	@LETTER="$$(basename $$(pwd) | sed 's/sushigo-//')"; \
-	CONTAINER="$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1)"; \
+	CONTAINER=$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1); \
 	if [ -z "$$CONTAINER" ]; then \
 		DEVLAB_START="$$(pwd)/../../scripts/start-e2e.sh"; \
 		if [ -x "$$DEVLAB_START" ]; then \
 			echo "$(YELLOW)⚡ Dev-lab E2E stack not running — auto-starting for sushigo-$$LETTER...$(NC)"; \
-			"$$DEVLAB_START" "sushigo-$$LETTER"; \
-			CONTAINER="$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1)"; \
+			"$$DEVLAB_START" "sushigo-$$LETTER" || exit 1; \
+			CONTAINER=$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1); \
+			if [ -z "$$CONTAINER" ]; then \
+				echo "$(RED)❌ Container e2e-api-$$LETTER not found after auto-start$(NC)"; \
+				exit 1; \
+			fi; \
 		else \
 			echo "$(RED)❌ Dev-lab E2E stack not running.$(NC)"; \
 			echo "   Start it with: $(YELLOW)make e2e WORKSPACE=sushigo-$$LETTER$(NC)  (from sushigo-dev-lab)"; \
@@ -184,13 +200,17 @@ cypress-devlab-run: ## Run ALL specs headless against dev-lab stack
 cypress-devlab-run-spec: ## Run a specific spec headless against dev-lab stack: make cypress-devlab-run-spec SPEC=login [GREP="text"]
 	@if [ -z "$(SPEC)" ]; then echo "$(RED)Usage: make cypress-devlab-run-spec SPEC=<name> [GREP='text']$(NC)"; exit 1; fi
 	@LETTER="$$(basename $$(pwd) | sed 's/sushigo-//')"; \
-	CONTAINER="$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1)"; \
+	CONTAINER=$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1); \
 	if [ -z "$$CONTAINER" ]; then \
 		DEVLAB_START="$$(pwd)/../../scripts/start-e2e.sh"; \
 		if [ -x "$$DEVLAB_START" ]; then \
 			echo "$(YELLOW)⚡ Dev-lab E2E stack not running — auto-starting for sushigo-$$LETTER...$(NC)"; \
-			"$$DEVLAB_START" "sushigo-$$LETTER"; \
-			CONTAINER="$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1)"; \
+			"$$DEVLAB_START" "sushigo-$$LETTER" || exit 1; \
+			CONTAINER=$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1); \
+			if [ -z "$$CONTAINER" ]; then \
+				echo "$(RED)❌ Container e2e-api-$$LETTER not found after auto-start$(NC)"; \
+				exit 1; \
+			fi; \
 		else \
 			echo "$(RED)❌ Dev-lab E2E stack not running.$(NC)"; \
 			echo "   Start it with: $(YELLOW)make e2e WORKSPACE=sushigo-$$LETTER$(NC)  (from sushigo-dev-lab)"; \

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,11 @@ cypress-devlab-spec: ## Run a specific spec headed against dev-lab stack: make c
 		npm --prefix code/webapp run cypress:run:devlab -- \
 		--headed --browser chrome \
 		--spec "cypress/e2e/$(SPEC).cy.ts" \
-		$(if $(GREP),--env grep="$(GREP)")
+		$(if $(GREP),--env grep="$(GREP)"); \
+	CYPRESS_EXIT=$$?; \
+	DEVLAB_STOP="$$(pwd)/../../scripts/stop-e2e.sh"; \
+	if [ -x "$$DEVLAB_STOP" ]; then "$$DEVLAB_STOP" "sushigo-$$LETTER"; fi; \
+	exit $$CYPRESS_EXIT
 
 cypress-devlab-headed: ## Run ALL specs headed (browser visible) against dev-lab stack
 	@LETTER="$$(basename $$(pwd) | sed 's/sushigo-//')"; \
@@ -143,7 +147,11 @@ cypress-devlab-headed: ## Run ALL specs headed (browser visible) against dev-lab
 	echo "  Base URL  : http://localhost:$$VITE_PORT"; \
 	E2E_CONTAINER="$$CONTAINER" VITE_PORT="$$VITE_PORT" E2E_API_PORT="$$API_PORT" \
 		npm --prefix code/webapp run cypress:run:devlab -- \
-		--headed --browser chrome
+		--headed --browser chrome; \
+	CYPRESS_EXIT=$$?; \
+	DEVLAB_STOP="$$(pwd)/../../scripts/stop-e2e.sh"; \
+	if [ -x "$$DEVLAB_STOP" ]; then "$$DEVLAB_STOP" "sushigo-$$LETTER"; fi; \
+	exit $$CYPRESS_EXIT
 
 cypress-devlab-run: ## Run ALL specs headless against dev-lab stack
 	@LETTER="$$(basename $$(pwd) | sed 's/sushigo-//')"; \
@@ -167,7 +175,11 @@ cypress-devlab-run: ## Run ALL specs headless against dev-lab stack
 	echo "  Container : $$CONTAINER"; \
 	echo "  Base URL  : http://localhost:$$VITE_PORT"; \
 	E2E_CONTAINER="$$CONTAINER" VITE_PORT="$$VITE_PORT" E2E_API_PORT="$$API_PORT" \
-		npm --prefix code/webapp run cypress:run:devlab
+		npm --prefix code/webapp run cypress:run:devlab; \
+	CYPRESS_EXIT=$$?; \
+	DEVLAB_STOP="$$(pwd)/../../scripts/stop-e2e.sh"; \
+	if [ -x "$$DEVLAB_STOP" ]; then "$$DEVLAB_STOP" "sushigo-$$LETTER"; fi; \
+	exit $$CYPRESS_EXIT
 
 cypress-devlab-run-spec: ## Run a specific spec headless against dev-lab stack: make cypress-devlab-run-spec SPEC=login [GREP="text"]
 	@if [ -z "$(SPEC)" ]; then echo "$(RED)Usage: make cypress-devlab-run-spec SPEC=<name> [GREP='text']$(NC)"; exit 1; fi
@@ -194,7 +206,11 @@ cypress-devlab-run-spec: ## Run a specific spec headless against dev-lab stack: 
 	E2E_CONTAINER="$$CONTAINER" VITE_PORT="$$VITE_PORT" E2E_API_PORT="$$API_PORT" \
 		npm --prefix code/webapp run cypress:run:devlab -- \
 		--spec "cypress/e2e/$(SPEC).cy.ts" \
-		$(if $(GREP),--env grep="$(GREP)")
+		$(if $(GREP),--env grep="$(GREP)"); \
+	CYPRESS_EXIT=$$?; \
+	DEVLAB_STOP="$$(pwd)/../../scripts/stop-e2e.sh"; \
+	if [ -x "$$DEVLAB_STOP" ]; then "$$DEVLAB_STOP" "sushigo-$$LETTER"; fi; \
+	exit $$CYPRESS_EXIT
 
 cypress-run-headed: cypress-up ## Ejecutar TODOS los tests con navegador visible (ver en VNC http://localhost:6080)
 	@echo "$(GREEN)Ejecutando todos los tests en modo headed (VNC: http://localhost:6080)...$(NC)"

--- a/Makefile
+++ b/Makefile
@@ -71,9 +71,16 @@ cypress-devlab: ## Open Cypress GUI against the sushigo-dev-lab E2E stack (run m
 	@LETTER="$$(basename $$(pwd) | sed 's/sushigo-//')"; \
 	CONTAINER="$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1)"; \
 	if [ -z "$$CONTAINER" ]; then \
-		echo "$(RED)❌ Dev-lab E2E stack not running.$(NC)"; \
-		echo "   Start it with: $(YELLOW)make e2e WORKSPACE=sushigo-$$LETTER$(NC)  (from sushigo-dev-lab)"; \
-		exit 1; \
+		DEVLAB_START="$$(pwd)/../../scripts/start-e2e.sh"; \
+		if [ -x "$$DEVLAB_START" ]; then \
+			echo "$(YELLOW)⚡ Dev-lab E2E stack not running — auto-starting for sushigo-$$LETTER...$(NC)"; \
+			"$$DEVLAB_START" "sushigo-$$LETTER"; \
+			CONTAINER="$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1)"; \
+		else \
+			echo "$(RED)❌ Dev-lab E2E stack not running.$(NC)"; \
+			echo "   Start it with: $(YELLOW)make e2e WORKSPACE=sushigo-$$LETTER$(NC)  (from sushigo-dev-lab)"; \
+			exit 1; \
+		fi; \
 	fi; \
 	OFFSET=$$(echo "$$LETTER" | tr 'a-h' '12345678'); \
 	VITE_PORT=$$((5180 + OFFSET)); \
@@ -90,9 +97,16 @@ cypress-devlab-spec: ## Run a specific spec headed against dev-lab stack: make c
 	@LETTER="$$(basename $$(pwd) | sed 's/sushigo-//')"; \
 	CONTAINER="$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1)"; \
 	if [ -z "$$CONTAINER" ]; then \
-		echo "$(RED)❌ Dev-lab E2E stack not running.$(NC)"; \
-		echo "   Start it with: $(YELLOW)make e2e WORKSPACE=sushigo-$$LETTER$(NC)  (from sushigo-dev-lab)"; \
-		exit 1; \
+		DEVLAB_START="$$(pwd)/../../scripts/start-e2e.sh"; \
+		if [ -x "$$DEVLAB_START" ]; then \
+			echo "$(YELLOW)⚡ Dev-lab E2E stack not running — auto-starting for sushigo-$$LETTER...$(NC)"; \
+			"$$DEVLAB_START" "sushigo-$$LETTER"; \
+			CONTAINER="$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1)"; \
+		else \
+			echo "$(RED)❌ Dev-lab E2E stack not running.$(NC)"; \
+			echo "   Start it with: $(YELLOW)make e2e WORKSPACE=sushigo-$$LETTER$(NC)  (from sushigo-dev-lab)"; \
+			exit 1; \
+		fi; \
 	fi; \
 	OFFSET=$$(echo "$$LETTER" | tr 'a-h' '12345678'); \
 	VITE_PORT=$$((5180 + OFFSET)); \
@@ -110,9 +124,16 @@ cypress-devlab-headed: ## Run ALL specs headed (browser visible) against dev-lab
 	@LETTER="$$(basename $$(pwd) | sed 's/sushigo-//')"; \
 	CONTAINER="$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1)"; \
 	if [ -z "$$CONTAINER" ]; then \
-		echo "$(RED)❌ Dev-lab E2E stack not running.$(NC)"; \
-		echo "   Start it with: $(YELLOW)make e2e WORKSPACE=sushigo-$$LETTER$(NC)  (from sushigo-dev-lab)"; \
-		exit 1; \
+		DEVLAB_START="$$(pwd)/../../scripts/start-e2e.sh"; \
+		if [ -x "$$DEVLAB_START" ]; then \
+			echo "$(YELLOW)⚡ Dev-lab E2E stack not running — auto-starting for sushigo-$$LETTER...$(NC)"; \
+			"$$DEVLAB_START" "sushigo-$$LETTER"; \
+			CONTAINER="$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1)"; \
+		else \
+			echo "$(RED)❌ Dev-lab E2E stack not running.$(NC)"; \
+			echo "   Start it with: $(YELLOW)make e2e WORKSPACE=sushigo-$$LETTER$(NC)  (from sushigo-dev-lab)"; \
+			exit 1; \
+		fi; \
 	fi; \
 	OFFSET=$$(echo "$$LETTER" | tr 'a-h' '12345678'); \
 	VITE_PORT=$$((5180 + OFFSET)); \
@@ -128,9 +149,16 @@ cypress-devlab-run: ## Run ALL specs headless against dev-lab stack
 	@LETTER="$$(basename $$(pwd) | sed 's/sushigo-//')"; \
 	CONTAINER="$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1)"; \
 	if [ -z "$$CONTAINER" ]; then \
-		echo "$(RED)❌ Dev-lab E2E stack not running.$(NC)"; \
-		echo "   Start it with: $(YELLOW)make e2e WORKSPACE=sushigo-$$LETTER$(NC)  (from sushigo-dev-lab)"; \
-		exit 1; \
+		DEVLAB_START="$$(pwd)/../../scripts/start-e2e.sh"; \
+		if [ -x "$$DEVLAB_START" ]; then \
+			echo "$(YELLOW)⚡ Dev-lab E2E stack not running — auto-starting for sushigo-$$LETTER...$(NC)"; \
+			"$$DEVLAB_START" "sushigo-$$LETTER"; \
+			CONTAINER="$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1)"; \
+		else \
+			echo "$(RED)❌ Dev-lab E2E stack not running.$(NC)"; \
+			echo "   Start it with: $(YELLOW)make e2e WORKSPACE=sushigo-$$LETTER$(NC)  (from sushigo-dev-lab)"; \
+			exit 1; \
+		fi; \
 	fi; \
 	OFFSET=$$(echo "$$LETTER" | tr 'a-h' '12345678'); \
 	VITE_PORT=$$((5180 + OFFSET)); \
@@ -146,9 +174,16 @@ cypress-devlab-run-spec: ## Run a specific spec headless against dev-lab stack: 
 	@LETTER="$$(basename $$(pwd) | sed 's/sushigo-//')"; \
 	CONTAINER="$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1)"; \
 	if [ -z "$$CONTAINER" ]; then \
-		echo "$(RED)❌ Dev-lab E2E stack not running.$(NC)"; \
-		echo "   Start it with: $(YELLOW)make e2e WORKSPACE=sushigo-$$LETTER$(NC)  (from sushigo-dev-lab)"; \
-		exit 1; \
+		DEVLAB_START="$$(pwd)/../../scripts/start-e2e.sh"; \
+		if [ -x "$$DEVLAB_START" ]; then \
+			echo "$(YELLOW)⚡ Dev-lab E2E stack not running — auto-starting for sushigo-$$LETTER...$(NC)"; \
+			"$$DEVLAB_START" "sushigo-$$LETTER"; \
+			CONTAINER="$$(docker ps --format '{{.Names}}' | grep "e2e-api-$$LETTER" | head -1)"; \
+		else \
+			echo "$(RED)❌ Dev-lab E2E stack not running.$(NC)"; \
+			echo "   Start it with: $(YELLOW)make e2e WORKSPACE=sushigo-$$LETTER$(NC)  (from sushigo-dev-lab)"; \
+			exit 1; \
+		fi; \
 	fi; \
 	OFFSET=$$(echo "$$LETTER" | tr 'a-h' '12345678'); \
 	VITE_PORT=$$((5180 + OFFSET)); \


### PR DESCRIPTION
## Summary

- The `cypress-devlab*` targets previously failed with an error if the dev-lab E2E stack was not running, requiring the developer to switch to `sushigo-dev-lab` and run `make e2e WORKSPACE=...` first
- Now they detect the dev-lab by checking for `../../scripts/start-e2e.sh` and auto-start the stack transparently before running Cypress
- Standalone clones (without the dev-lab structure) keep the original descriptive error message

**Affected targets:** `cypress-devlab`, `cypress-devlab-spec`, `cypress-devlab-headed`, `cypress-devlab-run`, `cypress-devlab-run-spec`

## Test plan

- [ ] With container stopped: `make cypress-devlab` auto-starts the stack and opens Cypress
- [ ] With container already running: no change in behavior
- [ ] In a standalone clone (no `../../scripts/start-e2e.sh`): shows original error message

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)