### PR TITLE
🔧 [#147] - Skip CI on doc-only PRs 🔧

### DIFF
--- a/.github/workflows/api-lint.yml
+++ b/.github/workflows/api-lint.yml
@@ -2,6 +2,8 @@ name: API Lint (PHP Pint)
 
 on:
   pull_request:
+    paths:
+      - 'code/api/**'
   push:
     branches:
       - main

--- a/.github/workflows/api-lint.yml
+++ b/.github/workflows/api-lint.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'code/api/**'
+      - '.github/workflows/api-lint.yml'
   push:
     branches:
       - main

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -2,6 +2,8 @@ name: API Tests (PHPUnit + Coverage)
 
 on:
   pull_request:
+    paths:
+      - 'code/api/**'
   push:
     branches:
       - main

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'code/api/**'
+      - '.github/workflows/api-tests.yml'
   push:
     branches:
       - main

--- a/.github/workflows/webapp-lint.yml
+++ b/.github/workflows/webapp-lint.yml
@@ -2,6 +2,8 @@ name: Webapp Lint (ESLint + TypeScript)
 
 on:
   pull_request:
+    paths:
+      - 'code/webapp/**'
   push:
     branches:
       - main

--- a/.github/workflows/webapp-lint.yml
+++ b/.github/workflows/webapp-lint.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'code/webapp/**'
+      - '.github/workflows/webapp-lint.yml'
   push:
     branches:
       - main

--- a/.github/workflows/webapp-tests.yml
+++ b/.github/workflows/webapp-tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'code/webapp/**'
+      - '.github/workflows/webapp-tests.yml'
   push:
     branches:
       - main

--- a/.github/workflows/webapp-tests.yml
+++ b/.github/workflows/webapp-tests.yml
@@ -2,6 +2,8 @@ name: Webapp Tests (Vitest + Coverage)
 
 on:
   pull_request:
+    paths:
+      - 'code/webapp/**'
   push:
     branches:
       - main

--- a/doc/tasks/2026-06/147-skip-ci-on-doc-only-prs.md
+++ b/doc/tasks/2026-06/147-skip-ci-on-doc-only-prs.md
@@ -12,10 +12,10 @@ Como desarrollador al mergear PRs de solo documentación, necesito que los CI wo
 
 ## ✅ Technical Tasks
 
-- [ ] 🔧 Add `paths: ['code/api/**']` to `on: pull_request:` trigger in `.github/workflows/api-lint.yml`
-- [ ] 🔧 Add `paths: ['code/api/**']` to `on: pull_request:` trigger in `.github/workflows/api-tests.yml`
-- [ ] 🔧 Add `paths: ['code/webapp/**']` to `on: pull_request:` trigger in `.github/workflows/webapp-lint.yml`
-- [ ] 🔧 Add `paths: ['code/webapp/**']` to `on: pull_request:` trigger in `.github/workflows/webapp-tests.yml`
+- [x] 🔧 Add `paths: ['code/api/**']` to `on: pull_request:` trigger in `.github/workflows/api-lint.yml`
+- [x] 🔧 Add `paths: ['code/api/**']` to `on: pull_request:` trigger in `.github/workflows/api-tests.yml`
+- [x] 🔧 Add `paths: ['code/webapp/**']` to `on: pull_request:` trigger in `.github/workflows/webapp-lint.yml`
+- [x] 🔧 Add `paths: ['code/webapp/**']` to `on: pull_request:` trigger in `.github/workflows/webapp-tests.yml`
 - [ ] 🧪 Verify: doc-only PR → zero CI checks appear → merge unblocked
 - [ ] 🧪 Verify: code PR → CI checks appear and run correctly
 - [ ] 🧪 Verify: mixed PR (code + docs) → only relevant suite runs
@@ -42,11 +42,11 @@ Como desarrollador al mergear PRs de solo documentación, necesito que los CI wo
 ## ⏱️ Time
 
 ### 📊 Estimates
-- **Optimistic:** `1h` · **Pessimistic:** `2h` · **Tracked:** _in progress_
+- **Optimistic:** `1h` · **Pessimistic:** `2h` · **Tracked:** 1m
 
 ### 📅 Sessions
 ```json
 [
-  { "date": "2026-06-14", "start": "02:06", "end": "?" }
+  { "date": "2026-06-14", "start": "02:06", "end": "02:07" }
 ]
 ```

--- a/doc/tasks/2026-06/147-skip-ci-on-doc-only-prs.md
+++ b/doc/tasks/2026-06/147-skip-ci-on-doc-only-prs.md
@@ -39,6 +39,14 @@ Como desarrollador al mergear PRs de solo documentación, necesito que los CI wo
 
 ---
 
-## ⏱️ Estimates
+## ⏱️ Time
 
-- **Optimistic:** `1h` · **Pessimistic:** `2h`
+### 📊 Estimates
+- **Optimistic:** `1h` · **Pessimistic:** `2h` · **Tracked:** _in progress_
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-06-14", "start": "02:06", "end": "?" }
+]
+```


### PR DESCRIPTION
## Summary
- Add `paths: ['code/api/**']` filter to `pull_request` trigger in `api-lint.yml` and `api-tests.yml` so API CI only runs when API code changes
- Add `paths: ['code/webapp/**']` filter to `pull_request` trigger in `webapp-lint.yml` and `webapp-tests.yml` so webapp CI only runs when webapp code changes
- `push` trigger on `main` is unchanged — all pushes to main still run full CI

## Test plan
- [ ] Open a doc-only PR (e.g. change a file in `doc/`) → zero CI checks should appear
- [ ] Open a PR changing `code/api/**` → `api-lint` and `api-tests` should trigger
- [ ] Open a PR changing `code/webapp/**` → `webapp-lint` and `webapp-tests` should trigger
- [ ] Open a mixed PR (code + docs) → only the relevant suite should run

## Closes
Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)