### PR TITLE
👁️ [#072][d] - Preview Weekly Payroll Close 👁️

### DIFF
--- a/code/api/.env.example
+++ b/code/api/.env.example
@@ -95,3 +95,10 @@ DEV_LOGIN_ALLOWED_ENVIRONMENTS=dev,devtest
 # The ClockBadge in the header shows when clock is in "simulated" mode.
 # CRITICAL: Must be false in production.
 CLOCK_SIMULATION_ENABLED=false
+
+# Payroll Attendance Seed (devtools)
+# -----------------------------------
+# Enables the devtools payroll seed endpoint for generating test attendance data.
+# When true, POST /api/v1/devtools/payroll/seed becomes available.
+# CRITICAL: Must be false in production.
+PAYROLL_SEED_ENABLED=false

--- a/code/api/app/Console/Commands/TestReset.php
+++ b/code/api/app/Console/Commands/TestReset.php
@@ -12,6 +12,7 @@ use Database\Seeders\Testing\CloseDayHappyPathSeeder;
 use Database\Seeders\Testing\CloseDayPendingLunchSeeder;
 use Database\Seeders\Testing\CoreTestSeeder;
 use Database\Seeders\Testing\NegotiatedExtraDaysSeeder;
+use Database\Seeders\Testing\PayrollPreviewSeeder;
 use Database\Seeders\Testing\ScheduleSummaryOverrideSeeder;
 use Database\Seeders\Testing\TodayReportStatusSeeder;
 use Illuminate\Console\Command;
@@ -70,6 +71,9 @@ class TestReset extends Command
         ],
         'fakes-employees' => [
             FakeEmployeesSeeder::class,
+        ],
+        'payroll-preview' => [
+            PayrollPreviewSeeder::class,
         ],
     ];
 

--- a/code/api/app/Enums/SeedScenario.php
+++ b/code/api/app/Enums/SeedScenario.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Enums;
+
+enum SeedScenario: string
+{
+    case FULL_WEEK = 'full_week';
+    case WITH_LATES = 'with_lates';
+    case WITH_UNPAID_LEAVE = 'with_unpaid_leave';
+    case WITH_OVERTIME = 'with_overtime';
+    case WITH_ABSENCES = 'with_absences';
+    case MIXED = 'mixed';
+}

--- a/code/api/app/Http/Controllers/Api/V1/Devtools/SeedPayrollController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Devtools/SeedPayrollController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Devtools;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Devtools\SeedPayrollRequest;
+use App\Services\PayrollSeedService;
+use App\Support\PayrollSeed\PayrollSeedGuard;
+use Illuminate\Http\JsonResponse;
+
+class SeedPayrollController extends Controller
+{
+    public function __construct(private PayrollSeedService $seedService) {}
+
+    public function __invoke(SeedPayrollRequest $request): JsonResponse
+    {
+        PayrollSeedGuard::validate();
+
+        $result = $this->seedService->seed(
+            $request->branchId(),
+            $request->periodStart(),
+            $request->periodEnd(),
+            $request->scenario(),
+        );
+
+        return response()->json([
+            'status' => 'ok',
+            'data' => $result,
+        ]);
+    }
+}

--- a/code/api/app/Http/Controllers/Api/V1/PayPeriods/PreviewPayPeriodController.php
+++ b/code/api/app/Http/Controllers/Api/V1/PayPeriods/PreviewPayPeriodController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\PayPeriods;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\PayPeriods\PreviewPayPeriodRequest;
+use App\Http\Responses\Common\ResponseEntity;
+use App\Models\Employee;
+use App\Models\Holiday;
+use App\Models\PunctualityRange;
+use App\Services\PayPeriodPreviewService;
+
+/**
+ * @OA\Get(
+ *   path="/api/v1/pay-periods/preview",
+ *   summary="Preview weekly payroll close",
+ *   description="Calculates payroll totals for all active employees of a branch in the given period. Does not persist any data.",
+ *   tags={"PayPeriods"},
+ *   security={{"passport": {}}},
+ *
+ *   @OA\Parameter(name="branch_id", in="query", required=true, @OA\Schema(type="integer")),
+ *   @OA\Parameter(name="period_start", in="query", required=true, @OA\Schema(type="string", format="date", example="2026-06-22")),
+ *   @OA\Parameter(name="period_end", in="query", required=true, @OA\Schema(type="string", format="date", example="2026-06-28")),
+ *
+ *   @OA\Response(response=200, description="Preview calculated successfully"),
+ *   @OA\Response(response=401, description="Unauthenticated"),
+ *   @OA\Response(response=403, description="Forbidden"),
+ *   @OA\Response(response=422, description="Validation error")
+ * )
+ */
+class PreviewPayPeriodController extends Controller
+{
+    public function __construct(private PayPeriodPreviewService $previewService) {}
+
+    public function __invoke(PreviewPayPeriodRequest $request): ResponseEntity
+    {
+        $branchId = $request->branchId();
+        $periodStart = $request->periodStart();
+        $periodEnd = $request->periodEnd();
+
+        $employees = Employee::with(['employmentPeriods'])
+            ->whereHas('employmentPeriods', function ($q) use ($branchId) {
+                $q->where('branch_id', $branchId)->where('is_active', true);
+            })
+            ->where('is_active', true)
+            ->orderBy('last_name')
+            ->orderBy('first_name')
+            ->get();
+
+        $holidays = Holiday::whereBetween('date', [$periodStart, $periodEnd])->get();
+        $punctualityRanges = PunctualityRange::orderBy('sort_order')->get();
+
+        $data = $employees->map(
+            fn (Employee $employee) => $this->previewService->buildEmployeePreview($employee, $periodStart, $periodEnd, $holidays, $punctualityRanges)
+        )->values()->all();
+
+        return new ResponseEntity(data: $data);
+    }
+}

--- a/code/api/app/Http/Requests/Devtools/SeedPayrollRequest.php
+++ b/code/api/app/Http/Requests/Devtools/SeedPayrollRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Requests\Devtools;
+
+use App\Enums\SeedScenario;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Enum;
+
+class SeedPayrollRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'branch_id' => ['required', 'integer', 'exists:branches,id'],
+            'period_start' => ['required', 'date'],
+            'period_end' => ['required', 'date', 'after_or_equal:period_start'],
+            'scenario' => ['required', new Enum(SeedScenario::class)],
+        ];
+    }
+
+    public function branchId(): int
+    {
+        return (int) $this->validated('branch_id');
+    }
+
+    public function periodStart(): string
+    {
+        return $this->validated('period_start');
+    }
+
+    public function periodEnd(): string
+    {
+        return $this->validated('period_end');
+    }
+
+    public function scenario(): SeedScenario
+    {
+        return SeedScenario::from($this->validated('scenario'));
+    }
+}

--- a/code/api/app/Http/Requests/PayPeriods/PreviewPayPeriodRequest.php
+++ b/code/api/app/Http/Requests/PayPeriods/PreviewPayPeriodRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\PayPeriods;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PreviewPayPeriodRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()->can('payroll.preview');
+    }
+
+    public function rules(): array
+    {
+        return [
+            'branch_id' => ['required', 'integer', 'exists:branches,id'],
+            'period_start' => ['required', 'date'],
+            'period_end' => ['required', 'date', 'after_or_equal:period_start'],
+        ];
+    }
+
+    public function branchId(): int
+    {
+        return (int) $this->validated('branch_id');
+    }
+
+    public function periodStart(): string
+    {
+        return $this->validated('period_start');
+    }
+
+    public function periodEnd(): string
+    {
+        return $this->validated('period_end');
+    }
+}

--- a/code/api/app/Models/OvertimeBankMovement.php
+++ b/code/api/app/Models/OvertimeBankMovement.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Models;
+
+use App\Support\Traits\HasPublicId;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class OvertimeBankMovement extends Model
+{
+    use HasFactory;
+    use HasPublicId;
+
+    const TYPE_EARNED = 'EARNED';
+
+    const TYPE_PAID = 'PAID';
+
+    const TYPE_EXPIRED = 'EXPIRED';
+
+    const TYPE_TRANSFERRED = 'TRANSFERRED';
+
+    protected $fillable = [
+        'employee_id',
+        'attendance_id',
+        'date',
+        'type',
+        'minutes',
+        'reference',
+        'meta',
+    ];
+
+    protected $casts = [
+        'date' => 'date',
+        'minutes' => 'integer',
+        'meta' => 'array',
+    ];
+
+    public function employee(): BelongsTo
+    {
+        return $this->belongsTo(Employee::class);
+    }
+
+    public function attendance(): BelongsTo
+    {
+        return $this->belongsTo(Attendance::class);
+    }
+
+    public function scopePaid(Builder $query): Builder
+    {
+        return $query->where('type', self::TYPE_PAID);
+    }
+
+    public function scopeEarned(Builder $query): Builder
+    {
+        return $query->where('type', self::TYPE_EARNED);
+    }
+
+    public function scopeInPeriod(Builder $query, string $start, string $end): Builder
+    {
+        return $query->whereBetween('date', [$start, $end]);
+    }
+}

--- a/code/api/app/Models/PartialLeave.php
+++ b/code/api/app/Models/PartialLeave.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use App\Support\Traits\HasPublicId;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PartialLeave extends Model
+{
+    use HasFactory;
+    use HasPublicId;
+
+    protected $fillable = [
+        'attendance_id',
+        'employee_id',
+        'date',
+        'duration_minutes',
+        'is_paid',
+        'reason',
+        'meta',
+    ];
+
+    protected $casts = [
+        'date' => 'date',
+        'duration_minutes' => 'integer',
+        'is_paid' => 'boolean',
+        'meta' => 'array',
+    ];
+
+    public function attendance(): BelongsTo
+    {
+        return $this->belongsTo(Attendance::class);
+    }
+
+    public function employee(): BelongsTo
+    {
+        return $this->belongsTo(Employee::class);
+    }
+}

--- a/code/api/app/Models/PayPeriod.php
+++ b/code/api/app/Models/PayPeriod.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Models;
+
+use App\Support\Traits\HasPublicId;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class PayPeriod extends Model
+{
+    use HasPublicId;
+
+    const STATUS_OPEN = 'OPEN';
+
+    const STATUS_CLOSED = 'CLOSED';
+
+    const STATUS_REOPENED = 'REOPENED';
+
+    protected $fillable = [
+        'branch_id',
+        'period_start',
+        'period_end',
+        'status',
+        'closed_by',
+        'closed_at',
+        'reopened_by',
+        'reopened_at',
+        'reopen_reason',
+        'meta',
+    ];
+
+    protected $casts = [
+        'period_start' => 'date',
+        'period_end' => 'date',
+        'closed_at' => 'datetime',
+        'reopened_at' => 'datetime',
+        'meta' => 'array',
+    ];
+
+    public function branch(): BelongsTo
+    {
+        return $this->belongsTo(Branch::class);
+    }
+
+    public function closedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'closed_by');
+    }
+
+    public function reopenedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'reopened_by');
+    }
+
+    public function payPeriodEmployees(): HasMany
+    {
+        return $this->hasMany(PayPeriodEmployee::class);
+    }
+
+    public function isOpen(): bool
+    {
+        return $this->status === self::STATUS_OPEN;
+    }
+
+    public function isClosed(): bool
+    {
+        return $this->status === self::STATUS_CLOSED;
+    }
+}

--- a/code/api/app/Models/PayPeriodEmployee.php
+++ b/code/api/app/Models/PayPeriodEmployee.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Models;
+
+use App\Support\Traits\HasPublicId;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class PayPeriodEmployee extends Model
+{
+    use HasPublicId;
+
+    protected $fillable = [
+        'pay_period_id',
+        'employee_id',
+        'base_pay',
+        'late_deductions',
+        'unpaid_leave_deductions',
+        'overtime_pay',
+        'extra_day_pay',
+        'punctuality_bonus',
+        'holiday_pay',
+        'other_adjustments',
+        'total_pay',
+        'free_hours_earned',
+        'daily_snapshot',
+    ];
+
+    protected $casts = [
+        'base_pay' => 'decimal:2',
+        'late_deductions' => 'decimal:2',
+        'unpaid_leave_deductions' => 'decimal:2',
+        'overtime_pay' => 'decimal:2',
+        'extra_day_pay' => 'decimal:2',
+        'punctuality_bonus' => 'decimal:2',
+        'holiday_pay' => 'decimal:2',
+        'other_adjustments' => 'decimal:2',
+        'total_pay' => 'decimal:2',
+        'free_hours_earned' => 'decimal:2',
+        'daily_snapshot' => 'array',
+    ];
+
+    public function payPeriod(): BelongsTo
+    {
+        return $this->belongsTo(PayPeriod::class);
+    }
+
+    public function employee(): BelongsTo
+    {
+        return $this->belongsTo(Employee::class);
+    }
+
+    public function lines(): HasMany
+    {
+        return $this->hasMany(PayPeriodLine::class);
+    }
+
+    public function calculateTotal(): float
+    {
+        return (float) $this->base_pay
+            - (float) $this->late_deductions
+            - (float) $this->unpaid_leave_deductions
+            + (float) $this->overtime_pay
+            + (float) $this->extra_day_pay
+            + (float) $this->punctuality_bonus
+            + (float) $this->holiday_pay
+            + (float) $this->other_adjustments;
+    }
+}

--- a/code/api/app/Models/PayPeriodLine.php
+++ b/code/api/app/Models/PayPeriodLine.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Models;
+
+use App\Support\Traits\HasPublicId;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PayPeriodLine extends Model
+{
+    use HasPublicId;
+
+    const CONCEPT_BASE_PAY = 'BASE_PAY';
+
+    const CONCEPT_LATE_DEDUCTION = 'LATE_DEDUCTION';
+
+    const CONCEPT_UNPAID_LEAVE = 'UNPAID_LEAVE';
+
+    const CONCEPT_OVERTIME = 'OVERTIME';
+
+    const CONCEPT_EXTRA_DAY = 'EXTRA_DAY';
+
+    const CONCEPT_PUNCTUALITY_BONUS = 'PUNCTUALITY_BONUS';
+
+    const CONCEPT_HOLIDAY = 'HOLIDAY';
+
+    const CONCEPT_OTHER = 'OTHER';
+
+    protected $fillable = [
+        'pay_period_employee_id',
+        'date',
+        'concept',
+        'description',
+        'amount',
+        'minutes',
+        'meta',
+    ];
+
+    protected $casts = [
+        'date' => 'date',
+        'amount' => 'decimal:2',
+        'minutes' => 'integer',
+        'meta' => 'array',
+    ];
+
+    public function payPeriodEmployee(): BelongsTo
+    {
+        return $this->belongsTo(PayPeriodEmployee::class);
+    }
+}

--- a/code/api/app/Services/PayPeriodPreviewService.php
+++ b/code/api/app/Services/PayPeriodPreviewService.php
@@ -1,0 +1,303 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Employee;
+use App\Models\EmployeeBonusConfig;
+use App\Models\EmployeeSchedule;
+use App\Models\EmploymentPeriod;
+use App\Models\Holiday;
+use App\Models\OvertimeBankMovement;
+use App\Models\PartialLeave;
+use App\Models\PunctualityRange;
+use App\Models\ScheduleDay;
+use App\Models\WageHistory;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+
+class PayPeriodPreviewService
+{
+    /**
+     * Build a payroll preview for a single employee over a date range.
+     * Does not persist any data.
+     *
+     * @return array{
+     *   employee: array,
+     *   base_pay: float,
+     *   late_deductions: float,
+     *   unpaid_leave_deductions: float,
+     *   overtime_pay: float,
+     *   extra_day_pay: float,
+     *   punctuality_bonus: float,
+     *   holiday_pay: float,
+     *   other_adjustments: float,
+     *   total_pay: float,
+     *   free_hours_earned: float,
+     *   pay_period_lines: array
+     * }
+     */
+    public function buildEmployeePreview(
+        Employee $employee,
+        string $periodStart,
+        string $periodEnd,
+        ?Collection $holidays = null,
+        ?Collection $punctualityRanges = null
+    ): array {
+        $start = Carbon::parse($periodStart);
+
+        // ── Load wage effective at period start ───────────────────────────────
+        $wage = WageHistory::where('employee_id', $employee->id)
+            ->effective($start)
+            ->latest('effective_from')
+            ->first();
+
+        $hourlyRate = $wage ? (float) $wage->hourly_rate : 0.0;
+        $minuteRate = $wage ? $wage->minuteRate() : 0.0;
+
+        // ── Load WORKED attendances in the period ─────────────────────────────
+        $attendances = $employee->attendances()
+            ->whereBetween('date', [$periodStart, $periodEnd])
+            ->where('day_status', 'WORKED')
+            ->get();
+
+        // ── Resolve scheduled minutes per worked day ──────────────────────────
+        $scheduledMinutes = $this->resolveScheduledMinutes($employee, $attendances, $periodStart);
+
+        // ── Partial leaves (linked to worked attendances) ─────────────────────
+        $partialLeaves = PartialLeave::where('employee_id', $employee->id)
+            ->whereBetween('date', [$periodStart, $periodEnd])
+            ->get();
+
+        // ── Overtime bank movements ───────────────────────────────────────────
+        $overtimeMovements = OvertimeBankMovement::where('employee_id', $employee->id)
+            ->inPeriod($periodStart, $periodEnd)
+            ->get();
+
+        // ── Negotiated extra days (APPROVED) ─────────────────────────────────
+        $extraDays = $employee->negotiatedExtraDays()
+            ->whereBetween('date', [$periodStart, $periodEnd])
+            ->where('status', 'APPROVED')
+            ->get();
+
+        // ── Holidays in the period ────────────────────────────────────────────
+        $holidays ??= Holiday::whereBetween('date', [$periodStart, $periodEnd])->get();
+
+        // ── Punctuality bonus ─────────────────────────────────────────────────
+        $bonusConfig = EmployeeBonusConfig::where('employee_id', $employee->id)
+            ->effective($start)
+            ->with('bonusGroup')
+            ->latest('effective_from')
+            ->first();
+
+        $ranges = $punctualityRanges ?? PunctualityRange::orderBy('sort_order')->get();
+
+        // ── Calculations ──────────────────────────────────────────────────────
+        $basePay = PayrollCalculator::calculateBasePay($scheduledMinutes, $hourlyRate);
+        $lateDeductions = PayrollCalculator::calculateLateDeductions($attendances, $minuteRate);
+        $unpaidLeaveDeductions = PayrollCalculator::calculateUnpaidLeaveDeductions($partialLeaves, $minuteRate);
+        $overtimePay = PayrollCalculator::calculateOvertimePay($overtimeMovements, $minuteRate);
+        $extraDayPay = PayrollCalculator::calculateExtraDayPay($extraDays);
+        $holidayPay = PayrollCalculator::calculateHolidayPay(
+            $attendances,
+            $holidays,
+            $scheduledMinutes,
+            $hourlyRate
+        );
+        $punctualityBonus = PunctualityService::calculateWeeklyBonusFromConfig(
+            $attendances,
+            $bonusConfig,
+            $ranges
+        );
+        $freeHoursEarned = PayrollCalculator::calculateFreeHoursEarned($overtimeMovements);
+
+        $totalPay = round(
+            $basePay - $lateDeductions - $unpaidLeaveDeductions
+            + $overtimePay + $extraDayPay + $punctualityBonus + $holidayPay,
+            2
+        );
+
+        // ── Pay period lines ──────────────────────────────────────────────────
+        $ctx = [
+            'hourlyRate' => $hourlyRate,
+            'minuteRate' => $minuteRate,
+            'scheduledMinutes' => $scheduledMinutes,
+            'periodEnd' => $periodEnd,
+        ];
+
+        $lines = $this->buildLines($attendances, $partialLeaves, $overtimeMovements, $extraDays, $holidays, $punctualityBonus, $ctx);
+
+        return [
+            'employee' => [
+                'id' => $employee->public_id,
+                'first_name' => $employee->first_name,
+                'last_name' => $employee->last_name,
+                'code' => $employee->code,
+            ],
+            'base_pay' => $basePay,
+            'late_deductions' => $lateDeductions,
+            'unpaid_leave_deductions' => $unpaidLeaveDeductions,
+            'overtime_pay' => $overtimePay,
+            'extra_day_pay' => $extraDayPay,
+            'punctuality_bonus' => $punctualityBonus,
+            'holiday_pay' => $holidayPay,
+            'other_adjustments' => 0.0,
+            'total_pay' => $totalPay,
+            'free_hours_earned' => $freeHoursEarned,
+            'pay_period_lines' => $lines,
+        ];
+    }
+
+    /**
+     * Resolve expected scheduled minutes for each worked attendance day.
+     */
+    private function resolveScheduledMinutes(Employee $employee, Collection $attendances, string $periodStart): Collection
+    {
+        if ($attendances->isEmpty()) {
+            return collect();
+        }
+
+        $scheduleDays = $this->loadScheduleDays($employee, $periodStart);
+
+        return $attendances->map(function ($attendance) use ($scheduleDays) {
+            $dayOfWeek = Carbon::parse($attendance->date)->dayOfWeekIso;
+            $scheduleDay = $scheduleDays[$dayOfWeek] ?? null;
+
+            return $scheduleDay ? ($scheduleDay->expectedDurationMinutes() ?? 0) : 0;
+        });
+    }
+
+    private function loadScheduleDays(Employee $employee, string $periodStart): Collection
+    {
+        $period = EmploymentPeriod::where('employee_id', $employee->id)
+            ->where('is_active', true)
+            ->whereDate('start_date', '<=', $periodStart)
+            ->where(function ($q) use ($periodStart) {
+                $q->whereNull('end_date')
+                    ->orWhereDate('end_date', '>=', $periodStart);
+            })
+            ->first();
+
+        $schedule = $period
+            ? EmployeeSchedule::effective($periodStart)->where('employment_period_id', $period->id)->first()
+            : null;
+
+        return $schedule
+            ? ScheduleDay::where('employee_schedule_id', $schedule->id)->get()->keyBy('day_of_week')
+            : collect();
+    }
+
+    /**
+     * Build the itemized line breakdown for this employee's period.
+     *
+     * @param  array{hourlyRate: float, minuteRate: float, scheduledMinutes: Collection, periodEnd: string}  $ctx
+     * @return array<int, array<string, mixed>>
+     */
+    private function buildLines(
+        Collection $attendances,
+        Collection $partialLeaves,
+        Collection $overtimeMovements,
+        Collection $extraDays,
+        Collection $holidays,
+        float $punctualityBonus,
+        array $ctx
+    ): array {
+        $lines = [];
+        $holidayMap = $holidays->keyBy(fn (Holiday $h) => $h->date->toDateString());
+
+        foreach ($attendances as $i => $attendance) {
+            $lines = array_merge($lines, $this->linesForAttendance($attendance, $i, $holidayMap, $ctx));
+        }
+
+        foreach ($partialLeaves as $leave) {
+            if (! $leave->is_paid) {
+                $amount = round((int) $leave->duration_minutes * $ctx['minuteRate'], 2);
+                $lines[] = [
+                    'date' => $leave->date->toDateString(),
+                    'concept' => 'UNPAID_LEAVE',
+                    'description' => "Unpaid leave ({$leave->duration_minutes} min)",
+                    'amount' => -$amount,
+                    'minutes' => $leave->duration_minutes,
+                ];
+            }
+        }
+
+        foreach ($overtimeMovements as $movement) {
+            if ($movement->type === OvertimeBankMovement::TYPE_PAID) {
+                $amount = round((int) $movement->minutes * $ctx['minuteRate'], 2);
+                $lines[] = [
+                    'date' => $movement->date->toDateString(),
+                    'concept' => 'OVERTIME',
+                    'description' => "Overtime paid ({$movement->minutes} min)",
+                    'amount' => $amount,
+                    'minutes' => $movement->minutes,
+                ];
+            }
+        }
+
+        foreach ($extraDays as $extraDay) {
+            $lines[] = [
+                'date' => $extraDay->date->toDateString(),
+                'concept' => 'EXTRA_DAY',
+                'description' => 'Negotiated extra day',
+                'amount' => (float) $extraDay->agreed_daily_wage,
+                'minutes' => null,
+            ];
+        }
+
+        if ($punctualityBonus > 0) {
+            $lines[] = [
+                'date' => $ctx['periodEnd'],
+                'concept' => 'PUNCTUALITY_BONUS',
+                'description' => 'Weekly punctuality bonus',
+                'amount' => $punctualityBonus,
+                'minutes' => null,
+            ];
+        }
+
+        return $lines;
+    }
+
+    /**
+     * Build line entries for a single attendance record (BASE_PAY, LATE_DEDUCTION, HOLIDAY).
+     *
+     * @param  Collection<int|string, mixed>  $holidayMap
+     * @param  array{hourlyRate: float, minuteRate: float, scheduledMinutes: Collection, periodEnd: string}  $ctx
+     * @return array<int, array<string, mixed>>
+     */
+    private function linesForAttendance(mixed $attendance, int $i, Collection $holidayMap, array $ctx): array
+    {
+        $lines = [];
+        $dateKey = is_string($attendance->date) ? $attendance->date : $attendance->date->toDateString();
+        $minutes = $ctx['scheduledMinutes'][$i] ?? 0;
+        $hourlyRate = $ctx['hourlyRate'];
+        $minuteRate = $ctx['minuteRate'];
+
+        $amount = round(($minutes / 60) * $hourlyRate, 2);
+        if ($amount > 0) {
+            $lines[] = ['date' => $dateKey, 'concept' => 'BASE_PAY', 'description' => "Base pay ({$minutes} min)", 'amount' => $amount, 'minutes' => $minutes];
+        }
+
+        $entryLate = (int) $attendance->entry_late_seconds;
+        if ($entryLate > 1800) {
+            $lateMin = (int) floor($entryLate / 60);
+            $lines[] = ['date' => $dateKey, 'concept' => 'LATE_DEDUCTION', 'description' => "Entry late ({$lateMin} min)", 'amount' => -round($lateMin * $minuteRate, 2), 'minutes' => $lateMin];
+        }
+
+        $lunchLate = (int) $attendance->lunch_late_seconds;
+        if ($lunchLate > 1800) {
+            $lateMin = (int) floor($lunchLate / 60);
+            $lines[] = ['date' => $dateKey, 'concept' => 'LATE_DEDUCTION', 'description' => "Lunch late ({$lateMin} min)", 'amount' => -round($lateMin * $minuteRate, 2), 'minutes' => $lateMin];
+        }
+
+        if (isset($holidayMap[$dateKey])) {
+            $holiday = $holidayMap[$dateKey];
+            $dailyWage = $hourlyRate * ($ctx['scheduledMinutes'][$i] ?? 0) / 60;
+            $holidayExtra = round($dailyWage * ((float) $holiday->pay_multiplier - 1), 2);
+            if ($holidayExtra > 0) {
+                $lines[] = ['date' => $dateKey, 'concept' => 'HOLIDAY', 'description' => "Holiday: {$holiday->name}", 'amount' => $holidayExtra, 'minutes' => null];
+            }
+        }
+
+        return $lines;
+    }
+}

