### PR TITLE
🐛 [#184] - Fix manager-approval-inbox E2E: wrong rest day + DevDebugger race

### DIFF
--- a/code/webapp/cypress/e2e/manager-approval-inbox.cy.ts
+++ b/code/webapp/cypress/e2e/manager-approval-inbox.cy.ts
@@ -23,7 +23,7 @@ import users from '../fixtures/users.json'
 const { email, password } = users.admin
 
 const API = Cypress.env('apiUrl') || 'https://devtest.api.sushigo.local/api/v1'
-const FUTURE_DATE = '2099-06-15'
+const FUTURE_DATE = '2099-06-14' // Sunday — only rest day in AttendanceTestSeeder schedule (ISO day 7)
 
 // ── Suite setup ──────────────────────────────────────────────────────────────
 
@@ -93,7 +93,9 @@ describe('Manager Approval Inbox — Approve', () => {
   beforeEach(() => {
     cy.loginByApi(email, password)
     cy.visitWithAuth('/solicitudes')
-    cy.url().should('include', '/solicitudes', { timeout: 10_000 })
+    // Wait for React to hydrate before closeDevDebugger takes its synchronous DOM snapshot.
+    // cy.url() passes before hydration; cy.contains() retries until React renders the heading.
+    cy.contains('Solicitudes', { timeout: 10_000 }).should('be.visible')
     cy.closeDevDebugger()
   })
 
@@ -141,7 +143,7 @@ describe('Manager Approval Inbox — Reject', () => {
   beforeEach(() => {
     cy.loginByApi(email, password)
     cy.visitWithAuth('/solicitudes')
-    cy.url().should('include', '/solicitudes', { timeout: 10_000 })
+    cy.contains('Solicitudes', { timeout: 10_000 }).should('be.visible')
     cy.closeDevDebugger()
   })
 


### PR DESCRIPTION
## Summary

- 🐛 `FUTURE_DATE` cambiado de `2099-06-15` (lunes) a `2099-06-14` (domingo) — `guardIsRestDay` lanzaba 422 porque el seeder solo marca Sunday (ISO day 7) como descanso
- 🔧 `cy.url().should()` reemplazado con `cy.contains('Solicitudes').should('be.visible')` en ambos `beforeEach` — garantiza que React haya hidratado antes del snapshot síncrono de `closeDevDebugger`, evitando que el DevDebugger (z-9999) cubra el `ConfirmDialog` (z-60)

## Root causes

**Fallo 1 — approve devuelve 422:**
`FUTURE_DATE = '2099-06-15'` es lunes (ISO day 1). `AttendanceTestSeeder` solo asigna `is_day_off = true` al día 7 (domingo). `guardIsRestDay` en `ExtraDayRequestHandler` valida que la fecha sea día de descanso y lanza 422 si no lo es.

**Fallo 2 — ConfirmDialog cubierto:**
`closeDevDebugger()` toma un snapshot síncrono del DOM via `cy.get('body').then()`. `cy.url().should('include', '/solicitudes')` resuelve tan pronto cambia la URL — antes de que React hidrate — por lo que el snapshot no encuentra el DevDebugger y hace no-op. React hidrata después, el DevDebugger aparece en `z-[9999]` y cubre el `ConfirmDialog` (`z-[60]` dentro del SlidePanel `z-50`). Cypress reporta `h3#confirm-dialog-title` como not visible (cubierto).

## Test plan

- [x] `make cypress-devlab-run-spec SPEC=manager-approval-inbox` — 3/3 passing

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)