### PR TITLE
🔧 [#066] - Ignore plan/ folder from git tracking 📋

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ node_modules/
 .env
 !.env.example
 
+# Local planning documents — never committed
+plan/
+


### PR DESCRIPTION
## Summary
- Add `plan/` to `.gitignore` — local planning documents (roadmaps, notes, drafts) that should never be committed

## Why
The `plan/` folder at the repo root is used for local-only planning documents (implementation roadmaps, wave planning, scratch notes). It must stay out of version control so each developer can maintain their own local planning state without polluting the repo.

## Test plan
- [ ] Verify `plan/` does not appear in `git status` after creating files inside it

🤖 Generated with [Claude Code](https://claude.com/claude-code)