--- a/code/api/app/Services/PayrollCalculator.php
+++ b/code/api/app/Services/PayrollCalculator.php
@@ -7,26 +7,149 @@ use Illuminate\Support\Collection;
 
 class PayrollCalculator
 {
+    // ── Base Pay ─────────────────────────────────────────────────────────────
+
+    /**
+     * Calculate base pay from scheduled minutes per worked day and hourly rate.
+     *
+     * @param  Collection<int, int>  $scheduledMinutes  Expected minutes per worked day
+     */
+    public static function calculateBasePay(Collection $scheduledMinutes, float $hourlyRate): float
+    {
+        $totalMinutes = $scheduledMinutes->sum();
+
+        return round(($totalMinutes / 60) * $hourlyRate, 2);
+    }
+
+    // ── Late Deductions ──────────────────────────────────────────────────────
+
+    /**
+     * Calculate total late deductions for a set of attendances.
+     *
+     * Deducts both entry tardiness and lunch return tardiness when each exceeds
+     * 1800 seconds (30 minutes). Uses floor division to convert seconds to minutes.
+     *
+     * @param  Collection<int, object>  $attendances  Objects with `entry_late_seconds` and `lunch_late_seconds`
+     */
+    public static function calculateLateDeductions(Collection $attendances, float $minuteRate): float
+    {
+        $total = 0.0;
+
+        foreach ($attendances as $attendance) {
+            $entryLate = (int) $attendance->entry_late_seconds;
+            $lunchLate = (int) $attendance->lunch_late_seconds;
+
+            if ($entryLate > 1800) {
+                $total += floor($entryLate / 60) * $minuteRate;
+            }
+
+            if ($lunchLate > 1800) {
+                $total += floor($lunchLate / 60) * $minuteRate;
+            }
+        }
+
+        return round($total, 2);
+    }
+
+    // ── Unpaid Leave Deductions ──────────────────────────────────────────────
+
+    /**
+     * Calculate deductions from unpaid partial leaves.
+     *
+     * @param  Collection<int, object>  $partialLeaves  Objects with `duration_minutes` and `is_paid`
+     */
+    public static function calculateUnpaidLeaveDeductions(Collection $partialLeaves, float $minuteRate): float
+    {
+        $total = 0.0;
+
+        foreach ($partialLeaves as $leave) {
+            if (! $leave->is_paid) {
+                $total += (int) $leave->duration_minutes * $minuteRate;
+            }
+        }
+
+        return round($total, 2);
+    }
+
+    // ── Overtime Pay ─────────────────────────────────────────────────────────
+
+    /**
+     * Calculate overtime pay from PAID overtime bank movements.
+     *
+     * @param  Collection<int, object>  $overtimeMovements  Objects with `type` and `minutes`
+     */
+    public static function calculateOvertimePay(Collection $overtimeMovements, float $minuteRate): float
+    {
+        $total = 0.0;
+
+        foreach ($overtimeMovements as $movement) {
+            if ($movement->type === 'PAID') {
+                $total += (int) $movement->minutes * $minuteRate;
+            }
+        }
+
+        return round($total, 2);
+    }
+
+    // ── Extra Day Pay ────────────────────────────────────────────────────────
+
+    /**
+     * Calculate pay for negotiated extra days worked (día de descanso negociado).
+     *
+     * @param  Collection<int, object>  $extraDays  Objects with `agreed_daily_wage`
+     */
+    public static function calculateExtraDayPay(Collection $extraDays): float
+    {
+        return round((float) $extraDays->sum('agreed_daily_wage'), 2);
+    }
+
+    // ── Free Hours Earned ────────────────────────────────────────────────────
+
+    /**
+     * Calculate free hours earned from EARNED overtime bank movements.
+     *
+     * @param  Collection<int, object>  $overtimeMovements
+     */
+    public static function calculateFreeHoursEarned(Collection $overtimeMovements): float
+    {
+        $minutes = 0;
+
+        foreach ($overtimeMovements as $movement) {
+            if ($movement->type === 'EARNED') {
+                $minutes += (int) $movement->minutes;
+            }
+        }
+
+        return round($minutes / 60, 2);
+    }
+
     /**
      * Calculate total holiday pay for a set of attendances.
      *
      * For each attendance whose date falls on a holiday AND whose day_status is WORKED,
      * the extra pay is: dailyWage × (pay_multiplier − 1).
      *
-     * @param  Collection<int, object>  $attendances  Collection of attendance objects with `date` and `day_status` fields.
-     * @param  Collection<int, Holiday>  $holidays  Collection of Holiday model instances.
+     * Per-day wages are derived from `$scheduledMinutes[$i]` and `$hourlyRate`
+     * so the result matches the HOLIDAY line items in the pay-period preview,
+     * even for employees whose scheduled hours vary across the week.
+     *
+     * @param  Collection<int, object>  $attendances  Attendance objects with `date` and `day_status`.
+     * @param  Collection<int, Holiday>  $holidays  Holiday model instances.
+     * @param  Collection<int, int|float>  $scheduledMinutes  Scheduled minutes per day, indexed parallel to $attendances.
+     * @param  float  $hourlyRate  Employee's hourly rate (same unit as wages).
      * @return float Total holiday extra pay amount.
      */
     public static function calculateHolidayPay(
         Collection $attendances,
         Collection $holidays,
-        float $dailyWage
+        Collection $scheduledMinutes,
+        float $hourlyRate
     ): float {
         $holidayMap = $holidays->keyBy(fn (Holiday $h) => $h->date->toDateString());
 
         $total = 0.0;
 
-        foreach ($attendances as $attendance) {
+        foreach ($attendances as $i => $attendance) {
             $dateKey = is_string($attendance->date)
                 ? $attendance->date
                 : $attendance->date->toDateString();
@@ -39,6 +162,7 @@ class PayrollCalculator
                 continue;
             }
 
+            $dailyWage = $hourlyRate * (($scheduledMinutes[$i] ?? 0) / 60);
             $multiplier = (float) $holidayMap[$dateKey]->pay_multiplier;
             $total += $dailyWage * ($multiplier - 1);
         }

--- a/code/api/app/Services/PayrollSeedService.php
+++ b/code/api/app/Services/PayrollSeedService.php
@@ -1,0 +1,410 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\DayStatus;
+use App\Enums\SeedScenario;
+use App\Models\Attendance;
+use App\Models\Employee;
+use App\Models\OvertimeBankMovement;
+use App\Models\PartialLeave;
+use Carbon\Carbon;
+use Carbon\CarbonPeriod;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+
+class PayrollSeedService
+{
+    // Base shift: 08:00–17:00, lunch 13:00–14:00 → 480 min net
+    private const SHIFT_START = '08:00:00';
+
+    private const SHIFT_END = '17:00:00';
+
+    private const LUNCH_START = '13:00:00';
+
+    private const LUNCH_END = '14:00:00';
+
+    private const NET_MINUTES = 480;
+
+    private const OVERTIME_END = '19:00:00'; // +2h extra
+
+    private const LATE_SECONDS = 2100;       // 35 min late
+
+    private const HALF_DAY_MINUTES = 240;    // 4h unpaid leave
+
+    private const OVERTIME_MINUTES = 120;    // 2h overtime
+
+    private const LUNCH_LATE_SECONDS = 1860; // 31 min late from lunch (> 1800s threshold)
+
+    private const LUNCH_LATE_END = '14:31:00'; // returned 31 min late (lunch was 13:00–14:00)
+
+    private const NET_MINUTES_LUNCH_LATE = 449; // 9h shift − 91 min actual lunch
+
+    /**
+     * @return array{ created: int, deleted: int, employees: list<string> }
+     */
+    public function seed(int $branchId, string $periodStart, string $periodEnd, SeedScenario $scenario): array
+    {
+        $employees = $this->activeEmployees($branchId);
+
+        if ($employees->isEmpty()) {
+            return ['created' => 0, 'deleted' => 0, 'employees' => []];
+        }
+
+        $employeeIds = $employees->pluck('id');
+
+        // Reset: wipe attendances and their associated records for the period
+        PartialLeave::whereIn('employee_id', $employeeIds)
+            ->whereBetween('date', [$periodStart, $periodEnd])
+            ->delete();
+
+        OvertimeBankMovement::whereIn('employee_id', $employeeIds)
+            ->whereBetween('date', [$periodStart, $periodEnd])
+            ->delete();
+
+        $deleted = Attendance::whereIn('employee_id', $employeeIds)
+            ->whereBetween('date', [$periodStart, $periodEnd])
+            ->delete();
+
+        $weekdays = $this->weekdaysInRange($periodStart, $periodEnd);
+        $now = now();
+        $created = 0;
+
+        foreach ($employees as $employeeIndex => $employee) {
+            $rows = $this->buildRows($employee->id, $weekdays, $scenario, $now, $employeeIndex);
+
+            foreach ($rows as $row) {
+                $attendance = Attendance::create($row['attendance']);
+                $created++;
+
+                if ($row['partial_leave'] !== null) {
+                    PartialLeave::create(array_merge($row['partial_leave'], [
+                        'attendance_id' => $attendance->id,
+                        'employee_id' => $employee->id,
+                    ]));
+                }
+
+                if ($row['overtime'] !== null) {
+                    OvertimeBankMovement::create(array_merge($row['overtime'], [
+                        'attendance_id' => $attendance->id,
+                        'employee_id' => $employee->id,
+                        'date' => $row['attendance']['date'],
+                    ]));
+                }
+            }
+        }
+
+        return [
+            'created' => $created,
+            'deleted' => $deleted,
+            'employees' => $employees->pluck('code')->sort()->values()->all(),
+        ];
+    }
+
+    /**
+     * @return list<array{attendance: array<string, mixed>, partial_leave: array<string, mixed>|null, overtime: array<string, mixed>|null}>
+     */
+    private function buildRows(int $employeeId, Collection $weekdays, SeedScenario $scenario, Carbon $now, int $employeeIndex = 0): array
+    {
+        $rows = [];
+
+        foreach ($weekdays as $index => $date) {
+            $row = match ($scenario) {
+                SeedScenario::FULL_WEEK => $this->workedRow($date),
+                SeedScenario::WITH_LATES => $this->lateOrWorkedRow($date, $index),
+                SeedScenario::WITH_UNPAID_LEAVE => $this->unpaidLeaveOrWorkedRow($date, $index),
+                SeedScenario::WITH_OVERTIME => $this->overtimeOrWorkedRow($date, $index),
+                SeedScenario::WITH_ABSENCES => $this->absenceOrWorkedRow($date, $index),
+                SeedScenario::MIXED => $this->mixedRow($date, $index, $employeeIndex),
+            };
+
+            $row['attendance'] = array_merge($row['attendance'], [
+                'employee_id' => $employeeId,
+                'public_id' => Str::ulid()->toString(),
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+
+            $rows[] = $row;
+        }
+
+        return $rows;
+    }
+
+    /** Mon and Wed (indices 0, 2) are 35 min late. */
+    private function lateOrWorkedRow(string $date, int $index): array
+    {
+        if (in_array($index, [0, 2], strict: true)) {
+            return [
+                'attendance' => [
+                    'date' => $date,
+                    'check_in' => $date.' 08:35:00',
+                    'check_out' => $date.' '.self::SHIFT_END,
+                    'lunch_start' => $date.' '.self::LUNCH_START,
+                    'lunch_end' => $date.' '.self::LUNCH_END,
+                    'entry_late_seconds' => self::LATE_SECONDS,
+                    'lunch_late_seconds' => 0,
+                    'net_worked_minutes' => self::NET_MINUTES - 35,
+                    'overtime_minutes' => 0,
+                    'overtime_authorized' => false,
+                    'day_status' => DayStatus::WORKED->value,
+                ],
+                'partial_leave' => null,
+                'overtime' => null,
+            ];
+        }
+
+        return $this->workedRow($date);
+    }
+
+    /**
+     * Thu (index 3) is a half-day unpaid leave.
+     * Attendance stays WORKED so BASE_PAY is generated; PartialLeave triggers UNPAID_LEAVE deduction.
+     */
+    private function unpaidLeaveOrWorkedRow(string $date, int $index): array
+    {
+        if ($index === 3) {
+            return [
+                'attendance' => [
+                    'date' => $date,
+                    'check_in' => $date.' '.self::SHIFT_START,
+                    'check_out' => $date.' 12:00:00',
+                    'lunch_start' => null,
+                    'lunch_end' => null,
+                    'entry_late_seconds' => 0,
+                    'lunch_late_seconds' => 0,
+                    'net_worked_minutes' => self::HALF_DAY_MINUTES,
+                    'overtime_minutes' => 0,
+                    'overtime_authorized' => false,
+                    'day_status' => DayStatus::WORKED->value,
+                ],
+                'partial_leave' => [
+                    'date' => $date,
+                    'duration_minutes' => self::HALF_DAY_MINUTES,
+                    'is_paid' => false,
+                    'reason' => 'Permiso no pagado — medio día',
+                ],
+                'overtime' => null,
+            ];
+        }
+
+        return $this->workedRow($date);
+    }
+
+    /** Tue, Thu, Fri (indices 1, 3, 4) have 2h paid overtime. */
+    private function overtimeOrWorkedRow(string $date, int $index): array
+    {
+        if (in_array($index, [1, 3, 4], strict: true)) {
+            return [
+                'attendance' => [
+                    'date' => $date,
+                    'check_in' => $date.' '.self::SHIFT_START,
+                    'check_out' => $date.' '.self::OVERTIME_END,
+                    'lunch_start' => $date.' '.self::LUNCH_START,
+                    'lunch_end' => $date.' '.self::LUNCH_END,
+                    'entry_late_seconds' => 0,
+                    'lunch_late_seconds' => 0,
+                    'net_worked_minutes' => self::NET_MINUTES + self::OVERTIME_MINUTES,
+                    'overtime_minutes' => self::OVERTIME_MINUTES,
+                    'overtime_authorized' => true,
+                    'day_status' => DayStatus::WORKED->value,
+                ],
+                'partial_leave' => null,
+                'overtime' => [
+                    'type' => OvertimeBankMovement::TYPE_PAID,
+                    'minutes' => self::OVERTIME_MINUTES,
+                    'reference' => 'payroll-seed',
+                ],
+            ];
+        }
+
+        return $this->workedRow($date);
+    }
+
+    /** Tue and Thu (indices 1, 3) are absences. */
+    private function absenceOrWorkedRow(string $date, int $index): array
+    {
+        if (in_array($index, [1, 3], strict: true)) {
+            return [
+                'attendance' => [
+                    'date' => $date,
+                    'check_in' => null,
+                    'check_out' => null,
+                    'lunch_start' => null,
+                    'lunch_end' => null,
+                    'entry_late_seconds' => 0,
+                    'lunch_late_seconds' => 0,
+                    'net_worked_minutes' => 0,
+                    'overtime_minutes' => 0,
+                    'overtime_authorized' => false,
+                    'day_status' => DayStatus::ABSENCE->value,
+                ],
+                'partial_leave' => null,
+                'overtime' => null,
+            ];
+        }
+
+        return $this->workedRow($date);
+    }
+
+    /**
+     * Each employee (by branch order) gets a distinct situation so the payroll
+     * preview shows all concept types at once.
+     *
+     * Employee % 7 → situation:
+     *   0 → Perfect week (punctual every day)
+     *   1 → Late entries  (Mon 35 min, Wed 35 min)
+     *   2 → Paid overtime (Tue 2 h, Fri 2 h)
+     *   3 → Absences      (Tue, Thu)
+     *   4 → Unpaid leave  (Thu half-day)
+     *   5 → Late lunch return (Wed 30 min)
+     *   6 → Combined      (Mon late + Wed overtime + Thu absent)
+     */
+    private function mixedRow(string $date, int $dayIndex, int $employeeIndex): array
+    {
+        return match ($employeeIndex % 7) {
+            0 => $this->workedRow($date),
+            1 => $this->lateOrWorkedRow($date, $dayIndex),
+            2 => $this->overtimeOrWorkedRow($date, $dayIndex),
+            3 => $this->absenceOrWorkedRow($date, $dayIndex),
+            4 => $this->unpaidLeaveOrWorkedRow($date, $dayIndex),
+            5 => $this->lunchLateOrWorkedRow($date, $dayIndex),
+            default => $this->combinedRow($date, $dayIndex),
+        };
+    }
+
+    /** Wed (index 2) returns 30 min late from lunch → lunch_late_seconds deductible. */
+    private function lunchLateOrWorkedRow(string $date, int $index): array
+    {
+        if ($index === 2) {
+            return [
+                'attendance' => [
+                    'date' => $date,
+                    'check_in' => $date.' '.self::SHIFT_START,
+                    'check_out' => $date.' '.self::SHIFT_END,
+                    'lunch_start' => $date.' '.self::LUNCH_START,
+                    'lunch_end' => $date.' '.self::LUNCH_LATE_END,
+                    'entry_late_seconds' => 0,
+                    'lunch_late_seconds' => self::LUNCH_LATE_SECONDS,
+                    'net_worked_minutes' => self::NET_MINUTES_LUNCH_LATE,
+                    'overtime_minutes' => 0,
+                    'overtime_authorized' => false,
+                    'day_status' => DayStatus::WORKED->value,
+                ],
+                'partial_leave' => null,
+                'overtime' => null,
+            ];
+        }
+
+        return $this->workedRow($date);
+    }
+
+    /**
+     * Mon (0) late 35 min · Wed (2) 2 h overtime · Thu (3) absent · rest normal.
+     * Combines LATE_DEDUCTION + OVERTIME + absent-day BASE_PAY gap in one employee.
+     */
+    private function combinedRow(string $date, int $index): array
+    {
+        return match ($index) {
+            0 => [
+                'attendance' => [
+                    'date' => $date,
+                    'check_in' => $date.' 08:35:00',
+                    'check_out' => $date.' '.self::SHIFT_END,
+                    'lunch_start' => $date.' '.self::LUNCH_START,
+                    'lunch_end' => $date.' '.self::LUNCH_END,
+                    'entry_late_seconds' => self::LATE_SECONDS,
+                    'lunch_late_seconds' => 0,
+                    'net_worked_minutes' => self::NET_MINUTES - 35,
+                    'overtime_minutes' => 0,
+                    'overtime_authorized' => false,
+                    'day_status' => DayStatus::WORKED->value,
+                ],
+                'partial_leave' => null,
+                'overtime' => null,
+            ],
+            2 => [
+                'attendance' => [
+                    'date' => $date,
+                    'check_in' => $date.' '.self::SHIFT_START,
+                    'check_out' => $date.' '.self::OVERTIME_END,
+                    'lunch_start' => $date.' '.self::LUNCH_START,
+                    'lunch_end' => $date.' '.self::LUNCH_END,
+                    'entry_late_seconds' => 0,
+                    'lunch_late_seconds' => 0,
+                    'net_worked_minutes' => self::NET_MINUTES + self::OVERTIME_MINUTES,
+                    'overtime_minutes' => self::OVERTIME_MINUTES,
+                    'overtime_authorized' => true,
+                    'day_status' => DayStatus::WORKED->value,
+                ],
+                'partial_leave' => null,
+                'overtime' => [
+                    'type' => OvertimeBankMovement::TYPE_PAID,
+                    'minutes' => self::OVERTIME_MINUTES,
+                    'reference' => 'payroll-seed',
+                ],
+            ],
+            3 => [
+                'attendance' => [
+                    'date' => $date,
+                    'check_in' => null,
+                    'check_out' => null,
+                    'lunch_start' => null,
+                    'lunch_end' => null,
+                    'entry_late_seconds' => 0,
+                    'lunch_late_seconds' => 0,
+                    'net_worked_minutes' => 0,
+                    'overtime_minutes' => 0,
+                    'overtime_authorized' => false,
+                    'day_status' => DayStatus::ABSENCE->value,
+                ],
+                'partial_leave' => null,
+                'overtime' => null,
+            ],
+            default => $this->workedRow($date),
+        };
+    }
+
+    private function workedRow(string $date): array
+    {
+        return [
+            'attendance' => [
+                'date' => $date,
+                'check_in' => $date.' '.self::SHIFT_START,
+                'check_out' => $date.' '.self::SHIFT_END,
+                'lunch_start' => $date.' '.self::LUNCH_START,
+                'lunch_end' => $date.' '.self::LUNCH_END,
+                'entry_late_seconds' => 0,
+                'lunch_late_seconds' => 0,
+                'net_worked_minutes' => self::NET_MINUTES,
+                'overtime_minutes' => 0,
+                'overtime_authorized' => false,
+                'day_status' => DayStatus::WORKED->value,
+            ],
+            'partial_leave' => null,
+            'overtime' => null,
+        ];
+    }
+
+    /** Returns Mon–Fri dates within the range as Y-m-d strings, indexed from 0. */
+    private function weekdaysInRange(string $periodStart, string $periodEnd): Collection
+    {
+        $period = CarbonPeriod::create($periodStart, $periodEnd);
+
+        return collect($period)
+            ->filter(fn (Carbon $d) => $d->isWeekday())
+            ->map(fn (Carbon $d) => $d->toDateString())
+            ->values();
+    }
+
+    private function activeEmployees(int $branchId): Collection
+    {
+        return Employee::where('is_active', true)
+            ->whereHas('employmentPeriods', fn ($q) => $q
+                ->where('branch_id', $branchId)
+                ->where('is_active', true))
+            ->orderBy('last_name')
+            ->orderBy('first_name')
+            ->get(['id', 'code', 'first_name', 'last_name']);
+    }
+}

--- a/code/api/app/Services/PunctualityService.php
+++ b/code/api/app/Services/PunctualityService.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\EmployeeBonusConfig;
+use App\Models\PunctualityBonusGroup;
+use App\Models\PunctualityRange;
+use Illuminate\Support\Collection;
+
+class PunctualityService
+{
+    /**
+     * Calculate weekly punctuality bonus for a set of worked attendances.
+     *
+     * For each attendance, finds the matching PunctualityRange by entry_late_seconds.
+     * The matching range's bonus_percentage is applied to the group's daily bonus amount.
+     *
+     * @param  Collection<int, object>  $attendances  Objects with `entry_late_seconds`
+     * @param  Collection<int, PunctualityRange>  $ranges
+     */
+    public static function calculateWeeklyBonus(
+        Collection $attendances,
+        PunctualityBonusGroup $bonusGroup,
+        Collection $ranges
+    ): float {
+        if ($attendances->isEmpty() || $ranges->isEmpty()) {
+            return 0.0;
+        }
+
+        $dailyBonus = $bonusGroup->dailyBonusAmount();
+        $total = 0.0;
+
+        foreach ($attendances as $attendance) {
+            $lateSeconds = (int) $attendance->entry_late_seconds;
+
+            foreach ($ranges as $range) {
+                if ($range->matches($lateSeconds)) {
+                    $total += $dailyBonus * ((float) $range->bonus_percentage / 100);
+                    break;
+                }
+            }
+        }
+
+        return round($total, 2);
+    }
+
+    /**
+     * Calculate weekly bonus from an optional EmployeeBonusConfig.
+     * Returns 0.0 when the employee has no active bonus configuration.
+     *
+     * @param  Collection<int, object>  $attendances
+     * @param  Collection<int, PunctualityRange>  $ranges
+     */
+    public static function calculateWeeklyBonusFromConfig(
+        Collection $attendances,
+        ?EmployeeBonusConfig $config,
+        Collection $ranges
+    ): float {
+        if ($config === null || $config->bonusGroup === null) {
+            return 0.0;
+        }
+
+        return self::calculateWeeklyBonus($attendances, $config->bonusGroup, $ranges);
+    }
+}

--- a/code/api/app/Support/PayrollSeed/PayrollSeedGuard.php
+++ b/code/api/app/Support/PayrollSeed/PayrollSeedGuard.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Support\PayrollSeed;
+
+use App\Exceptions\ClockSimulationMisconfigurationException;
+
+/**
+ * Guards devtools payroll seed endpoints.
+ *
+ * Returns 404 if seeding is not enabled or environment is not allowed.
+ * Throws ClockSimulationMisconfigurationException if 'production' is misconfigured in allowed envs.
+ */
+class PayrollSeedGuard
+{
+    public static function validate(): void
+    {
+        $allowedEnvs = array_map(
+            fn ($e) => strtolower(trim($e)),
+            explode(',', (string) config('payroll_seed.allowed_environments', ''))
+        );
+
+        if (in_array('production', $allowedEnvs, strict: true)) {
+            throw new ClockSimulationMisconfigurationException(
+                'PAYROLL_SEED_ALLOWED_ENVIRONMENTS must not contain "production". Critical misconfiguration.'
+            );
+        }
+
+        if (config('payroll_seed.enabled') !== true) {
+            abort(404);
+        }
+
+        if (! in_array(strtolower(app()->environment()), $allowedEnvs, strict: true)) {
+            abort(404);
+        }
+    }
+}

--- a/code/api/config/payroll_seed.php
+++ b/code/api/config/payroll_seed.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Payroll Seed Enabled
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, the devtools payroll seed endpoint is available.
+    | This should ALWAYS be false in production.
+    |
+    */
+    'enabled' => env('PAYROLL_SEED_ENABLED', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Allowed Environments
+    |--------------------------------------------------------------------------
+    |
+    | Comma-separated list of environments where payroll seeding is allowed.
+    | 'production' must NEVER be in this list.
+    |
+    */
+    'allowed_environments' => env('PAYROLL_SEED_ALLOWED_ENVIRONMENTS', 'local,devtest,testing'),
+];

--- a/code/api/database/factories/OvertimeBankMovementFactory.php
+++ b/code/api/database/factories/OvertimeBankMovementFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Employee;
+use App\Models\OvertimeBankMovement;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<OvertimeBankMovement> */
+class OvertimeBankMovementFactory extends Factory
+{
+    protected $model = OvertimeBankMovement::class;
+
+    public function definition(): array
+    {
+        return [
+            'employee_id' => Employee::factory(),
+            'attendance_id' => null,
+            'date' => now()->toDateString(),
+            'type' => OvertimeBankMovement::TYPE_EARNED,
+            'minutes' => fake()->numberBetween(15, 120),
+            'reference' => null,
+            'meta' => null,
+        ];
+    }
+
+    public function paid(): static
+    {
+        return $this->state(['type' => OvertimeBankMovement::TYPE_PAID]);
+    }
+
+    public function earned(): static
+    {
+        return $this->state(['type' => OvertimeBankMovement::TYPE_EARNED]);
+    }
+}

--- a/code/api/database/factories/PartialLeaveFactory.php
+++ b/code/api/database/factories/PartialLeaveFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Employee;
+use App\Models\PartialLeave;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<PartialLeave> */
+class PartialLeaveFactory extends Factory
+{
+    protected $model = PartialLeave::class;
+
+    public function definition(): array
+    {
+        return [
+            'employee_id' => Employee::factory(),
+            'attendance_id' => null,
+            'date' => now()->toDateString(),
+            'duration_minutes' => fake()->numberBetween(30, 240),
+            'is_paid' => false,
+            'reason' => fake()->optional()->sentence(),
+            'meta' => null,
+        ];
+    }
+
+    public function paid(): static
+    {
+        return $this->state(['is_paid' => true]);
+    }
+}

--- a/code/api/database/migrations/2026_06_24_000001_create_partial_leaves_table.php
+++ b/code/api/database/migrations/2026_06_24_000001_create_partial_leaves_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('partial_leaves', function (Blueprint $table) {
+            $table->id();
+            $table->string('public_id', 26)->unique();
+            $table->foreignId('attendance_id')->nullable()->constrained()->nullOnDelete();
+            $table->foreignId('employee_id')->constrained()->cascadeOnDelete();
+            $table->date('date');
+            $table->unsignedInteger('duration_minutes');
+            $table->boolean('is_paid')->default(false);
+            $table->string('reason')->nullable();
+            $table->json('meta')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('partial_leaves');
+    }
+};

--- a/code/api/database/migrations/2026_06_24_000002_create_overtime_bank_movements_table.php
+++ b/code/api/database/migrations/2026_06_24_000002_create_overtime_bank_movements_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('overtime_bank_movements', function (Blueprint $table) {
+            $table->id();
+            $table->string('public_id', 26)->unique();
+            $table->foreignId('employee_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('attendance_id')->nullable()->constrained()->nullOnDelete();
+            $table->date('date');
+            // EARNED: minutes added to bank; PAID: minutes paid out; EXPIRED: minutes removed
+            $table->enum('type', ['EARNED', 'PAID', 'EXPIRED', 'TRANSFERRED']);
+            $table->unsignedInteger('minutes');
+            $table->string('reference')->nullable();
+            $table->json('meta')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('overtime_bank_movements');
+    }
+};

--- a/code/api/database/migrations/2026_06_24_000003_create_pay_periods_table.php
+++ b/code/api/database/migrations/2026_06_24_000003_create_pay_periods_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('pay_periods', function (Blueprint $table) {
+            $table->id();
+            $table->string('public_id', 26)->unique();
+            $table->foreignId('branch_id')->constrained()->cascadeOnDelete();
+            $table->date('period_start');
+            $table->date('period_end');
+            $table->enum('status', ['OPEN', 'CLOSED', 'REOPENED'])->default('OPEN');
+            $table->foreignId('closed_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamp('closed_at')->nullable();
+            $table->foreignId('reopened_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamp('reopened_at')->nullable();
+            $table->text('reopen_reason')->nullable();
+            $table->json('meta')->nullable();
+            $table->timestamps();
+
+            $table->unique(['branch_id', 'period_start', 'period_end']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('pay_periods');
+    }
+};

--- a/code/api/database/migrations/2026_06_24_000004_create_pay_period_employees_table.php
+++ b/code/api/database/migrations/2026_06_24_000004_create_pay_period_employees_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('pay_period_employees', function (Blueprint $table) {
+            $table->id();
+            $table->string('public_id', 26)->unique();
+            $table->foreignId('pay_period_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('employee_id')->constrained()->cascadeOnDelete();
+            $table->decimal('base_pay', 10, 2)->default(0);
+            $table->decimal('late_deductions', 10, 2)->default(0);
+            $table->decimal('unpaid_leave_deductions', 10, 2)->default(0);
+            $table->decimal('overtime_pay', 10, 2)->default(0);
+            $table->decimal('extra_day_pay', 10, 2)->default(0);
+            $table->decimal('punctuality_bonus', 10, 2)->default(0);
+            $table->decimal('holiday_pay', 10, 2)->default(0);
+            $table->decimal('other_adjustments', 10, 2)->default(0);
+            $table->decimal('total_pay', 10, 2)->default(0);
+            $table->decimal('free_hours_earned', 8, 2)->default(0);
+            $table->json('daily_snapshot')->nullable();
+            $table->timestamps();
+
+            $table->unique(['pay_period_id', 'employee_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('pay_period_employees');
+    }
+};

--- a/code/api/database/migrations/2026_06_24_000005_create_pay_period_lines_table.php
+++ b/code/api/database/migrations/2026_06_24_000005_create_pay_period_lines_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('pay_period_lines', function (Blueprint $table) {
+            $table->id();
+            $table->string('public_id', 26)->unique();
+            $table->foreignId('pay_period_employee_id')->constrained()->cascadeOnDelete();
+            $table->date('date')->nullable();
+            $table->enum('concept', ['BASE_PAY', 'LATE_DEDUCTION', 'UNPAID_LEAVE', 'OVERTIME', 'EXTRA_DAY', 'PUNCTUALITY_BONUS', 'HOLIDAY', 'OTHER']);
+            $table->string('description');
+            $table->decimal('amount', 10, 2);
+            $table->unsignedInteger('minutes')->nullable();
+            $table->json('meta')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('pay_period_lines');
+    }
+};

--- a/code/api/database/seeders/Development/DevelopmentSeeder.php
+++ b/code/api/database/seeders/Development/DevelopmentSeeder.php
@@ -30,6 +30,7 @@ class DevelopmentSeeder extends Seeder
             EmployeeSeeder::class,
             EmployeeScheduleSeeder::class,
             ScheduleHistorySeeder::class,
+            WageSeeder::class,
             \Database\Seeders\UnitOfMeasureSeeder::class,
             \Database\Seeders\UomConversionSeeder::class,
             AttendanceAuditLogSeeder::class,

--- a/code/api/database/seeders/Development/PermissionSeeder.php
+++ b/code/api/database/seeders/Development/PermissionSeeder.php
@@ -22,6 +22,8 @@ class PermissionSeeder extends LockedSeeder
 
     private const REPORTS_PATTERN = 'reports.%';
 
+    private const PAYROLL_PATTERN = 'payroll.%';
+
     private const GROUP_INVENTARIO = 'Inventario';
 
     private const GROUP_CUENTAS_BANCARIAS = 'Cuentas bancarias';
@@ -128,6 +130,9 @@ class PermissionSeeder extends LockedSeeder
 
             // Reportes
             'reports.today' => ['label' => 'Ver reporte operacional del día', 'group' => 'Reportes'],
+
+            // Nómina
+            'payroll.preview' => ['label' => 'Ver preview de cierre de nómina', 'group' => 'Nómina'],
         ];
 
         foreach ($permissions as $name => $meta) {
@@ -157,6 +162,7 @@ class PermissionSeeder extends LockedSeeder
                             ->orWhere('name', 'like', self::INVENTORY_LOCATIONS_PATTERN)
                             ->orWhere('name', 'like', self::STOCK_PATTERN)
                             ->orWhere('name', 'like', self::REPORTS_PATTERN)
+                            ->orWhere('name', 'like', self::PAYROLL_PATTERN)
                             ->orWhereIn('name', ['punctuality.manage', 'holidays.manage']);
                     })
                     ->get()
@@ -188,7 +194,8 @@ class PermissionSeeder extends LockedSeeder
                             ->orWhere('name', 'like', self::EMPLOYEES_PATTERN)
                             ->orWhere('name', 'like', self::LEAVES_PATTERN)
                             ->orWhere('name', 'like', self::EMPLOYEE_REQUESTS_PATTERN)
-                            ->orWhere('name', 'like', self::REPORTS_PATTERN);
+                            ->orWhere('name', 'like', self::REPORTS_PATTERN)
+                            ->orWhere('name', 'like', self::PAYROLL_PATTERN);
                     })
                     ->get()
             );

--- a/code/api/database/seeders/Development/WageSeeder.php
+++ b/code/api/database/seeders/Development/WageSeeder.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Database\Seeders\Development;
+
+use App\Models\Employee;
+use App\Models\WageHistory;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Str;
+
+/**
+ * Seeds hourly_rate and weekly_scheduled_hours for all active employees
+ * so the payroll preview returns non-zero totals during local development.
+ */
+class WageSeeder extends Seeder
+{
+    private const HOURS_FULL = '48.00';
+
+    private const HOURS_STANDARD = '40.00';
+
+    private const DEFAULT_RATE = '80.00';
+
+    private const DEFAULT_HOURS = self::HOURS_STANDARD;
+
+    // Deterministic rates per employee code; factory employees fall back to default
+    private const RATES = [
+        'ADM-001' => ['hourly_rate' => '125.00', 'weekly_hours' => self::HOURS_FULL],
+        'ADM-002' => ['hourly_rate' => '110.00', 'weekly_hours' => self::HOURS_FULL],
+        'EMP-001' => ['hourly_rate' => '95.00',  'weekly_hours' => self::HOURS_FULL],
+        'EMP-002' => ['hourly_rate' => '80.00',  'weekly_hours' => self::HOURS_STANDARD],
+        'EMP-003' => ['hourly_rate' => '75.00',  'weekly_hours' => self::HOURS_STANDARD],
+        'EMP-004' => ['hourly_rate' => '78.00',  'weekly_hours' => self::HOURS_STANDARD],
+        'EMP-005' => ['hourly_rate' => '85.00',  'weekly_hours' => self::HOURS_FULL],
+        'EMP-006' => ['hourly_rate' => '82.00',  'weekly_hours' => self::HOURS_FULL],
+        'EMP-007' => ['hourly_rate' => '76.00',  'weekly_hours' => self::HOURS_STANDARD],
+        'EMP-008' => ['hourly_rate' => '79.00',  'weekly_hours' => self::HOURS_STANDARD],
+    ];
+
+    public function run(): void
+    {
+        $employees = Employee::where('is_active', true)
+            ->whereHas('employmentPeriods', fn ($q) => $q->where('is_active', true))
+            ->with(['employmentPeriods' => fn ($q) => $q->where('is_active', true)])
+            ->get();
+
+        $created = 0;
+        $skipped = 0;
+
+        foreach ($employees as $employee) {
+            $existing = WageHistory::where('employee_id', $employee->id)
+                ->whereNull('effective_to')
+                ->first();
+
+            if ($existing) {
+                $skipped++;
+
+                continue;
+            }
+
+            $rate = self::RATES[$employee->code] ?? null;
+            $start = $employee->employmentPeriods->first()?->start_date ?? now()->toDateString();
+
+            WageHistory::create([
+                'public_id' => Str::ulid()->toString(),
+                'employee_id' => $employee->id,
+                'hourly_rate' => $rate['hourly_rate'] ?? self::DEFAULT_RATE,
+                'weekly_scheduled_hours' => $rate['weekly_hours'] ?? self::DEFAULT_HOURS,
+                'effective_from' => $start,
+                'effective_to' => null,
+            ]);
+
+            $created++;
+        }
+
+        $this->command->info("✓ WageSeeder: {$created} wages created, {$skipped} skipped (already had wage)");
+    }
+}

--- a/code/api/database/seeders/Production/PermissionSeeder.php
+++ b/code/api/database/seeders/Production/PermissionSeeder.php
@@ -87,6 +87,9 @@ class PermissionSeeder extends LockedSeeder
             'punctuality.manage',
             'holidays.manage',
 
+            // Nómina
+            'payroll.preview',
+
             // Inventario — Ítems y variantes
             'items.view',
             'items.create',
@@ -145,7 +148,7 @@ class PermissionSeeder extends LockedSeeder
                             ->orWhere('name', 'like', 'items.%')
                             ->orWhere('name', 'like', 'inventory_locations.%')
                             ->orWhere('name', 'like', 'stock.%')
-                            ->orWhereIn('name', ['punctuality.manage', 'holidays.manage']);
+                            ->orWhereIn('name', ['punctuality.manage', 'holidays.manage', 'payroll.preview']);
                     })
                     ->get()
             );

--- a/code/api/database/seeders/Testing/CoreTestSeeder.php
+++ b/code/api/database/seeders/Testing/CoreTestSeeder.php
@@ -96,6 +96,7 @@ class CoreTestSeeder extends Seeder
         'punctuality.manage',
         'reports.today',
         'holidays.manage',
+        'payroll.preview',
     ];
 
     /** Basic view-only user permissions shared by most roles */
@@ -104,7 +105,7 @@ class CoreTestSeeder extends Seeder
     /** role name => permission name prefixes or exact names */
     private const ROLE_PERMISSIONS = [
         'super-admin' => '*',  // all permissions
-        'admin' => ['users.', 'employees.', 'leaves.', 'employee-requests.', 'items.', 'inventory_locations.', 'stock.', 'attendances.', 'punctuality.', 'reports.', 'holidays.'],
+        'admin' => ['users.', 'employees.', 'leaves.', 'employee-requests.', 'items.', 'inventory_locations.', 'stock.', 'attendances.', 'punctuality.', 'reports.', 'holidays.', 'payroll.'],
         'inventory-manager' => ['items.', 'inventory_locations.', 'stock.'],
         'manager' => [...self::BASIC_USER_VIEW, 'employees.', 'leaves.', 'employee-requests.', 'attendances.', 'reports.'],
         'cook' => self::BASIC_USER_VIEW,

--- a/code/api/database/seeders/Testing/PayrollPreviewSeeder.php
+++ b/code/api/database/seeders/Testing/PayrollPreviewSeeder.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Database\Seeders\Testing;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+/**
+ * Payroll preview test seeder.
+ *
+ * Creates 2 employees with attendance records for week 2026-06-22..2026-06-28
+ * so the payroll preview E2E spec can verify the table renders correctly.
+ *
+ * Always starts from truncated attendance/employee tables (CoreTestSeeder ran first).
+ */
+class PayrollPreviewSeeder extends Seeder
+{
+    private const HOURLY_RATE = '100.00';
+
+    private const WEEKLY_HOURS = '48.00';
+
+    private const EMPLOYEE_START_DATE = '2025-01-01';
+
+    private const EPOCH_DATE = '1970-01-01 ';
+
+    // Mon–Fri schedule: 08:00–17:00, lunch 13:00–14:00 → 8h net = 480 min
+    private const SHIFT_START = '08:00:00';
+
+    private const SHIFT_END = '17:00:00';
+
+    private const LUNCH_START = '13:00:00';
+
+    private const LUNCH_END = '14:00:00';
+
+    private const LUNCH_MINUTES = 60;
+
+    /** Mon–Fri of week 2026-06-22..2026-06-28 */
+    private const WORKED_DATES = [
+        '2026-06-22', // Mon
+        '2026-06-23', // Tue
+        '2026-06-24', // Wed
+        '2026-06-25', // Thu
+        '2026-06-26', // Fri
+    ];
+
+    public function run(): void
+    {
+        $now = now();
+        $branchId = DB::table('branches')->where('code', 'MAIN')->value('id');
+        $roleMap = DB::table('roles')->where('guard_name', 'api')->pluck('id', 'name')->toArray();
+        $hashedPassword = Hash::make('employee123456');
+
+        $employees = [
+            ['code' => 'PAY-001', 'first_name' => 'Ana',    'last_name' => 'Payroll',   'email' => 'pay001@sushigo.com'],
+            ['code' => 'PAY-002', 'first_name' => 'Carlos', 'last_name' => 'Nomina',    'email' => 'pay002@sushigo.com'],
+        ];
+
+        foreach ($employees as $emp) {
+            $userId = DB::table('users')->insertGetId([
+                'name' => "{$emp['first_name']} {$emp['last_name']}",
+                'email' => $emp['email'],
+                'password' => $hashedPassword,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+
+            DB::table('model_has_roles')->insert([
+                'role_id' => $roleMap['cook'] ?? 1,
+                'model_type' => 'App\\Models\\User',
+                'model_id' => $userId,
+            ]);
+
+            $employeeId = DB::table('employees')->insertGetId([
+                'public_id' => Str::ulid()->toString(),
+                'user_id' => $userId,
+                'code' => $emp['code'],
+                'first_name' => $emp['first_name'],
+                'last_name' => $emp['last_name'],
+                'is_active' => true,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+
+            $periodId = DB::table('employment_periods')->insertGetId([
+                'public_id' => Str::ulid()->toString(),
+                'employee_id' => $employeeId,
+                'branch_id' => $branchId,
+                'start_date' => self::EMPLOYEE_START_DATE,
+                'end_date' => null,
+                'is_active' => true,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+
+            $scheduleId = DB::table('employee_schedules')->insertGetId([
+                'public_id' => Str::ulid()->toString(),
+                'employment_period_id' => $periodId,
+                'effective_from' => self::EMPLOYEE_START_DATE,
+                'effective_to' => null,
+                'workday_type' => 'FULL',
+                'working_days_per_week' => 5,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+
+            // Mon–Fri working days
+            foreach (range(1, 5) as $dayOfWeek) {
+                DB::table('schedule_days')->insert([
+                    'employee_schedule_id' => $scheduleId,
+                    'day_of_week' => $dayOfWeek,
+                    'is_day_off' => false,
+                    'expected_start' => self::EPOCH_DATE.self::SHIFT_START,
+                    'expected_lunch_start' => self::EPOCH_DATE.self::LUNCH_START,
+                    'expected_lunch_end' => self::EPOCH_DATE.self::LUNCH_END,
+                    'lunch_duration_minutes' => self::LUNCH_MINUTES,
+                    'expected_end' => self::EPOCH_DATE.self::SHIFT_END,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ]);
+            }
+
+            // Sat & Sun rest
+            foreach ([6, 7] as $dayOfWeek) {
+                DB::table('schedule_days')->insert([
+                    'employee_schedule_id' => $scheduleId,
+                    'day_of_week' => $dayOfWeek,
+                    'is_day_off' => true,
+                    'expected_start' => null,
+                    'expected_lunch_start' => null,
+                    'expected_lunch_end' => null,
+                    'lunch_duration_minutes' => null,
+                    'expected_end' => null,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ]);
+            }
+
+            DB::table('wage_histories')->insert([
+                'public_id' => Str::ulid()->toString(),
+                'employee_id' => $employeeId,
+                'hourly_rate' => self::HOURLY_RATE,
+                'weekly_scheduled_hours' => self::WEEKLY_HOURS,
+                'effective_from' => self::EMPLOYEE_START_DATE,
+                'effective_to' => null,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+
+            foreach (self::WORKED_DATES as $date) {
+                DB::table('attendances')->insert([
+                    'public_id' => Str::ulid()->toString(),
+                    'employee_id' => $employeeId,
+                    'date' => $date,
+                    'check_in' => $date.' '.self::SHIFT_START,
+                    'check_out' => $date.' '.self::SHIFT_END,
+                    'lunch_start' => $date.' '.self::LUNCH_START,
+                    'lunch_end' => $date.' '.self::LUNCH_END,
+                    'entry_late_seconds' => 0,
+                    'lunch_late_seconds' => 0,
+                    'net_worked_minutes' => 480,
+                    'overtime_minutes' => 0,
+                    'overtime_authorized' => false,
+                    'day_status' => 'WORKED',
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ]);
+            }
+        }
+    }
+}

--- a/code/api/routes/api.php
+++ b/code/api/routes/api.php
@@ -20,6 +20,7 @@ use App\Http\Controllers\Api\V1\Dev\DevLoginController;
 use App\Http\Controllers\Api\V1\Dev\ListDevUsersController;
 use App\Http\Controllers\Api\V1\Devtools\GetClockController;
 use App\Http\Controllers\Api\V1\Devtools\ResetClockController;
+use App\Http\Controllers\Api\V1\Devtools\SeedPayrollController;
 use App\Http\Controllers\Api\V1\Devtools\SetClockController;
 use App\Http\Controllers\Api\V1\Devtools\ShiftClockController;
 use App\Http\Controllers\Api\V1\EmployeeRequests\ApproveEmployeeRequestController;
@@ -135,6 +136,12 @@ if (app()->environment('testing', 'local', 'dev', 'devtest')) {
         Route::post('set', SetClockController::class)->name('set');
         Route::post('shift', ShiftClockController::class)->name('shift');
         Route::post('reset', ResetClockController::class)->name('reset');
+    });
+
+    // ── Devtools payroll seed route ────────────────────────────────────────
+    // Protected by PayrollSeedGuard (env check + feature flag)
+    Route::prefix('v1/devtools/payroll')->name('devtools.payroll.')->middleware('auth:api')->group(function () {
+        Route::post('seed', SeedPayrollController::class)->name('seed');
     });
 }
 
@@ -352,6 +359,11 @@ Route::prefix('v1')->group(function () {
 
     Route::middleware('auth:api')->prefix('negotiated-extra-days')->group(function () {
         Route::delete('/{id}', CancelNegotiatedExtraDayController::class)->name('negotiated-extra-days.destroy');
+    });
+
+    // Pay Periods Module
+    Route::middleware('auth:api')->prefix('pay-periods')->name('pay-periods.')->group(function () {
+        Route::get('/preview', \App\Http\Controllers\Api\V1\PayPeriods\PreviewPayPeriodController::class)->name('preview');
     });
 
     // Punctuality config

--- a/code/api/tests/Feature/AttendancePayroll/PreviewPayPeriodApiTest.php
+++ b/code/api/tests/Feature/AttendancePayroll/PreviewPayPeriodApiTest.php
@@ -1,0 +1,289 @@
+<?php
+
+namespace Tests\Feature\AttendancePayroll;
+
+use App\Models\Attendance;
+use App\Models\Branch;
+use App\Models\Employee;
+use App\Models\EmploymentPeriod;
+use App\Models\OvertimeBankMovement;
+use App\Models\PartialLeave;
+use App\Models\User;
+use App\Models\WageHistory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class PreviewPayPeriodApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+
+    protected Branch $branch;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        app()[\Spatie\Permission\PermissionRegistrar::class]->forgetCachedPermissions();
+
+        Permission::create(['name' => 'payroll.preview', 'guard_name' => 'api']);
+
+        foreach (Employee::POSITION_ROLES as $roleName) {
+            Role::firstOrCreate(['name' => $roleName, 'guard_name' => 'api']);
+        }
+
+        $adminRole = Role::firstOrCreate(['name' => 'admin', 'guard_name' => 'api']);
+        $adminRole->givePermissionTo('payroll.preview');
+
+        $this->user = User::factory()->create();
+        $this->user->assignRole('admin');
+        $this->branch = Branch::factory()->create();
+
+        Passport::actingAs($this->user);
+    }
+
+    public function test_preview_returns_calculated_totals_for_active_employees(): void
+    {
+        $employee = Employee::factory()->create(['is_active' => true]);
+
+        EmploymentPeriod::factory()->create([
+            'employee_id' => $employee->id,
+            'branch_id' => $this->branch->id,
+            'is_active' => true,
+        ]);
+
+        WageHistory::factory()->effectiveBetween('2026-06-01')->create([
+            'employee_id' => $employee->id,
+            'hourly_rate' => 60.00,
+            'weekly_scheduled_hours' => 48.0,
+        ]);
+
+        // One WORKED attendance on Mon 2026-06-22 with minor late entry (below threshold)
+        Attendance::factory()->create([
+            'employee_id' => $employee->id,
+            'date' => '2026-06-22',
+            'day_status' => 'WORKED',
+            'entry_late_seconds' => 0,
+            'lunch_late_seconds' => 0,
+        ]);
+
+        $response = $this->getJson('/api/v1/pay-periods/preview?branch_id='.$this->branch->id.'&period_start=2026-06-22&period_end=2026-06-28');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'status',
+                'data' => [
+                    '*' => [
+                        'employee',
+                        'base_pay',
+                        'late_deductions',
+                        'unpaid_leave_deductions',
+                        'overtime_pay',
+                        'extra_day_pay',
+                        'punctuality_bonus',
+                        'holiday_pay',
+                        'other_adjustments',
+                        'total_pay',
+                        'free_hours_earned',
+                        'pay_period_lines',
+                    ],
+                ],
+            ]);
+
+        $this->assertCount(1, $response->json('data'));
+        $employeeData = $response->json('data.0');
+        $this->assertGreaterThanOrEqual(0, $employeeData['base_pay']);
+        $this->assertEquals(0.0, (float) $employeeData['late_deductions']);
+    }
+
+    public function test_preview_does_not_persist_any_data(): void
+    {
+        $employee = Employee::factory()->create(['is_active' => true]);
+        EmploymentPeriod::factory()->create([
+            'employee_id' => $employee->id,
+            'branch_id' => $this->branch->id,
+            'is_active' => true,
+        ]);
+        WageHistory::factory()->effectiveBetween('2026-06-01')->create([
+            'employee_id' => $employee->id,
+        ]);
+
+        $this->getJson('/api/v1/pay-periods/preview?branch_id='.$this->branch->id.'&period_start=2026-06-22&period_end=2026-06-28')
+            ->assertStatus(200);
+
+        $this->assertDatabaseCount('pay_periods', 0);
+        $this->assertDatabaseCount('pay_period_employees', 0);
+        $this->assertDatabaseCount('pay_period_lines', 0);
+    }
+
+    public function test_preview_excludes_employees_from_other_branches(): void
+    {
+        $otherBranch = Branch::factory()->create();
+
+        $employee = Employee::factory()->create(['is_active' => true]);
+        EmploymentPeriod::factory()->create([
+            'employee_id' => $employee->id,
+            'branch_id' => $otherBranch->id,
+            'is_active' => true,
+        ]);
+
+        $response = $this->getJson('/api/v1/pay-periods/preview?branch_id='.$this->branch->id.'&period_start=2026-06-22&period_end=2026-06-28');
+
+        $response->assertStatus(200);
+        $this->assertCount(0, $response->json('data'));
+    }
+
+    public function test_preview_returns_403_without_permission(): void
+    {
+        $unprivilegedUser = User::factory()->create();
+        Passport::actingAs($unprivilegedUser);
+
+        $this->getJson('/api/v1/pay-periods/preview?branch_id='.$this->branch->id.'&period_start=2026-06-22&period_end=2026-06-28')
+            ->assertStatus(403);
+    }
+
+    public function test_preview_returns_422_when_branch_id_missing(): void
+    {
+        $this->getJson('/api/v1/pay-periods/preview?period_start=2026-06-22&period_end=2026-06-28')
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['branch_id']);
+    }
+
+    public function test_preview_returns_422_when_period_dates_missing(): void
+    {
+        $this->getJson('/api/v1/pay-periods/preview?branch_id='.$this->branch->id)
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['period_start', 'period_end']);
+    }
+
+    public function test_preview_returns_422_when_period_end_before_period_start(): void
+    {
+        $this->getJson('/api/v1/pay-periods/preview?branch_id='.$this->branch->id.'&period_start=2026-06-28&period_end=2026-06-22')
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['period_end']);
+    }
+
+    public function test_preview_returns_zero_base_pay_when_employee_has_no_wage_history(): void
+    {
+        $employee = Employee::factory()->create(['is_active' => true]);
+        EmploymentPeriod::factory()->create([
+            'employee_id' => $employee->id,
+            'branch_id' => $this->branch->id,
+            'is_active' => true,
+        ]);
+
+        $response = $this->getJson('/api/v1/pay-periods/preview?branch_id='.$this->branch->id.'&period_start=2026-06-22&period_end=2026-06-28');
+
+        $response->assertStatus(200);
+        $this->assertCount(1, $response->json('data'));
+        $this->assertEquals(0.0, (float) $response->json('data.0.base_pay'));
+    }
+
+    public function test_preview_includes_late_deduction_line_when_entry_late_above_threshold(): void
+    {
+        $employee = Employee::factory()->create(['is_active' => true]);
+        EmploymentPeriod::factory()->create([
+            'employee_id' => $employee->id,
+            'branch_id' => $this->branch->id,
+            'is_active' => true,
+        ]);
+        WageHistory::factory()->effectiveBetween('2026-06-01')->create([
+            'employee_id' => $employee->id,
+            'hourly_rate' => 60.00,
+        ]);
+        Attendance::factory()->create([
+            'employee_id' => $employee->id,
+            'date' => '2026-06-22',
+            'day_status' => 'WORKED',
+            'entry_late_seconds' => 3600,
+            'lunch_late_seconds' => 0,
+        ]);
+
+        $response = $this->getJson('/api/v1/pay-periods/preview?branch_id='.$this->branch->id.'&period_start=2026-06-22&period_end=2026-06-28');
+
+        $response->assertStatus(200);
+        $data = $response->json('data.0');
+        $this->assertGreaterThan(0, (float) $data['late_deductions']);
+
+        $lateLine = collect($data['pay_period_lines'])->firstWhere('concept', 'LATE_DEDUCTION');
+        $this->assertNotNull($lateLine);
+        $this->assertStringContainsString('Entry late', $lateLine['description']);
+    }
+
+    public function test_preview_includes_unpaid_leave_deduction_line(): void
+    {
+        $employee = Employee::factory()->create(['is_active' => true]);
+        EmploymentPeriod::factory()->create([
+            'employee_id' => $employee->id,
+            'branch_id' => $this->branch->id,
+            'is_active' => true,
+        ]);
+        WageHistory::factory()->effectiveBetween('2026-06-01')->create([
+            'employee_id' => $employee->id,
+            'hourly_rate' => 60.00,
+        ]);
+        Attendance::factory()->create([
+            'employee_id' => $employee->id,
+            'date' => '2026-06-22',
+            'day_status' => 'WORKED',
+            'entry_late_seconds' => 0,
+            'lunch_late_seconds' => 0,
+        ]);
+        PartialLeave::factory()->create([
+            'employee_id' => $employee->id,
+            'date' => '2026-06-22',
+            'duration_minutes' => 120,
+            'is_paid' => false,
+        ]);
+
+        $response = $this->getJson('/api/v1/pay-periods/preview?branch_id='.$this->branch->id.'&period_start=2026-06-22&period_end=2026-06-28');
+
+        $response->assertStatus(200);
+        $data = $response->json('data.0');
+        $this->assertGreaterThan(0, (float) $data['unpaid_leave_deductions']);
+
+        $leaveLine = collect($data['pay_period_lines'])->firstWhere('concept', 'UNPAID_LEAVE');
+        $this->assertNotNull($leaveLine);
+    }
+
+    public function test_preview_includes_overtime_pay_line_for_paid_movements(): void
+    {
+        $employee = Employee::factory()->create(['is_active' => true]);
+        EmploymentPeriod::factory()->create([
+            'employee_id' => $employee->id,
+            'branch_id' => $this->branch->id,
+            'is_active' => true,
+        ]);
+        WageHistory::factory()->effectiveBetween('2026-06-01')->create([
+            'employee_id' => $employee->id,
+            'hourly_rate' => 60.00,
+        ]);
+        OvertimeBankMovement::factory()->create([
+            'employee_id' => $employee->id,
+            'date' => '2026-06-22',
+            'type' => OvertimeBankMovement::TYPE_PAID,
+            'minutes' => 60,
+        ]);
+
+        $response = $this->getJson('/api/v1/pay-periods/preview?branch_id='.$this->branch->id.'&period_start=2026-06-22&period_end=2026-06-28');
+
+        $response->assertStatus(200);
+        $data = $response->json('data.0');
+        $this->assertGreaterThan(0, (float) $data['overtime_pay']);
+
+        $overtimeLine = collect($data['pay_period_lines'])->firstWhere('concept', 'OVERTIME');
+        $this->assertNotNull($overtimeLine);
+    }
+
+    public function test_preview_returns_empty_data_when_no_active_employees_in_branch(): void
+    {
+        $response = $this->getJson('/api/v1/pay-periods/preview?branch_id='.$this->branch->id.'&period_start=2026-06-22&period_end=2026-06-28');
+
+        $response->assertStatus(200);
+        $this->assertCount(0, $response->json('data'));
+    }
+}

--- a/code/api/tests/Feature/Devtools/SeedPayrollEndpointTest.php
+++ b/code/api/tests/Feature/Devtools/SeedPayrollEndpointTest.php
@@ -1,0 +1,320 @@
+<?php
+
+namespace Tests\Feature\Devtools;
+
+use App\Exceptions\ClockSimulationMisconfigurationException;
+use App\Models\Branch;
+use App\Models\Employee;
+use App\Models\EmploymentPeriod;
+use App\Models\OvertimeBankMovement;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Laravel\Passport\Passport;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class SeedPayrollEndpointTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+
+    protected Branch $branch;
+
+    protected string $periodStart = '2026-06-23';
+
+    protected string $periodEnd = '2026-06-29';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('payroll_seed.enabled', true);
+        Config::set('payroll_seed.allowed_environments', 'testing');
+
+        foreach (Employee::POSITION_ROLES as $roleName) {
+            Role::firstOrCreate(['name' => $roleName, 'guard_name' => 'api']);
+        }
+
+        $this->user = User::factory()->create();
+        $this->branch = Branch::factory()->create();
+
+        Passport::actingAs($this->user);
+    }
+
+    private function createActiveEmployee(): Employee
+    {
+        $employee = Employee::factory()->create(['is_active' => true]);
+        EmploymentPeriod::factory()->create([
+            'employee_id' => $employee->id,
+            'branch_id' => $this->branch->id,
+            'is_active' => true,
+        ]);
+
+        return $employee;
+    }
+
+    // ── 404 guard ─────────────────────────────────────────────────────────────
+
+    public function test_returns_404_when_payroll_seed_disabled(): void
+    {
+        Config::set('payroll_seed.enabled', false);
+
+        $this->postJson('/api/v1/devtools/payroll/seed', [
+            'branch_id' => $this->branch->id,
+            'period_start' => $this->periodStart,
+            'period_end' => $this->periodEnd,
+            'scenario' => 'full_week',
+        ])->assertNotFound();
+    }
+
+    public function test_returns_404_when_environment_not_allowed(): void
+    {
+        Config::set('payroll_seed.allowed_environments', 'local,devtest');
+
+        $this->postJson('/api/v1/devtools/payroll/seed', [
+            'branch_id' => $this->branch->id,
+            'period_start' => $this->periodStart,
+            'period_end' => $this->periodEnd,
+            'scenario' => 'full_week',
+        ])->assertNotFound();
+    }
+
+    // ── Validation ────────────────────────────────────────────────────────────
+
+    public function test_returns_422_when_branch_id_missing(): void
+    {
+        $this->postJson('/api/v1/devtools/payroll/seed', [
+            'period_start' => $this->periodStart,
+            'period_end' => $this->periodEnd,
+            'scenario' => 'full_week',
+        ])->assertUnprocessable()
+            ->assertJsonValidationErrors(['branch_id']);
+    }
+
+    public function test_returns_422_when_scenario_invalid(): void
+    {
+        $this->postJson('/api/v1/devtools/payroll/seed', [
+            'branch_id' => $this->branch->id,
+            'period_start' => $this->periodStart,
+            'period_end' => $this->periodEnd,
+            'scenario' => 'not_a_real_scenario',
+        ])->assertUnprocessable()
+            ->assertJsonValidationErrors(['scenario']);
+    }
+
+    public function test_returns_422_when_period_end_before_period_start(): void
+    {
+        $this->postJson('/api/v1/devtools/payroll/seed', [
+            'branch_id' => $this->branch->id,
+            'period_start' => '2026-06-29',
+            'period_end' => '2026-06-23',
+            'scenario' => 'full_week',
+        ])->assertUnprocessable()
+            ->assertJsonValidationErrors(['period_end']);
+    }
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    public function test_seed_full_week_creates_5_attendances_per_employee(): void
+    {
+        $employee = $this->createActiveEmployee();
+
+        $response = $this->postJson('/api/v1/devtools/payroll/seed', [
+            'branch_id' => $this->branch->id,
+            'period_start' => $this->periodStart,
+            'period_end' => $this->periodEnd,
+            'scenario' => 'full_week',
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('status', 'ok')
+            ->assertJsonPath('data.created', 5);
+
+        $this->assertDatabaseCount('attendances', 5);
+        $this->assertDatabaseHas('attendances', [
+            'employee_id' => $employee->id,
+            'day_status' => 'WORKED',
+        ]);
+    }
+
+    public function test_seed_with_lates_creates_late_deductions(): void
+    {
+        $this->createActiveEmployee();
+
+        $response = $this->postJson('/api/v1/devtools/payroll/seed', [
+            'branch_id' => $this->branch->id,
+            'period_start' => $this->periodStart,
+            'period_end' => $this->periodEnd,
+            'scenario' => 'with_lates',
+        ]);
+
+        $response->assertOk();
+
+        // Mon and Wed (indices 0, 2) have 35 min late entry
+        $this->assertDatabaseHas('attendances', [
+            'entry_late_seconds' => 2100,
+        ]);
+    }
+
+    public function test_seed_with_unpaid_leave_creates_partial_leave_record(): void
+    {
+        $employee = $this->createActiveEmployee();
+
+        $this->postJson('/api/v1/devtools/payroll/seed', [
+            'branch_id' => $this->branch->id,
+            'period_start' => $this->periodStart,
+            'period_end' => $this->periodEnd,
+            'scenario' => 'with_unpaid_leave',
+        ])->assertOk();
+
+        $this->assertDatabaseHas('partial_leaves', [
+            'employee_id' => $employee->id,
+            'is_paid' => false,
+            'duration_minutes' => 240,
+        ]);
+    }
+
+    public function test_seed_with_overtime_creates_paid_overtime_bank_movements(): void
+    {
+        $employee = $this->createActiveEmployee();
+
+        $this->postJson('/api/v1/devtools/payroll/seed', [
+            'branch_id' => $this->branch->id,
+            'period_start' => $this->periodStart,
+            'period_end' => $this->periodEnd,
+            'scenario' => 'with_overtime',
+        ])->assertOk();
+
+        // Tue, Thu, Fri (3 days) get OvertimeBankMovement TYPE_PAID
+        $this->assertDatabaseCount('overtime_bank_movements', 3);
+        $this->assertDatabaseHas('overtime_bank_movements', [
+            'employee_id' => $employee->id,
+            'type' => 'PAID',
+            'minutes' => 120,
+        ]);
+    }
+
+    public function test_seed_with_absences_creates_absence_records(): void
+    {
+        $this->createActiveEmployee();
+
+        $this->postJson('/api/v1/devtools/payroll/seed', [
+            'branch_id' => $this->branch->id,
+            'period_start' => $this->periodStart,
+            'period_end' => $this->periodEnd,
+            'scenario' => 'with_absences',
+        ])->assertOk();
+
+        $this->assertDatabaseHas('attendances', [
+            'day_status' => 'ABSENCE',
+        ]);
+    }
+
+    public function test_seed_resets_existing_attendances_before_creating(): void
+    {
+        $employee = $this->createActiveEmployee();
+
+        // Seed once
+        $this->postJson('/api/v1/devtools/payroll/seed', [
+            'branch_id' => $this->branch->id,
+            'period_start' => $this->periodStart,
+            'period_end' => $this->periodEnd,
+            'scenario' => 'full_week',
+        ])->assertOk();
+
+        $this->assertDatabaseCount('attendances', 5);
+
+        // Seed again — should still be 5, not 10
+        $this->postJson('/api/v1/devtools/payroll/seed', [
+            'branch_id' => $this->branch->id,
+            'period_start' => $this->periodStart,
+            'period_end' => $this->periodEnd,
+            'scenario' => 'full_week',
+        ])->assertOk();
+
+        $this->assertDatabaseCount('attendances', 5);
+    }
+
+    public function test_seed_returns_employee_codes_in_response(): void
+    {
+        $employee = $this->createActiveEmployee();
+
+        $response = $this->postJson('/api/v1/devtools/payroll/seed', [
+            'branch_id' => $this->branch->id,
+            'period_start' => $this->periodStart,
+            'period_end' => $this->periodEnd,
+            'scenario' => 'full_week',
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.employees.0', $employee->code);
+    }
+
+    public function test_seed_ignores_employees_from_other_branches(): void
+    {
+        $this->createActiveEmployee();
+
+        $otherBranch = Branch::factory()->create();
+        $otherEmployee = Employee::factory()->create(['is_active' => true]);
+        EmploymentPeriod::factory()->create([
+            'employee_id' => $otherEmployee->id,
+            'branch_id' => $otherBranch->id,
+            'is_active' => true,
+        ]);
+
+        $response = $this->postJson('/api/v1/devtools/payroll/seed', [
+            'branch_id' => $this->branch->id,
+            'period_start' => $this->periodStart,
+            'period_end' => $this->periodEnd,
+            'scenario' => 'full_week',
+        ]);
+
+        // Only 5 records (1 employee, 5 days) not 10
+        $response->assertOk()->assertJsonPath('data.created', 5);
+    }
+
+    public function test_seed_returns_empty_result_when_no_active_employees(): void
+    {
+        $this->postJson('/api/v1/devtools/payroll/seed', [
+            'branch_id' => $this->branch->id,
+            'period_start' => $this->periodStart,
+            'period_end' => $this->periodEnd,
+            'scenario' => 'full_week',
+        ])->assertOk()
+            ->assertJsonPath('data.created', 0)
+            ->assertJsonPath('data.employees', []);
+    }
+
+    public function test_seed_mixed_scenario_with_7_employees_covers_all_slots(): void
+    {
+        // 7 employees exercise all mixedRow slots (% 7: 0–6), including
+        // lunchLateOrWorkedRow (slot 5) and combinedRow (slot 6)
+        for ($i = 0; $i < 7; $i++) {
+            $this->createActiveEmployee();
+        }
+
+        $this->postJson('/api/v1/devtools/payroll/seed', [
+            'branch_id' => $this->branch->id,
+            'period_start' => $this->periodStart,
+            'period_end' => $this->periodEnd,
+            'scenario' => 'mixed',
+        ])->assertOk()
+            ->assertJsonPath('data.created', 35); // 7 employees × 5 days
+    }
+
+    public function test_raises_misconfiguration_exception_when_production_in_allowed_environments(): void
+    {
+        Config::set('payroll_seed.allowed_environments', 'testing,production');
+
+        $this->expectException(ClockSimulationMisconfigurationException::class);
+
+        $this->withoutExceptionHandling()->postJson('/api/v1/devtools/payroll/seed', [
+            'branch_id' => $this->branch->id,
+            'period_start' => $this->periodStart,
+            'period_end' => $this->periodEnd,
+            'scenario' => 'full_week',
+        ]);
+    }
+}

--- a/code/api/tests/Unit/Models/OvertimeBankMovementTest.php
+++ b/code/api/tests/Unit/Models/OvertimeBankMovementTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\OvertimeBankMovement;
+use PHPUnit\Framework\TestCase;
+
+class OvertimeBankMovementTest extends TestCase
+{
+    public function test_type_constants_have_expected_values(): void
+    {
+        $this->assertSame('EARNED', OvertimeBankMovement::TYPE_EARNED);
+        $this->assertSame('PAID', OvertimeBankMovement::TYPE_PAID);
+        $this->assertSame('EXPIRED', OvertimeBankMovement::TYPE_EXPIRED);
+        $this->assertSame('TRANSFERRED', OvertimeBankMovement::TYPE_TRANSFERRED);
+    }
+}

--- a/code/api/tests/Unit/Models/PayPeriodEmployeeTest.php
+++ b/code/api/tests/Unit/Models/PayPeriodEmployeeTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\PayPeriodEmployee;
+use PHPUnit\Framework\TestCase;
+
+class PayPeriodEmployeeTest extends TestCase
+{
+    public function test_calculate_total_sums_all_positive_concepts(): void
+    {
+        $ppe = new PayPeriodEmployee;
+        $ppe->base_pay = '1000.00';
+        $ppe->late_deductions = '0.00';
+        $ppe->unpaid_leave_deductions = '0.00';
+        $ppe->overtime_pay = '200.00';
+        $ppe->extra_day_pay = '150.00';
+        $ppe->punctuality_bonus = '50.00';
+        $ppe->holiday_pay = '300.00';
+        $ppe->other_adjustments = '0.00';
+
+        $this->assertEqualsWithDelta(1700.0, $ppe->calculateTotal(), 0.001);
+    }
+
+    public function test_calculate_total_subtracts_deductions(): void
+    {
+        $ppe = new PayPeriodEmployee;
+        $ppe->base_pay = '1000.00';
+        $ppe->late_deductions = '80.00';
+        $ppe->unpaid_leave_deductions = '40.00';
+        $ppe->overtime_pay = '0.00';
+        $ppe->extra_day_pay = '0.00';
+        $ppe->punctuality_bonus = '0.00';
+        $ppe->holiday_pay = '0.00';
+        $ppe->other_adjustments = '0.00';
+
+        $this->assertEqualsWithDelta(880.0, $ppe->calculateTotal(), 0.001);
+    }
+
+    public function test_calculate_total_with_all_concepts(): void
+    {
+        $ppe = new PayPeriodEmployee;
+        $ppe->base_pay = '5000.00';
+        $ppe->late_deductions = '100.00';
+        $ppe->unpaid_leave_deductions = '50.00';
+        $ppe->overtime_pay = '300.00';
+        $ppe->extra_day_pay = '500.00';
+        $ppe->punctuality_bonus = '200.00';
+        $ppe->holiday_pay = '0.00';
+        $ppe->other_adjustments = '-25.00';
+
+        // 5000 - 100 - 50 + 300 + 500 + 200 + 0 + (-25) = 5825
+        $this->assertEqualsWithDelta(5825.0, $ppe->calculateTotal(), 0.001);
+    }
+}

--- a/code/api/tests/Unit/Models/PayPeriodTest.php
+++ b/code/api/tests/Unit/Models/PayPeriodTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\PayPeriod;
+use PHPUnit\Framework\TestCase;
+
+class PayPeriodTest extends TestCase
+{
+    public function test_is_open_returns_true_when_status_open(): void
+    {
+        $period = new PayPeriod;
+        $period->status = PayPeriod::STATUS_OPEN;
+
+        $this->assertTrue($period->isOpen());
+        $this->assertFalse($period->isClosed());
+    }
+
+    public function test_is_closed_returns_true_when_status_closed(): void
+    {
+        $period = new PayPeriod;
+        $period->status = PayPeriod::STATUS_CLOSED;
+
+        $this->assertFalse($period->isOpen());
+        $this->assertTrue($period->isClosed());
+    }
+
+    public function test_is_open_and_is_closed_both_false_when_reopened(): void
+    {
+        $period = new PayPeriod;
+        $period->status = PayPeriod::STATUS_REOPENED;
+
+        $this->assertFalse($period->isOpen());
+        $this->assertFalse($period->isClosed());
+    }
+
+    public function test_status_constants_have_expected_values(): void
+    {
+        $this->assertSame('OPEN', PayPeriod::STATUS_OPEN);
+        $this->assertSame('CLOSED', PayPeriod::STATUS_CLOSED);
+        $this->assertSame('REOPENED', PayPeriod::STATUS_REOPENED);
+    }
+}

--- a/code/api/tests/Unit/Services/PayrollCalculatorTest.php
+++ b/code/api/tests/Unit/Services/PayrollCalculatorTest.php
@@ -8,6 +8,8 @@ use Carbon\Carbon;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
+// ── PayrollCalculator extended tests are appended at the bottom of this file ──
+
 class PayrollCalculatorTest extends TestCase
 {
     private function makeAttendance(string $date, string $dayStatus): object
@@ -40,10 +42,9 @@ class PayrollCalculatorTest extends TestCase
             $this->makeHoliday('2026-01-01', 2.0),
         ]);
 
-        $dailyWage = 500.0;
-
-        // extra_pay = dailyWage × (pay_multiplier − 1) = 500 × 1 = 500
-        $result = PayrollCalculator::calculateHolidayPay($attendances, $holidays, $dailyWage);
+        // hourlyRate=500, scheduledMinutes=[60] → dailyWage = 500×60/60 = 500
+        // extra_pay = 500 × (2 − 1) = 500
+        $result = PayrollCalculator::calculateHolidayPay($attendances, $holidays, collect([60]), 500.0);
 
         $this->assertEquals(500.0, $result);
     }
@@ -59,10 +60,9 @@ class PayrollCalculatorTest extends TestCase
             $this->makeHoliday('2026-01-01', 3.0),
         ]);
 
-        $dailyWage = 500.0;
-
+        // hourlyRate=500, scheduledMinutes=[60] → dailyWage = 500
         // extra_pay = 500 × (3 − 1) = 1000
-        $result = PayrollCalculator::calculateHolidayPay($attendances, $holidays, $dailyWage);
+        $result = PayrollCalculator::calculateHolidayPay($attendances, $holidays, collect([60]), 500.0);
 
         $this->assertEquals(1000.0, $result);
     }
@@ -78,7 +78,7 @@ class PayrollCalculatorTest extends TestCase
             $this->makeHoliday('2026-01-01', 2.0),
         ]);
 
-        $result = PayrollCalculator::calculateHolidayPay($attendances, $holidays, 500.0);
+        $result = PayrollCalculator::calculateHolidayPay($attendances, $holidays, collect([60]), 500.0);
 
         $this->assertEquals(0.0, $result);
     }
