### PR TITLE
🐛 [#182] - Fix extra-day-employee-request.cy.ts — CalendarPicker + ConfirmDialog

### DIFF
--- a/code/webapp/cypress/e2e/extra-day-employee-request.cy.ts
+++ b/code/webapp/cypress/e2e/extra-day-employee-request.cy.ts
@@ -6,12 +6,13 @@
  * sees it in the list as PENDING, and cancels it.
  *
  * User used: admin@sushigo.com (has Employee profile ADM-001 in test seeder)
+ * Rest day: Sunday (day_of_week=7) — AttendanceTestSeeder sets Mon–Sat as working days.
  *
  * Happy path flow:
  *   1. Employee logs in and navigates to /solicitudes
  *   2. Clicks "➕ Día extra"
  *   3. ExtraDayRequestForm SlidePanel opens
- *   4. Enters a future date (2099-01-15)
+ *   4. Picks the next upcoming Sunday via the CalendarPicker custom component
  *   5. Leaves prima % at default (100)
  *   6. Clicks "Enviar solicitud"
  *   7. Request card appears with "⏳ Pendiente de aprobación"
@@ -26,6 +27,31 @@
 import users from '../fixtures/users.json'
 
 const { email, password } = users.admin
+
+// ── Date helpers (evaluated at test-queue time, not runtime) ─────────────────
+
+function isoDate(d: Date): string {
+  return [
+    d.getFullYear(),
+    String(d.getMonth() + 1).padStart(2, '0'),
+    String(d.getDate()).padStart(2, '0'),
+  ].join('-')
+}
+
+/** Returns YYYY-MM-DD of the next Sunday (never today even if today is Sunday). */
+function nextSunday(): string {
+  const today = new Date()
+  const dow = today.getDay() // 0=Sun … 6=Sat
+  const daysAhead = dow === 0 ? 7 : 7 - dow
+  const d = new Date(today)
+  d.setDate(today.getDate() + daysAhead)
+  return isoDate(d)
+}
+
+/** True when isoDate falls in the same calendar month as today. */
+function isCurrentMonth(iso: string): boolean {
+  return iso.startsWith(isoDate(new Date()).slice(0, 7))
+}
 
 // ── Suite setup ──────────────────────────────────────────────────────────────
 
@@ -50,12 +76,34 @@ function assertSlidePanelOpen() {
   cy.contains('Solicitar día extra', { timeout: 8_000 }).should('be.visible')
 }
 
+/**
+ * Picks `targetDate` (YYYY-MM-DD) in the CalendarPicker inside the open SlidePanel.
+ * The RestDayPicker fetches the employee schedule on mount; this waits for the
+ * trigger button to appear (loading state shows "Cargando horario…" instead).
+ * Navigates to the next month if the target date falls outside the current view.
+ */
+function pickDate(targetDate: string) {
+  // Wait for schedule fetch to finish — trigger button replaces the loader
+  cy.contains('button', 'Seleccionar fecha de descanso', { timeout: 10_000 }).click()
+
+  // Calendar opens; navigate forward if target is in a different month
+  if (!isCurrentMonth(targetDate)) {
+    cy.get('button[aria-label="Siguiente"]').click()
+  }
+
+  // force:true needed because the calendar dropdown (z-50 absolute) is reported
+  // as covered by the SlidePanel's overflow-y-auto scroll container
+  cy.get(`button[aria-label="${targetDate}"]`).should('not.be.disabled').click({ force: true })
+}
+
 // ══════════════════════════════════════════════════════════════════════════════
 // Happy Path — submit request → PENDING card → cancel
 // ══════════════════════════════════════════════════════════════════════════════
 
 describe('Extra Day Employee Self-Request — Happy Path', () => {
   it('submits a request, sees PENDING card, then cancels it', () => {
+    const targetDate = nextSunday()
+
     cy.intercept('POST', '**/employee-requests').as('createRequest')
     cy.intercept('PATCH', '**/employee-requests/*/cancel').as('cancelRequest')
     cy.intercept('GET', '**/employee-requests*').as('listRequests')
@@ -64,8 +112,8 @@ describe('Extra Day Employee Self-Request — Happy Path', () => {
     openExtraDayForm()
     assertSlidePanelOpen()
 
-    // Step 2: Enter a future date
-    cy.get('input[type="date"]').clear().type('2099-01-15')
+    // Step 2: Pick the next Sunday via the CalendarPicker custom component
+    pickDate(targetDate)
 
     // Step 3: Leave prima % at default (100) and submit
     cy.contains('button', 'Enviar solicitud').click()
@@ -77,8 +125,9 @@ describe('Extra Day Employee Self-Request — Happy Path', () => {
     cy.contains('Pendiente de aprobación', { timeout: 8_000 }).should('be.visible')
     cy.contains('⏳ Día extra solicitado').should('be.visible')
 
-    // Step 6: Cancel the request
+    // Step 6: Cancel the request — opens ConfirmDialog, then confirms
     cy.contains('button', 'Cancelar').click()
+    cy.contains('button', 'Sí, cancelar').click()
 
     cy.wait('@cancelRequest').its('response.statusCode').should('eq', 200)
 


### PR DESCRIPTION
Closes #182

## Summary

- **Replace stale `input[type="date"]` selector** with a `pickDate()` helper that interacts with the custom `CalendarPicker` (trigger button + day grid with `aria-label="YYYY-MM-DD"`). Date is computed dynamically as the next Sunday — the rest day defined in `AttendanceTestSeeder` (Mon–Sat working, Sunday off).
- **Add month navigation guard** — `isCurrentMonth()` checks if the target Sunday is in the current calendar view; if not, clicks "Siguiente" to advance one month.
- **`{ force: true }` on day button click** — Cypress reports the day button as covered by the SlidePanel's `overflow-y-auto` container, even though the dropdown sits at `z-50 absolute`. Force bypasses the actionability check without affecting real behaviour.
- **Add `ConfirmDialog` confirmation step** — The "Cancelar" button on `RequestStatusCard` now opens a confirmation dialog before firing the PATCH. Added `cy.contains('button', 'Sí, cancelar').click()` so the cancel actually goes through.

## Test plan

- [x] `make cypress-devlab-run-spec SPEC=extra-day-employee-request` → ✅ 1/1 passing (13 s)
- [x] No other spec files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)