### PR TITLE
📚 [#147] - Verify: doc-only PR triggers no CI

### DIFF
--- a/doc/tasks/2026-06/147-skip-ci-on-doc-only-prs.md
+++ b/doc/tasks/2026-06/147-skip-ci-on-doc-only-prs.md
@@ -47,6 +47,7 @@ Como desarrollador al mergear PRs de solo documentación, necesito que los CI wo
 ### 📅 Sessions
 ```json
 [
-  { "date": "2026-06-14", "start": "02:06", "end": "02:07" }
+  { "date": "2026-06-14", "start": "02:06", "end": "02:07" },
+  { "date": "2026-06-16", "start": "verify", "end": "verify" }
 ]
 ```


### PR DESCRIPTION
## Purpose

Verification test for task #147. This PR contains **only a documentation change** (`doc/tasks/**`) and should trigger **zero CI workflows**.

Expected behavior:
- ❌ `api-lint` → not triggered
- ❌ `api-tests` → not triggered
- ❌ `webapp-lint` → not triggered
- ❌ `webapp-tests` → not triggered

If no checks appear on this PR, the feature works correctly. This PR will be closed after verification.

## Workspace
`sushigo-b` — `test/147-doc-only-pr-verify`