@@ -96,7 +96,7 @@ class PayrollCalculatorTest extends TestCase
             $this->makeHoliday('2026-01-01', 2.0),
         ]);
 
-        $result = PayrollCalculator::calculateHolidayPay($attendances, $holidays, 500.0);
+        $result = PayrollCalculator::calculateHolidayPay($attendances, $holidays, collect([60, 60, 60]), 500.0);
 
         $this->assertEquals(0.0, $result);
     }
@@ -116,10 +116,9 @@ class PayrollCalculatorTest extends TestCase
             $this->makeHoliday('2026-09-16', 2.0),
         ]);
 
-        $dailyWage = 400.0;
-
-        // 2 worked holidays × 400 × 1 = 800
-        $result = PayrollCalculator::calculateHolidayPay($attendances, $holidays, $dailyWage);
+        // hourlyRate=400, scheduledMinutes=[60,60,60] → dailyWage = 400 each
+        // 2 worked holidays × 400 × (2−1) = 800
+        $result = PayrollCalculator::calculateHolidayPay($attendances, $holidays, collect([60, 60, 60]), 400.0);
 
         $this->assertEquals(800.0, $result);
     }
@@ -134,6 +133,7 @@ class PayrollCalculatorTest extends TestCase
         $result = PayrollCalculator::calculateHolidayPay(
             $attendances,
             collect(),
+            collect([60]),
             500.0
         );
 
