### PR TITLE
🐛 [#190] Fix schedule-history E2E: DevDebugger timing and slide panel scroll

### DIFF
--- a/code/webapp/cypress/e2e/schedule-history.cy.ts
+++ b/code/webapp/cypress/e2e/schedule-history.cy.ts
@@ -34,6 +34,10 @@ describe('Schedule History', () => {
     cy.url().should('not.include', '/login', { timeout: 10_000 })
     cy.visit('/employees')
     cy.url().should('include', '/employees', { timeout: 10_000 })
+    // Wait for the employee table to exist before closing the debugger.
+    // closeDevDebugger() uses a synchronous jQuery snapshot — if React hasn't
+    // hydrated yet the DevDebugger won't be in the DOM and the command no-ops.
+    cy.get('table', { timeout: 10_000 }).should('exist')
     cy.closeDevDebugger()
   })
 
@@ -86,8 +90,9 @@ describe('Schedule History', () => {
     // Select a position
     cy.contains('label', 'Cocinero').find('[role="switch"]').click({ force: true })
 
-    // Create employee
-    cy.contains('button', 'Crear').click()
+    // force: true required — the submit button may be outside the slide panel's overflow-y-auto
+    // visible area; all other form elements in this panel also use { force: true }
+    cy.contains('button', 'Crear').click({ force: true })
 
     // Wait for detail view
     cy.contains('Test NoSchedule', { timeout: 10_000 }).scrollIntoView().should('be.visible')


### PR DESCRIPTION
## Summary

- Added `cy.get('table').should('exist')` wait before `closeDevDebugger()` in `beforeEach` — fixes test 1 where the DevDebugger was left visible (covering the "Cerrar" button) because the synchronous jQuery snapshot ran before React hydrated
- Changed `cy.contains('button', 'Crear').click()` to `.click({ force: true })` — fixes test 2 where Cypress's scroll algorithm fails to resolve visibility for elements inside a `fixed`-positioned `overflow-y-auto` container

## Root cause

**Test 1**: `closeDevDebugger()` uses a synchronous jQuery snapshot to detect the DevDebugger. If React hasn't mounted yet when the snapshot runs, the command silently no-ops, leaving the expanded DevDebugger visible at x:860–1240 y:100–676 (1280×720 viewport) — which overlaps the dialog's "Cerrar" button at ~y:540.

**Test 2**: The employee creation form's "Crear" submit button can be scrolled below the slide panel's `overflow-y-auto` visible area after form inputs auto-scroll the panel. Cypress's visibility check incorrectly reports the element as hidden even after scroll retries inside a `fixed`-positioned ancestor. All other form interactions in the same test already use `{ force: true }`.

## Test plan

- [x] `make cypress-devlab-run-spec SPEC=schedule-history` — both tests pass (2/2, 16s)
- [x] Test 1: `shows schedule history with ACTIVO badge and date range` ✅
- [x] Test 2: `shows empty state when employee has no schedule history` ✅

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)