### PR TITLE
🐛 [#185] - Add table hydration guard before closeDevDebugger in E2E

### DIFF
--- a/code/webapp/cypress/e2e/schedule-indefinite-summary.cy.ts
+++ b/code/webapp/cypress/e2e/schedule-indefinite-summary.cy.ts
@@ -45,6 +45,10 @@ describe('Indefinite override — employee card summary', () => {
     cy.url().should('not.include', '/login', { timeout: 10_000 })
     cy.visit('/employees')
     cy.url().should('include', '/employees', { timeout: 10_000 })
+    // Wait for the employee table to render before closing the DevDebugger.
+    // cy.closeDevDebugger uses a synchronous DOM check — React must be
+    // hydrated first or the DevDebugger won't be found and stays open.
+    cy.get('table', { timeout: 10_000 }).should('exist')
     cy.closeDevDebugger()
   })
 
@@ -85,6 +89,7 @@ describe('Indefinite override — schedule dialog compact summary', () => {
     cy.url().should('not.include', '/login', { timeout: 10_000 })
     cy.visit('/employees')
     cy.url().should('include', '/employees', { timeout: 10_000 })
+    cy.get('table', { timeout: 10_000 }).should('exist')
     cy.closeDevDebugger()
   })
 


### PR DESCRIPTION
## Summary

- `schedule-indefinite-summary.cy.ts` fallaba en el tercer test: el badge `⚡ +1` no era visible porque el DevDebugger lo tapaba
- Root cause: `cy.closeDevDebugger()` usa un check sincrónico del DOM — si React no ha hidratado aún, el DevDebugger no está en el DOM y el shortcut nunca se envía
- Fix: agregar `cy.get('table').should('exist')` antes de `cy.closeDevDebugger()` en ambos `beforeEach`, el mismo patrón ya documentado en `employee-bonus-config.cy.ts`

## Test plan

- [x] `make cypress-devlab-run-spec SPEC=schedule-indefinite-summary` → 3/3 passing
- [x] No otros tests afectados (cambio es aditivo, solo agrega un guard de hidratación)

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)