@@ -150,6 +150,7 @@ class PayrollCalculatorTest extends TestCase
         $result = PayrollCalculator::calculateHolidayPay(
             collect(),
             $holidays,
+            collect(),
             500.0
         );
 
@@ -170,8 +171,159 @@ class PayrollCalculatorTest extends TestCase
             $this->makeHoliday('2026-01-01', 2.0),
         ]);
 
-        $result = PayrollCalculator::calculateHolidayPay($attendances, $holidays, 600.0);
+        // hourlyRate=600, scheduledMinutes=[60] → dailyWage = 600
+        $result = PayrollCalculator::calculateHolidayPay($attendances, $holidays, collect([60]), 600.0);
 
         $this->assertEquals(600.0, $result);
+    }
+
+    // ── calculateBasePay ─────────────────────────────────────────────────────
+
+    #[Test]
+    public function calculates_base_pay_from_scheduled_minutes_and_hourly_rate(): void
+    {
+        // 3 days × 480 min each → 1440 min total
+        $scheduledMinutes = collect([480, 480, 480]);
+        $hourlyRate = 100.0; // 100/hr = 1.6666/min
+
+        // base_pay = (1440 / 60) × 100 = 24 × 100 = 2400
+        $result = PayrollCalculator::calculateBasePay($scheduledMinutes, $hourlyRate);
+
+        $this->assertEquals(2400.0, $result);
+    }
+
+    #[Test]
+    public function calculate_base_pay_returns_zero_for_no_worked_days(): void
+    {
+        $result = PayrollCalculator::calculateBasePay(collect(), 100.0);
+
+        $this->assertEquals(0.0, $result);
+    }
+
+    // ── calculateLateDeductions ──────────────────────────────────────────────
+
+    #[Test]
+    public function deducts_entry_late_minutes_when_above_threshold(): void
+    {
+        // 1801 seconds = 30 min 1 sec → deductible, floor(1801/60) = 30 min
+        $attendance = (object) [
+            'entry_late_seconds' => 1801,
+            'lunch_late_seconds' => 0,
+        ];
+
+        $minuteRate = 2.0; // $2 per minute
+
+        $result = PayrollCalculator::calculateLateDeductions(collect([$attendance]), $minuteRate);
+
+        $this->assertEquals(60.0, $result); // 30 min × $2
+    }
+
+    #[Test]
+    public function does_not_deduct_entry_late_at_or_below_1800_seconds(): void
+    {
+        $attendance = (object) [
+            'entry_late_seconds' => 1800,
+            'lunch_late_seconds' => 0,
+        ];
+
+        $result = PayrollCalculator::calculateLateDeductions(collect([$attendance]), 2.0);
+
+        $this->assertEquals(0.0, $result);
+    }
+
+    #[Test]
+    public function deducts_lunch_late_minutes_when_above_threshold(): void
+    {
+        $attendance = (object) [
+            'entry_late_seconds' => 0,
+            'lunch_late_seconds' => 2400, // 40 min → floor = 40 min
+        ];
+
+        $result = PayrollCalculator::calculateLateDeductions(collect([$attendance]), 2.0);
+
+        $this->assertEquals(80.0, $result); // 40 min × $2
+    }
+
+    #[Test]
+    public function accumulates_both_entry_and_lunch_late_deductions(): void
+    {
+        $attendance = (object) [
+            'entry_late_seconds' => 1900, // floor(1900/60) = 31 min
+            'lunch_late_seconds' => 1900, // floor(1900/60) = 31 min
+        ];
+
+        $result = PayrollCalculator::calculateLateDeductions(collect([$attendance]), 1.0);
+
+        $this->assertEquals(62.0, $result); // 31 + 31 = 62 min × $1
+    }
+
+    // ── calculateUnpaidLeaveDeductions ───────────────────────────────────────
+
+    #[Test]
+    public function deducts_minutes_for_unpaid_partial_leaves(): void
+    {
+        $leave = (object) ['duration_minutes' => 60, 'is_paid' => false];
+
+        $result = PayrollCalculator::calculateUnpaidLeaveDeductions(collect([$leave]), 2.0);
+
+        $this->assertEquals(120.0, $result); // 60 min × $2
+    }
+
+    #[Test]
+    public function skips_paid_partial_leaves(): void
+    {
+        $leave = (object) ['duration_minutes' => 60, 'is_paid' => true];
+
+        $result = PayrollCalculator::calculateUnpaidLeaveDeductions(collect([$leave]), 2.0);
+
+        $this->assertEquals(0.0, $result);
+    }
+
+    // ── calculateOvertimePay ─────────────────────────────────────────────────
+
+    #[Test]
+    public function sums_paid_overtime_movements(): void
+    {
+        $movement = (object) ['type' => 'PAID', 'minutes' => 120];
+
+        $result = PayrollCalculator::calculateOvertimePay(collect([$movement]), 2.0);
+
+        $this->assertEquals(240.0, $result); // 120 min × $2
+    }
+
+    #[Test]
+    public function skips_earned_and_expired_overtime_movements(): void
+    {
+        $movements = collect([
+            (object) ['type' => 'EARNED', 'minutes' => 60],
+            (object) ['type' => 'EXPIRED', 'minutes' => 60],
+        ]);
+
+        $result = PayrollCalculator::calculateOvertimePay($movements, 2.0);
+
+        $this->assertEquals(0.0, $result);
+    }
+
+    // ── calculateExtraDayPay ─────────────────────────────────────────────────
+
+    #[Test]
+    public function sums_agreed_daily_wages_for_extra_days(): void
+    {
+        $extraDays = collect([
+            (object) ['agreed_daily_wage' => 500.0],
+            (object) ['agreed_daily_wage' => 750.0],
+        ]);
+
+        $result = PayrollCalculator::calculateExtraDayPay($extraDays);
+
+        $this->assertEquals(1250.0, $result);
+    }
+
+    #[Test]
+    public function calculate_extra_day_pay_returns_zero_when_empty(): void
+    {
+        $result = PayrollCalculator::calculateExtraDayPay(collect());
+
+        $this->assertEquals(0.0, $result);
     }
 }

--- a/code/api/tests/Unit/Services/PunctualityServiceTest.php
+++ b/code/api/tests/Unit/Services/PunctualityServiceTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\EmployeeBonusConfig;
+use App\Models\PunctualityBonusGroup;
+use App\Models\PunctualityRange;
+use App\Services\PunctualityService;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class PunctualityServiceTest extends TestCase
+{
+    private function makeRange(int $minSeconds, ?int $maxSeconds, float $bonusPercentage, int $sortOrder = 1): PunctualityRange
+    {
+        $range = new PunctualityRange;
+        $range->min_seconds = $minSeconds;
+        $range->max_seconds = $maxSeconds;
+        $range->bonus_percentage = $bonusPercentage;
+        $range->sort_order = $sortOrder;
+
+        return $range;
+    }
+
+    private function makeBonusGroup(float $weeklyBonus, int $divisor): PunctualityBonusGroup
+    {
+        $group = new PunctualityBonusGroup;
+        $group->weekly_bonus_amount = $weeklyBonus;
+        $group->working_days_divisor = $divisor;
+
+        return $group;
+    }
+
+    private function makeAttendance(int $entryLateSeconds): object
+    {
+        return (object) ['entry_late_seconds' => $entryLateSeconds];
+    }
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    #[Test]
+    public function returns_full_bonus_when_all_days_perfectly_on_time(): void
+    {
+        // Range: 0–0 seconds late → 100%
+        $ranges = collect([
+            $this->makeRange(0, 0, 100.0, 1),
+        ]);
+        $group = $this->makeBonusGroup(600.0, 6); // daily = 100
+
+        $attendances = collect([
+            $this->makeAttendance(0),
+            $this->makeAttendance(0),
+            $this->makeAttendance(0),
+        ]);
+
+        $result = PunctualityService::calculateWeeklyBonus($attendances, $group, $ranges);
+
+        // 3 × (100 × 1.0) = 300
+        $this->assertEquals(300.0, $result);
+    }
+
+    #[Test]
+    public function returns_partial_bonus_when_some_days_within_grace_range(): void
+    {
+        $ranges = collect([
+            $this->makeRange(0, 0, 100.0, 1),      // exactly on time
+            $this->makeRange(1, 900, 50.0, 2),      // up to 15 min late
+        ]);
+        $group = $this->makeBonusGroup(600.0, 6); // daily = 100
+
+        $attendances = collect([
+            $this->makeAttendance(0),    // on time → 100% → 100
+            $this->makeAttendance(300),  // 5 min late → 50% → 50
+            $this->makeAttendance(300),  // 5 min late → 50% → 50
+        ]);
+
+        $result = PunctualityService::calculateWeeklyBonus($attendances, $group, $ranges);
+
+        $this->assertEquals(200.0, $result);
+    }
+
+    #[Test]
+    public function returns_zero_when_no_range_matches(): void
+    {
+        $ranges = collect([
+            $this->makeRange(0, 900, 100.0, 1), // 0–15 min late
+        ]);
+        $group = $this->makeBonusGroup(600.0, 6);
+
+        // All attendances are > 900 seconds late — no range matches
+        $attendances = collect([
+            $this->makeAttendance(1800),
+            $this->makeAttendance(3600),
+        ]);
+
+        $result = PunctualityService::calculateWeeklyBonus($attendances, $group, $ranges);
+
+        $this->assertEquals(0.0, $result);
+    }
+
+    #[Test]
+    public function uses_open_ended_range_when_max_is_null(): void
+    {
+        // Range 0–∞ seconds → 75%
+        $ranges = collect([
+            $this->makeRange(0, null, 75.0, 1),
+        ]);
+        $group = $this->makeBonusGroup(400.0, 4); // daily = 100
+
+        $attendances = collect([
+            $this->makeAttendance(0),
+            $this->makeAttendance(99999), // very late — still matches open-ended range
+        ]);
+
+        $result = PunctualityService::calculateWeeklyBonus($attendances, $group, $ranges);
+
+        // 2 × (100 × 0.75) = 150
+        $this->assertEquals(150.0, $result);
+    }
+
+    #[Test]
+    public function returns_zero_when_attendances_empty(): void
+    {
+        $ranges = collect([
+            $this->makeRange(0, null, 100.0),
+        ]);
+        $group = $this->makeBonusGroup(600.0, 6);
+
+        $result = PunctualityService::calculateWeeklyBonus(collect(), $group, $ranges);
+
+        $this->assertEquals(0.0, $result);
+    }
+
+    #[Test]
+    public function returns_zero_when_ranges_empty(): void
+    {
+        $group = $this->makeBonusGroup(600.0, 6);
+
+        $attendances = collect([
+            $this->makeAttendance(0),
+            $this->makeAttendance(0),
+        ]);
+
+        $result = PunctualityService::calculateWeeklyBonus($attendances, $group, collect());
+
+        $this->assertEquals(0.0, $result);
+    }
+
+    #[Test]
+    public function employee_without_bonus_config_returns_zero(): void
+    {
+        $result = PunctualityService::calculateWeeklyBonusFromConfig(
+            collect([$this->makeAttendance(0)]),
+            null,  // no EmployeeBonusConfig
+            collect()
+        );
+
+        $this->assertEquals(0.0, $result);
+    }
+}

--- a/code/webapp/cypress/e2e/attendance-today-report.cy.ts
+++ b/code/webapp/cypress/e2e/attendance-today-report.cy.ts
@@ -9,12 +9,14 @@
  *
  * DB reset strategy
  * ─────────────────
- * • before() → cy.task('test:reset', 'attendance') ONCE per file.
- * • Uses seeded employees EMP-001 (Carlos Mendoza) and EMP-003 (Pedro López).
+ * • before() → cy.task('test:reset', 'today-report-statuses') ONCE per file.
  *
- * Employees used (seeded via attendance scenario):
- *   EMP-001  Mendoza, Carlos   → check-in at 13:00 (on time)
- *   EMP-003  López, Pedro      → check-in at 13:15 (+15 min late)
+ * Test date: 2026-06-18 (Thursday) — matches TodayReportStatusSeeder.TEST_DATE
+ *
+ * Employees used (seeded by TodayReportStatusSeeder):
+ *   EMP-001  Mendoza, Carlos   → arrived      (check-in 13:00 CDMX, on time)
+ *   EMP-002  García, María     → late         (check-in 13:15 CDMX, +15 min)
+ *   EMP-003  López, Pedro      → not_arrived  (no attendance record)
  *
  * Para correr solo este archivo:
  *   make cypress-spec SPEC=attendance-today-report
@@ -27,12 +29,12 @@ const { email: adminEmail, password: adminPassword } = users.admin;
 // ── Suite setup ─────────────────────────────────────────────────────────────
 
 before(() => {
-  cy.task("test:reset", "attendance", { timeout: 60_000 });
+  cy.task("test:reset", "today-report-statuses", { timeout: 60_000 });
 });
 
-// Test time: 14:30 CDMX — after both check-ins have been recorded by the seeder
-const TEST_TIME_ISO = "2026-04-02T14:30:00-06:00";
-const TEST_TIME_UTC = new Date("2026-04-02T20:30:00Z");
+// Test time: 14:30 CDMX on 2026-06-18 — matches TodayReportStatusSeeder.TEST_DATE
+const TEST_TIME_ISO = "2026-06-18T14:30:00-06:00";
+const TEST_TIME_UTC = new Date("2026-06-18T20:30:00Z");
 
 beforeEach(() => {
   cy.intercept({ url: /\/api\/v1\// }, (req) => {
@@ -74,9 +76,9 @@ it("shows 'A tiempo' badge for employee checked in on time (EMP-001)", () => {
   cy.contains("Mendoza").closest("tr").contains("A tiempo").should("be.visible");
 });
 
-it("shows 'Tardanza' badge for late employee (EMP-003)", () => {
-  // EMP-003 Pedro López is seeded with check-in at 13:15 (+15 min late)
-  cy.contains("López").closest("tr").contains("Tardanza").should("be.visible");
+it("shows 'Tardanza' badge for late employee (EMP-002)", () => {
+  // EMP-002 María García is seeded with check-in at 13:15 (+15 min late)
+  cy.contains("García").closest("tr").contains("Tardanza").should("be.visible");
 });
 
 it("shows 'No registrado' badge for employees without check-in", () => {

--- a/code/webapp/cypress/e2e/employee-negotiated-extra-days.cy.ts
+++ b/code/webapp/cypress/e2e/employee-negotiated-extra-days.cy.ts
@@ -136,9 +136,16 @@ describe('Negotiated Extra Days — History Dialog', () => {
     openHistory()
     cy.wait('@listExtraDays')
 
-    // Apply date_from filter (2026-05-01)
+    // Apply date_from filter set to today-30 days: always hides the 3 past
+    // records (seeded at today-90, today-69, today-54 days) while leaving the
+    // future record (today+30 days) visible. A hardcoded date would break once
+    // today-54 days overtakes it.
+    const thirtyDaysAgo = new Date()
+    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30)
+    const filterDate = thirtyDaysAgo.toISOString().slice(0, 10)
+
     cy.intercept('GET', '**/negotiated-extra-days**').as('listFiltered')
-    cy.get('#history-date-from').clear().type('2026-05-01')
+    cy.get('#history-date-from').clear().type(filterDate)
     cy.wait('@listFiltered').its('response.statusCode').should('eq', 200)
 
     cy.contains('Turno especial').should('not.exist')

--- a/code/webapp/cypress/e2e/payroll-close-preview.cy.ts
+++ b/code/webapp/cypress/e2e/payroll-close-preview.cy.ts
@@ -1,0 +1,71 @@
+/**
+ * Payroll Close Preview — E2E tests
+ *
+ * Covers the happy path for the weekly payroll preview:
+ *   1. Manager navigates to /attendance/payroll/close
+ *   2. Selects the week 2026-06-22..2026-06-28
+ *   3. Clicks "Calcular preview"
+ *   4. Verifies the table renders with 2 employee rows (PAY-001, PAY-002)
+ *   5. Expands one row and verifies BASE_PAY lines are present
+ *
+ * Pre-seeded data (via test:reset --seeders=payroll-preview):
+ *   - CoreTestSeeder: branch MAIN, admin user (admin@sushigo.com / admin123456)
+ *   - PayrollPreviewSeeder: PAY-001 Ana Payroll & PAY-002 Carlos Nomina
+ *     Each employee: Mon–Fri WORKED 08:00–17:00, hourly_rate=100, weekly_scheduled_hours=48
+ *
+ * Expected base_pay per employee:
+ *   5 days × 8h × $100/h = $4,000
+ *
+ * To run only this spec:
+ *   make cypress-spec SPEC=payroll-close-preview
+ */
+
+const PERIOD_START = '2026-06-22'
+const PERIOD_END = '2026-06-28'
+
+describe('Payroll Close Preview — happy path', () => {
+  before(() => {
+    cy.task('test:reset', 'payroll-preview')
+  })
+
+  beforeEach(() => {
+    cy.loginByApi('admin@sushigo.com', 'admin123456')
+    cy.visitWithAuth('/attendance/payroll/close')
+  })
+
+  it('renders the page and date inputs', () => {
+    cy.contains('h1, h2', 'Cierre de Nómina').should('be.visible')
+    cy.get('[data-testid="payroll-preview-form"] input[type="date"]').should('have.length', 2)
+    cy.contains('button', 'Calcular preview').should('be.visible')
+  })
+
+  it('shows employee rows after clicking Calcular preview', () => {
+    cy.intercept('GET', '**/pay-periods/preview**').as('preview')
+
+    cy.get('input[type="date"]').first().clear().type(PERIOD_START)
+    cy.get('input[type="date"]').last().clear().type(PERIOD_END)
+    cy.contains('button', 'Calcular preview').click()
+
+    cy.wait('@preview')
+
+    cy.contains('Payroll').should('be.visible')
+    cy.contains('Nomina').should('be.visible')
+
+    // Two employee rows
+    cy.get('[data-testid="employee-preview-row"]').should('have.length.gte', 2)
+  })
+
+  it('expands a row and shows BASE_PAY lines', () => {
+    cy.intercept('GET', '**/pay-periods/preview**').as('preview')
+
+    cy.get('input[type="date"]').first().clear().type(PERIOD_START)
+    cy.get('input[type="date"]').last().clear().type(PERIOD_END)
+    cy.contains('button', 'Calcular preview').click()
+
+    cy.wait('@preview')
+
+    // Expand first employee row
+    cy.get('[data-testid="employee-preview-row"]').first().click()
+    cy.contains('BASE_PAY').should('be.visible')
+  })
+})

--- a/code/webapp/src/App.tsx
+++ b/code/webapp/src/App.tsx
@@ -5,7 +5,6 @@ import { ThemeProvider } from '@/contexts/ThemeContext';
 import { SidebarProvider } from '@/contexts/SidebarContext';
 import { ToastProvider } from '@/components/ui/toast-provider';
 import { BranchSelectionDialog } from '@/components/auth';
-import { DevDebugger } from '@/components/dev';
 import { routeTree } from './routeTree.gen';
 
 const queryClient = new QueryClient({
@@ -40,7 +39,6 @@ function App() {
             <RouterProvider router={router} />
             <BranchSelectionDialog />
             <ReactQueryDevtools initialIsOpen={false} />
-            {import.meta.env.DEV && <DevDebugger />}
           </ToastProvider>
         </SidebarProvider>
       </ThemeProvider>

--- a/code/webapp/src/components/dev/DevDebugger.tsx
+++ b/code/webapp/src/components/dev/DevDebugger.tsx
@@ -12,10 +12,20 @@ import {
     Search,
     Loader2,
     GitBranch,
+    Zap,
     type LucideIcon,
 } from 'lucide-react'
+import { useRouterState } from '@tanstack/react-router'
 import { gitBranch } from 'virtual:git-branch'
 import { useDevDebugger } from './use-dev-debugger'
+import { PayrollCloseActions } from './page-actions/payroll-close-actions'
+
+const PAGE_ACTIONS: Record<string, { title: string; component: React.ReactNode }> = {
+    '/attendance/payroll/close': {
+        title: 'Cierre de Nómina',
+        component: <PayrollCloseActions />,
+    },
+}
 
 export function DevDebugger() {
     const {
@@ -51,6 +61,9 @@ export function DevDebugger() {
         refreshQueries,
         handleDevLogin,
     } = useDevDebugger()
+
+    const currentPath = useRouterState({ select: (s) => s.location.pathname })
+    const pageAction = PAGE_ACTIONS[currentPath] ?? null
 
     const [permissionInputFocused, setPermissionInputFocused] = useState(false)
 
@@ -168,6 +181,17 @@ export function DevDebugger() {
                         <p className="text-xs text-gray-400">No autenticado</p>
                     )}
                 </Section>
+
+                {pageAction && (
+                    <Section
+                        icon={Zap}
+                        title={`Acciones — ${pageAction.title}`}
+                        isExpanded={state.expandedSections.pageActions}
+                        onToggle={() => toggleSection('pageActions')}
+                    >
+                        {pageAction.component}
+                    </Section>
+                )}
 
                 <Section
                     icon={Shield}

--- a/code/webapp/src/components/dev/__tests__/DevDebugger.test.tsx
+++ b/code/webapp/src/components/dev/__tests__/DevDebugger.test.tsx
@@ -34,6 +34,11 @@ vi.mock('@/stores/auth.store', () => ({
   }),
 }))
 
+vi.mock('@tanstack/react-router', () => ({
+  useRouterState: ({ select }: { select?: (s: { location: { pathname: string } }) => unknown } = {}) =>
+    select ? select({ location: { pathname: '/dashboard' } }) : { location: { pathname: '/dashboard' } },
+}))
+
 vi.mock('@tanstack/react-query', () => ({
   useQueryClient: () => ({
     invalidateQueries,
@@ -44,6 +49,12 @@ vi.mock('@tanstack/react-query', () => ({
   useQuery: () => ({
     data: mockDevUsersQueryData,
     isLoading: mockIsLoadingDevUsers,
+  }),
+  useMutation: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+    isSuccess: false,
+    data: null,
   }),
 }))
 

--- a/code/webapp/src/components/dev/page-actions/__tests__/payroll-close-actions.test.tsx
+++ b/code/webapp/src/components/dev/page-actions/__tests__/payroll-close-actions.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockMutate = vi.fn()
+const mockInvalidateQueries = vi.fn()
+let mockIsPending = false
+let mockCurrentBranch: { id: number; name: string } | null = { id: 1, name: 'Main' }
+
+vi.mock('@tanstack/react-query', () => ({
+    useMutation: ({ onSuccess, onError }: {
+        onSuccess?: (data: unknown) => void
+        onError?: (err: unknown) => void
+    }) => ({
+        mutate: () => {
+            mockMutate({ onSuccess, onError })
+        },
+        isPending: mockIsPending,
+    }),
+    useQueryClient: () => ({
+        invalidateQueries: mockInvalidateQueries,
+    }),
+}))
+
+vi.mock('@/stores/auth.store', () => ({
+    useAuthStore: (selector: (s: { currentBranch: typeof mockCurrentBranch }) => unknown) =>
+        selector({ currentBranch: mockCurrentBranch }),
+}))
+
+vi.mock('@/services/payroll-devtools.service', () => ({
+    seedPayrollAttendance: vi.fn(),
+}))
+
+vi.mock('@/lib/api-error', () => ({
+    getApiErrorMessage: (_err: unknown, fallback: string) => fallback,
+}))
+
+import { PayrollCloseActions } from '../payroll-close-actions'
+
+afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+    mockIsPending = false
+    mockCurrentBranch = { id: 1, name: 'Main' }
+})
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('PayrollCloseActions', () => {
+    beforeEach(() => {
+        render(<PayrollCloseActions />)
+    })
+
+    it('renders Generar button and date inputs', () => {
+        expect(screen.getByRole('button', { name: /Generar asistencias/i })).toBeTruthy()
+        expect(document.querySelectorAll('input[type="date"]')).toHaveLength(2)
+    })
+
+    it('renders all 6 scenario radio options', () => {
+        const radios = document.querySelectorAll('input[type="radio"]')
+        expect(radios).toHaveLength(6)
+    })
+
+    it('defaults to full_week scenario selected', () => {
+        const radios = Array.from(document.querySelectorAll<HTMLInputElement>('input[type="radio"]'))
+        const fullWeek = radios.find((r) => r.value === 'full_week')
+        expect(fullWeek?.checked).toBe(true)
+    })
+
+    it('calls mutate when button is clicked', () => {
+        fireEvent.click(screen.getByRole('button', { name: /Generar asistencias/i }))
+        expect(mockMutate).toHaveBeenCalledOnce()
+    })
+
+    it('shows success result when onSuccess callback fires', async () => {
+        vi.mocked(mockMutate).mockImplementationOnce(
+            ({ onSuccess }: { onSuccess?: (d: unknown) => void }) => {
+                onSuccess?.({ created: 5, deleted: 3, employees: ['EMP-001', 'EMP-002'] })
+            },
+        )
+
+        fireEvent.click(screen.getByRole('button', { name: /Generar asistencias/i }))
+
+        await waitFor(() => {
+            expect(document.body.textContent).toContain('5 registros creados')
+            expect(document.body.textContent).toContain('3 eliminados')
+            expect(document.body.textContent).toContain('EMP-001, EMP-002')
+        })
+    })
+
+    it('shows error message when onError callback fires', async () => {
+        vi.mocked(mockMutate).mockImplementationOnce(
+            ({ onError }: { onError?: (e: unknown) => void }) => {
+                onError?.(new Error('Network Error'))
+            },
+        )
+
+        fireEvent.click(screen.getByRole('button', { name: /Generar asistencias/i }))
+
+        await waitFor(() => {
+            expect(document.body.textContent).toContain('Error al generar asistencias')
+        })
+    })
+
+    it('changing scenario radio updates selection', () => {
+        const radios = Array.from(document.querySelectorAll<HTMLInputElement>('input[type="radio"]'))
+        const latesRadio = radios.find((r) => r.value === 'with_lates')
+        expect(latesRadio).toBeTruthy()
+        fireEvent.click(latesRadio!)
+        expect(latesRadio!.checked).toBe(true)
+    })
+})

--- a/code/webapp/src/components/dev/page-actions/payroll-close-actions.tsx
+++ b/code/webapp/src/components/dev/page-actions/payroll-close-actions.tsx
@@ -1,0 +1,130 @@
+import { useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useAuthStore } from '@/stores/auth.store'
+import { seedPayrollAttendance, type SeedScenario, type SeedPayrollResult } from '@/services/payroll-devtools.service'
+import { getApiErrorMessage } from '@/lib/api-error'
+
+function currentWeekRange(): { start: string; end: string } {
+    const today = new Date()
+    const day = today.getDay() // 0 = Sun
+    const diffToMon = day === 0 ? -6 : 1 - day
+    const mon = new Date(today)
+    mon.setDate(today.getDate() + diffToMon)
+    const sun = new Date(mon)
+    sun.setDate(mon.getDate() + 6)
+    const fmt = (d: Date) =>
+        `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+    return { start: fmt(mon), end: fmt(sun) }
+}
+
+const SCENARIOS: { value: SeedScenario; label: string }[] = [
+    { value: 'full_week',         label: 'Semana completa (L–V, puntual)' },
+    { value: 'with_lates',        label: 'Con retardos (L y Mi, 35 min)' },
+    { value: 'with_unpaid_leave', label: 'Con permiso no pagado (Ju, medio día)' },
+    { value: 'with_overtime',     label: 'Con horas extra pagadas (Ma, Ju, Vi)' },
+    { value: 'with_absences',     label: 'Con faltas (Ma y Ju)' },
+    { value: 'mixed',             label: '★ Variado — cada empleado distinto' },
+]
+
+export function PayrollCloseActions() {
+    const defaultRange = currentWeekRange()
+    const [periodStart, setPeriodStart] = useState(defaultRange.start)
+    const [periodEnd, setPeriodEnd]     = useState(defaultRange.end)
+    const [scenario, setScenario]       = useState<SeedScenario>('full_week')
+    const [result, setResult]           = useState<SeedPayrollResult | null>(null)
+    const [error, setError]             = useState<string | null>(null)
+
+    const currentBranch = useAuthStore((s) => s.currentBranch)
+    const queryClient   = useQueryClient()
+
+    const { mutate, isPending } = useMutation({
+        mutationFn: () =>
+            seedPayrollAttendance({
+                branch_id:    currentBranch?.id ?? 1,
+                period_start: periodStart,
+                period_end:   periodEnd,
+                scenario,
+            }),
+        onSuccess: (data) => {
+            setResult(data)
+            setError(null)
+            queryClient.invalidateQueries({ queryKey: ['payroll', 'preview'] })
+        },
+        onError: (err: unknown) => {
+            setError(getApiErrorMessage(err, 'Error al generar asistencias'))
+            setResult(null)
+        },
+    })
+
+    return (
+        <div className="space-y-3 text-xs">
+            <div className="flex gap-2">
+                <div className="flex-1 space-y-0.5">
+                    <p className="text-[10px] font-medium text-gray-500 uppercase tracking-wide">Inicio</p>
+                    <input
+                        type="date"
+                        value={periodStart}
+                        onChange={(e) => setPeriodStart(e.target.value)}
+                        className="w-full bg-gray-700 text-white text-xs rounded px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                    />
+                </div>
+                <div className="flex-1 space-y-0.5">
+                    <p className="text-[10px] font-medium text-gray-500 uppercase tracking-wide">Fin</p>
+                    <input
+                        type="date"
+                        value={periodEnd}
+                        onChange={(e) => setPeriodEnd(e.target.value)}
+                        className="w-full bg-gray-700 text-white text-xs rounded px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                    />
+                </div>
+            </div>
+
+            <div className="space-y-0.5">
+                <p className="text-[10px] font-medium text-gray-500 uppercase tracking-wide">Escenario</p>
+                <div className="space-y-1">
+                    {SCENARIOS.map((s) => (
+                        <label
+                            key={s.value}
+                            className="flex items-center gap-2 cursor-pointer hover:text-white text-gray-300 transition-colors"
+                        >
+                            <input
+                                type="radio"
+                                name="seed-scenario"
+                                value={s.value}
+                                checked={scenario === s.value}
+                                onChange={() => setScenario(s.value)}
+                                className="accent-blue-500"
+                            />
+                            <span>{s.label}</span>
+                        </label>
+                    ))}
+                </div>
+            </div>
+
+            <button
+                type="button"
+                onClick={() => mutate()}
+                disabled={isPending || !periodStart || !periodEnd}
+                className="w-full bg-amber-600 hover:bg-amber-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-xs font-semibold rounded px-3 py-2 transition-colors"
+            >
+                {isPending ? 'Generando...' : 'Generar asistencias'}
+            </button>
+
+            {error && (
+                <p className="text-red-400 text-[10px] font-mono">{error}</p>
+            )}
+
+            {result && (
+                <div className="bg-gray-900 rounded p-2 font-mono space-y-0.5">
+                    <p className="text-green-400">✅ {result.created} registros creados</p>
+                    <p className="text-gray-400">{result.deleted} eliminados (reset)</p>
+                    {result.employees.length > 0 && (
+                        <p className="text-gray-500">
+                            {result.employees.join(', ')}
+                        </p>
+                    )}
+                </div>
+            )}
+        </div>
+    )
+}

--- a/code/webapp/src/components/dev/use-dev-debugger.ts
+++ b/code/webapp/src/components/dev/use-dev-debugger.ts
@@ -12,6 +12,7 @@ export interface DebuggerState {
         roles: boolean
         queries: boolean
         devLogin: boolean
+        pageActions: boolean
     }
 }
 
@@ -27,6 +28,7 @@ function getDefaultState(): DebuggerState {
             roles: false,
             queries: false,
             devLogin: true,
+            pageActions: true,
         },
     }
 }

--- a/code/webapp/src/components/layout/Layout.tsx
+++ b/code/webapp/src/components/layout/Layout.tsx
@@ -5,12 +5,14 @@ import Header from './Header';
 import Sidebar from './Sidebar';
 import { Breadcrumbs } from '@/components/ui/breadcrumbs';
 import { Loader2 } from 'lucide-react';
+import { DevDebugger } from '@/components/dev';
 
 export default function Layout() {
     const { isAuthenticated, isLoading, initializeAuth, user, _hasHydrated } = useAuthStore();
     const router = useRouter();
     const routerState = useRouterState();
     const currentPath = routerState.location.pathname;
+    const devTools = import.meta.env.DEV ? <DevDebugger /> : null;
 
     // Initialize auth after hydration completes
     useEffect(() => {
@@ -49,40 +51,51 @@ export default function Layout() {
     // Login page handles its own loading state to preserve form data
     if (isLoading && !isPublicRoute) {
         return (
-            <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-sushigo-navy/5 via-sushigo-coral/5 to-sushigo-cream/30">
-                <Loader2 className="h-12 w-12 animate-spin text-sushigo-navy" />
-            </div>
+            <>
+                <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-sushigo-navy/5 via-sushigo-coral/5 to-sushigo-cream/30">
+                    <Loader2 className="h-12 w-12 animate-spin text-sushigo-navy" />
+                </div>
+                {devTools}
+            </>
         );
     }
 
     // Don't show sidebar/header on login and logout pages
     if (isPublicRoute) {
-        return <Outlet />;
+        return (
+            <>
+                <Outlet />
+                {devTools}
+            </>
+        );
     }
 
     // Show main layout only if authenticated
     if (!isAuthenticated) {
-        return null;
+        return devTools;
     }
 
     return (
-        <div className="flex h-screen overflow-hidden bg-background">
-            <Sidebar />
+        <>
+            <div className="flex h-screen overflow-hidden bg-background">
+                <Sidebar />
 
-            <div className="flex-1 flex flex-col overflow-hidden">
-                <Header />
+                <div className="flex-1 flex flex-col overflow-hidden">
+                    <Header />
 
-                <main className="flex-1 overflow-y-auto p-4 lg:p-6 bg-gradient-to-br from-sushigo-cream/30 via-background to-sushigo-navy/5">
-                    {/* Breadcrumbs - Only show if not on home page */}
-                    {currentPath !== '/' && (
-                        <div className="mb-4">
-                            <Breadcrumbs />
-                        </div>
-                    )}
+                    <main className="flex-1 overflow-y-auto p-4 lg:p-6 bg-gradient-to-br from-sushigo-cream/30 via-background to-sushigo-navy/5">
+                        {/* Breadcrumbs - Only show if not on home page */}
+                        {currentPath !== '/' && (
+                            <div className="mb-4">
+                                <Breadcrumbs />
+                            </div>
+                        )}
 
-                    <Outlet />
-                </main>
+                        <Outlet />
+                    </main>
+                </div>
             </div>
-        </div>
+            {devTools}
+        </>
     );
 }

--- a/code/webapp/src/components/layout/Sidebar.tsx
+++ b/code/webapp/src/components/layout/Sidebar.tsx
@@ -69,6 +69,7 @@ const menuItems: MenuItem[] = [
         subItems: [
             { label: 'Hoy', path: '/attendance/today' },
             { label: 'Reporte del Día', path: '/attendance/reports/today', requiredPermission: 'reports.today' },
+            { label: 'Cierre de Nómina', path: '/attendance/payroll/close', requiredPermission: 'payroll.preview' },
             { label: 'Puntualidad', path: '/attendance/punctuality-config', requiredPermission: 'punctuality.manage' },
             { label: 'Festivos', path: '/attendance/config/holidays', requiredPermission: 'holidays.manage' },
         ]

--- a/code/webapp/src/components/layout/__tests__/Layout.test.tsx
+++ b/code/webapp/src/components/layout/__tests__/Layout.test.tsx
@@ -38,6 +38,7 @@ vi.mock('@/stores/auth.store', () => ({
 vi.mock('@/components/layout/Header', () => ({ default: () => null }))
 vi.mock('@/components/layout/Sidebar', () => ({ default: () => null }))
 vi.mock('@/components/ui/breadcrumbs', () => ({ Breadcrumbs: () => null }))
+vi.mock('@/components/dev', () => ({ DevDebugger: () => null }))
 
 let mockPathname = '/dashboard'
 

--- a/code/webapp/src/pages/attendance/payroll/close.tsx
+++ b/code/webapp/src/pages/attendance/payroll/close.tsx
@@ -1,0 +1,207 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { useState } from 'react'
+import { requirePermission } from '@/lib/route-guards'
+import { PageContainer } from '@/components/ui/page-container'
+import { PageHeader } from '@/components/ui/page-header'
+import { NoBranchState } from '@/components/attendance'
+import { useClosePreviewPage } from './use-close-preview'
+import type { PayPeriodEmployeePreview, PayPeriodLine } from '@/types/attendance-payroll'
+
+// ── Route ─────────────────────────────────────────────────────────────────────
+
+export const Route = createFileRoute('/attendance/payroll/close')({
+  beforeLoad: requirePermission('payroll.preview'),
+  component: PayrollClosePage,
+})
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+export function PayrollClosePage() {
+  const { rows, isLoading, errorMessage, hasBranch, calculate, pendingRange, setPendingRange } =
+    useClosePreviewPage()
+
+  if (!hasBranch) {
+    return (
+      <PageContainer>
+        <NoBranchState />
+      </PageContainer>
+    )
+  }
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title="Cierre de Nómina"
+        description="Preview del cierre semanal — sin persistencia de datos"
+      />
+
+      <div data-testid="payroll-preview-form" className="mb-6 flex flex-wrap items-end gap-4">
+        <div className="flex flex-col gap-1">
+          <label htmlFor="period-start" className="text-sm font-medium text-gray-700">
+            Inicio del período
+          </label>
+          <input
+            id="period-start"
+            type="date"
+            className="rounded border border-gray-300 px-3 py-2 text-sm"
+            value={pendingRange.periodStart}
+            onChange={e => setPendingRange({ ...pendingRange, periodStart: e.target.value })}
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <label htmlFor="period-end" className="text-sm font-medium text-gray-700">
+            Fin del período
+          </label>
+          <input
+            id="period-end"
+            type="date"
+            className="rounded border border-gray-300 px-3 py-2 text-sm"
+            value={pendingRange.periodEnd}
+            onChange={e => setPendingRange({ ...pendingRange, periodEnd: e.target.value })}
+          />
+        </div>
+        <button
+          onClick={calculate}
+          disabled={isLoading}
+          className="rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+        >
+          {isLoading ? 'Calculando...' : 'Calcular preview'}
+        </button>
+      </div>
+
+      {errorMessage && (
+        <p className="mb-4 rounded border border-red-300 bg-red-50 px-4 py-2 text-sm text-red-700">
+          {errorMessage}
+        </p>
+      )}
+
+      {isLoading && <PreviewSkeleton />}
+
+      {!isLoading && rows.length > 0 && (
+        <div className="space-y-2">
+          {rows.map(row => (
+            <EmployeePreviewRow key={row.employee.id} row={row} />
+          ))}
+        </div>
+      )}
+
+      {!isLoading && rows.length === 0 && (
+        <p className="text-sm text-gray-500">
+          Selecciona un rango de fechas y presiona &ldquo;Calcular preview&rdquo;.
+        </p>
+      )}
+    </PageContainer>
+  )
+}
+
+// ── Employee row ──────────────────────────────────────────────────────────────
+
+function EmployeePreviewRow({ row }: { readonly row: PayPeriodEmployeePreview }) {
+  const [expanded, setExpanded] = useState(false)
+  const name = `${row.employee.first_name} ${row.employee.last_name}`
+
+  const totalDeductions = row.late_deductions + row.unpaid_leave_deductions
+  const totalExtras = row.overtime_pay + row.extra_day_pay + row.punctuality_bonus + row.holiday_pay
+
+  return (
+    <div data-testid="employee-preview-row" className="rounded-lg border border-gray-200 bg-white shadow-sm">
+      <button
+        type="button"
+        aria-expanded={expanded}
+        className="flex w-full items-center justify-between px-4 py-3 text-left"
+        onClick={() => setExpanded(prev => !prev)}
+      >
+        <span className="font-medium text-gray-900">{name}</span>
+        <div className="flex items-center gap-6 text-sm">
+          <span className="text-gray-600">
+            Base: <span className="font-mono">${row.base_pay.toFixed(2)}</span>
+          </span>
+          {totalDeductions > 0 && (
+            <span className="text-red-600">
+              −<span className="font-mono">${totalDeductions.toFixed(2)}</span>
+            </span>
+          )}
+          {totalExtras > 0 && (
+            <span className="text-green-600">
+              +<span className="font-mono">${totalExtras.toFixed(2)}</span>
+            </span>
+          )}
+          <span className="rounded bg-indigo-100 px-2 py-0.5 font-semibold text-indigo-800">
+            Total: ${row.total_pay.toFixed(2)}
+          </span>
+          <span className="text-gray-400">{expanded ? '▲' : '▼'}</span>
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="border-t border-gray-100 px-4 py-3">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-xs font-medium uppercase text-gray-500">
+                <th className="pb-2 pr-2 w-6">Día</th>
+                <th className="pb-2 pr-4">Fecha</th>
+                <th className="pb-2 pr-4">Concepto</th>
+                <th className="pb-2 pr-4">Descripción</th>
+                <th className="pb-2 text-right">Monto</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-50">
+              {sortLines(row.pay_period_lines).map((line, i) => (
+                <LineRow key={`${line.concept}-${line.date ?? i}`} line={line} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// D L M X J V S — Sunday-first to align with Date#getDay(). X for Miércoles to avoid clash with Martes (M).
+const DAY_INITIALS = ['D', 'L', 'M', 'X', 'J', 'V', 'S'] as const
+
+function dayInitial(dateStr: string | null): string {
+  if (!dateStr) return ''
+  const parts = dateStr.split('-').map(Number)
+  const [year, month, day] = parts as [number, number, number]
+  return DAY_INITIALS[new Date(year, month - 1, day).getDay()] ?? ''
+}
+
+function sortLines(lines: PayPeriodLine[]): PayPeriodLine[] {
+  return [...lines].sort((a, b) => {
+    if (!a.date && !b.date) return 0
+    if (!a.date) return 1
+    if (!b.date) return -1
+    return a.date.localeCompare(b.date)
+  })
+}
+
+function LineRow({ line }: { readonly line: PayPeriodLine }) {
+  const isDeduction = line.amount < 0
+  const initial = dayInitial(line.date)
+  return (
+    <tr>
+      <td className="py-1 pr-2 font-semibold text-gray-400 w-6">{initial}</td>
+      <td className="py-1 pr-4 text-gray-500">{line.date ?? '—'}</td>
+      <td className="py-1 pr-4">
+        <span className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs text-gray-600">
+          {line.concept}
+        </span>
+      </td>
+      <td className="py-1 pr-4 text-gray-700">{line.description}</td>
+      <td className={`py-1 text-right font-mono ${isDeduction ? 'text-red-600' : 'text-gray-900'}`}>
+        ${Math.abs(line.amount).toFixed(2)}
+      </td>
+    </tr>
+  )
+}
+
+function PreviewSkeleton() {
+  return (
+    <div className="space-y-2">
+      {[1, 2, 3].map(i => (
+        <div key={i} className="h-14 animate-pulse rounded-lg bg-gray-100" />
+      ))}
+    </div>
+  )
+}

--- a/code/webapp/src/pages/attendance/payroll/use-close-preview.ts
+++ b/code/webapp/src/pages/attendance/payroll/use-close-preview.ts
@@ -1,0 +1,54 @@
+import { useState } from 'react'
+import { useAuthStore } from '@/stores/auth.store'
+import { useClosePreview, type ClosePreviewRange } from '@/services/payroll-hooks'
+import { getApiErrorMessage } from '@/lib/api-error'
+import type { PayPeriodEmployeePreview } from '@/types/attendance-payroll'
+
+function currentWeekRange(): ClosePreviewRange {
+  const now = new Date()
+  const day = now.getDay()
+  const diffToMonday = (day === 0 ? -6 : 1 - day)
+  const monday = new Date(now)
+  monday.setDate(now.getDate() + diffToMonday)
+  const sunday = new Date(monday)
+  sunday.setDate(monday.getDate() + 6)
+
+  const fmt = (d: Date) =>
+    `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+  return { periodStart: fmt(monday), periodEnd: fmt(sunday) }
+}
+
+export interface UseClosePreviewResult {
+  range: ClosePreviewRange
+  setRange: (range: ClosePreviewRange) => void
+  rows: PayPeriodEmployeePreview[]
+  isLoading: boolean
+  errorMessage: string | null
+  hasBranch: boolean
+  calculate: () => void
+  pendingRange: ClosePreviewRange
+  setPendingRange: (range: ClosePreviewRange) => void
+}
+
+export function useClosePreviewPage(): UseClosePreviewResult {
+  const currentBranch = useAuthStore(s => s.currentBranch)
+  const branchId = currentBranch?.id ?? null
+
+  const defaultRange = currentWeekRange()
+  const [pendingRange, setPendingRange] = useState<ClosePreviewRange>(defaultRange)
+  const [activeRange, setActiveRange] = useState<ClosePreviewRange | null>(null)
+
+  const { data = [], isLoading, error } = useClosePreview(branchId, activeRange)
+
+  return {
+    range: pendingRange,
+    setRange: setPendingRange,
+    rows: data,
+    isLoading,
+    errorMessage: error ? getApiErrorMessage(error, 'Error al calcular el preview') : null,
+    hasBranch: Boolean(branchId),
+    calculate: () => setActiveRange(pendingRange),
+    pendingRange,
+    setPendingRange,
+  }
+}

--- a/code/webapp/src/routeTree.gen.ts
+++ b/code/webapp/src/routeTree.gen.ts
@@ -36,6 +36,7 @@ import { Route as CashBankAccountsRouteImport } from './pages/cash/bank-accounts
 import { Route as AttendanceTodayRouteImport } from './pages/attendance/today'
 import { Route as AttendancePunctualityConfigRouteImport } from './pages/attendance/punctuality-config'
 import { Route as AttendanceReportsTodayRouteImport } from './pages/attendance/reports/today'
+import { Route as AttendancePayrollCloseRouteImport } from './pages/attendance/payroll/close'
 import { Route as AttendanceConfigHolidaysRouteImport } from './pages/attendance/config/holidays'
 
 const UnauthorizedRoute = UnauthorizedRouteImport.update({
@@ -174,6 +175,11 @@ const AttendanceReportsTodayRoute = AttendanceReportsTodayRouteImport.update({
   path: '/attendance/reports/today',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AttendancePayrollCloseRoute = AttendancePayrollCloseRouteImport.update({
+  id: '/attendance/payroll/close',
+  path: '/attendance/payroll/close',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AttendanceConfigHolidaysRoute =
   AttendanceConfigHolidaysRouteImport.update({
     id: '/attendance/config/holidays',
@@ -209,6 +215,7 @@ export interface FileRoutesByFullPath {
   '/cash/': typeof CashIndexRoute
   '/inventory/': typeof InventoryIndexRoute
   '/attendance/config/holidays': typeof AttendanceConfigHolidaysRoute
+  '/attendance/payroll/close': typeof AttendancePayrollCloseRoute
   '/attendance/reports/today': typeof AttendanceReportsTodayRoute
 }
 export interface FileRoutesByTo {
@@ -237,6 +244,7 @@ export interface FileRoutesByTo {
   '/cash': typeof CashIndexRoute
   '/inventory': typeof InventoryIndexRoute
   '/attendance/config/holidays': typeof AttendanceConfigHolidaysRoute
+  '/attendance/payroll/close': typeof AttendancePayrollCloseRoute
   '/attendance/reports/today': typeof AttendanceReportsTodayRoute
 }
 export interface FileRoutesById {
@@ -268,6 +276,7 @@ export interface FileRoutesById {
   '/cash/': typeof CashIndexRoute
   '/inventory/': typeof InventoryIndexRoute
   '/attendance/config/holidays': typeof AttendanceConfigHolidaysRoute
+  '/attendance/payroll/close': typeof AttendancePayrollCloseRoute
   '/attendance/reports/today': typeof AttendanceReportsTodayRoute
 }
 export interface FileRouteTypes {
@@ -300,6 +309,7 @@ export interface FileRouteTypes {
     | '/cash/'
     | '/inventory/'
     | '/attendance/config/holidays'
+    | '/attendance/payroll/close'
     | '/attendance/reports/today'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -328,6 +338,7 @@ export interface FileRouteTypes {
     | '/cash'
     | '/inventory'
     | '/attendance/config/holidays'
+    | '/attendance/payroll/close'
     | '/attendance/reports/today'
   id:
     | '__root__'
@@ -358,6 +369,7 @@ export interface FileRouteTypes {
     | '/cash/'
     | '/inventory/'
     | '/attendance/config/holidays'
+    | '/attendance/payroll/close'
     | '/attendance/reports/today'
   fileRoutesById: FileRoutesById
 }
@@ -381,6 +393,7 @@ export interface RootRouteChildren {
   AttendancePunctualityConfigRoute: typeof AttendancePunctualityConfigRoute
   AttendanceTodayRoute: typeof AttendanceTodayRoute
   AttendanceConfigHolidaysRoute: typeof AttendanceConfigHolidaysRoute
+  AttendancePayrollCloseRoute: typeof AttendancePayrollCloseRoute
   AttendanceReportsTodayRoute: typeof AttendanceReportsTodayRoute
 }
 
@@ -575,6 +588,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AttendanceReportsTodayRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/attendance/payroll/close': {
+      id: '/attendance/payroll/close'
+      path: '/attendance/payroll/close'
+      fullPath: '/attendance/payroll/close'
+      preLoaderRoute: typeof AttendancePayrollCloseRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/attendance/config/holidays': {
       id: '/attendance/config/holidays'
       path: '/attendance/config/holidays'
@@ -639,6 +659,7 @@ const rootRouteChildren: RootRouteChildren = {
   AttendancePunctualityConfigRoute: AttendancePunctualityConfigRoute,
   AttendanceTodayRoute: AttendanceTodayRoute,
   AttendanceConfigHolidaysRoute: AttendanceConfigHolidaysRoute,
+  AttendancePayrollCloseRoute: AttendancePayrollCloseRoute,
   AttendanceReportsTodayRoute: AttendanceReportsTodayRoute,
 }
 export const routeTree = rootRouteImport

--- a/code/webapp/src/services/__tests__/payroll-api.test.ts
+++ b/code/webapp/src/services/__tests__/payroll-api.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+const mockGet = vi.fn()
+
+vi.mock('@/lib/api-client', () => ({
+  apiClient: {
+    get: (...args: unknown[]) => mockGet(...args),
+  },
+}))
+
+import { payrollApi } from '../payroll.service'
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+const mockPreviewData = {
+  status: 200,
+  data: [
+    {
+      employee: { id: 'emp-ulid', first_name: 'Juan', last_name: 'García', code: 'EMP-001' },
+      base_pay: 4800.0,
+      late_deductions: 0.0,
+      unpaid_leave_deductions: 0.0,
+      overtime_pay: 0.0,
+      extra_day_pay: 0.0,
+      punctuality_bonus: 150.0,
+      holiday_pay: 0.0,
+      other_adjustments: 0.0,
+      total_pay: 4950.0,
+      free_hours_earned: 0.0,
+      pay_period_lines: [],
+    },
+  ],
+}
+
+describe('payrollApi.getClosePreview', () => {
+  it('calls GET /pay-periods/preview with correct params', async () => {
+    mockGet.mockResolvedValue({ data: mockPreviewData })
+
+    await payrollApi.getClosePreview(1, '2026-06-22', '2026-06-28')
+
+    expect(mockGet).toHaveBeenCalledWith('/pay-periods/preview', {
+      params: { branch_id: 1, period_start: '2026-06-22', period_end: '2026-06-28' },
+    })
+  })
+
+  it('returns the full response data', async () => {
+    mockGet.mockResolvedValue({ data: mockPreviewData })
+
+    const result = await payrollApi.getClosePreview(1, '2026-06-22', '2026-06-28')
+
+    expect(result.data.data).toHaveLength(1)
+    const first = result.data.data[0]
+    expect(first?.total_pay).toBe(4950.0)
+  })
+})

--- a/code/webapp/src/services/__tests__/payroll-devtools.service.test.ts
+++ b/code/webapp/src/services/__tests__/payroll-devtools.service.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { seedPayrollAttendance } from '@/services/payroll-devtools.service'
+
+vi.mock('@/lib/api-client', () => ({
+    apiClient: {
+        post: vi.fn(),
+    },
+}))
+
+import { apiClient } from '@/lib/api-client'
+
+describe('seedPayrollAttendance', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('calls POST /devtools/payroll/seed with given params and returns data', async () => {
+        const mockResult = { created: 5, deleted: 0, employees: ['EMP-001'] }
+        vi.mocked(apiClient.post).mockResolvedValueOnce({
+            data: { status: 'ok', data: mockResult },
+        } as never)
+
+        const result = await seedPayrollAttendance({
+            branch_id: 1,
+            period_start: '2026-06-23',
+            period_end: '2026-06-29',
+            scenario: 'full_week',
+        })
+
+        expect(apiClient.post).toHaveBeenCalledWith('/devtools/payroll/seed', {
+            branch_id: 1,
+            period_start: '2026-06-23',
+            period_end: '2026-06-29',
+            scenario: 'full_week',
+        })
+        expect(result).toEqual(mockResult)
+    })
+})

--- a/code/webapp/src/services/__tests__/payroll-hooks.test.ts
+++ b/code/webapp/src/services/__tests__/payroll-hooks.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import React from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockGetClosePreview = vi.fn()
+
+vi.mock('@/services/payroll.service', () => ({
+  payrollApi: {
+    getClosePreview: (...args: unknown[]) => mockGetClosePreview(...args),
+  },
+}))
+
+import { useClosePreview } from '../payroll-hooks'
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+    },
+  })
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children)
+  return { queryClient, wrapper }
+}
+
+const mockRows = [
+  {
+    employee: { id: 'ulid-1', first_name: 'Ana', last_name: 'Payroll', code: 'P001' },
+    base_pay: 4800,
+    late_deductions: 0,
+    unpaid_leave_deductions: 0,
+    overtime_pay: 0,
+    extra_day_pay: 0,
+    punctuality_bonus: 0,
+    holiday_pay: 0,
+    other_adjustments: 0,
+    total_pay: 4800,
+    free_hours_earned: 0,
+    pay_period_lines: [],
+  },
+]
+
+describe('useClosePreview', () => {
+  it('is disabled when branchId is null', () => {
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useClosePreview(null, null), { wrapper })
+
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(mockGetClosePreview).not.toHaveBeenCalled()
+  })
+
+  it('is disabled when range is null', () => {
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useClosePreview(1, null), { wrapper })
+
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(mockGetClosePreview).not.toHaveBeenCalled()
+  })
+
+  it('fetches preview data when branchId and range are provided', async () => {
+    mockGetClosePreview.mockResolvedValue({ data: { data: mockRows } })
+    const { wrapper } = makeWrapper()
+
+    const { result } = renderHook(
+      () => useClosePreview(1, { periodStart: '2026-06-22', periodEnd: '2026-06-28' }),
+      { wrapper },
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockGetClosePreview).toHaveBeenCalledWith(1, '2026-06-22', '2026-06-28')
+    expect(result.current.data).toHaveLength(1)
+    const first = result.current.data?.[0]
+    expect(first?.employee.first_name).toBe('Ana')
+  })
+
+  it('returns empty array from queryFn when branchId is falsy at call time', async () => {
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(
+      () => useClosePreview(0, { periodStart: '2026-06-22', periodEnd: '2026-06-28' }),
+      { wrapper },
+    )
+
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+})

--- a/code/webapp/src/services/payroll-devtools.service.ts
+++ b/code/webapp/src/services/payroll-devtools.service.ts
@@ -1,0 +1,30 @@
+import { apiClient } from '@/lib/api-client'
+
+export type SeedScenario =
+    | 'full_week'
+    | 'with_lates'
+    | 'with_unpaid_leave'
+    | 'with_overtime'
+    | 'with_absences'
+    | 'mixed'
+
+export interface SeedPayrollParams {
+    branch_id: number
+    period_start: string
+    period_end: string
+    scenario: SeedScenario
+}
+
+export interface SeedPayrollResult {
+    created: number
+    deleted: number
+    employees: string[]
+}
+
+export async function seedPayrollAttendance(params: SeedPayrollParams): Promise<SeedPayrollResult> {
+    const res = await apiClient.post<{ status: string; data: SeedPayrollResult }>(
+        '/devtools/payroll/seed',
+        params,
+    )
+    return res.data.data
+}

--- a/code/webapp/src/services/payroll-hooks.ts
+++ b/code/webapp/src/services/payroll-hooks.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query'
+import { payrollApi } from './payroll.service'
+import type { PayPeriodEmployeePreview } from '@/types/attendance-payroll'
+
+export interface ClosePreviewRange {
+  periodStart: string
+  periodEnd: string
+}
+
+export function useClosePreview(branchId: number | null, range: ClosePreviewRange | null) {
+  return useQuery<PayPeriodEmployeePreview[]>({
+    queryKey: ['payroll', 'preview', branchId, range?.periodStart, range?.periodEnd],
+    queryFn: async () => {
+      if (!branchId || !range) return []
+      const res = await payrollApi.getClosePreview(branchId, range.periodStart, range.periodEnd)
+      return res.data.data
+    },
+    enabled: Boolean(branchId && range),
+    staleTime: 0,
+  })
+}

--- a/code/webapp/src/services/payroll.service.ts
+++ b/code/webapp/src/services/payroll.service.ts
@@ -1,0 +1,9 @@
+import { apiClient } from '@/lib/api-client'
+import type { PayPeriodPreviewResponse } from '@/types/attendance-payroll'
+
+export const payrollApi = {
+  getClosePreview: (branchId: number, periodStart: string, periodEnd: string) =>
+    apiClient.get<PayPeriodPreviewResponse>('/pay-periods/preview', {
+      params: { branch_id: branchId, period_start: periodStart, period_end: periodEnd },
+    }),
+}

--- a/code/webapp/src/types/attendance-payroll.ts
+++ b/code/webapp/src/types/attendance-payroll.ts
@@ -67,3 +67,50 @@ export interface CreateHolidayDefinitionPayload {
 }
 
 export type UpdateHolidayDefinitionPayload = Partial<CreateHolidayDefinitionPayload>
+
+// ── Pay Period types ──────────────────────────────────────────────────────────
+
+export type PayPeriodStatus = 'OPEN' | 'CLOSED' | 'REOPENED'
+
+export type PayConcept =
+  | 'BASE_PAY'
+  | 'LATE_DEDUCTION'
+  | 'UNPAID_LEAVE'
+  | 'OVERTIME'
+  | 'EXTRA_DAY'
+  | 'PUNCTUALITY_BONUS'
+  | 'HOLIDAY'
+  | 'OTHER'
+
+export interface PayPeriodLine {
+  date: string | null
+  concept: PayConcept
+  description: string
+  amount: number
+  minutes: number | null
+}
+
+export interface PayPeriodEmployeePreview {
+  employee: {
+    id: string
+    first_name: string
+    last_name: string
+    code: string
+  }
+  base_pay: number
+  late_deductions: number
+  unpaid_leave_deductions: number
+  overtime_pay: number
+  extra_day_pay: number
+  punctuality_bonus: number
+  holiday_pay: number
+  other_adjustments: number
+  total_pay: number
+  free_hours_earned: number
+  pay_period_lines: PayPeriodLine[]
+}
+
+export interface PayPeriodPreviewResponse {
+  status: number
+  data: PayPeriodEmployeePreview[]
+}

--- a/doc/tasks/2026-06/072-payroll-close-preview.md
+++ b/doc/tasks/2026-06/072-payroll-close-preview.md
@@ -46,6 +46,14 @@ Como Manager, quiero ver un preview del cierre semanal de nómina con los totale
 
 ---
 
-## ⏱️ Estimates
+## ⏱️ Time
 
-- **Optimistic:** `8h` · **Pessimistic:** `13h`
+### 📊 Estimates
+- **Optimistic:** `8h` · **Pessimistic:** `13h` · **Tracked:** `0h 29min`
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-06-24", "start": "08:40", "end": "09:09" }
+]
+```

--- a/doc/tasks/2026-06/072-payroll-close-preview.md
+++ b/doc/tasks/2026-06/072-payroll-close-preview.md
@@ -49,11 +49,31 @@ Como Manager, quiero ver un preview del cierre semanal de nómina con los totale
 ## ⏱️ Time
 
 ### 📊 Estimates
-- **Optimistic:** `8h` · **Pessimistic:** `13h` · **Tracked:** `0h 29min`
+- **Optimistic:** `8h` · **Pessimistic:** `13h` · **Tracked:** `14h 35min`
 
 ### 📅 Sessions
 ```json
 [
-  { "date": "2026-06-24", "start": "08:40", "end": "09:09" }
+  { "date": "2026-06-24", "start": "08:40", "end": "21:00", "duration": "12h 20min",
+    "summary": "Full backend + frontend implementation, 3-pass SonarCloud iteration, first PR review round (8 threads), payroll-close-preview Cypress spec. Context ran out." },
+  { "date": "2026-06-25", "start": "09:00", "end": "09:45", "duration": "45min",
+    "summary": "Fix attendance-today-report.cy.ts (wrong task/date/employee) and employee-negotiated-extra-days.cy.ts (hardcoded filter date drift)." },
+  { "date": "2026-06-26", "start": "06:00", "end": "07:30", "duration": "1h 30min",
+    "summary": "Second PR review round (5 threads: DAY_INITIALS comment, auth:api middleware, useRouterState mock, lunch_late threshold, calculateHolidayPay per-day refactor). Squash 18→1 commits. Issue closed." }
 ]
 ```
+
+## 📊 Retrospective
+- **Actual total:** 14h 35min (740 min + 45 min + 90 min)
+- **vs optimistic:** +6h 35min
+- **vs pessimistic:** +1h 35min
+
+**Justification:**
+
+The core feature (preview endpoint + UI) landed within the optimistic estimate. The overrun accumulated across three activities not contemplated in the original scope:
+
+1. **SonarCloud iteration (3 passes, ~3h):** New code coverage had to reach ≥80% on both `api` and `webapp`. Achieving that required writing 16 PHPUnit tests for the seed endpoint (including edge cases like the `mixed` 7-employee scenario and the `ClockSimulationMisconfigurationException` guard), 8 Vitest tests (payroll service, hooks, PayrollCloseActions component), and a Pint auto-fix commit. The `php:S1142` code smell in `combinedRow` (4 return statements) required refactoring to a `match` expression.
+
+2. **Two rounds of PR review comments (~2h):** The first round had 8 threads (all addressed in commit `0342e46`: UTC date shift in `currentWeekRange`, data-testid, aria-expanded, intercept+wait, N+1 query for holidays, mock payload alignment). The second round added 5 more threads, including a `calculateHolidayPay` signature change that required updating 7 unit tests so per-day wages match the HOLIDAY line items exactly.
+
+3. **Cypress spec drift (~45min):** Two existing specs broke due to state that accumulated since they were written — `attendance-today-report.cy.ts` relied on a task that seeds no check-in records, and `employee-negotiated-extra-days.cy.ts` used a hardcoded filter date (`2026-05-01`) that `today−54 days` had overtaken. Both were outside the task's original scope.


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/pay-periods/preview` endpoint that computes full payroll breakdown for all active branch employees over a date range without persisting any data
- Implements `PayrollCalculator` pure static methods (base pay, late deductions, unpaid leave, overtime, extra day, free hours) and a new `PunctualityService::calculateWeeklyBonus` for tiered range-based weekly bonuses
- Adds `/attendance/payroll/close` page with date-range selector, per-employee preview table with expandable daily evidence, and loading skeleton

## What was built

**Backend:**
- 5 migrations: `partial_leaves`, `overtime_bank_movements`, `pay_periods`, `pay_period_employees`, `pay_period_lines`
- 5 models: `PartialLeave`, `OvertimeBankMovement`, `PayPeriod`, `PayPeriodEmployee`, `PayPeriodLine`
- `PunctualityService::calculateWeeklyBonus` — tiered range-based punctuality bonus using `PunctualityBonusGroup` + `PunctualityRange`
- `PayrollCalculator` expanded with 6 pure static methods for all pay concepts
- `PayPeriodPreviewService` — orchestrates all concepts per employee (no DB write)
- `PreviewPayPeriodController` + `PreviewPayPeriodRequest` with `payroll.preview` permission gate

**Frontend:**
- `PayPeriodEmployeePreview`, `PayPeriodLine`, `PayConcept` types in `attendance-payroll.ts`
- `payroll.service.ts` + `payroll-hooks.ts` (`useClosePreview`)
- `use-close-preview.ts` page hook — defaults to current Mon–Sun week
- `close.tsx` — date selector, preview table, expandable breakdown per employee, skeleton loader

## Test plan
- [ ] PHPUnit unit: `php artisan test --filter="PayrollCalculatorTest|PunctualityServiceTest"` (23 tests)
- [ ] PHPUnit feature: `php artisan test --filter="PreviewPayPeriodApiTest"` (7 tests)
- [ ] Vitest: `npx vitest run src/services/__tests__/payroll-api.test.ts` (2 tests)
- [ ] Linters: Pint ✅ · ESLint ✅ · TypeScript ✅
- [ ] Cypress E2E: `make cypress-run SPEC=cypress/e2e/payroll-close-preview.cy.ts`

## Closes
Closes #72

## Workspace
`sushigo-d` — `feature/072-preview-payroll-close`

🤖 Generated with [Claude Code](https://claude.com/claude-code)