### PR TITLE
✨ [#068][a] - Weekly payroll summary report ✨

### DIFF
--- a/.github/workflows/webapp-tests.yml
+++ b/.github/workflows/webapp-tests.yml
@@ -8,8 +8,12 @@ on:
 
 jobs:
   webapp-tests:
-    name: webapp-tests
+    name: webapp-tests (shard ${{ matrix.shard }}/${{ strategy.job-total }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
 
     defaults:
       run:
@@ -39,9 +43,69 @@ jobs:
         if: steps.changes.outputs.webapp == 'true'
         run: npm ci
 
-      - name: Run Vitest with coverage
+      # Sharded across 4 parallel jobs — running the full 200-file suite with
+      # V8 coverage in a single process accumulates enough memory/GC pressure
+      # by the end to hang GH Actions' low-resource runners. Each shard only
+      # covers ~1/4 of the files, keeping per-process overhead low. Shards
+      # write a "blob" report instead of the final coverage report; a separate
+      # job merges them back into one report for SonarCloud.
+      - name: Run Vitest shard with coverage
         if: steps.changes.outputs.webapp == 'true'
-        run: npm run test:coverage
+        run: npx vitest run --coverage --reporter=blob --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+
+      - name: Upload blob report
+        if: steps.changes.outputs.webapp == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: webapp-blob-report-${{ matrix.shard }}
+          path: code/webapp/.vitest-reports/
+          include-hidden-files: true
+          retention-days: 1
+
+  webapp-coverage-merge:
+    name: webapp-coverage-merge
+    runs-on: ubuntu-latest
+    needs: webapp-tests
+
+    defaults:
+      run:
+        working-directory: code/webapp
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect changes in code/webapp
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            webapp:
+              - 'code/webapp/**'
+
+      - name: Setup Node 24
+        if: steps.changes.outputs.webapp == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: code/webapp/package-lock.json
+
+      - name: Install dependencies
+        if: steps.changes.outputs.webapp == 'true'
+        run: npm ci
+
+      - name: Download all blob reports
+        if: steps.changes.outputs.webapp == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          path: code/webapp/.vitest-reports
+          pattern: webapp-blob-report-*
+          merge-multiple: true
+
+      - name: Merge shard reports into final coverage
+        if: steps.changes.outputs.webapp == 'true'
+        run: npx vitest run --mergeReports=.vitest-reports --coverage
 
       - name: Upload coverage report
         if: steps.changes.outputs.webapp == 'true'
@@ -54,8 +118,8 @@ jobs:
   webapp-sonar:
     name: webapp-sonar
     runs-on: ubuntu-latest
-    needs: webapp-tests
-    if: needs.webapp-tests.result == 'success'
+    needs: webapp-coverage-merge
+    if: needs.webapp-coverage-merge.result == 'success'
 
     steps:
       - name: Checkout

--- a/code/api/.env.example
+++ b/code/api/.env.example
@@ -102,3 +102,9 @@ CLOCK_SIMULATION_ENABLED=false
 # When true, POST /api/v1/devtools/payroll/seed becomes available.
 # CRITICAL: Must be false in production.
 PAYROLL_SEED_ENABLED=false
+
+# Payroll — Week Start Day
+# ------------------------
+# ISO weekday on which the payroll week begins: 1=Monday … 7=Sunday
+# SushiGo convention: weeks run Monday–Sunday (cut-off end of Sunday).
+WEEK_START_DAY=1

--- a/code/api/app/Actions/Employee/CreateEmployeeAction.php
+++ b/code/api/app/Actions/Employee/CreateEmployeeAction.php
@@ -39,6 +39,7 @@ class CreateEmployeeAction
                 'first_name' => $data['first_name'],
                 'last_name' => $data['last_name'],
                 'is_active' => $data['is_active'] ?? true,
+                'attendance_exempt' => $data['attendance_exempt'] ?? false,
                 'meta' => $data['meta'] ?? null,
             ]);
 

--- a/code/api/app/Console/Commands/TestReset.php
+++ b/code/api/app/Console/Commands/TestReset.php
@@ -15,6 +15,7 @@ use Database\Seeders\Testing\NegotiatedExtraDaysSeeder;
 use Database\Seeders\Testing\PayrollPreviewSeeder;
 use Database\Seeders\Testing\ScheduleSummaryOverrideSeeder;
 use Database\Seeders\Testing\TodayReportStatusSeeder;
+use Database\Seeders\Testing\WeeklySummarySeeder;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -68,6 +69,10 @@ class TestReset extends Command
         'today-report-statuses' => [
             AttendanceTestSeeder::class,
             TodayReportStatusSeeder::class,
+        ],
+        'weekly-summary' => [
+            AttendanceTestSeeder::class,
+            WeeklySummarySeeder::class,
         ],
         'fakes-employees' => [
             FakeEmployeesSeeder::class,

--- a/code/api/app/Enums/OvertimeMovementType.php
+++ b/code/api/app/Enums/OvertimeMovementType.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Enums;
+
+enum OvertimeMovementType: string
+{
+    case EARNED = 'EARNED';
+    case USED = 'USED';
+    case PAID = 'PAID';
+    case ADJUSTMENT = 'ADJUSTMENT';
+
+    /** Positive impact = minutes added to bank; negative = minutes removed. */
+    public function balanceImpact(int $minutes): int
+    {
+        return match ($this) {
+            self::EARNED => abs($minutes),
+            self::USED, self::PAID => -abs($minutes),
+            self::ADJUSTMENT => $minutes,
+        };
+    }
+}

--- a/code/api/app/Enums/OvertimeOrigin.php
+++ b/code/api/app/Enums/OvertimeOrigin.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum OvertimeOrigin: string
+{
+    case AUTO = 'AUTO';
+    case MANUAL = 'MANUAL';
+}

--- a/code/api/app/Enums/OvertimeValuationMethod.php
+++ b/code/api/app/Enums/OvertimeValuationMethod.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum OvertimeValuationMethod: string
+{
+    case LFT_PROPORTIONAL = 'LFT_PROPORTIONAL';
+    case AGREED_RATE = 'AGREED_RATE';
+}

--- a/code/api/app/Enums/PartialLeaveType.php
+++ b/code/api/app/Enums/PartialLeaveType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum PartialLeaveType: string
+{
+    case ARRIVE_LATE = 'ARRIVE_LATE';
+    case LEAVE_EARLY = 'LEAVE_EARLY';
+    case TAKE_TIME = 'TAKE_TIME';
+}

--- a/code/api/app/Http/Controllers/Api/V1/Attendances/TodayAttendanceController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Attendances/TodayAttendanceController.php
@@ -32,6 +32,7 @@ use Carbon\Carbon;
  * }
  *
  * Employees are ordered by last_name ASC, first_name ASC.
+ * Employees marked `attendance_exempt` (e.g. admin, super-admin) never appear here.
  *
  * @OA\Get(
  *     path="/api/v1/attendances/today",
@@ -104,6 +105,7 @@ class TodayAttendanceController extends Controller
             // ExtraDayNegotiationDialog. Only the most recent effective record is needed.
             'wageHistories' => fn ($q) => $q->effective($today)->latest('effective_from'),
         ])
+            ->where('attendance_exempt', false)
             ->whereHas('employmentPeriods', function ($q) use ($branchId) {
                 $q->where('branch_id', $branchId)
                     ->where('is_active', true);

--- a/code/api/app/Http/Controllers/Api/V1/Reports/WeeklySummaryController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Reports/WeeklySummaryController.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Reports;
+
+use App\Enums\DayStatus;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Reports\WeeklySummaryRequest;
+use App\Http\Responses\Reports\WeeklySummaryResponse;
+use App\Models\Attendance;
+use App\Models\Employee;
+use App\Models\EmployeeBonusConfig;
+use App\Models\Holiday;
+use App\Models\NegotiatedExtraDay;
+use App\Models\PartialLeave;
+use App\Models\PunctualityRange;
+use App\Models\WageHistory;
+use App\Services\PayrollCalculator;
+use App\Services\PunctualityService;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+
+/**
+ * GET /api/v1/reports/weekly-summary
+ *
+ * Returns the complete financial breakdown for one employee in a period.
+ * Calculates live (no closed-period snapshot required).
+ *
+ * Query params:
+ *   employee_id  — Employee public_id (ULID)
+ *   period_start — YYYY-MM-DD
+ *   period_end   — YYYY-MM-DD
+ */
+class WeeklySummaryController extends Controller
+{
+    public function __invoke(WeeklySummaryRequest $request): WeeklySummaryResponse
+    {
+        $employee = $request->employee();
+        $periodStart = $request->validated('period_start');
+        $periodEnd = $request->validated('period_end');
+
+        $attendances = Attendance::where('employee_id', $employee->id)
+            ->whereBetween('date', [$periodStart, $periodEnd])
+            ->with('partialLeaves')
+            ->orderBy('date')
+            ->get();
+
+        $wage = WageHistory::where('employee_id', $employee->id)
+            ->effective($periodStart)
+            ->orderByDesc('effective_from')
+            ->first();
+
+        $hourlyRate = $wage ? (float) $wage->hourly_rate : 0.0;
+        $minuteRate = $hourlyRate / 60;
+
+        $scheduledWorkingDays = $attendances->filter(
+            fn (Attendance $a) => $a->day_status !== DayStatus::DAY_OFF
+        )->count();
+
+        // Scheduled minutes per worked day with rest-day proration for calculateBasePay.
+        $workedAttendances = $attendances->filter(fn (Attendance $a) => $a->day_status === DayStatus::WORKED)->values();
+        $scheduledMinutesForBase = $this->buildScheduledMinutesWithRestDay($wage, $scheduledWorkingDays, $workedAttendances->count());
+
+        // Per-attendance daily minutes (no rest-day) for calculateHolidayPay.
+        // Also map to plain objects so day_status is a string, not a DayStatus enum.
+        $dailyMinutes = ($wage && $scheduledWorkingDays > 0)
+            ? ((float) $wage->weekly_scheduled_hours / $scheduledWorkingDays) * 60
+            : 0.0;
+        $attendanceDtos = $attendances->values()->map(fn (Attendance $a) => (object) [
+            'date' => $a->date->toDateString(),
+            'day_status' => $a->day_status->value,
+        ]);
+        $scheduledMinutesForHoliday = $attendances->map(fn () => $dailyMinutes)->values();
+
+        $partialLeaves = $attendances->flatMap(fn (Attendance $a) => $a->partialLeaves);
+
+        $extraDays = NegotiatedExtraDay::where('employee_id', $employee->id)
+            ->where('status', NegotiatedExtraDay::STATUS_APPROVED)
+            ->whereBetween('date', [$periodStart, $periodEnd])
+            ->get();
+
+        $holidays = Holiday::whereBetween('date', [$periodStart, $periodEnd])->get();
+
+        // Punctuality bonus via new static API.
+        $config = EmployeeBonusConfig::where('employee_id', $employee->id)
+            ->effective(Carbon::parse($periodStart))
+            ->orderByDesc('effective_from')
+            ->with('bonusGroup')
+            ->first();
+        $ranges = PunctualityRange::all()->sortBy('sort_order')->values();
+        $weeklyBonus = PunctualityService::calculateWeeklyBonusFromConfig($workedAttendances, $config, $ranges);
+
+        $punctualDays = $this->countPunctualDays($attendances);
+        $lastTwoPunctual = $this->lastTwoDaysPunctual($attendances);
+        $freeHours = $this->calculateFreeHours($punctualDays, $lastTwoPunctual);
+
+        $basePay = PayrollCalculator::calculateBasePay($scheduledMinutesForBase, $hourlyRate);
+        $lateDeductions = PayrollCalculator::calculateLateDeductions($attendances, $minuteRate);
+        $unpaidLeaveDeductions = PayrollCalculator::calculateUnpaidLeaveDeductions($partialLeaves, $minuteRate);
+        $extraDayPay = PayrollCalculator::calculateExtraDayPay($extraDays);
+        $holidayPay = PayrollCalculator::calculateHolidayPay($attendanceDtos, $holidays, $scheduledMinutesForHoliday, $hourlyRate);
+        $overtimePay = $this->calculateOvertimePay($employee, $periodStart, $periodEnd, $minuteRate);
+
+        $totalPay = round(
+            $basePay
+            - $lateDeductions
+            - $unpaidLeaveDeductions
+            + $extraDayPay
+            + $holidayPay
+            + $weeklyBonus
+            + $overtimePay,
+            2
+        );
+
+        $dailyEvidence = $this->buildDailyEvidence($attendances, $periodStart, $periodEnd);
+
+        return new WeeklySummaryResponse([
+            'employee_id' => $employee->public_id,
+            'period_start' => $periodStart,
+            'period_end' => $periodEnd,
+            'base_pay' => $basePay,
+            'late_deductions' => $lateDeductions,
+            'unpaid_leave_deductions' => $unpaidLeaveDeductions,
+            'overtime_pay' => $overtimePay,
+            'extra_day_pay' => $extraDayPay,
+            'holiday_pay' => $holidayPay,
+            'punctuality_bonus' => $weeklyBonus,
+            'free_hours_earned' => $freeHours,
+            'total_pay' => $totalPay,
+            'daily_evidence' => $dailyEvidence,
+        ]);
+    }
+
+    /**
+     * Scheduled minutes per worked day, including proportional rest-day.
+     *
+     * Formula: (dailyHours + dailyHours/scheduledWorkingDays) × 60
+     *
+     * @return Collection<int, int>
+     */
+    private function buildScheduledMinutesWithRestDay(?WageHistory $wage, int $scheduledWorkingDays, int $workedCount): Collection
+    {
+        if (! $wage || $scheduledWorkingDays === 0) {
+            return collect(array_fill(0, $workedCount, 0));
+        }
+
+        $dailyHours = (float) $wage->weekly_scheduled_hours / $scheduledWorkingDays;
+        $effectiveMinutes = (int) round(($dailyHours + $dailyHours / $scheduledWorkingDays) * 60);
+
+        return collect(array_fill(0, $workedCount, $effectiveMinutes));
+    }
+
+    private function countPunctualDays(Collection $attendances): int
+    {
+        return $attendances->filter(
+            fn (Attendance $a) => $a->day_status === DayStatus::WORKED
+                && ($a->entry_late_seconds ?? 0) === 0
+        )->count();
+    }
+
+    private function lastTwoDaysPunctual(Collection $attendances): bool
+    {
+        $worked = $attendances
+            ->filter(fn (Attendance $a) => $a->day_status === DayStatus::WORKED)
+            ->sortByDesc('date')
+            ->take(2);
+
+        if ($worked->count() < 2) {
+            return false;
+        }
+
+        return $worked->every(fn (Attendance $a) => ($a->entry_late_seconds ?? 0) === 0);
+    }
+
+    private function calculateFreeHours(int $punctualDays, bool $lastTwoDaysPunctual): float
+    {
+        if (! $lastTwoDaysPunctual) {
+            return 0.0;
+        }
+
+        return match (true) {
+            $punctualDays >= 5 => 1.0,
+            $punctualDays === 4 => 0.5,
+            default => 0.0,
+        };
+    }
+
+    private function calculateOvertimePay(Employee $employee, string $start, string $end, float $minuteRate): float
+    {
+        // Sum of authorized overtime minutes × minuteRate within the period.
+        // OvertimeBankMovement::PAID movements will take precedence once the bank system is live (AP-038/039).
+        $authorizedOvertimeMinutes = Attendance::where('employee_id', $employee->id)
+            ->whereBetween('date', [$start, $end])
+            ->where('overtime_authorized', true)
+            ->sum('overtime_minutes');
+
+        return round((float) $authorizedOvertimeMinutes * $minuteRate, 2);
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    private function buildDailyEvidence(Collection $attendances, string $periodStart, string $periodEnd): array
+    {
+        $attendanceMap = $attendances->keyBy(fn (Attendance $a) => $a->date->toDateString());
+
+        $evidence = [];
+        $current = Carbon::parse($periodStart);
+        $end = Carbon::parse($periodEnd);
+
+        while ($current->lte($end)) {
+            $dateStr = $current->toDateString();
+            $a = $attendanceMap->get($dateStr);
+
+            $evidence[] = $a instanceof Attendance
+                ? $this->buildAttendanceRow($a, $dateStr)
+                : ['date' => $dateStr, 'check_in' => null, 'check_out' => null, 'day_status' => null, 'late_minutes' => 0, 'deducted_minutes' => 0, 'partial_leaves' => [], 'overtime_minutes' => 0, 'overtime_authorized' => false];
+
+            $current->addDay();
+        }
+
+        return $evidence;
+    }
+
+    /** @return array<string, mixed> */
+    private function buildAttendanceRow(Attendance $a, string $dateStr): array
+    {
+        $lateMinutes = $a->entry_late_seconds ? (int) floor($a->entry_late_seconds / 60) : 0;
+        $deductedMinutes = $a->isEntryLateDeductible() ? $lateMinutes : 0;
+        $lunchLateMin = $a->lunch_late_seconds ? (int) floor($a->lunch_late_seconds / 60) : 0;
+        if ($a->isLunchLateDeductible()) {
+            $deductedMinutes += $lunchLateMin;
+        }
+
+        return [
+            'date' => $dateStr,
+            'check_in' => $a->check_in?->toIso8601String(),
+            'check_out' => $a->check_out?->toIso8601String(),
+            'day_status' => $a->day_status->value,
+            'late_minutes' => $lateMinutes,
+            'deducted_minutes' => $deductedMinutes,
+            'partial_leaves' => $a->partialLeaves->map(fn (PartialLeave $pl) => [
+                'duration_minutes' => $pl->duration_minutes,
+                'is_paid' => $pl->is_paid,
+            ])->values()->all(),
+            'overtime_minutes' => $a->overtime_minutes ?? 0,
+            'overtime_authorized' => (bool) ($a->overtime_authorized ?? false),
+        ];
+    }
+}

--- a/code/api/app/Http/Controllers/Api/V1/Reports/WeeklySummaryController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Reports/WeeklySummaryController.php
@@ -2,22 +2,10 @@
 
 namespace App\Http\Controllers\Api\V1\Reports;
 
-use App\Enums\DayStatus;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Reports\WeeklySummaryRequest;
 use App\Http\Responses\Reports\WeeklySummaryResponse;
-use App\Models\Attendance;
-use App\Models\Employee;
-use App\Models\EmployeeBonusConfig;
-use App\Models\Holiday;
-use App\Models\NegotiatedExtraDay;
-use App\Models\PartialLeave;
-use App\Models\PunctualityRange;
-use App\Models\WageHistory;
-use App\Services\PayrollCalculator;
-use App\Services\PunctualityService;
-use Carbon\Carbon;
-use Illuminate\Support\Collection;
+use App\Services\WeeklySummaryService;
 
 /**
  * GET /api/v1/reports/weekly-summary
@@ -32,216 +20,16 @@ use Illuminate\Support\Collection;
  */
 class WeeklySummaryController extends Controller
 {
+    public function __construct(private WeeklySummaryService $weeklySummaryService) {}
+
     public function __invoke(WeeklySummaryRequest $request): WeeklySummaryResponse
     {
-        $employee = $request->employee();
-        $periodStart = $request->validated('period_start');
-        $periodEnd = $request->validated('period_end');
-
-        $attendances = Attendance::where('employee_id', $employee->id)
-            ->whereBetween('date', [$periodStart, $periodEnd])
-            ->with('partialLeaves')
-            ->orderBy('date')
-            ->get();
-
-        $wage = WageHistory::where('employee_id', $employee->id)
-            ->effective($periodStart)
-            ->orderByDesc('effective_from')
-            ->first();
-
-        $hourlyRate = $wage ? (float) $wage->hourly_rate : 0.0;
-        $minuteRate = $hourlyRate / 60;
-
-        $scheduledWorkingDays = $attendances->filter(
-            fn (Attendance $a) => $a->day_status !== DayStatus::DAY_OFF
-        )->count();
-
-        // Scheduled minutes per worked day with rest-day proration for calculateBasePay.
-        $workedAttendances = $attendances->filter(fn (Attendance $a) => $a->day_status === DayStatus::WORKED)->values();
-        $scheduledMinutesForBase = $this->buildScheduledMinutesWithRestDay($wage, $scheduledWorkingDays, $workedAttendances->count());
-
-        // Per-attendance daily minutes (no rest-day) for calculateHolidayPay.
-        // Also map to plain objects so day_status is a string, not a DayStatus enum.
-        $dailyMinutes = ($wage && $scheduledWorkingDays > 0)
-            ? ((float) $wage->weekly_scheduled_hours / $scheduledWorkingDays) * 60
-            : 0.0;
-        $attendanceDtos = $attendances->values()->map(fn (Attendance $a) => (object) [
-            'date' => $a->date->toDateString(),
-            'day_status' => $a->day_status->value,
-        ]);
-        $scheduledMinutesForHoliday = $attendances->map(fn () => $dailyMinutes)->values();
-
-        $partialLeaves = $attendances->flatMap(fn (Attendance $a) => $a->partialLeaves);
-
-        $extraDays = NegotiatedExtraDay::where('employee_id', $employee->id)
-            ->where('status', NegotiatedExtraDay::STATUS_APPROVED)
-            ->whereBetween('date', [$periodStart, $periodEnd])
-            ->get();
-
-        $holidays = Holiday::whereBetween('date', [$periodStart, $periodEnd])->get();
-
-        // Punctuality bonus via new static API.
-        $config = EmployeeBonusConfig::where('employee_id', $employee->id)
-            ->effective(Carbon::parse($periodStart))
-            ->orderByDesc('effective_from')
-            ->with('bonusGroup')
-            ->first();
-        $ranges = PunctualityRange::all()->sortBy('sort_order')->values();
-        $weeklyBonus = PunctualityService::calculateWeeklyBonusFromConfig($workedAttendances, $config, $ranges);
-
-        $punctualDays = $this->countPunctualDays($attendances);
-        $lastTwoPunctual = $this->lastTwoDaysPunctual($attendances);
-        $freeHours = $this->calculateFreeHours($punctualDays, $lastTwoPunctual);
-
-        $basePay = PayrollCalculator::calculateBasePay($scheduledMinutesForBase, $hourlyRate);
-        $lateDeductions = PayrollCalculator::calculateLateDeductions($attendances, $minuteRate);
-        $unpaidLeaveDeductions = PayrollCalculator::calculateUnpaidLeaveDeductions($partialLeaves, $minuteRate);
-        $extraDayPay = PayrollCalculator::calculateExtraDayPay($extraDays);
-        $holidayPay = PayrollCalculator::calculateHolidayPay($attendanceDtos, $holidays, $scheduledMinutesForHoliday, $hourlyRate);
-        $overtimePay = $this->calculateOvertimePay($employee, $periodStart, $periodEnd, $minuteRate);
-
-        $totalPay = round(
-            $basePay
-            - $lateDeductions
-            - $unpaidLeaveDeductions
-            + $extraDayPay
-            + $holidayPay
-            + $weeklyBonus
-            + $overtimePay,
-            2
+        $summary = $this->weeklySummaryService->buildSummary(
+            $request->employee(),
+            $request->validated('period_start'),
+            $request->validated('period_end'),
         );
 
-        $dailyEvidence = $this->buildDailyEvidence($attendances, $periodStart, $periodEnd);
-
-        return new WeeklySummaryResponse([
-            'employee_id' => $employee->public_id,
-            'period_start' => $periodStart,
-            'period_end' => $periodEnd,
-            'base_pay' => $basePay,
-            'late_deductions' => $lateDeductions,
-            'unpaid_leave_deductions' => $unpaidLeaveDeductions,
-            'overtime_pay' => $overtimePay,
-            'extra_day_pay' => $extraDayPay,
-            'holiday_pay' => $holidayPay,
-            'punctuality_bonus' => $weeklyBonus,
-            'free_hours_earned' => $freeHours,
-            'total_pay' => $totalPay,
-            'daily_evidence' => $dailyEvidence,
-        ]);
-    }
-
-    /**
-     * Scheduled minutes per worked day, including proportional rest-day.
-     *
-     * Formula: (dailyHours + dailyHours/scheduledWorkingDays) × 60
-     *
-     * @return Collection<int, int>
-     */
-    private function buildScheduledMinutesWithRestDay(?WageHistory $wage, int $scheduledWorkingDays, int $workedCount): Collection
-    {
-        if (! $wage || $scheduledWorkingDays === 0) {
-            return collect(array_fill(0, $workedCount, 0));
-        }
-
-        $dailyHours = (float) $wage->weekly_scheduled_hours / $scheduledWorkingDays;
-        $effectiveMinutes = (int) round(($dailyHours + $dailyHours / $scheduledWorkingDays) * 60);
-
-        return collect(array_fill(0, $workedCount, $effectiveMinutes));
-    }
-
-    private function countPunctualDays(Collection $attendances): int
-    {
-        return $attendances->filter(
-            fn (Attendance $a) => $a->day_status === DayStatus::WORKED
-                && ($a->entry_late_seconds ?? 0) === 0
-        )->count();
-    }
-
-    private function lastTwoDaysPunctual(Collection $attendances): bool
-    {
-        $worked = $attendances
-            ->filter(fn (Attendance $a) => $a->day_status === DayStatus::WORKED)
-            ->sortByDesc('date')
-            ->take(2);
-
-        if ($worked->count() < 2) {
-            return false;
-        }
-
-        return $worked->every(fn (Attendance $a) => ($a->entry_late_seconds ?? 0) === 0);
-    }
-
-    private function calculateFreeHours(int $punctualDays, bool $lastTwoDaysPunctual): float
-    {
-        if (! $lastTwoDaysPunctual) {
-            return 0.0;
-        }
-
-        return match (true) {
-            $punctualDays >= 5 => 1.0,
-            $punctualDays === 4 => 0.5,
-            default => 0.0,
-        };
-    }
-
-    private function calculateOvertimePay(Employee $employee, string $start, string $end, float $minuteRate): float
-    {
-        // Sum of authorized overtime minutes × minuteRate within the period.
-        // OvertimeBankMovement::PAID movements will take precedence once the bank system is live (AP-038/039).
-        $authorizedOvertimeMinutes = Attendance::where('employee_id', $employee->id)
-            ->whereBetween('date', [$start, $end])
-            ->where('overtime_authorized', true)
-            ->sum('overtime_minutes');
-
-        return round((float) $authorizedOvertimeMinutes * $minuteRate, 2);
-    }
-
-    /** @return array<int, array<string, mixed>> */
-    private function buildDailyEvidence(Collection $attendances, string $periodStart, string $periodEnd): array
-    {
-        $attendanceMap = $attendances->keyBy(fn (Attendance $a) => $a->date->toDateString());
-
-        $evidence = [];
-        $current = Carbon::parse($periodStart);
-        $end = Carbon::parse($periodEnd);
-
-        while ($current->lte($end)) {
-            $dateStr = $current->toDateString();
-            $a = $attendanceMap->get($dateStr);
-
-            $evidence[] = $a instanceof Attendance
-                ? $this->buildAttendanceRow($a, $dateStr)
-                : ['date' => $dateStr, 'check_in' => null, 'check_out' => null, 'day_status' => null, 'late_minutes' => 0, 'deducted_minutes' => 0, 'partial_leaves' => [], 'overtime_minutes' => 0, 'overtime_authorized' => false];
-
-            $current->addDay();
-        }
-
-        return $evidence;
-    }
-
-    /** @return array<string, mixed> */
-    private function buildAttendanceRow(Attendance $a, string $dateStr): array
-    {
-        $lateMinutes = $a->entry_late_seconds ? (int) floor($a->entry_late_seconds / 60) : 0;
-        $deductedMinutes = $a->isEntryLateDeductible() ? $lateMinutes : 0;
-        $lunchLateMin = $a->lunch_late_seconds ? (int) floor($a->lunch_late_seconds / 60) : 0;
-        if ($a->isLunchLateDeductible()) {
-            $deductedMinutes += $lunchLateMin;
-        }
-
-        return [
-            'date' => $dateStr,
-            'check_in' => $a->check_in?->toIso8601String(),
-            'check_out' => $a->check_out?->toIso8601String(),
-            'day_status' => $a->day_status->value,
-            'late_minutes' => $lateMinutes,
-            'deducted_minutes' => $deductedMinutes,
-            'partial_leaves' => $a->partialLeaves->map(fn (PartialLeave $pl) => [
-                'duration_minutes' => $pl->duration_minutes,
-                'is_paid' => $pl->is_paid,
-            ])->values()->all(),
-            'overtime_minutes' => $a->overtime_minutes ?? 0,
-            'overtime_authorized' => (bool) ($a->overtime_authorized ?? false),
-        ];
+        return new WeeklySummaryResponse($summary);
     }
 }

--- a/code/api/app/Http/Requests/Employees/StoreEmployeeRequest.php
+++ b/code/api/app/Http/Requests/Employees/StoreEmployeeRequest.php
@@ -19,6 +19,7 @@ use Illuminate\Validation\Rule;
  *   @OA\Property(property="phone", type="string", example="5512345678", description="National phone number without country code (required if email not provided). Country code (+52 for Mexico) is added automatically. A WhatsApp message with password setup link will be sent."),
  *   @OA\Property(property="branch_id", type="integer", example=1, description="Branch ID for the initial employment period"),
  *   @OA\Property(property="start_date", type="string", format="date", example="2026-01-15", description="Start date for the initial employment period"),
+ *   @OA\Property(property="attendance_exempt", type="boolean", example=false, description="True for roles (e.g. admin, super-admin) that do not check in/out — excluded from the attendance list. Defaults to false."),
  *   @OA\Property(property="meta", type="object", nullable=true, description="Additional metadata"),
  * )
  */
@@ -42,6 +43,7 @@ class StoreEmployeeRequest extends FormRequest
             'meta' => ['nullable', 'array'],
             'branch_id' => ['required', 'integer', Rule::exists('branches', 'id')->whereNull('deleted_at')],
             'start_date' => ['required', 'date'],
+            'attendance_exempt' => ['sometimes', 'boolean'],
         ];
     }
 

--- a/code/api/app/Http/Requests/Employees/UpdateEmployeeRequest.php
+++ b/code/api/app/Http/Requests/Employees/UpdateEmployeeRequest.php
@@ -15,6 +15,7 @@ use Illuminate\Validation\Rule;
  *   @OA\Property(property="roles", type="array", @OA\Items(type="string", enum={"manager", "cook", "kitchen-assistant", "delivery-driver", "acting-manager", "admin", "super-admin"}), example={"cook"}, description="Position roles (super-admin only visible to super-admins)"),
  *   @OA\Property(property="email", type="string", format="email", example="juan.perez@sushigo.com", description="User email (admin only)"),
  *   @OA\Property(property="phone", type="string", example="5512345678", description="National phone number (admin only)"),
+ *   @OA\Property(property="attendance_exempt", type="boolean", example=false, description="True for roles (e.g. admin, super-admin) that do not check in/out — excluded from the attendance list."),
  *   @OA\Property(property="meta", type="object", nullable=true),
  * )
  */
@@ -32,6 +33,7 @@ class UpdateEmployeeRequest extends FormRequest
             'last_name' => ['sometimes', 'string', 'max:100'],
             'roles' => ['sometimes', 'array', 'min:1'],
             'roles.*' => ['string', Rule::in(Employee::getAssignableRolesFor($this->user()))],
+            'attendance_exempt' => ['sometimes', 'boolean'],
             'meta' => ['nullable', 'array'],
         ];
 

--- a/code/api/app/Http/Requests/Reports/WeeklySummaryRequest.php
+++ b/code/api/app/Http/Requests/Reports/WeeklySummaryRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests\Reports;
 
 use App\Models\Employee;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class WeeklySummaryRequest extends FormRequest
 {
@@ -15,7 +16,11 @@ class WeeklySummaryRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'employee_id' => ['required', 'string', 'exists:employees,public_id'],
+            'employee_id' => [
+                'required',
+                'string',
+                Rule::exists('employees', 'public_id')->whereNull('deleted_at'),
+            ],
             'period_start' => ['required', 'date'],
             'period_end' => ['required', 'date', 'after_or_equal:period_start'],
         ];

--- a/code/api/app/Http/Requests/Reports/WeeklySummaryRequest.php
+++ b/code/api/app/Http/Requests/Reports/WeeklySummaryRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests\Reports;
+
+use App\Models\Employee;
+use Illuminate\Foundation\Http\FormRequest;
+
+class WeeklySummaryRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()->can('reports.weekly-summary');
+    }
+
+    public function rules(): array
+    {
+        return [
+            'employee_id' => ['required', 'string', 'exists:employees,public_id'],
+            'period_start' => ['required', 'date'],
+            'period_end' => ['required', 'date', 'after_or_equal:period_start'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'employee_id.required' => 'El employee_id es requerido.',
+            'employee_id.exists' => 'El empleado indicado no existe.',
+            'period_start.required' => 'La fecha de inicio del período es requerida.',
+            'period_end.required' => 'La fecha de fin del período es requerida.',
+            'period_end.after_or_equal' => 'La fecha de fin debe ser igual o posterior a la fecha de inicio.',
+        ];
+    }
+
+    public function employee(): Employee
+    {
+        return Employee::where('public_id', $this->validated('employee_id'))->firstOrFail();
+    }
+}

--- a/code/api/app/Http/Resources/Employee/EmployeeResource.php
+++ b/code/api/app/Http/Resources/Employee/EmployeeResource.php
@@ -15,6 +15,7 @@ use App\Http\Resources\BaseResource;
  *     @OA\Property(property="last_name", type="string", example="Perez"),
  *     @OA\Property(property="roles", type="array", @OA\Items(type="string", enum={"manager", "cook", "kitchen-assistant", "delivery-driver", "acting-manager"}), example={"cook"}, description="Position roles"),
  *     @OA\Property(property="is_active", type="boolean", example=true),
+ *     @OA\Property(property="attendance_exempt", type="boolean", example=false, description="True for roles (e.g. admin, super-admin) that do not check in/out — excluded from the attendance list"),
  *     @OA\Property(property="has_active_period", type="boolean", nullable=true, example=true, description="True when employee has at least one active employment period"),
  *     @OA\Property(property="has_user", type="boolean", example=true, description="Whether the employee has a linked user account"),
  *     @OA\Property(property="email", type="string", format="email", nullable=true, example="juan@sushigo.com"),
@@ -52,6 +53,7 @@ class EmployeeResource extends BaseResource
             'last_name' => $this->last_name,
             'roles' => $this->getPositionRoles(),
             'is_active' => $this->is_active,
+            'attendance_exempt' => $this->attendance_exempt,
             'has_active_period' => $this->active_employment_periods_count !== null
                 ? $this->active_employment_periods_count > 0
                 : ($this->relationLoaded('employmentPeriods')

--- a/code/api/app/Http/Responses/Reports/WeeklySummaryResponse.php
+++ b/code/api/app/Http/Responses/Reports/WeeklySummaryResponse.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Responses\Reports;
+
+use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Http\JsonResponse;
+
+class WeeklySummaryResponse implements Responsable
+{
+    /** @param array<string, mixed> $data */
+    public function __construct(protected array $data) {}
+
+    public function toResponse($request): JsonResponse
+    {
+        return response()->json([
+            'status' => 200,
+            'data' => $this->data,
+        ], 200);
+    }
+}

--- a/code/api/app/Models/Attendance.php
+++ b/code/api/app/Models/Attendance.php
@@ -65,24 +65,14 @@ class Attendance extends Model
         return $this->belongsTo(User::class, 'confirmed_by');
     }
 
-    /**
-     * Partial leaves linked to this attendance record.
-     *
-     * @see AP-020 — PartialLeave model (pending implementation)
-     */
     public function partialLeaves(): HasMany
     {
-        return $this->hasMany(PartialLeave::class); // AP-020
+        return $this->hasMany(PartialLeave::class);
     }
 
-    /**
-     * Overtime bank movements generated from this attendance day.
-     *
-     * @see AP-034 — OvertimeBankMovement model (pending implementation)
-     */
     public function overtimeBankMovements(): HasMany
     {
-        return $this->hasMany(OvertimeBankMovement::class); // AP-034
+        return $this->hasMany(OvertimeBankMovement::class);
     }
 
     public function scopeByDate(Builder $query, string $date): Builder

--- a/code/api/app/Models/Employee.php
+++ b/code/api/app/Models/Employee.php
@@ -133,7 +133,7 @@ class Employee extends Model
 
     public function overtimeBankMovements(): HasMany
     {
-        return $this->hasMany(OvertimeBankMovement::class)->orderBy('period_date', 'desc');
+        return $this->hasMany(OvertimeBankMovement::class)->orderBy('date', 'desc');
     }
 
     public function bonusConfigs(): HasMany

--- a/code/api/app/Models/Employee.php
+++ b/code/api/app/Models/Employee.php
@@ -76,11 +76,13 @@ class Employee extends Model
         'first_name',
         'last_name',
         'is_active',
+        'attendance_exempt',
         'meta',
     ];
 
     protected $casts = [
         'is_active' => 'boolean',
+        'attendance_exempt' => 'boolean',
         'meta' => 'array',
     ];
 
@@ -122,6 +124,16 @@ class Employee extends Model
     public function employeeRequests(): HasMany
     {
         return $this->hasMany(EmployeeRequest::class)->orderBy('created_at', 'desc');
+    }
+
+    public function punctualityExceptions(): HasMany
+    {
+        return $this->hasMany(PunctualityException::class)->orderBy('effective_from', 'desc');
+    }
+
+    public function overtimeBankMovements(): HasMany
+    {
+        return $this->hasMany(OvertimeBankMovement::class)->orderBy('period_date', 'desc');
     }
 
     public function bonusConfigs(): HasMany

--- a/code/api/app/Models/PunctualityException.php
+++ b/code/api/app/Models/PunctualityException.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Models;
+
+use App\Support\Traits\HasPublicId;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PunctualityException extends Model
+{
+    use HasPublicId;
+
+    protected $fillable = [
+        'employee_id',
+        'day_of_week',
+        'forced_percentage',
+        'effective_from',
+        'effective_to',
+        'reason',
+    ];
+
+    protected $casts = [
+        'day_of_week' => 'integer',
+        'forced_percentage' => 'decimal:2',
+        'effective_from' => 'date',
+        'effective_to' => 'date',
+    ];
+
+    public function employee(): BelongsTo
+    {
+        return $this->belongsTo(Employee::class);
+    }
+
+    /** Exceptions effective on a given date. */
+    public function scopeEffective(Builder $query, Carbon $date): Builder
+    {
+        return $query
+            ->where('effective_from', '<=', $date->toDateString())
+            ->where(function (Builder $q) use ($date) {
+                $q->whereNull('effective_to')
+                    ->orWhere('effective_to', '>=', $date->toDateString());
+            });
+    }
+
+    /** True if this exception applies to the given day-of-week (0=Sun … 6=Sat). Null day_of_week = applies every day. */
+    public function appliesToDay(int $dayOfWeek): bool
+    {
+        return $this->day_of_week === null || $this->day_of_week === $dayOfWeek;
+    }
+}

--- a/code/api/app/Models/PunctualityException.php
+++ b/code/api/app/Models/PunctualityException.php
@@ -44,7 +44,7 @@ class PunctualityException extends Model
             });
     }
 
-    /** True if this exception applies to the given day-of-week (0=Sun … 6=Sat). Null day_of_week = applies every day. */
+    /** True if this exception applies to the given ISO 8601 day-of-week (1=Mon … 7=Sun). Null day_of_week = applies every day. */
     public function appliesToDay(int $dayOfWeek): bool
     {
         return $this->day_of_week === null || $this->day_of_week === $dayOfWeek;

--- a/code/api/app/Repositories/EmployeeRepository.php
+++ b/code/api/app/Repositories/EmployeeRepository.php
@@ -20,6 +20,7 @@ class EmployeeRepository extends BaseRepository
     /**
      * Load all active employees for a branch with today's attendance and
      * any approved leave covering the given date, ordered by last then first name.
+     * Employees marked `attendance_exempt` (e.g. admin, super-admin) are excluded.
      */
     public function getActiveForReport(int $branchId, string $today): Collection
     {
@@ -45,6 +46,7 @@ class EmployeeRepository extends BaseRepository
                             ]),
                     ]),
             ])
+            ->where('attendance_exempt', false)
             ->whereHas('employmentPeriods', fn ($q) => $q
                 ->where('branch_id', $branchId)
                 ->where('is_active', true)

--- a/code/api/app/Services/WeeklySummaryService.php
+++ b/code/api/app/Services/WeeklySummaryService.php
@@ -1,0 +1,233 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\DayStatus;
+use App\Models\Attendance;
+use App\Models\Employee;
+use App\Models\EmployeeBonusConfig;
+use App\Models\Holiday;
+use App\Models\NegotiatedExtraDay;
+use App\Models\PartialLeave;
+use App\Models\PunctualityRange;
+use App\Models\WageHistory;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+
+class WeeklySummaryService
+{
+    /**
+     * Build the complete financial breakdown for one employee in a period.
+     * Calculates live (no closed-period snapshot required).
+     *
+     * @return array<string, mixed>
+     */
+    public function buildSummary(Employee $employee, string $periodStart, string $periodEnd): array
+    {
+        $attendances = Attendance::where('employee_id', $employee->id)
+            ->whereBetween('date', [$periodStart, $periodEnd])
+            ->with('partialLeaves')
+            ->orderBy('date')
+            ->get();
+
+        $wage = WageHistory::where('employee_id', $employee->id)
+            ->effective($periodStart)
+            ->orderByDesc('effective_from')
+            ->first();
+
+        $hourlyRate = $wage ? (float) $wage->hourly_rate : 0.0;
+        $minuteRate = $hourlyRate / 60;
+
+        $scheduledWorkingDays = $attendances->filter(
+            fn (Attendance $a) => $a->day_status !== DayStatus::DAY_OFF
+        )->count();
+
+        // Scheduled minutes per worked day with rest-day proration for calculateBasePay.
+        $workedAttendances = $attendances->filter(fn (Attendance $a) => $a->day_status === DayStatus::WORKED)->values();
+        $scheduledMinutesForBase = $this->buildScheduledMinutesWithRestDay($wage, $scheduledWorkingDays, $workedAttendances->count());
+
+        // Per-attendance daily minutes (no rest-day) for calculateHolidayPay.
+        // Also map to plain objects so day_status is a string, not a DayStatus enum.
+        $dailyMinutes = ($wage && $scheduledWorkingDays > 0)
+            ? ((float) $wage->weekly_scheduled_hours / $scheduledWorkingDays) * 60
+            : 0.0;
+        $attendanceDtos = $attendances->values()->map(fn (Attendance $a) => (object) [
+            'date' => $a->date->toDateString(),
+            'day_status' => $a->day_status->value,
+        ]);
+        $scheduledMinutesForHoliday = $attendances->map(fn () => $dailyMinutes)->values();
+
+        $partialLeaves = $attendances->flatMap(fn (Attendance $a) => $a->partialLeaves);
+
+        $extraDays = NegotiatedExtraDay::where('employee_id', $employee->id)
+            ->where('status', NegotiatedExtraDay::STATUS_APPROVED)
+            ->whereBetween('date', [$periodStart, $periodEnd])
+            ->get();
+
+        $holidays = Holiday::whereBetween('date', [$periodStart, $periodEnd])->get();
+
+        // Punctuality bonus via new static API.
+        $config = EmployeeBonusConfig::where('employee_id', $employee->id)
+            ->effective(Carbon::parse($periodStart))
+            ->orderByDesc('effective_from')
+            ->with('bonusGroup')
+            ->first();
+        $ranges = PunctualityRange::all()->sortBy('sort_order')->values();
+        $weeklyBonus = PunctualityService::calculateWeeklyBonusFromConfig($workedAttendances, $config, $ranges);
+
+        $punctualDays = $this->countPunctualDays($attendances);
+        $lastTwoPunctual = $this->lastTwoDaysPunctual($attendances);
+        $freeHours = $this->calculateFreeHours($punctualDays, $lastTwoPunctual);
+
+        $basePay = PayrollCalculator::calculateBasePay($scheduledMinutesForBase, $hourlyRate);
+        $lateDeductions = PayrollCalculator::calculateLateDeductions($attendances, $minuteRate);
+        $unpaidLeaveDeductions = PayrollCalculator::calculateUnpaidLeaveDeductions($partialLeaves, $minuteRate);
+        $extraDayPay = PayrollCalculator::calculateExtraDayPay($extraDays);
+        $holidayPay = PayrollCalculator::calculateHolidayPay($attendanceDtos, $holidays, $scheduledMinutesForHoliday, $hourlyRate);
+        $overtimePay = $this->calculateOvertimePay($employee, $periodStart, $periodEnd, $minuteRate);
+
+        $totalPay = round(
+            $basePay
+            - $lateDeductions
+            - $unpaidLeaveDeductions
+            + $extraDayPay
+            + $holidayPay
+            + $weeklyBonus
+            + $overtimePay,
+            2
+        );
+
+        $dailyEvidence = $this->buildDailyEvidence($attendances, $periodStart, $periodEnd);
+
+        return [
+            'employee_id' => $employee->public_id,
+            'period_start' => $periodStart,
+            'period_end' => $periodEnd,
+            'base_pay' => $basePay,
+            'late_deductions' => $lateDeductions,
+            'unpaid_leave_deductions' => $unpaidLeaveDeductions,
+            'overtime_pay' => $overtimePay,
+            'extra_day_pay' => $extraDayPay,
+            'holiday_pay' => $holidayPay,
+            'punctuality_bonus' => $weeklyBonus,
+            'free_hours_earned' => $freeHours,
+            'total_pay' => $totalPay,
+            'daily_evidence' => $dailyEvidence,
+        ];
+    }
+
+    /**
+     * Scheduled minutes per worked day, including proportional rest-day.
+     *
+     * Formula: (dailyHours + dailyHours/scheduledWorkingDays) × 60
+     *
+     * @return Collection<int, int>
+     */
+    private function buildScheduledMinutesWithRestDay(?WageHistory $wage, int $scheduledWorkingDays, int $workedCount): Collection
+    {
+        if (! $wage || $scheduledWorkingDays === 0) {
+            return collect(array_fill(0, $workedCount, 0));
+        }
+
+        $dailyHours = (float) $wage->weekly_scheduled_hours / $scheduledWorkingDays;
+        $effectiveMinutes = (int) round(($dailyHours + $dailyHours / $scheduledWorkingDays) * 60);
+
+        return collect(array_fill(0, $workedCount, $effectiveMinutes));
+    }
+
+    private function countPunctualDays(Collection $attendances): int
+    {
+        return $attendances->filter(
+            fn (Attendance $a) => $a->day_status === DayStatus::WORKED
+                && ($a->entry_late_seconds ?? 0) === 0
+        )->count();
+    }
+
+    private function lastTwoDaysPunctual(Collection $attendances): bool
+    {
+        $worked = $attendances
+            ->filter(fn (Attendance $a) => $a->day_status === DayStatus::WORKED)
+            ->sortByDesc('date')
+            ->take(2);
+
+        if ($worked->count() < 2) {
+            return false;
+        }
+
+        return $worked->every(fn (Attendance $a) => ($a->entry_late_seconds ?? 0) === 0);
+    }
+
+    private function calculateFreeHours(int $punctualDays, bool $lastTwoDaysPunctual): float
+    {
+        if (! $lastTwoDaysPunctual) {
+            return 0.0;
+        }
+
+        return match (true) {
+            $punctualDays >= 5 => 1.0,
+            $punctualDays === 4 => 0.5,
+            default => 0.0,
+        };
+    }
+
+    private function calculateOvertimePay(Employee $employee, string $start, string $end, float $minuteRate): float
+    {
+        // Sum of authorized overtime minutes × minuteRate within the period.
+        // OvertimeBankMovement::PAID movements will take precedence once the bank system is live (AP-038/039).
+        $authorizedOvertimeMinutes = Attendance::where('employee_id', $employee->id)
+            ->whereBetween('date', [$start, $end])
+            ->where('overtime_authorized', true)
+            ->sum('overtime_minutes');
+
+        return round((float) $authorizedOvertimeMinutes * $minuteRate, 2);
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    private function buildDailyEvidence(Collection $attendances, string $periodStart, string $periodEnd): array
+    {
+        $attendanceMap = $attendances->keyBy(fn (Attendance $a) => $a->date->toDateString());
+
+        $evidence = [];
+        $current = Carbon::parse($periodStart);
+        $end = Carbon::parse($periodEnd);
+
+        while ($current->lte($end)) {
+            $dateStr = $current->toDateString();
+            $a = $attendanceMap->get($dateStr);
+
+            $evidence[] = $a instanceof Attendance
+                ? $this->buildAttendanceRow($a, $dateStr)
+                : ['date' => $dateStr, 'check_in' => null, 'check_out' => null, 'day_status' => null, 'late_minutes' => 0, 'deducted_minutes' => 0, 'partial_leaves' => [], 'overtime_minutes' => 0, 'overtime_authorized' => false];
+
+            $current->addDay();
+        }
+
+        return $evidence;
+    }
+
+    /** @return array<string, mixed> */
+    private function buildAttendanceRow(Attendance $a, string $dateStr): array
+    {
+        $lateMinutes = $a->entry_late_seconds ? (int) floor($a->entry_late_seconds / 60) : 0;
+        $deductedMinutes = $a->isEntryLateDeductible() ? $lateMinutes : 0;
+        $lunchLateMin = $a->lunch_late_seconds ? (int) floor($a->lunch_late_seconds / 60) : 0;
+        if ($a->isLunchLateDeductible()) {
+            $deductedMinutes += $lunchLateMin;
+        }
+
+        return [
+            'date' => $dateStr,
+            'check_in' => $a->check_in?->toIso8601String(),
+            'check_out' => $a->check_out?->toIso8601String(),
+            'day_status' => $a->day_status->value,
+            'late_minutes' => $lateMinutes,
+            'deducted_minutes' => $deductedMinutes,
+            'partial_leaves' => $a->partialLeaves->map(fn (PartialLeave $pl) => [
+                'duration_minutes' => $pl->duration_minutes,
+                'is_paid' => $pl->is_paid,
+            ])->values()->all(),
+            'overtime_minutes' => $a->overtime_minutes ?? 0,
+            'overtime_authorized' => (bool) ($a->overtime_authorized ?? false),
+        ];
+    }
+}

--- a/code/api/app/Services/WeeklySummaryService.php
+++ b/code/api/app/Services/WeeklySummaryService.php
@@ -38,8 +38,12 @@ class WeeklySummaryService
         $hourlyRate = $wage ? (float) $wage->hourly_rate : 0.0;
         $minuteRate = $hourlyRate / 60;
 
+        // EXTRA days are outside the regular schedule (a negotiated extra shift on
+        // what would otherwise be a rest day) and are already compensated
+        // separately via extra_day_pay below — counting them here would dilute
+        // the per-day rate for the regularly scheduled days.
         $scheduledWorkingDays = $attendances->filter(
-            fn (Attendance $a) => $a->day_status !== DayStatus::DAY_OFF
+            fn (Attendance $a) => ! in_array($a->day_status, [DayStatus::DAY_OFF, DayStatus::EXTRA], true)
         )->count();
 
         // Scheduled minutes per worked day with rest-day proration for calculateBasePay.

--- a/code/api/config/payroll.php
+++ b/code/api/config/payroll.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Week Start Day
+    |--------------------------------------------------------------------------
+    |
+    | The ISO weekday on which the payroll week begins.
+    | 1 = Monday (default) … 7 = Sunday
+    |
+    | SushiGo convention: weeks run Monday–Sunday. The cut-off happens at the
+    | end of Sunday; payments are issued on Monday of the following week.
+    |
+    */
+    'week_start_day' => (int) env('WEEK_START_DAY', 1),
+];

--- a/code/api/config/seeders.php
+++ b/code/api/config/seeders.php
@@ -49,6 +49,8 @@ return [
                 'first_name' => 'Admin',
                 'last_name' => 'User',
                 'position_roles' => ['manager'],
+                // Admins are free of attendance tracking, like super-admin (which has no employee record)
+                'attendance_exempt' => true,
             ],
         ],
         [
@@ -162,7 +164,6 @@ return [
     */
 
     'factory_counts' => [
-        'users' => 10,
         'employees' => 5,
     ],
 

--- a/code/api/database/migrations/2026_06_24_000006_create_punctuality_exceptions_table.php
+++ b/code/api/database/migrations/2026_06_24_000006_create_punctuality_exceptions_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -12,7 +13,8 @@ return new class extends Migration
             $table->id();
             $table->string('public_id', 26)->unique();
             $table->unsignedBigInteger('employee_id');
-            // 0=Sunday … 6=Saturday (Carbon convention); null = applies every day of week
+            // ISO 8601 day: 1=Monday … 7=Sunday — matches schedule_days/schedule_day_overrides
+            // and every caller's Carbon::dayOfWeekIso(). Null = applies every day of week.
             $table->tinyInteger('day_of_week')->unsigned()->nullable();
             $table->decimal('forced_percentage', 5, 2);
             $table->date('effective_from');
@@ -24,6 +26,8 @@ return new class extends Migration
         Schema::table('punctuality_exceptions', function (Blueprint $table) {
             $table->foreign('employee_id')->references('id')->on('employees')->cascadeOnDelete();
         });
+
+        DB::statement('ALTER TABLE punctuality_exceptions ADD CONSTRAINT punctuality_exceptions_dow_range_check CHECK (day_of_week BETWEEN 1 AND 7)');
     }
 
     public function down(): void

--- a/code/api/database/migrations/2026_06_24_000006_create_punctuality_exceptions_table.php
+++ b/code/api/database/migrations/2026_06_24_000006_create_punctuality_exceptions_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('punctuality_exceptions', function (Blueprint $table) {
+            $table->id();
+            $table->string('public_id', 26)->unique();
+            $table->unsignedBigInteger('employee_id');
+            // 0=Sunday … 6=Saturday (Carbon convention); null = applies every day of week
+            $table->tinyInteger('day_of_week')->unsigned()->nullable();
+            $table->decimal('forced_percentage', 5, 2);
+            $table->date('effective_from');
+            $table->date('effective_to')->nullable();
+            $table->text('reason')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::table('punctuality_exceptions', function (Blueprint $table) {
+            $table->foreign('employee_id')->references('id')->on('employees')->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('punctuality_exceptions');
+    }
+};

--- a/code/api/database/migrations/2026_07_01_000000_add_attendance_exempt_to_employees.php
+++ b/code/api/database/migrations/2026_07_01_000000_add_attendance_exempt_to_employees.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            $table->boolean('attendance_exempt')->default(false)->after('is_active')
+                ->comment('True for roles (e.g. admin, super-admin) that do not check in/out — excluded from the attendance list');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            $table->dropColumn('attendance_exempt');
+        });
+    }
+};

--- a/code/api/database/seeders/Development/AdminEmployeeSeeder.php
+++ b/code/api/database/seeders/Development/AdminEmployeeSeeder.php
@@ -55,6 +55,7 @@ class AdminEmployeeSeeder extends OnceSeeder
                 'first_name' => $employeeData['first_name'],
                 'last_name' => $employeeData['last_name'],
                 'is_active' => true,
+                'attendance_exempt' => $employeeData['attendance_exempt'] ?? false,
             ]);
 
             // Sync position roles onto the User (preserves admin/inventory-manager roles)

--- a/code/api/database/seeders/Development/AttendanceHistorySeeder.php
+++ b/code/api/database/seeders/Development/AttendanceHistorySeeder.php
@@ -1,0 +1,357 @@
+<?php
+
+namespace Database\Seeders\Development;
+
+use App\Enums\DayStatus;
+use App\Enums\LeaveStatus;
+use App\Models\EmployeeSchedule;
+use App\Models\EmploymentPeriod;
+use App\Models\Leave;
+use App\Models\LeaveType;
+use App\Models\ScheduleDayOverride;
+use App\Models\User;
+use App\Support\Clock\ApplicationClock;
+use Carbon\Carbon;
+use Database\Seeders\Base\OnceSeeder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+/**
+ * Seed a full attendance history for every non-exempt employee, spanning from
+ * each of their employment periods' start_date up to today (or end_date for
+ * closed periods). Re-entry employees (multiple periods) get one history
+ * block per period, with the natural gap between periods left empty.
+ *
+ * Each working day (per the employee's effective schedule, override-aware)
+ * rolls a weighted outcome:
+ *   - ~78%  WORKED, mostly on time, some with a few minutes of harmless variance
+ *   - ~12%  WORKED but late (5–75 min late; some cross the 30-min deductible line)
+ *   - ~5%   ABSENCE (unexcused falta)
+ *   - ~4%   LEAVE block (1–2 days, backed by an approved Leave — medical/personal/paid permission)
+ *   - ~2%   Vacation block (3–6 days, backed by an approved Leave, paid, notes "Vacaciones")
+ * Rest days (per schedule) get DAY_OFF, mirroring CloseDayAction's own
+ * classification so historical data matches what the real close-day flow
+ * would have produced.
+ *
+ * Employees marked `attendance_exempt` (e.g. admin) are skipped entirely —
+ * they never appear in the attendance list, so they need no history.
+ *
+ * Attendance rows are bulk-inserted (bypassing model events) for performance;
+ * Leave records use Eloquent since there are comparatively few of them.
+ */
+class AttendanceHistorySeeder extends OnceSeeder
+{
+    private const LATE_CHANCE = 12;       // % of working days that start late
+
+    private const LATE_MIN_MINUTES = 5;
+
+    private const LATE_MAX_MINUTES = 75;
+
+    private const LUNCH_LATE_CHANCE = 8;  // % of working days with a late lunch return
+
+    private const LUNCH_LATE_MIN_MINUTES = 5;
+
+    private const LUNCH_LATE_MAX_MINUTES = 35;
+
+    private const ABSENCE_CHANCE = 5;     // % of working days rolled as unexcused absence
+
+    private const PERMISSION_CHANCE = 4;  // % of working days that start a 1–2 day leave block
+
+    private const VACATION_CHANCE = 2;    // % of working days that start a 3–6 day vacation block
+
+    // Fallback shift for periods with no seeded EmployeeSchedule (e.g. the factory
+    // "baja" employees — EmployeeScheduleSeeder only covers active periods). Mirrors
+    // EmployeeScheduleSeeder's own standard shift so history stays plausible.
+    private const DEFAULT_SHIFT_START = '13:00:00';
+
+    private const DEFAULT_SHIFT_END = '22:00:00';
+
+    private const DEFAULT_LUNCH_START = '16:00:00';
+
+    private const DEFAULT_LUNCH_END = '16:30:00';
+
+    private const DEFAULT_REST_DOW = 7; // Sunday
+
+    private string $businessTimezone;
+
+    private string $today;
+
+    private ?int $adminUserId = null;
+
+    /** @var array<string, int> LeaveType code => id */
+    private array $leaveTypeIds = [];
+
+    public function run(): void
+    {
+        $this->businessTimezone = config('app.business_timezone');
+        $this->today = app(ApplicationClock::class)->todayInBusinessTz();
+
+        $admin = User::whereHas('roles', fn ($q) => $q->where('name', 'admin'))->first();
+        $this->adminUserId = $admin?->id;
+
+        $this->leaveTypeIds = LeaveType::pluck('id', 'code')->all();
+
+        $periods = EmploymentPeriod::whereHas('employee', fn ($q) => $q->where('attendance_exempt', false))
+            ->with('employee')
+            ->orderBy('employee_id')
+            ->orderBy('start_date')
+            ->get();
+
+        if ($periods->isEmpty()) {
+            $this->command->warn('⚠️  No employment periods found. Skipping AttendanceHistorySeeder.');
+
+            return;
+        }
+
+        $totalRows = 0;
+        $totalLeaves = 0;
+
+        foreach ($periods->groupBy('employee_id') as $employeePeriods) {
+            [$rows, $leaves] = $this->buildEmployeeHistory($employeePeriods);
+
+            foreach (array_chunk($rows, 500) as $chunk) {
+                DB::table('attendances')->insert($chunk);
+            }
+
+            $totalRows += count($rows);
+            $totalLeaves += $leaves;
+        }
+
+        $this->command->info("✓ Seeded attendance history: {$totalRows} attendance records, {$totalLeaves} leave requests, across {$periods->pluck('employee_id')->unique()->count()} employees");
+    }
+
+    /**
+     * @param  Collection<int, EmploymentPeriod>  $periods  All periods for one employee, oldest first
+     * @return array{0: list<array<string, mixed>>, 1: int} [attendance rows, leave count]
+     */
+    private function buildEmployeeHistory(Collection $periods): array
+    {
+        $rows = [];
+        $leaveCount = 0;
+        $now = now();
+        $todayCarbon = Carbon::parse($this->today);
+
+        foreach ($periods as $period) {
+            $employeeId = $period->employee_id;
+            $cursor = Carbon::parse($period->start_date);
+            $end = $period->end_date ? Carbon::parse($period->end_date) : $todayCarbon->copy();
+            if ($end->gt($todayCarbon)) {
+                $end = $todayCarbon->copy();
+            }
+
+            if ($cursor->gt($end)) {
+                continue;
+            }
+
+            // Idempotency guard — skip this period's range if already seeded (e.g. re-running locally).
+            $alreadySeeded = DB::table('attendances')
+                ->where('employee_id', $employeeId)
+                ->whereBetween('date', [$cursor->toDateString(), $end->toDateString()])
+                ->exists();
+            if ($alreadySeeded) {
+                continue;
+            }
+
+            $daysLeftInBlock = 0;
+
+            while ($cursor->lte($end)) {
+                $date = $cursor->toDateString();
+
+                if ($daysLeftInBlock > 0) {
+                    $rows[] = $this->simpleRow($employeeId, $date, DayStatus::LEAVE, $now);
+                    $daysLeftInBlock--;
+                    $cursor->addDay();
+
+                    continue;
+                }
+
+                $scheduleDay = $this->resolveScheduleDay($date, $cursor->dayOfWeekIso, $period);
+
+                if (! $scheduleDay) {
+                    $rows[] = $this->simpleRow($employeeId, $date, DayStatus::DAY_OFF, $now);
+                    $cursor->addDay();
+
+                    continue;
+                }
+
+                $roll = mt_rand(1, 100);
+
+                if ($roll <= self::VACATION_CHANCE) {
+                    $blockLen = mt_rand(3, 6);
+                    $blockEnd = (clone $cursor)->addDays($blockLen - 1)->min($end);
+                    $daysLeftInBlock = $cursor->diffInDays($blockEnd);
+                    $this->createLeave($employeeId, $date, $blockEnd->toDateString(), LeaveType::PERMISSION_PAID, 'Vacaciones');
+                    $leaveCount++;
+                    $rows[] = $this->simpleRow($employeeId, $date, DayStatus::LEAVE, $now);
+                } elseif ($roll <= self::VACATION_CHANCE + self::PERMISSION_CHANCE) {
+                    $blockLen = mt_rand(1, 2);
+                    $blockEnd = (clone $cursor)->addDays($blockLen - 1)->min($end);
+                    $daysLeftInBlock = $cursor->diffInDays($blockEnd);
+                    [$typeCode, $notes] = $this->randomPermissionType();
+                    $this->createLeave($employeeId, $date, $blockEnd->toDateString(), $typeCode, $notes);
+                    $leaveCount++;
+                    $rows[] = $this->simpleRow($employeeId, $date, DayStatus::LEAVE, $now);
+                } elseif ($roll <= self::VACATION_CHANCE + self::PERMISSION_CHANCE + self::ABSENCE_CHANCE) {
+                    $rows[] = $this->simpleRow($employeeId, $date, DayStatus::ABSENCE, $now);
+                } else {
+                    $rows[] = $this->workedRow($employeeId, $date, $scheduleDay, $now);
+                }
+
+                $cursor->addDay();
+            }
+        }
+
+        return [$rows, $leaveCount];
+    }
+
+    /**
+     * Resolves the effective shift times for a date within a *specific* (possibly
+     * closed) employment period — mirrors ResolvesEffectiveScheduleDay, but scoped
+     * to the period we already know applied on that date, so closed (re-entry)
+     * periods resolve correctly too.
+     *
+     * Returns null on a rest day. Falls back to the company's standard shift
+     * (13:00–22:00, Sunday off) when the period has no seeded EmployeeSchedule at
+     * all — this happens for the factory "baja" employees, since
+     * EmployeeScheduleSeeder only covers active periods.
+     *
+     * @return array{start: string, end: string, lunch_start: ?string, lunch_end: ?string}|null
+     */
+    private function resolveScheduleDay(string $date, int $dayOfWeek, EmploymentPeriod $period): ?array
+    {
+        $schedule = EmployeeSchedule::effective($date)
+            ->where('employment_period_id', $period->id)
+            ->first();
+
+        if (! $schedule) {
+            return $dayOfWeek === self::DEFAULT_REST_DOW ? null : [
+                'start' => self::DEFAULT_SHIFT_START,
+                'end' => self::DEFAULT_SHIFT_END,
+                'lunch_start' => self::DEFAULT_LUNCH_START,
+                'lunch_end' => self::DEFAULT_LUNCH_END,
+            ];
+        }
+
+        $override = ScheduleDayOverride::effective($date)
+            ->where('employment_period_id', $period->id)
+            ->where('day_of_week', $dayOfWeek)
+            ->first();
+
+        $dayConfig = $override ?? $schedule->dayConfig($dayOfWeek);
+
+        if (! $dayConfig || $dayConfig->is_day_off) {
+            return null;
+        }
+
+        return [
+            'start' => $dayConfig->expected_start->format('H:i:s'),
+            'end' => $dayConfig->expected_end->format('H:i:s'),
+            'lunch_start' => $dayConfig->expected_lunch_start?->format('H:i:s'),
+            'lunch_end' => $dayConfig->expected_lunch_end?->format('H:i:s'),
+        ];
+    }
+
+    /**
+     * @return array{0: string, 1: string} [LeaveType code, notes]
+     */
+    private function randomPermissionType(): array
+    {
+        return collect([
+            [LeaveType::MEDICAL, 'Incapacidad médica'],
+            [LeaveType::PERSONAL, 'Permiso personal'],
+            [LeaveType::PERMISSION_PAID, 'Permiso con goce de sueldo'],
+        ])->random();
+    }
+
+    private function createLeave(int $employeeId, string $start, string $end, string $typeCode, string $notes): void
+    {
+        $typeId = $this->leaveTypeIds[$typeCode] ?? null;
+
+        if (! $typeId || ! $this->adminUserId) {
+            return;
+        }
+
+        Leave::create([
+            'employee_id' => $employeeId,
+            'leave_type_id' => $typeId,
+            'start_date' => $start,
+            'end_date' => $end,
+            'status' => LeaveStatus::APPROVED,
+            'requested_by' => $this->adminUserId,
+            'approved_by' => $this->adminUserId,
+            'approved_at' => Carbon::parse($start)->subDay(),
+            'notes' => $notes,
+        ]);
+    }
+
+    /**
+     * A normal working day: check-in/lunch/check-out around the scheduled times, with realistic variance.
+     *
+     * @param  array{start: string, end: string, lunch_start: ?string, lunch_end: ?string}  $shift
+     */
+    private function workedRow(int $employeeId, string $date, array $shift, Carbon $now): array
+    {
+        $expectedStart = $shift['start'];
+        $expectedEnd = $shift['end'];
+        $lunchStart = $shift['lunch_start'];
+        $lunchEnd = $shift['lunch_end'];
+
+        $lateMinutes = mt_rand(1, 100) <= self::LATE_CHANCE
+            ? mt_rand(self::LATE_MIN_MINUTES, self::LATE_MAX_MINUTES)
+            : 0;
+
+        $checkIn = Carbon::parse("{$date} {$expectedStart}", $this->businessTimezone)->addMinutes($lateMinutes);
+        $checkOut = Carbon::parse("{$date} {$expectedEnd}", $this->businessTimezone);
+
+        $lunchLateMinutes = ($lunchStart && $lunchEnd && mt_rand(1, 100) <= self::LUNCH_LATE_CHANCE)
+            ? mt_rand(self::LUNCH_LATE_MIN_MINUTES, self::LUNCH_LATE_MAX_MINUTES)
+            : 0;
+
+        $lunchStartAt = $lunchStart ? Carbon::parse("{$date} {$lunchStart}", $this->businessTimezone) : null;
+        $lunchEndAt = $lunchEnd ? Carbon::parse("{$date} {$lunchEnd}", $this->businessTimezone)->addMinutes($lunchLateMinutes) : null;
+
+        $lunchMinutes = ($lunchStartAt && $lunchEndAt) ? $lunchStartAt->diffInMinutes($lunchEndAt) : 0;
+        $netWorkedMinutes = max(0, $checkIn->diffInMinutes($checkOut) - $lunchMinutes);
+
+        return [
+            'employee_id' => $employeeId,
+            'public_id' => (string) Str::ulid(),
+            'date' => $date,
+            'check_in' => $checkIn->clone()->utc()->format('Y-m-d H:i:s'),
+            'check_out' => $checkOut->clone()->utc()->format('Y-m-d H:i:s'),
+            'lunch_start' => $lunchStartAt?->clone()->utc()->format('Y-m-d H:i:s'),
+            'lunch_end' => $lunchEndAt?->clone()->utc()->format('Y-m-d H:i:s'),
+            'entry_late_seconds' => $lateMinutes * 60,
+            'lunch_late_seconds' => $lunchLateMinutes * 60,
+            'net_worked_minutes' => $netWorkedMinutes,
+            'overtime_minutes' => 0,
+            'overtime_authorized' => false,
+            'day_status' => DayStatus::WORKED->value,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ];
+    }
+
+    /** A day with no clock events: DAY_OFF, ABSENCE, or LEAVE. */
+    private function simpleRow(int $employeeId, string $date, DayStatus $status, Carbon $now): array
+    {
+        return [
+            'employee_id' => $employeeId,
+            'public_id' => (string) Str::ulid(),
+            'date' => $date,
+            'check_in' => null,
+            'check_out' => null,
+            'lunch_start' => null,
+            'lunch_end' => null,
+            'entry_late_seconds' => 0,
+            'lunch_late_seconds' => 0,
+            'net_worked_minutes' => null,
+            'overtime_minutes' => 0,
+            'overtime_authorized' => false,
+            'day_status' => $status->value,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ];
+    }
+}

--- a/code/api/database/seeders/Development/AttendanceHistorySeeder.php
+++ b/code/api/database/seeders/Development/AttendanceHistorySeeder.php
@@ -73,6 +73,8 @@ class AttendanceHistorySeeder extends OnceSeeder
 
     private const DEFAULT_REST_DOW = 7; // Sunday
 
+    private const DB_DATETIME_FORMAT = 'Y-m-d H:i:s';
+
     private string $businessTimezone;
 
     private string $today;
@@ -133,76 +135,108 @@ class AttendanceHistorySeeder extends OnceSeeder
         $todayCarbon = Carbon::parse($this->today);
 
         foreach ($periods as $period) {
-            $employeeId = $period->employee_id;
-            $cursor = Carbon::parse($period->start_date);
-            $end = $period->end_date ? Carbon::parse($period->end_date) : $todayCarbon->copy();
-            if ($end->gt($todayCarbon)) {
-                $end = $todayCarbon->copy();
-            }
-
-            if ($cursor->gt($end)) {
-                continue;
-            }
-
-            // Idempotency guard — skip this period's range if already seeded (e.g. re-running locally).
-            $alreadySeeded = DB::table('attendances')
-                ->where('employee_id', $employeeId)
-                ->whereBetween('date', [$cursor->toDateString(), $end->toDateString()])
-                ->exists();
-            if ($alreadySeeded) {
-                continue;
-            }
-
-            $daysLeftInBlock = 0;
-
-            while ($cursor->lte($end)) {
-                $date = $cursor->toDateString();
-
-                if ($daysLeftInBlock > 0) {
-                    $rows[] = $this->simpleRow($employeeId, $date, DayStatus::LEAVE, $now);
-                    $daysLeftInBlock--;
-                    $cursor->addDay();
-
-                    continue;
-                }
-
-                $scheduleDay = $this->resolveScheduleDay($date, $cursor->dayOfWeekIso, $period);
-
-                if (! $scheduleDay) {
-                    $rows[] = $this->simpleRow($employeeId, $date, DayStatus::DAY_OFF, $now);
-                    $cursor->addDay();
-
-                    continue;
-                }
-
-                $roll = mt_rand(1, 100);
-
-                if ($roll <= self::VACATION_CHANCE) {
-                    $blockLen = mt_rand(3, 6);
-                    $blockEnd = (clone $cursor)->addDays($blockLen - 1)->min($end);
-                    $daysLeftInBlock = $cursor->diffInDays($blockEnd);
-                    $this->createLeave($employeeId, $date, $blockEnd->toDateString(), LeaveType::PERMISSION_PAID, 'Vacaciones');
-                    $leaveCount++;
-                    $rows[] = $this->simpleRow($employeeId, $date, DayStatus::LEAVE, $now);
-                } elseif ($roll <= self::VACATION_CHANCE + self::PERMISSION_CHANCE) {
-                    $blockLen = mt_rand(1, 2);
-                    $blockEnd = (clone $cursor)->addDays($blockLen - 1)->min($end);
-                    $daysLeftInBlock = $cursor->diffInDays($blockEnd);
-                    [$typeCode, $notes] = $this->randomPermissionType();
-                    $this->createLeave($employeeId, $date, $blockEnd->toDateString(), $typeCode, $notes);
-                    $leaveCount++;
-                    $rows[] = $this->simpleRow($employeeId, $date, DayStatus::LEAVE, $now);
-                } elseif ($roll <= self::VACATION_CHANCE + self::PERMISSION_CHANCE + self::ABSENCE_CHANCE) {
-                    $rows[] = $this->simpleRow($employeeId, $date, DayStatus::ABSENCE, $now);
-                } else {
-                    $rows[] = $this->workedRow($employeeId, $date, $scheduleDay, $now);
-                }
-
-                $cursor->addDay();
-            }
+            [$periodRows, $periodLeaves] = $this->buildPeriodHistory($period, $todayCarbon, $now);
+            $rows = [...$rows, ...$periodRows];
+            $leaveCount += $periodLeaves;
         }
 
         return [$rows, $leaveCount];
+    }
+
+    /**
+     * Builds attendance rows for a single employment period, day by day.
+     *
+     * @return array{0: list<array<string, mixed>>, 1: int} [attendance rows, leave count]
+     */
+    private function buildPeriodHistory(EmploymentPeriod $period, Carbon $todayCarbon, Carbon $now): array
+    {
+        $employeeId = $period->employee_id;
+        $cursor = Carbon::parse($period->start_date);
+        $end = $period->end_date ? Carbon::parse($period->end_date) : $todayCarbon->copy();
+        if ($end->gt($todayCarbon)) {
+            $end = $todayCarbon->copy();
+        }
+
+        if ($cursor->gt($end) || $this->periodAlreadySeeded($employeeId, $cursor, $end)) {
+            return [[], 0];
+        }
+
+        $rows = [];
+        $leaveCount = 0;
+        $daysLeftInBlock = 0;
+
+        while ($cursor->lte($end)) {
+            $date = $cursor->toDateString();
+
+            if ($daysLeftInBlock > 0) {
+                $rows[] = $this->simpleRow($employeeId, $date, DayStatus::LEAVE, $now);
+                $daysLeftInBlock--;
+                $cursor->addDay();
+
+                continue;
+            }
+
+            $scheduleDay = $this->resolveScheduleDay($date, $cursor->dayOfWeekIso, $period);
+
+            if (! $scheduleDay) {
+                $rows[] = $this->simpleRow($employeeId, $date, DayStatus::DAY_OFF, $now);
+                $cursor->addDay();
+
+                continue;
+            }
+
+            [$dayRows, $daysLeftInBlock, $leaveAdded] = $this->rollWorkingDay($employeeId, $date, $scheduleDay, $cursor, $end, $now);
+            $rows = [...$rows, ...$dayRows];
+            $leaveCount += $leaveAdded;
+
+            $cursor->addDay();
+        }
+
+        return [$rows, $leaveCount];
+    }
+
+    /** Idempotency guard — true if this period's range was already seeded (e.g. re-running locally). */
+    private function periodAlreadySeeded(int $employeeId, Carbon $cursor, Carbon $end): bool
+    {
+        return DB::table('attendances')
+            ->where('employee_id', $employeeId)
+            ->whereBetween('date', [$cursor->toDateString(), $end->toDateString()])
+            ->exists();
+    }
+
+    /**
+     * Rolls the weighted outcome for one working day: vacation/permission block,
+     * unexcused absence, or a normal worked day.
+     *
+     * @param  array{start: string, end: string, lunch_start: ?string, lunch_end: ?string}  $scheduleDay
+     * @return array{0: list<array<string, mixed>>, 1: int, 2: int} [rows, daysLeftInBlock, leaveCount added]
+     */
+    private function rollWorkingDay(int $employeeId, string $date, array $scheduleDay, Carbon $cursor, Carbon $end, Carbon $now): array
+    {
+        $roll = random_int(1, 100);
+        $daysLeftInBlock = 0;
+        $leaveAdded = 0;
+
+        if ($roll <= self::VACATION_CHANCE) {
+            $blockEnd = (clone $cursor)->addDays(random_int(3, 6) - 1)->min($end);
+            $this->createLeave($employeeId, $date, $blockEnd->toDateString(), LeaveType::PERMISSION_PAID, 'Vacaciones');
+            $rows = [$this->simpleRow($employeeId, $date, DayStatus::LEAVE, $now)];
+            $daysLeftInBlock = $cursor->diffInDays($blockEnd);
+            $leaveAdded = 1;
+        } elseif ($roll <= self::VACATION_CHANCE + self::PERMISSION_CHANCE) {
+            $blockEnd = (clone $cursor)->addDays(random_int(1, 2) - 1)->min($end);
+            [$typeCode, $notes] = $this->randomPermissionType();
+            $this->createLeave($employeeId, $date, $blockEnd->toDateString(), $typeCode, $notes);
+            $rows = [$this->simpleRow($employeeId, $date, DayStatus::LEAVE, $now)];
+            $daysLeftInBlock = $cursor->diffInDays($blockEnd);
+            $leaveAdded = 1;
+        } elseif ($roll <= self::VACATION_CHANCE + self::PERMISSION_CHANCE + self::ABSENCE_CHANCE) {
+            $rows = [$this->simpleRow($employeeId, $date, DayStatus::ABSENCE, $now)];
+        } else {
+            $rows = [$this->workedRow($employeeId, $date, $scheduleDay, $now)];
+        }
+
+        return [$rows, $daysLeftInBlock, $leaveAdded];
     }
 
     /**
@@ -297,15 +331,15 @@ class AttendanceHistorySeeder extends OnceSeeder
         $lunchStart = $shift['lunch_start'];
         $lunchEnd = $shift['lunch_end'];
 
-        $lateMinutes = mt_rand(1, 100) <= self::LATE_CHANCE
-            ? mt_rand(self::LATE_MIN_MINUTES, self::LATE_MAX_MINUTES)
+        $lateMinutes = random_int(1, 100) <= self::LATE_CHANCE
+            ? random_int(self::LATE_MIN_MINUTES, self::LATE_MAX_MINUTES)
             : 0;
 
         $checkIn = Carbon::parse("{$date} {$expectedStart}", $this->businessTimezone)->addMinutes($lateMinutes);
         $checkOut = Carbon::parse("{$date} {$expectedEnd}", $this->businessTimezone);
 
-        $lunchLateMinutes = ($lunchStart && $lunchEnd && mt_rand(1, 100) <= self::LUNCH_LATE_CHANCE)
-            ? mt_rand(self::LUNCH_LATE_MIN_MINUTES, self::LUNCH_LATE_MAX_MINUTES)
+        $lunchLateMinutes = ($lunchStart && $lunchEnd && random_int(1, 100) <= self::LUNCH_LATE_CHANCE)
+            ? random_int(self::LUNCH_LATE_MIN_MINUTES, self::LUNCH_LATE_MAX_MINUTES)
             : 0;
 
         $lunchStartAt = $lunchStart ? Carbon::parse("{$date} {$lunchStart}", $this->businessTimezone) : null;
@@ -318,10 +352,10 @@ class AttendanceHistorySeeder extends OnceSeeder
             'employee_id' => $employeeId,
             'public_id' => (string) Str::ulid(),
             'date' => $date,
-            'check_in' => $checkIn->clone()->utc()->format('Y-m-d H:i:s'),
-            'check_out' => $checkOut->clone()->utc()->format('Y-m-d H:i:s'),
-            'lunch_start' => $lunchStartAt?->clone()->utc()->format('Y-m-d H:i:s'),
-            'lunch_end' => $lunchEndAt?->clone()->utc()->format('Y-m-d H:i:s'),
+            'check_in' => $checkIn->clone()->utc()->format(self::DB_DATETIME_FORMAT),
+            'check_out' => $checkOut->clone()->utc()->format(self::DB_DATETIME_FORMAT),
+            'lunch_start' => $lunchStartAt?->clone()->utc()->format(self::DB_DATETIME_FORMAT),
+            'lunch_end' => $lunchEndAt?->clone()->utc()->format(self::DB_DATETIME_FORMAT),
             'entry_late_seconds' => $lateMinutes * 60,
             'lunch_late_seconds' => $lunchLateMinutes * 60,
             'net_worked_minutes' => $netWorkedMinutes,

--- a/code/api/database/seeders/Development/DevelopmentSeeder.php
+++ b/code/api/database/seeders/Development/DevelopmentSeeder.php
@@ -36,6 +36,7 @@ class DevelopmentSeeder extends Seeder
             \Database\Seeders\UomConversionSeeder::class,
             AttendanceAuditLogSeeder::class,
             \Database\Seeders\LeaveTypeSeeder::class,
+            AttendanceHistorySeeder::class,
             PunctualityRangeSeeder::class,
             PunctualityBonusGroupSeeder::class,
             HolidayDefinitionSeeder::class,

--- a/code/api/database/seeders/Development/EmployeeSeeder.php
+++ b/code/api/database/seeders/Development/EmployeeSeeder.php
@@ -42,7 +42,6 @@ class EmployeeSeeder extends OnceSeeder
         }
 
         $this->seedConfigEmployees($action, $branch);
-        $this->seedFactoryEmployees($branch);
         $this->seedFactoryBaja($branch);
         $this->seedDosReingresos($action, $branch);
         $this->seedReingresoTres($action, $branch);
@@ -92,34 +91,6 @@ class EmployeeSeeder extends OnceSeeder
 
             $this->command->info("✓ Employee created: {$employee->code} - {$employee->first_name} {$employee->last_name} (hired: {$hireDate->toDateString()}, user: {$credential}, roles: {$roles})");
         }
-    }
-
-    /**
-     * Create random employees with linked user accounts via factory
-     * and assign them to the main branch with an employment period.
-     */
-    private function seedFactoryEmployees(Branch $branch): void
-    {
-        $factoryCount = config('seeders.factory_counts.employees', 5);
-        $factoryEmployees = Employee::factory($factoryCount)->withUser()->create();
-
-        foreach ($factoryEmployees as $employee) {
-            $hireDate = $this->randomDateBetween(now()->subYears(3), now());
-
-            $period = EmploymentPeriod::factory()->create([
-                'employee_id' => $employee->id,
-                'branch_id' => $branch->id,
-                'start_date' => $hireDate->toDateString(),
-                'is_active' => true,
-            ]);
-
-            // Align all timestamps to the hire date
-            $employee->update(['created_at' => $hireDate, 'updated_at' => $hireDate]);
-            $period->update(['created_at' => $hireDate, 'updated_at' => $hireDate]);
-            $employee->user?->update(['created_at' => $hireDate, 'updated_at' => $hireDate]);
-        }
-
-        $this->command->info("✓ Created {$factoryCount} random employees with users (factory) assigned to branch: {$branch->name}");
     }
 
     /**

--- a/code/api/database/seeders/Development/PermissionSeeder.php
+++ b/code/api/database/seeders/Development/PermissionSeeder.php
@@ -133,6 +133,7 @@ class PermissionSeeder extends LockedSeeder
 
             // Reportes
             'reports.today' => ['label' => 'Ver reporte operacional del día', 'group' => 'Reportes'],
+            'reports.weekly-summary' => ['label' => 'Ver resumen semanal por empleado', 'group' => 'Reportes'],
 
             // Nómina
             'payroll.preview' => ['label' => 'Ver preview de cierre de nómina', 'group' => 'Nómina'],

--- a/code/api/database/seeders/Development/UserSeeder.php
+++ b/code/api/database/seeders/Development/UserSeeder.php
@@ -56,6 +56,7 @@ class UserSeeder extends OnceSeeder
                         'first_name' => $empData['first_name'],
                         'last_name' => $empData['last_name'],
                         'is_active' => true,
+                        'attendance_exempt' => $empData['attendance_exempt'] ?? false,
                         'created_at' => $hireDate,
                         'updated_at' => $hireDate,
                     ]);
@@ -131,10 +132,6 @@ class UserSeeder extends OnceSeeder
                 }
             }
         }
-
-        $factoryCount = config('seeders.factory_counts.users', 10);
-        User::factory($factoryCount)->create();
-        $this->command->info("✓ Created {$factoryCount} random users");
 
         $this->command->info('✓ Development users seeded successfully');
     }

--- a/code/api/database/seeders/Testing/CoreTestSeeder.php
+++ b/code/api/database/seeders/Testing/CoreTestSeeder.php
@@ -95,6 +95,7 @@ class CoreTestSeeder extends Seeder
         'attendances.create',
         'punctuality.manage',
         'reports.today',
+        'reports.weekly-summary',
         'holidays.manage',
         'payroll.preview',
     ];

--- a/code/api/database/seeders/Testing/WeeklySummarySeeder.php
+++ b/code/api/database/seeders/Testing/WeeklySummarySeeder.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Database\Seeders\Testing;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+/**
+ * Weekly summary seeder — one full week of attendance for EMP-001.
+ *
+ * Period: 2026-06-16 (Mon) to 2026-06-22 (Sun)
+ * Schedule from AttendanceTestSeeder: 13:00-22:00 Mon-Sat, lunch 15:00-15:30
+ *
+ * Attendance map:
+ *   2026-06-16 Mon — WORKED, entry 60 min late (entry_late_seconds = 3600, deductible)
+ *   2026-06-17 Tue — WORKED, on time
+ *   2026-06-18 Wed — WORKED, on time
+ *   2026-06-19 Thu — WORKED, on time
+ *   2026-06-20 Fri — WORKED, on time
+ *   2026-06-21 Sat — WORKED, on time
+ *   2026-06-22 Sun — DAY_OFF
+ *
+ * Expected payroll (AttendanceTestSeeder wages: 40.00/h, 54h/week, 6 working days):
+ *   daily_rate          = 40 × (54/6)   = 360.00
+ *   rest_day_portion    = 360 / 6       = 60.00
+ *   base_pay            = 6 × (360+60)  = 2520.00
+ *   late_deductions     = 60 × (40/60)  = 40.00  (1 day × 60 min × minuteRate)
+ *   punctuality_bonus   = 0.00          (no EmployeeBonusConfig seeded)
+ *   total_pay           = 2480.00
+ *
+ * Used by the attendance-weekly-summary Cypress spec via:
+ *   cy.task('test:reset', 'weekly-summary')
+ *
+ * Requires: CoreTestSeeder + AttendanceTestSeeder ran first.
+ */
+class WeeklySummarySeeder extends Seeder
+{
+    // 14:00 CDMX (UTC-6) = 20:00 UTC — exactly 1h late on Jun 16 (shift starts 13:00 CDMX = 19:00 UTC)
+    private const LATE_CHECKIN_UTC = '2026-06-16 20:00:00';
+
+    private const ON_TIME_CHECKIN = '19:00:00'; // 13:00 CDMX
+
+    private const CHECKOUT_UTC = '04:00:00';    // 22:00 CDMX next day UTC
+
+    private const LUNCH_START = '21:00:00';     // 15:00 CDMX
+
+    private const LUNCH_END = '21:30:00';       // 15:30 CDMX
+
+    public function run(): void
+    {
+        $now = now();
+
+        $employeeId = DB::table('employees')->where('code', 'EMP-001')->value('id');
+
+        $this->seedAttendances($employeeId, $now);
+    }
+
+    private function seedAttendances(int $employeeId, mixed $now): void
+    {
+        $days = [
+            // Mon — 60 min late
+            [
+                'date' => '2026-06-16',
+                'check_in' => self::LATE_CHECKIN_UTC,
+                'check_out' => '2026-06-17 '.self::CHECKOUT_UTC,
+                'entry_late_seconds' => 3600,
+                'day_status' => 'WORKED',
+            ],
+            // Tue-Sat — on time
+            ['date' => '2026-06-17', 'check_in' => '2026-06-17 '.self::ON_TIME_CHECKIN, 'check_out' => '2026-06-18 '.self::CHECKOUT_UTC, 'entry_late_seconds' => 0, 'day_status' => 'WORKED'],
+            ['date' => '2026-06-18', 'check_in' => '2026-06-18 '.self::ON_TIME_CHECKIN, 'check_out' => '2026-06-19 '.self::CHECKOUT_UTC, 'entry_late_seconds' => 0, 'day_status' => 'WORKED'],
+            ['date' => '2026-06-19', 'check_in' => '2026-06-19 '.self::ON_TIME_CHECKIN, 'check_out' => '2026-06-20 '.self::CHECKOUT_UTC, 'entry_late_seconds' => 0, 'day_status' => 'WORKED'],
+            ['date' => '2026-06-20', 'check_in' => '2026-06-20 '.self::ON_TIME_CHECKIN, 'check_out' => '2026-06-21 '.self::CHECKOUT_UTC, 'entry_late_seconds' => 0, 'day_status' => 'WORKED'],
+            ['date' => '2026-06-21', 'check_in' => '2026-06-21 '.self::ON_TIME_CHECKIN, 'check_out' => '2026-06-22 '.self::CHECKOUT_UTC, 'entry_late_seconds' => 0, 'day_status' => 'WORKED'],
+            // Sun — DAY_OFF
+            ['date' => '2026-06-22', 'check_in' => null, 'check_out' => null, 'entry_late_seconds' => 0, 'day_status' => 'DAY_OFF'],
+        ];
+
+        $rows = [];
+
+        foreach ($days as $day) {
+            $lunchStart = ($day['day_status'] === 'WORKED' && $day['check_in'])
+                ? substr($day['date'], 0, 10).' '.self::LUNCH_START
+                : null;
+            $lunchEnd = ($day['day_status'] === 'WORKED' && $day['check_in'])
+                ? substr($day['date'], 0, 10).' '.self::LUNCH_END
+                : null;
+
+            $rows[] = [
+                'employee_id' => $employeeId,
+                'date' => $day['date'],
+                'check_in' => $day['check_in'],
+                'check_out' => $day['check_out'],
+                'lunch_start' => $lunchStart,
+                'lunch_end' => $lunchEnd,
+                'entry_late_seconds' => $day['entry_late_seconds'],
+                'lunch_late_seconds' => 0,
+                'net_worked_minutes' => null,
+                'overtime_minutes' => 0,
+                'overtime_authorized' => false,
+                'overtime_authorized_by' => null,
+                'overtime_authorized_at' => null,
+                'day_status' => $day['day_status'],
+                'confirmed_by' => null,
+                'meta' => null,
+                'public_id' => (string) Str::ulid(),
+                'created_at' => $now,
+                'updated_at' => $now,
+            ];
+        }
+
+        DB::table('attendances')->insert($rows);
+    }
+}

--- a/code/api/routes/api.php
+++ b/code/api/routes/api.php
@@ -92,6 +92,7 @@ use App\Http\Controllers\Api\V1\Punctuality\ListPunctualityBonusGroupsController
 use App\Http\Controllers\Api\V1\Punctuality\ListPunctualityRangesController;
 use App\Http\Controllers\Api\V1\Punctuality\UpdatePunctualityRangesController;
 use App\Http\Controllers\Api\V1\Reports\TodayReportController;
+use App\Http\Controllers\Api\V1\Reports\WeeklySummaryController;
 use App\Http\Controllers\Api\V1\Schedules\CreateScheduleController;
 use App\Http\Controllers\Api\V1\Schedules\CreateScheduleDayOverrideController;
 use App\Http\Controllers\Api\V1\Schedules\CurrentScheduleController;
@@ -353,6 +354,7 @@ Route::prefix('v1')->group(function () {
     // Reports Module
     Route::middleware('auth:api')->prefix('reports')->name('reports.')->group(function () {
         Route::get('today', TodayReportController::class)->name('today');
+        Route::get('weekly-summary', WeeklySummaryController::class)->name('weekly-summary');
     });
 
     // Negotiated Extra Days Module (All Protected)

--- a/code/api/tests/Feature/AttendancePayroll/CreateEmployeeActionTest.php
+++ b/code/api/tests/Feature/AttendancePayroll/CreateEmployeeActionTest.php
@@ -298,6 +298,39 @@ class CreateEmployeeActionTest extends TestCase
     }
 
     #[Test]
+    public function it_defaults_attendance_exempt_to_false(): void
+    {
+        $employee = ($this->action)([
+            'code' => 'EMP-EXEMPT-DEFAULT',
+            'first_name' => 'Default',
+            'last_name' => 'Exempt',
+            'roles' => ['cook'],
+            'email' => 'default-exempt@sushigo.com',
+            'branch_id' => $this->branch->id,
+            'start_date' => '2026-01-15',
+        ]);
+
+        $this->assertFalse($employee->attendance_exempt);
+    }
+
+    #[Test]
+    public function it_can_create_attendance_exempt_employee(): void
+    {
+        $employee = ($this->action)([
+            'code' => 'EMP-EXEMPT',
+            'first_name' => 'Admin',
+            'last_name' => 'Free',
+            'roles' => ['admin'],
+            'email' => 'exempt@sushigo.com',
+            'branch_id' => $this->branch->id,
+            'start_date' => '2026-01-15',
+            'attendance_exempt' => true,
+        ]);
+
+        $this->assertTrue($employee->attendance_exempt);
+    }
+
+    #[Test]
     public function it_eager_loads_user_relation(): void
     {
         $employee = ($this->action)([

--- a/code/api/tests/Feature/AttendancePayroll/EmployeeModelTest.php
+++ b/code/api/tests/Feature/AttendancePayroll/EmployeeModelTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\AttendancePayroll;
 
 use App\Http\Resources\Employee\EmployeeResource;
 use App\Models\Employee;
+use App\Models\OvertimeBankMovement;
 use App\Models\User;
 use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -237,5 +238,19 @@ class EmployeeModelTest extends TestCase
         $this->assertContains(Employee::ROLE_COOK, $resourceArray['roles']);
         $this->assertContains(Employee::ROLE_DELIVERY_DRIVER, $resourceArray['roles']);
         $this->assertArrayNotHasKey('role', $resourceArray);
+    }
+
+    #[Test]
+    public function it_lists_overtime_bank_movements_ordered_by_date_desc(): void
+    {
+        $employee = Employee::factory()->create();
+        $older = OvertimeBankMovement::factory()->for($employee)->create(['date' => now()->subDays(5)]);
+        $newer = OvertimeBankMovement::factory()->for($employee)->create(['date' => now()]);
+
+        $movements = $employee->overtimeBankMovements;
+
+        $this->assertCount(2, $movements);
+        $this->assertEquals($newer->id, $movements->first()->id);
+        $this->assertEquals($older->id, $movements->last()->id);
     }
 }

--- a/code/api/tests/Feature/AttendancePayroll/TodayAttendanceApiTest.php
+++ b/code/api/tests/Feature/AttendancePayroll/TodayAttendanceApiTest.php
@@ -72,6 +72,21 @@ class TodayAttendanceApiTest extends TestCase
     }
 
     #[Test]
+    public function excludes_employees_marked_attendance_exempt(): void
+    {
+        $tracked = $this->makeEmployeeForBranch($this->branch);
+        $exempt = $this->makeEmployeeForBranch($this->branch);
+        $exempt->update(['attendance_exempt' => true]);
+
+        $response = $this->getJson("/api/v1/attendances/today?branch_id={$this->branch->id}");
+
+        $response->assertStatus(200);
+        $ids = collect($response->json('data'))->pluck('employee.id');
+        $this->assertTrue($ids->contains($tracked->public_id));
+        $this->assertFalse($ids->contains($exempt->public_id));
+    }
+
+    #[Test]
     public function employees_without_attendance_have_null_attendance(): void
     {
         $employee = $this->makeEmployeeForBranch($this->branch);

--- a/code/api/tests/Feature/AttendancePayroll/WeeklySummaryApiTest.php
+++ b/code/api/tests/Feature/AttendancePayroll/WeeklySummaryApiTest.php
@@ -236,6 +236,29 @@ class WeeklySummaryApiTest extends TestCase
     }
 
     #[Test]
+    public function extra_day_does_not_dilute_base_pay(): void
+    {
+        // Same 6 WORKED + 1 EXTRA shape as extra_day_pay_returns_agreed_daily_wage.
+        // The extra (rest-day) shift must not count toward scheduledWorkingDays —
+        // it is compensated separately via extra_day_pay — so base_pay should match
+        // the 6-worked + 1-day-off scenario (1120.0), not a diluted ~940.
+        $this->createWeek([
+            [DayStatus::WORKED, 0],
+            [DayStatus::WORKED, 0],
+            [DayStatus::WORKED, 0],
+            [DayStatus::WORKED, 0],
+            [DayStatus::WORKED, 0],
+            [DayStatus::WORKED, 0],
+            [DayStatus::EXTRA, 0],
+        ]);
+
+        $response = $this->getJson($this->url($this->employee->public_id, '2026-06-16', '2026-06-22'));
+        $response->assertStatus(200);
+
+        $this->assertEqualsWithDelta(1120.0, $response->json('data.base_pay'), 0.01);
+    }
+
+    #[Test]
     public function daily_evidence_has_correct_count(): void
     {
         $this->createWeek([

--- a/code/api/tests/Feature/AttendancePayroll/WeeklySummaryApiTest.php
+++ b/code/api/tests/Feature/AttendancePayroll/WeeklySummaryApiTest.php
@@ -302,6 +302,17 @@ class WeeklySummaryApiTest extends TestCase
     }
 
     #[Test]
+    public function returns_422_when_employee_is_soft_deleted(): void
+    {
+        $deleted = Employee::factory()->create();
+        $deleted->delete();
+
+        $this->getJson($this->url($deleted->public_id, '2026-06-16', '2026-06-22'))
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['employee_id']);
+    }
+
+    #[Test]
     public function returns_422_when_period_end_before_period_start(): void
     {
         $this->getJson($this->url($this->employee->public_id, '2026-06-22', '2026-06-16'))

--- a/code/api/tests/Feature/AttendancePayroll/WeeklySummaryApiTest.php
+++ b/code/api/tests/Feature/AttendancePayroll/WeeklySummaryApiTest.php
@@ -1,0 +1,311 @@
+<?php
+
+namespace Tests\Feature\AttendancePayroll;
+
+use App\Enums\DayStatus;
+use App\Models\Attendance;
+use App\Models\Branch;
+use App\Models\Employee;
+use App\Models\EmployeeBonusConfig;
+use App\Models\NegotiatedExtraDay;
+use App\Models\PunctualityBonusGroup;
+use App\Models\PunctualityRange;
+use App\Models\User;
+use App\Models\WageHistory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+/**
+ * Feature tests for GET /api/v1/reports/weekly-summary
+ *
+ * Covers:
+ *   - Happy path: returns full financial breakdown + daily evidence
+ *   - Correct base_pay with rest day proration
+ *   - Correct late_deductions for entry/lunch tardiness >30 min
+ *   - Correct punctuality_bonus from PunctualityService
+ *   - Correct extra_day_pay from NegotiatedExtraDay
+ *   - 401 when unauthenticated
+ *   - 403 when user lacks reports.weekly-summary permission
+ *   - 422 when required params are missing or invalid
+ */
+class WeeklySummaryApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $manager;
+
+    private Employee $employee;
+
+    private Branch $branch;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        app()[PermissionRegistrar::class]->forgetCachedPermissions();
+
+        Permission::create(['name' => 'reports.weekly-summary', 'guard_name' => 'api']);
+        $role = Role::create(['name' => 'manager', 'guard_name' => 'api']);
+        $role->givePermissionTo('reports.weekly-summary');
+
+        foreach (Employee::POSITION_ROLES as $roleName) {
+            Role::firstOrCreate(['name' => $roleName, 'guard_name' => 'api']);
+        }
+
+        $this->manager = User::factory()->create();
+        $this->manager->assignRole('manager');
+        $this->branch = Branch::factory()->create();
+        $this->employee = Employee::factory()->create();
+
+        WageHistory::create([
+            'employee_id' => $this->employee->id,
+            'hourly_rate' => '20.00',
+            'weekly_scheduled_hours' => '48.00',
+            'effective_from' => '2026-01-01',
+        ]);
+
+        // Bonus group + ranges
+        $group = PunctualityBonusGroup::create([
+            'name' => 'Grupo $110',
+            'weekly_bonus_amount' => '110.00',
+            'working_days_divisor' => 6,
+            'is_active' => true,
+        ]);
+
+        EmployeeBonusConfig::create([
+            'employee_id' => $this->employee->id,
+            'punctuality_bonus_group_id' => $group->id,
+            'effective_from' => '2026-01-01',
+            'effective_to' => null,
+        ]);
+
+        PunctualityRange::create(['min_seconds' => 0, 'max_seconds' => 0, 'bonus_percentage' => '100.00', 'sort_order' => 1]);
+        PunctualityRange::create(['min_seconds' => 1, 'max_seconds' => 1800, 'bonus_percentage' => '50.00', 'sort_order' => 2]);
+        PunctualityRange::create(['min_seconds' => 1801, 'max_seconds' => null, 'bonus_percentage' => '0.00', 'sort_order' => 3]);
+
+        Passport::actingAs($this->manager);
+    }
+
+    private function url(string $employeeId, string $start, string $end): string
+    {
+        return "/api/v1/reports/weekly-summary?employee_id={$employeeId}&period_start={$start}&period_end={$end}";
+    }
+
+    private function createWeek(array $statuses): void
+    {
+        $dates = ['2026-06-16', '2026-06-17', '2026-06-18', '2026-06-19', '2026-06-20', '2026-06-21', '2026-06-22'];
+
+        foreach ($dates as $i => $date) {
+            [$status, $lateSeconds] = $statuses[$i] ?? [DayStatus::DAY_OFF, 0];
+
+            Attendance::create([
+                'employee_id' => $this->employee->id,
+                'date' => $date,
+                'day_status' => $status,
+                'entry_late_seconds' => $lateSeconds,
+                'lunch_late_seconds' => 0,
+            ]);
+        }
+    }
+
+    // ── Happy path ───────────────────────────────────────────────────────────
+
+    #[Test]
+    public function returns_200_with_full_breakdown_for_worked_week(): void
+    {
+        $this->createWeek([
+            [DayStatus::WORKED, 0],
+            [DayStatus::WORKED, 0],
+            [DayStatus::WORKED, 0],
+            [DayStatus::WORKED, 0],
+            [DayStatus::WORKED, 0],
+            [DayStatus::WORKED, 0],
+            [DayStatus::DAY_OFF, 0],
+        ]);
+
+        $response = $this->getJson($this->url(
+            $this->employee->public_id,
+            '2026-06-16',
+            '2026-06-22'
+        ));
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'status',
+                'data' => [
+                    'employee_id',
+                    'period_start',
+                    'period_end',
+                    'base_pay',
+                    'late_deductions',
+                    'unpaid_leave_deductions',
+                    'overtime_pay',
+                    'extra_day_pay',
+                    'holiday_pay',
+                    'punctuality_bonus',
+                    'free_hours_earned',
+                    'total_pay',
+                    'daily_evidence' => [
+                        '*' => [
+                            'date',
+                            'check_in',
+                            'check_out',
+                            'day_status',
+                            'late_minutes',
+                            'deducted_minutes',
+                            'partial_leaves',
+                            'overtime_minutes',
+                            'overtime_authorized',
+                        ],
+                    ],
+                ],
+            ]);
+    }
+
+    #[Test]
+    public function base_pay_includes_rest_day_proration(): void
+    {
+        // 6 worked + 1 day_off
+        $this->createWeek([
+            [DayStatus::WORKED, 0],
+            [DayStatus::WORKED, 0],
+            [DayStatus::WORKED, 0],
+            [DayStatus::WORKED, 0],
+            [DayStatus::WORKED, 0],
+            [DayStatus::WORKED, 0],
+            [DayStatus::DAY_OFF, 0],
+        ]);
+
+        $response = $this->getJson($this->url($this->employee->public_id, '2026-06-16', '2026-06-22'));
+        $response->assertStatus(200);
+
+        // daily_rate = 20 × 8 = 160; base = 6 × 160 × (7/6) = 1120
+        $this->assertEqualsWithDelta(1120.0, $response->json('data.base_pay'), 0.01);
+    }
+
+    #[Test]
+    public function late_deductions_applied_only_for_over_30_min(): void
+    {
+        $this->createWeek([]);
+        // Overwrite day 1 with entry late > 30 min
+        Attendance::where('employee_id', $this->employee->id)->where('date', '2026-06-16')
+            ->update(['day_status' => DayStatus::WORKED, 'entry_late_seconds' => 3600]);
+        Attendance::where('employee_id', $this->employee->id)->where('date', '2026-06-22')
+            ->update(['day_status' => DayStatus::DAY_OFF]);
+
+        $response = $this->getJson($this->url($this->employee->public_id, '2026-06-16', '2026-06-22'));
+        $response->assertStatus(200);
+
+        // minuteRate = 20/60 = 0.333; 60 min × 0.333 = 20
+        $this->assertGreaterThan(0, $response->json('data.late_deductions'));
+    }
+
+    #[Test]
+    public function extra_day_pay_returns_agreed_daily_wage(): void
+    {
+        $this->createWeek([
+            [DayStatus::WORKED, 0],
+            [DayStatus::WORKED, 0],
+            [DayStatus::WORKED, 0],
+            [DayStatus::WORKED, 0],
+            [DayStatus::WORKED, 0],
+            [DayStatus::WORKED, 0],
+            [DayStatus::EXTRA, 0],
+        ]);
+
+        NegotiatedExtraDay::create([
+            'employee_id' => $this->employee->id,
+            'branch_id' => $this->branch->id,
+            'date' => '2026-06-22',
+            'agreed_daily_wage' => '500.00',
+            'prima_percent' => '25.0000',
+            'prima_amount' => '125.00',
+            'status' => NegotiatedExtraDay::STATUS_APPROVED,
+            'approved_by' => $this->manager->id,
+        ]);
+
+        $response = $this->getJson($this->url($this->employee->public_id, '2026-06-16', '2026-06-22'));
+        $response->assertStatus(200);
+
+        $this->assertEqualsWithDelta(500.0, $response->json('data.extra_day_pay'), 0.01);
+    }
+
+    #[Test]
+    public function daily_evidence_has_correct_count(): void
+    {
+        $this->createWeek([
+            [DayStatus::WORKED, 0],
+            [DayStatus::WORKED, 0],
+            [DayStatus::WORKED, 0],
+            [DayStatus::WORKED, 0],
+            [DayStatus::WORKED, 0],
+            [DayStatus::WORKED, 0],
+            [DayStatus::DAY_OFF, 0],
+        ]);
+
+        $response = $this->getJson($this->url($this->employee->public_id, '2026-06-16', '2026-06-22'));
+        $response->assertStatus(200);
+
+        $this->assertCount(7, $response->json('data.daily_evidence'));
+    }
+
+    // ── Auth / authorization ─────────────────────────────────────────────────
+
+    #[Test]
+    public function returns_401_when_unauthenticated(): void
+    {
+        auth()->forgetGuards();
+
+        $this->getJson($this->url($this->employee->public_id, '2026-06-16', '2026-06-22'))
+            ->assertStatus(401);
+    }
+
+    #[Test]
+    public function returns_403_when_user_lacks_permission(): void
+    {
+        $noPermUser = User::factory()->create();
+        Passport::actingAs($noPermUser);
+
+        $this->getJson($this->url($this->employee->public_id, '2026-06-16', '2026-06-22'))
+            ->assertStatus(403);
+    }
+
+    // ── Validation ───────────────────────────────────────────────────────────
+
+    #[Test]
+    public function returns_422_when_employee_id_missing(): void
+    {
+        $this->getJson('/api/v1/reports/weekly-summary?period_start=2026-06-16&period_end=2026-06-22')
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['employee_id']);
+    }
+
+    #[Test]
+    public function returns_422_when_period_start_missing(): void
+    {
+        $this->getJson("/api/v1/reports/weekly-summary?employee_id={$this->employee->public_id}&period_end=2026-06-22")
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['period_start']);
+    }
+
+    #[Test]
+    public function returns_422_when_employee_not_found(): void
+    {
+        $this->getJson($this->url('nonexistent-id', '2026-06-16', '2026-06-22'))
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['employee_id']);
+    }
+
+    #[Test]
+    public function returns_422_when_period_end_before_period_start(): void
+    {
+        $this->getJson($this->url($this->employee->public_id, '2026-06-22', '2026-06-16'))
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['period_end']);
+    }
+}

--- a/code/api/tests/Feature/Employees/UpdateEmployeeContactTest.php
+++ b/code/api/tests/Feature/Employees/UpdateEmployeeContactTest.php
@@ -97,4 +97,21 @@ class UpdateEmployeeContactTest extends TestCase
         $this->assertDatabaseHas('users', ['id' => $user->id, 'email' => 'u@x.com']);
         $this->assertDatabaseHas('employees', ['id' => $employee->id, 'user_id' => $user->id]);
     }
+
+    #[Test]
+    public function admin_can_toggle_attendance_exempt(): void
+    {
+        $admin = User::factory()->create();
+        $admin->assignRole('admin');
+        Passport::actingAs($admin);
+
+        $employee = Employee::factory()->create(['attendance_exempt' => false]);
+
+        $response = $this->putJson("/api/v1/employees/{$employee->public_id}", [
+            'attendance_exempt' => true,
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('employees', ['id' => $employee->id, 'attendance_exempt' => true]);
+    }
 }

--- a/code/api/tests/Unit/Models/PunctualityExceptionTest.php
+++ b/code/api/tests/Unit/Models/PunctualityExceptionTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\PunctualityException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class PunctualityExceptionTest extends TestCase
+{
+    #[Test]
+    public function it_matches_sunday_using_iso_8601_numbering(): void
+    {
+        $exception = new PunctualityException(['day_of_week' => 7]);
+
+        $this->assertTrue($exception->appliesToDay(7));
+        $this->assertFalse($exception->appliesToDay(0));
+    }
+
+    #[Test]
+    public function it_matches_monday_through_saturday(): void
+    {
+        $exception = new PunctualityException(['day_of_week' => 1]);
+
+        $this->assertTrue($exception->appliesToDay(1));
+        $this->assertFalse($exception->appliesToDay(2));
+    }
+
+    #[Test]
+    public function null_day_of_week_applies_to_every_day(): void
+    {
+        $exception = new PunctualityException(['day_of_week' => null]);
+
+        foreach (range(1, 7) as $isoDay) {
+            $this->assertTrue($exception->appliesToDay($isoDay));
+        }
+    }
+}

--- a/code/webapp/.env.example
+++ b/code/webapp/.env.example
@@ -74,3 +74,10 @@ VITE_AGENT_LABEL=
 # Mirrors the envBadge pattern from atreyu-library.
 # 🟢 = local dev | 🟠 = QA/staging | (empty) = production
 VITE_ENV_BADGE=
+
+# Payroll — Week Start Day
+# ------------------------
+# ISO weekday on which the payroll week begins: 1=Monday … 7=Sunday
+# SushiGo convention: weeks run Monday–Sunday (cut-off end of Sunday).
+# Must match WEEK_START_DAY in the backend .env.
+VITE_WEEK_START_DAY=1

--- a/code/webapp/.gitignore
+++ b/code/webapp/.gitignore
@@ -26,6 +26,7 @@ dist-ssr
 src/routeTree.gen.ts
 # Coverage reports
 coverage
+.vitest-reports
 
 # Cypress
 cypress/videos

--- a/code/webapp/cypress/e2e/attendance-exempt-employee.cy.ts
+++ b/code/webapp/cypress/e2e/attendance-exempt-employee.cy.ts
@@ -1,0 +1,57 @@
+/**
+ * Attendance Exempt Employee — E2E happy path
+ *
+ * Verifies that marking an employee as "Libre de asistencia" removes them
+ * from the attendance list — their attendance is considered automatic, so
+ * they no longer need to check in/out (roles like admin/super-admin).
+ *
+ * DB reset strategy
+ * ─────────────────
+ * • before() → cy.task('test:reset', 'attendance') ONCE per file.
+ *   EMP-001 (Carlos Mendoza) is marked exempt during the test; EMP-002
+ *   (María García) is left untouched as a control that stays tracked.
+ *
+ * Para correr solo este archivo:
+ *   make cypress-spec SPEC=attendance-exempt-employee
+ */
+
+import users from '../fixtures/users.json'
+
+const { email, password } = users.admin
+
+before(() => {
+  cy.task('test:reset', 'attendance', { timeout: 60_000 })
+})
+
+beforeEach(() => {
+  cy.loginByApi(email, password)
+})
+
+it('excludes an employee marked "Libre de asistencia" from the attendance list', () => {
+  // ── 1. Mark EMP-001 (Carlos Mendoza) as attendance-exempt ──────────────────
+  cy.visitWithAuth('/employees')
+  cy.closeDevDebugger()
+
+  cy.contains('tr', 'EMP-001', { timeout: 10_000 })
+    .find('button[title="Ver detalle"]')
+    .click()
+  cy.contains('h2', 'Detalle de Empleado', { timeout: 10_000 }).should('be.visible')
+
+  cy.contains('button', 'Editar').click()
+  cy.contains('label', 'Libre de asistencia', { timeout: 10_000 })
+    .find('[role="switch"]')
+    .click({ force: true })
+  cy.contains('button', 'Actualizar').click()
+
+  // Back to the detail view — update succeeded
+  cy.contains('h2', 'Detalle de Empleado', { timeout: 10_000 }).should('be.visible')
+
+  // ── 2. Verify EMP-001 no longer appears in the attendance list ─────────────
+  cy.visitWithAuth('/attendance')
+  cy.contains('Asistencia', { timeout: 10_000 }).should('be.visible')
+  cy.closeDevDebugger()
+
+  cy.contains('Mendoza, Carlos').should('not.exist')
+  // Control: an employee that was not marked exempt still appears
+  cy.contains('García, María', { timeout: 10_000 }).should('be.visible')
+})

--- a/code/webapp/cypress/e2e/attendance-weekly-summary-dialog.cy.ts
+++ b/code/webapp/cypress/e2e/attendance-weekly-summary-dialog.cy.ts
@@ -1,0 +1,182 @@
+/**
+ * Weekly Summary Dialog — E2E happy-path tests
+ *
+ * Covers the weekly summary slide panel launched from the attendance today page:
+ *   - Admin sees the BarChart3 button on each employee card (has reports.weekly-summary)
+ *   - Clicking the button opens the slide panel with the employee name in the title
+ *   - The week label defaults to the current week (Monday–Sunday)
+ *   - The payroll breakdown and daily evidence table load correctly
+ *   - Clicking the week label shows/hides the calendar
+ *   - Navigating to the previous/next week re-fetches and updates the results
+ *   - Picking a week from the calendar re-fetches and updates the results
+ *   - The "current week" shortcut appears after navigating away and restores it
+ *   - Closing the panel hides it
+ *
+ * DB reset strategy
+ * ─────────────────
+ * • before() → cy.task('test:reset', 'weekly-summary') — reuses the same seed as
+ *   the standalone weekly summary spec (EMP-001 Carlos Mendoza, week 2026-06-16 → 2026-06-22).
+ *
+ * Para correr solo este archivo:
+ *   make cypress-spec SPEC=attendance-weekly-summary-dialog
+ */
+
+import users from '../fixtures/users.json'
+
+const { email: adminEmail, password: adminPassword } = users.admin
+const TEST_TIME_ISO = '2026-06-17T14:30:00-06:00'
+
+before(() => {
+  cy.task('test:reset', 'weekly-summary', { timeout: 60_000 })
+})
+
+beforeEach(() => {
+  cy.intercept({ url: /\/api\/v1\// }, (req) => {
+    req.headers['X-Test-Time'] = TEST_TIME_ISO
+    req.continue()
+  }).as('apiWithTestTime')
+
+  cy.loginByApi(adminEmail, adminPassword)
+  cy.visitWithAuth('/attendance')
+  cy.contains('Asistencia', { timeout: 10_000 }).should('be.visible')
+  cy.closeDevDebugger()
+})
+
+it('shows weekly summary button on each employee card', () => {
+  cy.get('[data-testid="btn-weekly-summary"]', { timeout: 10_000 })
+    .should('have.length.greaterThan', 0)
+})
+
+it('opens the slide panel with the employee name when clicking the button', () => {
+  cy.get('[data-testid="btn-weekly-summary"]').first().click()
+
+  // Panel title contains "Resumen semanal —"
+  cy.contains('Resumen semanal —', { timeout: 8_000 }).should('be.visible')
+
+  // Week label is pre-filled with the current week (Monday–Sunday)
+  cy.get('[data-testid="dialog-week-label"]')
+    .should('contain', '16')
+    .and('contain', '22')
+
+  // No "current week" shortcut when already viewing the current week
+  cy.get('[data-testid="dialog-current-week"]').should('not.exist')
+})
+
+it('loads payroll breakdown and daily evidence for EMP-001', () => {
+  // Open the panel for the first employee (EMP-001 Carlos Mendoza in test seed)
+  cy.get('[data-testid="btn-weekly-summary"]').first().click()
+
+  cy.contains('Desglose de pago', { timeout: 10_000 }).should('be.visible')
+  cy.contains('Sueldo base (c/descanso)').should('be.visible')
+  cy.contains('Total a pagar').should('be.visible')
+
+  cy.contains('Evidencia diaria').should('be.visible')
+  cy.get('table tbody tr').should('have.length', 7)
+})
+
+it('keeps the calendar hidden by default and toggles it via the week label', () => {
+  cy.get('[data-testid="btn-weekly-summary"]').first().click()
+  cy.contains('Desglose de pago', { timeout: 10_000 }).should('be.visible')
+
+  cy.get('[data-testid="week-calendar"]').should('not.exist')
+  cy.get('[data-testid="dialog-week-label"]').should('have.attr', 'aria-expanded', 'false')
+
+  cy.get('[data-testid="dialog-week-label"]').click()
+  cy.get('[data-testid="week-calendar"]').should('be.visible')
+  cy.get('[data-testid="dialog-week-label"]').should('have.attr', 'aria-expanded', 'true')
+
+  cy.get('[data-testid="dialog-week-label"]').click()
+  cy.get('[data-testid="week-calendar"]').should('not.exist')
+  cy.get('[data-testid="dialog-week-label"]').should('have.attr', 'aria-expanded', 'false')
+})
+
+it('updates results when navigating to the previous week', () => {
+  cy.get('[data-testid="btn-weekly-summary"]').first().click()
+  cy.contains('Desglose de pago', { timeout: 10_000 }).should('be.visible')
+
+  cy.get('[data-testid="dialog-prev-week"]').click()
+
+  // Week label moves back 7 days
+  cy.get('[data-testid="dialog-week-label"]')
+    .should('contain', '9')
+    .and('contain', '15')
+
+  // Results reload (may show zeros — just verify table still renders)
+  cy.get('table tbody tr', { timeout: 10_000 }).should('have.length', 7)
+})
+
+it('picks a different week from the calendar', () => {
+  cy.get('[data-testid="btn-weekly-summary"]').first().click()
+  cy.contains('Desglose de pago', { timeout: 10_000 }).should('be.visible')
+
+  cy.get('[data-testid="dialog-week-label"]').click() // open the calendar
+  cy.get('[data-testid="week-calendar"]').should('contain', 'Junio 2026')
+  cy.get('[data-testid="week-calendar-row"]').first().click()
+
+  // First week of June 2026 (2026-06-01 – 2026-06-07)
+  cy.get('[data-testid="dialog-week-label"]')
+    .should('contain', '1')
+    .and('contain', '7')
+
+  cy.get('table tbody tr', { timeout: 10_000 }).should('have.length', 7)
+})
+
+it('browses the calendar to a different month without moving the selected week', () => {
+  cy.get('[data-testid="btn-weekly-summary"]').first().click()
+  cy.contains('Desglose de pago', { timeout: 10_000 }).should('be.visible')
+
+  cy.get('[data-testid="dialog-week-label"]').click() // open the calendar
+  cy.get('[data-testid="week-calendar-next"]').click()
+  cy.get('[data-testid="week-calendar"]').should('contain', 'Julio 2026')
+
+  // Selected week (June) is unaffected until a row is actually clicked
+  cy.get('[data-testid="dialog-week-label"]')
+    .should('contain', '16')
+    .and('contain', '22')
+})
+
+it('jumps to a different month/year via the calendar view label', () => {
+  cy.get('[data-testid="btn-weekly-summary"]').first().click()
+  cy.contains('Desglose de pago', { timeout: 10_000 }).should('be.visible')
+
+  cy.get('[data-testid="dialog-week-label"]').click() // open the calendar
+  // weeks -> months -> years
+  cy.get('[data-testid="week-calendar-view-label"]').click()
+  cy.get('[data-testid="week-calendar"]').should('contain', '2026')
+  cy.get('[data-testid="week-calendar-view-label"]').click()
+  cy.get('[data-testid="week-calendar-year-option"]').should('have.length.greaterThan', 0)
+
+  cy.get('[data-testid="week-calendar-year-option"]').contains('2027').click()
+  // Selecting a year moves to the months view for that year
+  cy.get('[data-testid="week-calendar"]').should('contain', '2027')
+
+  cy.get('[data-testid="week-calendar-month-option"]').contains('Ene').click()
+  cy.get('[data-testid="week-calendar"]').should('contain', 'Enero 2027')
+  cy.get('[data-testid="week-calendar-row"]').should('have.length.greaterThan', 0)
+})
+
+it('shows the current-week shortcut after navigating away and restores it on click', () => {
+  cy.get('[data-testid="btn-weekly-summary"]').first().click()
+  cy.contains('Desglose de pago', { timeout: 10_000 }).should('be.visible')
+
+  cy.get('[data-testid="dialog-current-week"]').should('not.exist')
+
+  cy.get('[data-testid="dialog-prev-week"]').click()
+  cy.get('[data-testid="dialog-current-week"]').should('be.visible').click()
+
+  // Back to the current week (Monday–Sunday containing the mocked test time)
+  cy.get('[data-testid="dialog-week-label"]')
+    .should('contain', '16')
+    .and('contain', '22')
+  cy.get('[data-testid="dialog-current-week"]').should('not.exist')
+})
+
+it('closes the panel when the close button is clicked', () => {
+  cy.get('[data-testid="btn-weekly-summary"]').first().click()
+  cy.contains('Resumen semanal —', { timeout: 8_000 }).should('be.visible')
+
+  // SlidePanel renders a close button with aria-label or X icon
+  cy.get('button[aria-label="Close"], button[aria-label="Cerrar"]').first().click()
+
+  cy.contains('Resumen semanal —').should('not.exist')
+})

--- a/code/webapp/src/components/attendance/EmployeeAttendanceCard.tsx
+++ b/code/webapp/src/components/attendance/EmployeeAttendanceCard.tsx
@@ -12,6 +12,7 @@ import {
     BedDouble,
     UserX,
     Lock,
+    BarChart3,
 } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -240,6 +241,7 @@ export interface EmployeeAttendanceCardProps {
     onCheckOut: (employee: TodayAttendanceEmployee, attendanceId: string) => void
     onOvertimeDecision: (employee: TodayAttendanceEmployee, attendanceId: string) => void
     onMarkDayStatus: (employee: TodayAttendanceEmployee, status: 'ABSENCE') => void
+    onWeeklySummary?: (employee: TodayAttendanceEmployee) => void
     canEdit?: boolean
 }
 
@@ -251,6 +253,7 @@ export function EmployeeAttendanceCard({
     onCheckOut,
     onOvertimeDecision,
     onMarkDayStatus,
+    onWeeklySummary,
     canEdit = true,
 }: Readonly<EmployeeAttendanceCardProps>) {
     const phase = getAttendancePhase(row.attendance)
@@ -306,7 +309,7 @@ export function EmployeeAttendanceCard({
                 getPhaseCardClass(phase)
             )}
         >
-            {/* Header: Name + Phase Badge */}
+            {/* Header: Name + Phase Badge + Weekly Summary */}
             <div className="flex items-start justify-between gap-2">
                 <div className="min-w-0">
                     <p className="font-semibold text-sm truncate text-foreground">
@@ -314,7 +317,20 @@ export function EmployeeAttendanceCard({
                     </p>
                     <p className="text-xs text-muted-foreground">{row.employee.code}</p>
                 </div>
-                <PhaseBadge phase={phase} />
+                <div className="flex items-center gap-1.5 shrink-0">
+                    {onWeeklySummary && (
+                        <button
+                            type="button"
+                            data-testid="btn-weekly-summary"
+                            aria-label="Ver resumen semanal"
+                            onClick={() => onWeeklySummary(row.employee)}
+                            className="rounded p-0.5 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                        >
+                            <BarChart3 className="h-4 w-4" />
+                        </button>
+                    )}
+                    <PhaseBadge phase={phase} />
+                </div>
             </div>
 
             {/* Role badges */}

--- a/code/webapp/src/components/attendance/WeeklySummaryDialog.tsx
+++ b/code/webapp/src/components/attendance/WeeklySummaryDialog.tsx
@@ -1,0 +1,225 @@
+import { useState } from 'react'
+import { ChevronLeft, ChevronRight, ChevronDown, CalendarCheck } from 'lucide-react'
+import { SlidePanel } from '@/components/ui/slide-panel'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { WeekCalendar } from '@/components/attendance/week-calendar'
+import { formatWeekTitle } from '@/lib/week'
+import type { WeeklySummaryResponse, DailyEvidenceItem } from '@/types/report'
+
+// ── Shared display helpers ───────────────────────────────────────────────────
+
+export function formatMoney(value: number): string {
+  return `$${value.toFixed(2)}`
+}
+
+export function formatOvertime(minutes: number, authorized: boolean): string {
+  if (minutes <= 0) return '—'
+  return `${minutes}${authorized ? ' ✓' : ''}`
+}
+
+export function ConceptRow({ label, value, highlight }: Readonly<{ label: string; value: number; highlight?: boolean }>) {
+  return (
+    <div className={`flex justify-between py-1 ${highlight ? 'font-semibold text-primary' : ''}`}>
+      <span className="text-sm">{label}</span>
+      <span className="text-sm tabular-nums">{formatMoney(value)}</span>
+    </div>
+  )
+}
+
+export function DailyEvidenceTable({ rows }: Readonly<{ rows: DailyEvidenceItem[] }>) {
+  if (rows.length === 0) return null
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b text-left text-muted-foreground">
+            <th className="py-2 pr-4 font-medium">Fecha</th>
+            <th className="py-2 pr-4 font-medium">Estado</th>
+            <th className="py-2 pr-4 font-medium">Entrada</th>
+            <th className="py-2 pr-4 font-medium">Salida</th>
+            <th className="py-2 pr-4 font-medium text-right">Tard. min</th>
+            <th className="py-2 pr-4 font-medium text-right">Desc. min</th>
+            <th className="py-2 font-medium text-right">Extra min</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.date} className="border-b last:border-0">
+              <td className="py-2 pr-4 tabular-nums">{row.date}</td>
+              <td className="py-2 pr-4">{row.day_status ?? '—'}</td>
+              <td className="py-2 pr-4 tabular-nums">
+                {row.check_in ? row.check_in.substring(11, 16) : '—'}
+              </td>
+              <td className="py-2 pr-4 tabular-nums">
+                {row.check_out ? row.check_out.substring(11, 16) : '—'}
+              </td>
+              <td className="py-2 pr-4 text-right tabular-nums">{row.late_minutes}</td>
+              <td className="py-2 pr-4 text-right tabular-nums">{row.deducted_minutes}</td>
+              <td className="py-2 text-right tabular-nums">
+                {formatOvertime(row.overtime_minutes, row.overtime_authorized)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export function WeeklySummaryContent({ summary }: Readonly<{ summary: WeeklySummaryResponse }>) {
+  return (
+    <div className="grid grid-cols-1 gap-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Desglose de pago</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-1">
+          <ConceptRow label="Sueldo base (c/descanso)"    value={summary.base_pay} />
+          <ConceptRow label="Deducciones por tardanza"    value={-summary.late_deductions} />
+          <ConceptRow label="Ded. permisos no pagados"    value={-summary.unpaid_leave_deductions} />
+          <ConceptRow label="Día extra negociado"         value={summary.extra_day_pay} />
+          <ConceptRow label="Pago día festivo"            value={summary.holiday_pay} />
+          <ConceptRow label="Bono de puntualidad"         value={summary.punctuality_bonus} />
+          <ConceptRow label="Tiempo extra"                value={summary.overtime_pay} />
+          <div className="border-t mt-2 pt-2">
+            <ConceptRow label="Total a pagar" value={summary.total_pay} highlight />
+          </div>
+          <p className="text-xs text-muted-foreground pt-2">
+            Horas libres ganadas: {summary.free_hours_earned}h
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Evidencia diaria</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <DailyEvidenceTable rows={summary.daily_evidence} />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+// ── Dialog ─────────────────────────────────────────────────────────────────────
+
+export interface WeeklySummaryDialogProps {
+  isOpen: boolean
+  onClose: () => void
+  employeeName: string
+  periodStart: string
+  periodEnd: string
+  onPrevWeek: () => void
+  onNextWeek: () => void
+  onJumpToDate: (dateStr: string) => void
+  isCurrentWeek: boolean
+  isEarliestWeek: boolean
+  earliestWeekStart: string | null
+  onGoToCurrentWeek: () => void
+  summary: WeeklySummaryResponse | null
+  isLoading: boolean
+  isError: boolean
+}
+
+export function WeeklySummaryDialog({
+  isOpen,
+  onClose,
+  employeeName,
+  periodStart,
+  periodEnd,
+  onPrevWeek,
+  onNextWeek,
+  onJumpToDate,
+  isCurrentWeek,
+  isEarliestWeek,
+  earliestWeekStart,
+  onGoToCurrentWeek,
+  summary,
+  isLoading,
+  isError,
+}: Readonly<WeeklySummaryDialogProps>) {
+  const [isCalendarOpen, setIsCalendarOpen] = useState(false)
+
+  return (
+    <SlidePanel
+      isOpen={isOpen}
+      onClose={onClose}
+      title={`Resumen semanal — ${employeeName}`}
+      description="Desglose de pago para el período seleccionado"
+      size="lg"
+    >
+      <div className="space-y-4">
+        {/* Week navigator */}
+        <div className="flex items-center justify-between gap-2">
+          <button
+            type="button"
+            data-testid="dialog-prev-week"
+            onClick={onPrevWeek}
+            disabled={isEarliestWeek}
+            className="shrink-0 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-30 disabled:hover:bg-transparent"
+            title={isEarliestWeek ? 'El empleado no tenía periodo activo antes de esta semana' : 'Semana anterior'}
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+
+          <div className="flex flex-1 items-center justify-center gap-2">
+            <button
+              type="button"
+              data-testid="dialog-week-label"
+              onClick={() => setIsCalendarOpen((v) => !v)}
+              aria-expanded={isCalendarOpen}
+              title={isCalendarOpen ? 'Ocultar calendario' : 'Mostrar calendario'}
+              className="flex items-center gap-1 rounded px-1 py-0.5 text-sm font-medium hover:bg-muted"
+            >
+              {formatWeekTitle(periodStart, periodEnd)}
+              <ChevronDown className={`h-3.5 w-3.5 text-muted-foreground transition-transform ${isCalendarOpen ? '' : '-rotate-90'}`} />
+            </button>
+            {!isCurrentWeek && (
+              <button
+                type="button"
+                data-testid="dialog-current-week"
+                onClick={onGoToCurrentWeek}
+                className="flex items-center gap-1 rounded px-2 py-0.5 text-xs font-medium text-emerald-700 hover:bg-emerald-50 dark:text-emerald-400 dark:hover:bg-emerald-900/20"
+                title="Volver a la semana actual"
+              >
+                <CalendarCheck className="h-3.5 w-3.5" />
+                Semana actual
+              </button>
+            )}
+          </div>
+
+          <button
+            type="button"
+            data-testid="dialog-next-week"
+            onClick={onNextWeek}
+            disabled={isCurrentWeek}
+            className="shrink-0 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-30 disabled:hover:bg-transparent"
+            title={isCurrentWeek ? 'No se pueden seleccionar semanas futuras' : 'Semana siguiente'}
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+        </div>
+
+        {isCalendarOpen && (
+          <WeekCalendar
+            periodStart={periodStart}
+            earliestWeekStart={earliestWeekStart}
+            onSelectDate={onJumpToDate}
+          />
+        )}
+
+        {isLoading && (
+          <p className="text-sm text-muted-foreground">Cargando resumen...</p>
+        )}
+        {isError && (
+          <p className="text-sm text-destructive">
+            Error al cargar el resumen. Verifica el rango de fechas e intenta de nuevo.
+          </p>
+        )}
+        {summary && <WeeklySummaryContent summary={summary} />}
+      </div>
+    </SlidePanel>
+  )
+}

--- a/code/webapp/src/components/attendance/__tests__/WeeklySummaryDialog.test.tsx
+++ b/code/webapp/src/components/attendance/__tests__/WeeklySummaryDialog.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup, fireEvent } from '@testing-library/react'
+import { WeeklySummaryDialog } from '../WeeklySummaryDialog'
+
+afterEach(() => {
+  cleanup()
+  document.body.style.overflow = 'unset'
+})
+
+const defaultProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  employeeName: 'Mendoza, Carlos',
+  periodStart: '2026-06-15',
+  periodEnd: '2026-06-21',
+  onPrevWeek: vi.fn(),
+  onNextWeek: vi.fn(),
+  onJumpToDate: vi.fn(),
+  isCurrentWeek: true,
+  isEarliestWeek: false,
+  earliestWeekStart: null,
+  onGoToCurrentWeek: vi.fn(),
+  summary: null,
+  isLoading: false,
+  isError: false,
+}
+
+describe('WeeklySummaryDialog — calendar toggle', () => {
+  it('hides the calendar by default', () => {
+    const { queryByTestId, getByTestId } = render(<WeeklySummaryDialog {...defaultProps} />)
+    expect(queryByTestId('week-calendar')).toBeNull()
+    expect(getByTestId('dialog-week-label').getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('shows the calendar when the week label is clicked', () => {
+    const { getByTestId } = render(<WeeklySummaryDialog {...defaultProps} />)
+
+    fireEvent.click(getByTestId('dialog-week-label'))
+
+    expect(getByTestId('week-calendar')).toBeDefined()
+    expect(getByTestId('dialog-week-label').getAttribute('aria-expanded')).toBe('true')
+  })
+
+  it('hides the calendar again on a second click', () => {
+    const { getByTestId, queryByTestId } = render(<WeeklySummaryDialog {...defaultProps} />)
+
+    fireEvent.click(getByTestId('dialog-week-label'))
+    expect(getByTestId('week-calendar')).toBeDefined()
+
+    fireEvent.click(getByTestId('dialog-week-label'))
+    expect(queryByTestId('week-calendar')).toBeNull()
+    expect(getByTestId('dialog-week-label').getAttribute('aria-expanded')).toBe('false')
+  })
+})

--- a/code/webapp/src/components/attendance/__tests__/use-weekly-summary-dialog.test.ts
+++ b/code/webapp/src/components/attendance/__tests__/use-weekly-summary-dialog.test.ts
@@ -1,0 +1,255 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import React from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+vi.mock('@/services/report.service', () => ({
+  useWeeklySummary: vi.fn(() => ({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+  })),
+}))
+
+vi.mock('@/services/employee-hooks', () => ({
+  useEmployee: vi.fn(() => ({ data: undefined })),
+}))
+
+import { useEmployee } from '@/services/employee-hooks'
+import { useWeeklySummaryDialog } from '../use-weekly-summary-dialog'
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children)
+  return { wrapper }
+}
+
+describe('useWeeklySummaryDialog', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    // Wednesday within the week 2026-06-15 – 2026-06-21, kept consistent with
+    // the fixed dates used throughout this file
+    vi.setSystemTime(new Date('2026-06-17T12:00:00'))
+    // Reset to "no hire-date restriction" — individual tests override as needed
+    vi.mocked(useEmployee).mockReturnValue({ data: undefined } as never)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it('starts closed with pre-filled current-week dates', () => {
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useWeeklySummaryDialog(), { wrapper })
+
+    expect(result.current.isOpen).toBe(false)
+    expect(result.current.periodStart).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    expect(result.current.periodEnd).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+
+  it('opens with the given employee and resets to the current week', () => {
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useWeeklySummaryDialog(), { wrapper })
+
+    act(() => {
+      result.current.open('emp-ulid-001', 'Mendoza, Carlos')
+    })
+
+    expect(result.current.isOpen).toBe(true)
+    expect(result.current.employeePublicId).toBe('emp-ulid-001')
+    expect(result.current.employeeName).toBe('Mendoza, Carlos')
+    expect(result.current.isCurrentWeek).toBe(true)
+  })
+
+  it('shifts both period bounds back 7 days on prevWeek', () => {
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useWeeklySummaryDialog(), { wrapper })
+
+    act(() => {
+      result.current.open('emp-ulid-001', 'Mendoza, Carlos')
+    })
+    const { periodStart: startBefore, periodEnd: endBefore } = result.current
+
+    act(() => {
+      result.current.prevWeek()
+    })
+
+    expect(result.current.periodStart).not.toBe(startBefore)
+    expect(result.current.periodEnd).not.toBe(endBefore)
+    const startDiff = new Date(startBefore).getTime() - new Date(result.current.periodStart).getTime()
+    const endDiff = new Date(endBefore).getTime() - new Date(result.current.periodEnd).getTime()
+    expect(startDiff).toBe(7 * 24 * 60 * 60 * 1000)
+    expect(endDiff).toBe(7 * 24 * 60 * 60 * 1000)
+    expect(result.current.isCurrentWeek).toBe(false)
+  })
+
+  it('shifts both period bounds forward 7 days on nextWeek, after moving back', () => {
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useWeeklySummaryDialog(), { wrapper })
+
+    act(() => {
+      result.current.open('emp-ulid-001', 'Mendoza, Carlos')
+      result.current.prevWeek()
+    })
+    const { periodStart: startBefore, periodEnd: endBefore } = result.current
+
+    act(() => {
+      result.current.nextWeek()
+    })
+
+    const startDiff = new Date(result.current.periodStart).getTime() - new Date(startBefore).getTime()
+    const endDiff = new Date(result.current.periodEnd).getTime() - new Date(endBefore).getTime()
+    expect(startDiff).toBe(7 * 24 * 60 * 60 * 1000)
+    expect(endDiff).toBe(7 * 24 * 60 * 60 * 1000)
+    expect(result.current.isCurrentWeek).toBe(true)
+  })
+
+  it('nextWeek is a no-op once the current week is reached (no future weeks)', () => {
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useWeeklySummaryDialog(), { wrapper })
+
+    act(() => {
+      result.current.open('emp-ulid-001', 'Mendoza, Carlos')
+    })
+    expect(result.current.isCurrentWeek).toBe(true)
+    const { periodStart, periodEnd } = result.current
+
+    act(() => {
+      result.current.nextWeek()
+    })
+
+    expect(result.current.periodStart).toBe(periodStart)
+    expect(result.current.periodEnd).toBe(periodEnd)
+  })
+
+  it('jumps to the week containing an arbitrary date', () => {
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useWeeklySummaryDialog(), { wrapper })
+
+    act(() => {
+      result.current.open('emp-ulid-001', 'Mendoza, Carlos')
+      result.current.prevWeek() // move away first, so the jump below is observable
+      result.current.jumpToDate('2026-06-17') // Wednesday, current week
+    })
+
+    expect(result.current.periodStart).toBe('2026-06-15')
+    expect(result.current.periodEnd).toBe('2026-06-21')
+  })
+
+  it('jumpToDate ignores dates whose week is in the future', () => {
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useWeeklySummaryDialog(), { wrapper })
+
+    act(() => {
+      result.current.open('emp-ulid-001', 'Mendoza, Carlos')
+    })
+    const { periodStart, periodEnd } = result.current
+
+    act(() => {
+      result.current.jumpToDate('2026-07-01') // a future week relative to mocked "now"
+    })
+
+    expect(result.current.periodStart).toBe(periodStart)
+    expect(result.current.periodEnd).toBe(periodEnd)
+  })
+
+  it('exposes isEarliestWeek and blocks navigation before the employee hire date', () => {
+    vi.mocked(useEmployee).mockReturnValue({
+      data: {
+        employment_periods: [
+          { id: 'p1', branch_id: 1, branch_name: 'Main', start_date: '2026-06-08', end_date: null, termination_reason: null, is_active: true },
+        ],
+      },
+    } as never)
+
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useWeeklySummaryDialog(), { wrapper })
+
+    act(() => {
+      result.current.open('emp-ulid-001', 'Mendoza, Carlos')
+    })
+
+    expect(result.current.earliestWeekStart).toBe('2026-06-08')
+    expect(result.current.isEarliestWeek).toBe(false) // current week (06-15) is after hire week
+
+    act(() => {
+      result.current.jumpToDate('2026-06-08') // move to the hire week
+    })
+    expect(result.current.isEarliestWeek).toBe(true)
+    const { periodStart, periodEnd } = result.current
+
+    // Cannot go further back than the hire week
+    act(() => {
+      result.current.prevWeek()
+    })
+    expect(result.current.periodStart).toBe(periodStart)
+    expect(result.current.periodEnd).toBe(periodEnd)
+
+    // Cannot jump to a date before the hire date either
+    act(() => {
+      result.current.jumpToDate('2026-05-01')
+    })
+    expect(result.current.periodStart).toBe(periodStart)
+  })
+
+  it('uses the earliest of multiple employment periods as the hire date', () => {
+    vi.mocked(useEmployee).mockReturnValue({
+      data: {
+        employment_periods: [
+          { id: 'p2', branch_id: 1, branch_name: 'Main', start_date: '2026-05-04', end_date: '2026-05-18', termination_reason: 'resignation', is_active: false },
+          { id: 'p1', branch_id: 1, branch_name: 'Main', start_date: '2026-06-08', end_date: null, termination_reason: null, is_active: true },
+        ],
+      },
+    } as never)
+
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useWeeklySummaryDialog(), { wrapper })
+
+    act(() => {
+      result.current.open('emp-ulid-001', 'Mendoza, Carlos')
+    })
+
+    expect(result.current.earliestWeekStart).toBe('2026-05-04')
+  })
+
+  it('goToCurrentWeek restores the current week after navigating away', () => {
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useWeeklySummaryDialog(), { wrapper })
+
+    act(() => {
+      result.current.open('emp-ulid-001', 'Mendoza, Carlos')
+    })
+    const currentStart = result.current.periodStart
+
+    act(() => {
+      result.current.jumpToDate('2020-01-01')
+    })
+    expect(result.current.isCurrentWeek).toBe(false)
+
+    act(() => {
+      result.current.goToCurrentWeek()
+    })
+
+    expect(result.current.periodStart).toBe(currentStart)
+    expect(result.current.isCurrentWeek).toBe(true)
+  })
+
+  it('closes when close() is called', () => {
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useWeeklySummaryDialog(), { wrapper })
+
+    act(() => {
+      result.current.open('emp-ulid-001', 'Mendoza, Carlos')
+    })
+    act(() => {
+      result.current.close()
+    })
+
+    expect(result.current.isOpen).toBe(false)
+  })
+})

--- a/code/webapp/src/components/attendance/__tests__/week-calendar.test.tsx
+++ b/code/webapp/src/components/attendance/__tests__/week-calendar.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, cleanup, fireEvent } from '@testing-library/react'
+import { WeekCalendar } from '../week-calendar'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  // Wednesday within the week 2026-06-15 – 2026-06-21, kept consistent with
+  // the fixed dates used throughout this file
+  vi.setSystemTime(new Date('2026-06-17T12:00:00'))
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  cleanup()
+})
+
+describe('WeekCalendar', () => {
+  it('renders one row per week of the month containing periodStart', () => {
+    // June 2026 has 5 weeks (week 5 spills into July)
+    const { getAllByTestId } = render(
+      <WeekCalendar periodStart="2026-06-15" earliestWeekStart={null} onSelectDate={vi.fn()} />
+    )
+    expect(getAllByTestId('week-calendar-row')).toHaveLength(5)
+  })
+
+  it('marks the row matching periodStart as selected', () => {
+    const { getAllByTestId } = render(
+      <WeekCalendar periodStart="2026-06-15" earliestWeekStart={null} onSelectDate={vi.fn()} />
+    )
+    const rows = getAllByTestId('week-calendar-row')
+    const selected = rows.filter((row) => row.getAttribute('aria-pressed') === 'true')
+    expect(selected).toHaveLength(1)
+    // "3rd week of June [year week 24] - date range"
+    expect(selected[0]!.getAttribute('title')).toBe('3ra sem. de Jun. [24] - 15 jun – 21 jun 2026')
+  })
+
+  it('calls onSelectDate with the week start when a row is clicked', () => {
+    const onSelectDate = vi.fn()
+    const { getAllByTestId } = render(
+      <WeekCalendar periodStart="2026-06-15" earliestWeekStart={null} onSelectDate={onSelectDate} />
+    )
+    const rows = getAllByTestId('week-calendar-row')
+    fireEvent.click(rows[1]!) // week 2 (2026-06-08), a past week
+
+    expect(onSelectDate).toHaveBeenCalledWith('2026-06-08')
+  })
+
+  it('disables weeks after the current one and ignores clicks on them', () => {
+    const onSelectDate = vi.fn()
+    // "Now" is mocked to 2026-06-17, so the current week starts 2026-06-15
+    const { getAllByTestId } = render(
+      <WeekCalendar periodStart="2026-06-15" earliestWeekStart={null} onSelectDate={onSelectDate} />
+    )
+    const rows = getAllByTestId('week-calendar-row') as HTMLButtonElement[]
+    // Rows: [06-01, 06-08, 06-15 (current), 06-22 (future), 06-29 (future)]
+    expect(rows[3]!.disabled).toBe(true)
+    expect(rows[4]!.disabled).toBe(true)
+    expect(rows[2]!.disabled).toBe(false)
+
+    fireEvent.click(rows[3]!)
+    expect(onSelectDate).not.toHaveBeenCalled()
+  })
+
+  it('disables weeks before the employee hire date and ignores clicks on them', () => {
+    const onSelectDate = vi.fn()
+    // Hire date falls inside week 2 (2026-06-08 – 06-14), so week 1 (06-01) is out of bounds
+    const { getAllByTestId } = render(
+      <WeekCalendar periodStart="2026-06-15" earliestWeekStart="2026-06-08" onSelectDate={onSelectDate} />
+    )
+    const rows = getAllByTestId('week-calendar-row') as HTMLButtonElement[]
+    // Rows: [06-01 (before hire), 06-08 (hire week), 06-15 (current), 06-22, 06-29]
+    expect(rows[0]!.disabled).toBe(true)
+    expect(rows[1]!.disabled).toBe(false)
+    expect(rows[2]!.disabled).toBe(false)
+
+    fireEvent.click(rows[0]!)
+    expect(onSelectDate).not.toHaveBeenCalled()
+  })
+
+  it('navigates to the previous/next month without changing the selection', () => {
+    const { getByTestId, getAllByTestId } = render(
+      <WeekCalendar periodStart="2026-06-15" earliestWeekStart={null} onSelectDate={vi.fn()} />
+    )
+    expect(getByTestId('week-calendar').textContent).toContain('Junio 2026')
+
+    fireEvent.click(getByTestId('week-calendar-next'))
+    expect(getByTestId('week-calendar').textContent).toContain('Julio 2026')
+    // July 2026 has 4 weeks, none selected (periodStart is still in June)
+    const rows = getAllByTestId('week-calendar-row')
+    expect(rows.filter((row) => row.getAttribute('aria-pressed') === 'true')).toHaveLength(0)
+
+    fireEvent.click(getByTestId('week-calendar-prev'))
+    expect(getByTestId('week-calendar').textContent).toContain('Junio 2026')
+  })
+
+  it('cycles from weeks to months view when the label is clicked, and jumps to a month', () => {
+    const { getByTestId } = render(
+      <WeekCalendar periodStart="2026-06-15" earliestWeekStart={null} onSelectDate={vi.fn()} />
+    )
+    fireEvent.click(getByTestId('week-calendar-view-label'))
+    expect(getByTestId('week-calendar-view-label').textContent).toBe('2026')
+
+    const monthOptions = document.querySelectorAll('[data-testid="week-calendar-month-option"]')
+    fireEvent.click(monthOptions[0]!) // Enero
+
+    expect(getByTestId('week-calendar-view-label').textContent).toContain('Enero 2026')
+  })
+
+  it('cycles to years view and jumps to a different year', () => {
+    const { getByTestId } = render(
+      <WeekCalendar periodStart="2026-06-15" earliestWeekStart={null} onSelectDate={vi.fn()} />
+    )
+    fireEvent.click(getByTestId('week-calendar-view-label')) // weeks -> months
+    fireEvent.click(getByTestId('week-calendar-view-label')) // months -> years
+
+    const yearOptions = document.querySelectorAll('[data-testid="week-calendar-year-option"]')
+    const targetYear = yearOptions[0]!.textContent
+    fireEvent.click(yearOptions[0]!)
+
+    // Selecting a year moves to the months view for that year
+    expect(getByTestId('week-calendar-view-label').textContent).toBe(targetYear)
+  })
+
+  it('prev/next shift by year while in the months view', () => {
+    const { getByTestId } = render(
+      <WeekCalendar periodStart="2026-06-15" earliestWeekStart={null} onSelectDate={vi.fn()} />
+    )
+    fireEvent.click(getByTestId('week-calendar-view-label')) // weeks -> months
+    expect(getByTestId('week-calendar-view-label').textContent).toBe('2026')
+
+    fireEvent.click(getByTestId('week-calendar-next'))
+    expect(getByTestId('week-calendar-view-label').textContent).toBe('2027')
+
+    fireEvent.click(getByTestId('week-calendar-prev'))
+    fireEvent.click(getByTestId('week-calendar-prev'))
+    expect(getByTestId('week-calendar-view-label').textContent).toBe('2025')
+  })
+})

--- a/code/webapp/src/components/attendance/index.ts
+++ b/code/webapp/src/components/attendance/index.ts
@@ -44,6 +44,12 @@ export type { ExtraDayNegotiationDialogProps } from './ExtraDayNegotiationDialog
 export { useExtraDayExpress } from './use-extra-day-express'
 export { useExtraDayNegotiationDialog } from './use-extra-day-negotiation-dialog'
 
+// Weekly Summary Dialog
+export { WeeklySummaryDialog } from './WeeklySummaryDialog'
+export type { WeeklySummaryDialogProps } from './WeeklySummaryDialog'
+export { useWeeklySummaryDialog } from './use-weekly-summary-dialog'
+export type { WeeklySummaryDialogState } from './use-weekly-summary-dialog'
+
 // Register Leave Dialog
 export { RegisterLeaveDialog } from './RegisterLeaveDialog'
 export type { RegisterLeaveDialogProps } from './RegisterLeaveDialog'

--- a/code/webapp/src/components/attendance/use-weekly-summary-dialog.ts
+++ b/code/webapp/src/components/attendance/use-weekly-summary-dialog.ts
@@ -42,7 +42,7 @@ export function useWeeklySummaryDialog(): WeeklySummaryDialogState {
   const { data: employee } = useEmployee(employeePublicId)
   const periods = employee?.employment_periods ?? []
   const hireDate = periods.length > 0
-    ? periods.reduce((earliest, p) => (p.start_date < earliest ? p.start_date : earliest), periods[0]!.start_date)
+    ? periods.reduce((earliest, p) => (p.start_date < earliest ? p.start_date : earliest), periods[0]!.start_date) // NOSONAR — start_date is an ISO date string, not a number; Math.min() would coerce it to NaN
     : null
   const earliestWeekStart = hireDate ? weekRangeContaining(hireDate).start : null
 

--- a/code/webapp/src/components/attendance/use-weekly-summary-dialog.ts
+++ b/code/webapp/src/components/attendance/use-weekly-summary-dialog.ts
@@ -1,0 +1,99 @@
+import { useState } from 'react'
+import { useWeeklySummary } from '@/services/report.service'
+import { useEmployee } from '@/services/employee-hooks'
+import { currentWeekRange, weekRangeContaining, addDays } from '@/lib/week'
+import type { WeeklySummaryResponse } from '@/types/report'
+
+export interface WeeklySummaryDialogState {
+  isOpen: boolean
+  employeeName: string
+  employeePublicId: string
+  periodStart: string
+  periodEnd: string
+  prevWeek: () => void
+  nextWeek: () => void
+  jumpToDate: (dateStr: string) => void
+  isCurrentWeek: boolean
+  isEarliestWeek: boolean
+  earliestWeekStart: string | null
+  goToCurrentWeek: () => void
+  summary: WeeklySummaryResponse | null
+  isLoading: boolean
+  isError: boolean
+  open: (publicId: string, name: string) => void
+  close: () => void
+}
+
+export function useWeeklySummaryDialog(): WeeklySummaryDialogState {
+  const [isOpen, setIsOpen] = useState(false)
+  const [employeePublicId, setEmployeePublicId] = useState('')
+  const [employeeName, setEmployeeName] = useState('')
+  const { start, end } = currentWeekRange()
+  const [periodStart, setPeriodStart] = useState(start)
+  const [periodEnd, setPeriodEnd] = useState(end)
+
+  const shouldQuery = isOpen && !!employeePublicId && !!periodStart && !!periodEnd
+  const { data, isLoading, isError } = useWeeklySummary(
+    shouldQuery ? employeePublicId : null,
+    shouldQuery ? periodStart : null,
+    shouldQuery ? periodEnd : null,
+  )
+
+  const { data: employee } = useEmployee(employeePublicId)
+  const periods = employee?.employment_periods ?? []
+  const hireDate = periods.length > 0
+    ? periods.reduce((earliest, p) => (p.start_date < earliest ? p.start_date : earliest), periods[0]!.start_date)
+    : null
+  const earliestWeekStart = hireDate ? weekRangeContaining(hireDate).start : null
+
+  function open(publicId: string, name: string) {
+    setEmployeePublicId(publicId)
+    setEmployeeName(name)
+    const { start: s, end: e } = currentWeekRange()
+    setPeriodStart(s)
+    setPeriodEnd(e)
+    setIsOpen(true)
+  }
+
+  function shiftWeek(days: number) {
+    setPeriodStart((prev) => addDays(prev, days))
+    setPeriodEnd((prev) => addDays(prev, days))
+  }
+
+  function jumpToDate(dateStr: string) {
+    const { start: s, end: e } = weekRangeContaining(dateStr)
+    if (s > currentWeekRange().start) return // future weeks are not selectable
+    if (earliestWeekStart !== null && s < earliestWeekStart) return // before the employee's hire date
+    setPeriodStart(s)
+    setPeriodEnd(e)
+  }
+
+  function goToCurrentWeek() {
+    const { start: s, end: e } = currentWeekRange()
+    setPeriodStart(s)
+    setPeriodEnd(e)
+  }
+
+  const isCurrentWeek = periodStart === currentWeekRange().start
+  const isEarliestWeek = earliestWeekStart !== null && periodStart === earliestWeekStart
+
+  return {
+    isOpen,
+    employeeName,
+    employeePublicId,
+    periodStart,
+    periodEnd,
+    prevWeek: () => { if (!isEarliestWeek) shiftWeek(-7) },
+    nextWeek: () => { if (!isCurrentWeek) shiftWeek(7) },
+    jumpToDate,
+    isCurrentWeek,
+    isEarliestWeek,
+    earliestWeekStart,
+    goToCurrentWeek,
+    summary: data ?? null,
+    isLoading,
+    isError,
+    open,
+    close: () => setIsOpen(false),
+  }
+}

--- a/code/webapp/src/components/attendance/week-calendar.tsx
+++ b/code/webapp/src/components/attendance/week-calendar.tsx
@@ -1,0 +1,230 @@
+import { useEffect, useState } from 'react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import {
+  weeksInMonth,
+  formatWeekOrdinal,
+  formatWeekTitle,
+  currentWeekRange,
+  addDays,
+  MONTH_NAMES,
+  MONTH_NAMES_SHORT,
+} from '@/lib/week'
+
+const DAY_HEADERS = ['L', 'M', 'X', 'J', 'V', 'S', 'D']
+
+const YEARS_PER_PAGE = 12
+
+/** First year shown for a given yearPage (12 per page, pages are decade-aligned). */
+function yearPageStart(year: number, page: number): number {
+  return Math.floor(year / YEARS_PER_PAGE) * YEARS_PER_PAGE + page * YEARS_PER_PAGE
+}
+
+type View = 'weeks' | 'months' | 'years'
+
+export interface WeekCalendarProps {
+  readonly periodStart: string
+  readonly earliestWeekStart: string | null
+  readonly onSelectDate: (dateStr: string) => void
+}
+
+export function WeekCalendar({ periodStart, earliestWeekStart, onSelectDate }: WeekCalendarProps) {
+  const initial = new Date(periodStart + 'T00:00:00')
+  const [view, setView] = useState<View>('weeks')
+  const [year, setYear] = useState(initial.getFullYear())
+  const [month, setMonth] = useState(initial.getMonth())
+  const [yearPage, setYearPage] = useState(0)
+
+  const weeks = weeksInMonth(year, month)
+  const currentWeekStart = currentWeekRange().start
+
+  // Follow periodStart when it moves to a different month (e.g. prev/next-week
+  // arrows crossing a month boundary, or "current week"). Clicking a row never
+  // triggers this, since a row's date always belongs to the month already shown.
+  useEffect(() => {
+    const target = new Date(periodStart + 'T00:00:00')
+    if (target.getFullYear() !== year || target.getMonth() !== month) {
+      setYear(target.getFullYear())
+      setMonth(target.getMonth())
+      setView('weeks')
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [periodStart])
+
+  function prevMonth() {
+    if (month === 0) { setMonth(11); setYear((y) => y - 1) }
+    else setMonth((m) => m - 1)
+  }
+
+  function nextMonth() {
+    if (month === 11) { setMonth(0); setYear((y) => y + 1) }
+    else setMonth((m) => m + 1)
+  }
+
+  function handlePrev() {
+    if (view === 'weeks') prevMonth()
+    else if (view === 'months') setYear((y) => y - 1)
+    else setYearPage((p) => p - 1)
+  }
+
+  function handleNext() {
+    if (view === 'weeks') nextMonth()
+    else if (view === 'months') setYear((y) => y + 1)
+    else setYearPage((p) => p + 1)
+  }
+
+  function cycleView() {
+    setView((v) => {
+      if (v === 'weeks') return 'months'
+      if (v === 'months') return 'years'
+      return 'weeks'
+    })
+  }
+
+  const baseYear = yearPageStart(year, yearPage)
+  const years = Array.from({ length: YEARS_PER_PAGE }, (_, i) => baseYear + i)
+
+  return (
+    <div data-testid="week-calendar" className="rounded-md border border-border p-3">
+      {/* Navigator — arrows shift month/year/year-page depending on the active view */}
+      <div className="mb-2 flex items-center justify-between">
+        <button
+          type="button"
+          data-testid="week-calendar-prev"
+          onClick={handlePrev}
+          aria-label="Anterior"
+          className="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </button>
+
+        <button
+          type="button"
+          data-testid="week-calendar-view-label"
+          onClick={cycleView}
+          title="Click para cambiar de vista"
+          className="flex-1 rounded px-1 py-0.5 text-center text-sm font-medium capitalize hover:bg-muted"
+        >
+          {view === 'weeks' && `${MONTH_NAMES[month]} ${year}`}
+          {view === 'months' && `${year}`}
+          {view === 'years' && `${years[0]} – ${years[YEARS_PER_PAGE - 1]}`}
+        </button>
+
+        <button
+          type="button"
+          data-testid="week-calendar-next"
+          onClick={handleNext}
+          aria-label="Siguiente"
+          className="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </button>
+      </div>
+
+      {/* Years view */}
+      {view === 'years' && (
+        <div className="grid grid-cols-4 gap-1">
+          {years.map((y) => (
+            <button
+              key={y}
+              type="button"
+              data-testid="week-calendar-year-option"
+              onClick={() => { setYear(y); setYearPage(0); setView('months') }}
+              className={cn(
+                'rounded py-1.5 text-sm transition-colors hover:bg-emerald-50 hover:text-emerald-800 dark:hover:bg-emerald-900/20 dark:hover:text-emerald-300',
+                y === year && 'bg-emerald-600 font-semibold text-white hover:bg-emerald-700',
+              )}
+            >
+              {y}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Months view */}
+      {view === 'months' && (
+        <div className="grid grid-cols-3 gap-1">
+          {MONTH_NAMES_SHORT.map((label, i) => (
+            <button
+              key={label}
+              type="button"
+              data-testid="week-calendar-month-option"
+              onClick={() => { setMonth(i); setView('weeks') }}
+              className={cn(
+                'rounded py-2 text-sm transition-colors hover:bg-emerald-50 hover:text-emerald-800 dark:hover:bg-emerald-900/20 dark:hover:text-emerald-300',
+                i === month && 'bg-emerald-600 font-semibold text-white hover:bg-emerald-700',
+              )}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Weeks view — one row per week, clicking anywhere in the row selects that week */}
+      {view === 'weeks' && (
+        <>
+          <div className="mb-1 grid grid-cols-[2.5rem_repeat(7,1fr)] gap-0.5">
+            <span />
+            {DAY_HEADERS.map((h) => (
+              <div key={h} className="flex h-6 items-center justify-center text-xs font-medium text-muted-foreground">
+                {h}
+              </div>
+            ))}
+          </div>
+
+          <div className="space-y-0.5">
+            {weeks.map((week, index) => {
+              const isSelected = week.start === periodStart
+              const isFuture = week.start > currentWeekStart
+              const isBeforeHire = earliestWeekStart !== null && week.start < earliestWeekStart
+              const isDisabled = isFuture || isBeforeHire
+              const ordinal = formatWeekOrdinal(index + 1)
+              const disabledTitle = isFuture
+                ? 'No se pueden seleccionar semanas futuras'
+                : 'El empleado no tenía periodo activo antes de esta semana'
+              return (
+                <button
+                  key={week.start}
+                  type="button"
+                  data-testid="week-calendar-row"
+                  onClick={() => onSelectDate(week.start)}
+                  disabled={isDisabled}
+                  aria-pressed={isSelected}
+                  aria-disabled={isDisabled}
+                  title={isDisabled ? disabledTitle : formatWeekTitle(week.start, week.end)}
+                  className={cn(
+                    'grid w-full grid-cols-[2.5rem_repeat(7,1fr)] items-center gap-0.5 rounded transition-colors',
+                    isDisabled && 'cursor-not-allowed opacity-40',
+                    !isDisabled && isSelected && 'bg-emerald-600 text-white hover:bg-emerald-700',
+                    !isDisabled && !isSelected && 'hover:bg-emerald-50 dark:hover:bg-emerald-900/20',
+                  )}
+                >
+                  <span className={cn('text-xs font-medium', !isSelected && 'text-muted-foreground')}>
+                    {ordinal}
+                  </span>
+                  {Array.from({ length: 7 }, (_, i) => {
+                    const dayIso = addDays(week.start, i)
+                    const dayDate = new Date(`${dayIso}T00:00:00`)
+                    const inMonth = dayDate.getMonth() === month
+                    return (
+                      <span
+                        key={dayIso}
+                        className={cn(
+                          'flex h-8 items-center justify-center text-sm',
+                          !inMonth && !isSelected && 'text-muted-foreground/40',
+                        )}
+                      >
+                        {dayDate.getDate()}
+                      </span>
+                    )
+                  })}
+                </button>
+              )
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/code/webapp/src/components/employees/__tests__/employee-columns.test.tsx
+++ b/code/webapp/src/components/employees/__tests__/employee-columns.test.tsx
@@ -12,6 +12,7 @@ const mockEmployee: Employee = {
     first_name: 'Juan',
     last_name: 'Pérez',
     is_active: true,
+    attendance_exempt: false,
     has_active_period: true,
     has_user: true,
     roles: ['manager', 'cook'] as EmployeePositionRole[],

--- a/code/webapp/src/components/employees/__tests__/employee-info-header.test.tsx
+++ b/code/webapp/src/components/employees/__tests__/employee-info-header.test.tsx
@@ -19,6 +19,7 @@ const mockEmployee: Employee = {
     phone: '555-1234',
     phone_country: '+1',
     is_active: true,
+    attendance_exempt: false,
     has_user: true,
     roles: ['manager', 'cook'],
     meta: null,

--- a/code/webapp/src/components/employees/__tests__/schedule-section.test.tsx
+++ b/code/webapp/src/components/employees/__tests__/schedule-section.test.tsx
@@ -107,6 +107,7 @@ const mockEmployee: Employee = {
   last_name: 'Pérez',
   roles: ['cook'],
   is_active: true,
+  attendance_exempt: false,
   has_user: false,
   meta: null,
   employment_periods: [

--- a/code/webapp/src/components/employees/__tests__/use-employee-detail-actions.test.ts
+++ b/code/webapp/src/components/employees/__tests__/use-employee-detail-actions.test.ts
@@ -30,6 +30,7 @@ const mockEmployee: Employee = {
     phone_country: 'MX',
     roles: ['cook'] as EmployeePositionRole[],
     is_active: true,
+    attendance_exempt: false,
     has_active_period: true,
     has_user: false,
     meta: null,

--- a/code/webapp/src/components/employees/__tests__/use-employee-form.test.ts
+++ b/code/webapp/src/components/employees/__tests__/use-employee-form.test.ts
@@ -39,6 +39,7 @@ const mockEmployee: Employee = {
   email: 'juan@example.com',
   phone: null,
   is_active: true,
+  attendance_exempt: false,
   has_user: true,
   roles: [],
   meta: null,

--- a/code/webapp/src/components/employees/employee-edit-create-form.tsx
+++ b/code/webapp/src/components/employees/employee-edit-create-form.tsx
@@ -32,6 +32,7 @@ function buildSchema(assignableRoles: string[]) {
       roles: z.array(roleEnum).min(1, 'Selecciona al menos un puesto'),
       email: z.string().max(255).optional(),
       phone: z.string().max(10).optional(),
+      attendance_exempt: z.boolean(),
       // ── context flags (not submitted, used for conditional validation) ───────
       canEditContact: z.boolean(),
       // hasBranch reflects whether the auth store has a currentBranch selected.
@@ -146,6 +147,7 @@ export function EmployeeEditCreateForm({
         email: employee.email ?? '',
         phone: employee.phone ?? '',
         start_date: '',
+        attendance_exempt: employee.attendance_exempt,
         canEditContact,
         hasBranch,
       }
@@ -159,6 +161,8 @@ export function EmployeeEditCreateForm({
       email: '',
       phone: '',
       start_date: today,
+      // Disabled by default — most employees are tied to attendance tracking.
+      attendance_exempt: false,
       canEditContact,
       hasBranch,
     }
@@ -293,6 +297,24 @@ export function EmployeeEditCreateForm({
                 ))
               )}
             </div>
+          )}
+        />
+      </FormField>
+
+      {/* Attendance exemption — off by default; enable for roles free of attendance tracking (e.g. admin) */}
+      <FormField
+        label="Asistencia"
+        hint="Si se habilita, este empleado no aparecerá en la lista de asistencia (su asistencia se considera automática)"
+      >
+        <Controller
+          name="attendance_exempt"
+          control={control}
+          render={({ field }) => (
+            <ToggleSwitch
+              label="Libre de asistencia"
+              checked={field.value}
+              onChange={field.onChange}
+            />
           )}
         />
       </FormField>

--- a/code/webapp/src/components/employees/use-employee-form.ts
+++ b/code/webapp/src/components/employees/use-employee-form.ts
@@ -106,6 +106,7 @@ export function useEmployeeForm({
           roles: (values.roles as EmployeePositionRole[]).filter((r) =>
             assignableRoles.includes(r),
           ),
+          attendance_exempt: values.attendance_exempt,
         }
 
         if (isAdmin) {
@@ -136,6 +137,7 @@ export function useEmployeeForm({
           phone: values.phone,
           start_date: (values as { start_date: string }).start_date,
           branch_id: currentBranch.id,
+          attendance_exempt: values.attendance_exempt,
         })
         // Stay on the panel so the admin can assign a schedule right away.
         // Store the created employee for immediate rendering, then notify the

--- a/code/webapp/src/lib/__tests__/week.test.ts
+++ b/code/webapp/src/lib/__tests__/week.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest'
+import {
+  currentWeekRange,
+  weekRangeContaining,
+  addDays,
+  formatWeekLabel,
+  weeksInYear,
+  weekNumberForDate,
+  weeksInMonth,
+  weekOrdinalInMonth,
+  formatWeekOrdinal,
+  formatWeekTitle,
+} from '../week'
+
+describe('addDays', () => {
+  it('adds days within the same month', () => {
+    expect(addDays('2026-06-16', 1)).toBe('2026-06-17')
+  })
+
+  it('subtracts days across a month boundary', () => {
+    expect(addDays('2026-06-01', -1)).toBe('2026-05-31')
+  })
+
+  it('shifts a full week forward', () => {
+    expect(addDays('2026-06-16', 7)).toBe('2026-06-23')
+  })
+
+  it('shifts a full week backward', () => {
+    expect(addDays('2026-06-16', -7)).toBe('2026-06-09')
+  })
+})
+
+describe('weekRangeContaining', () => {
+  it('returns the Monday–Sunday range for a mid-week date', () => {
+    // 2026-06-17 is a Wednesday
+    expect(weekRangeContaining('2026-06-17')).toEqual({ start: '2026-06-15', end: '2026-06-21' })
+  })
+
+  it('returns the same range when the date is itself the Monday', () => {
+    expect(weekRangeContaining('2026-06-15')).toEqual({ start: '2026-06-15', end: '2026-06-21' })
+  })
+})
+
+describe('formatWeekLabel', () => {
+  it('includes both day numbers and the end year', () => {
+    const label = formatWeekLabel('2026-06-16', '2026-06-22')
+    expect(label).toContain('16')
+    expect(label).toContain('22')
+    expect(label).toContain('2026')
+  })
+})
+
+describe('currentWeekRange', () => {
+  it('returns a 6-day span between start and end', () => {
+    const { start, end } = currentWeekRange()
+    expect(addDays(start, 6)).toBe(end)
+  })
+})
+
+describe('weeksInYear', () => {
+  it('numbers weeks from 1, each a 7-day Mon–Sun span', () => {
+    const weeks = weeksInYear(2026)
+    expect(weeks[0]!.weekNumber).toBe(1)
+    weeks.forEach((week, i) => {
+      expect(week.weekNumber).toBe(i + 1)
+      expect(addDays(week.start, 6)).toBe(week.end)
+    })
+  })
+
+  it('chains weeks 7 days apart with no gaps or overlaps', () => {
+    const weeks = weeksInYear(2026)
+    for (let i = 1; i < weeks.length; i++) {
+      expect(addDays(weeks[i - 1]!.start, 7)).toBe(weeks[i]!.start)
+    }
+  })
+
+  it('week 1 starts on the first Monday on/after Jan 1, not before', () => {
+    const weeks = weeksInYear(2026)
+    // 2026-01-01 is a Thursday, so the first Monday on/after it is 2026-01-05
+    expect(weeks[0]!.start).toBe('2026-01-05')
+  })
+
+  it('does not include the boundary week twice across consecutive years', () => {
+    const weeks2026 = weeksInYear(2026)
+    const lastOf2026 = weeks2026[weeks2026.length - 1]!
+    const firstOf2027 = weeksInYear(2027)[0]!
+    expect(lastOf2026.start).not.toBe(firstOf2027.start)
+    expect(addDays(lastOf2026.start, 7)).toBe(firstOf2027.start)
+  })
+})
+
+describe('weekNumberForDate', () => {
+  it('resolves a mid-year week to the correct year and number', () => {
+    const weeks = weeksInYear(2026)
+    const midYear = weeks[24]!
+    expect(weekNumberForDate(midYear.start)).toEqual({ year: 2026, weekNumber: 25 })
+  })
+
+  it('resolves week 1 to the year whose Jan 1 the first Monday follows', () => {
+    expect(weekNumberForDate('2026-01-05')).toEqual({ year: 2026, weekNumber: 1 })
+  })
+})
+
+describe('weeksInMonth', () => {
+  it('groups weeks under the month they start in, even if they end in the next one', () => {
+    const weeks = weeksInMonth(2026, 5) // June 2026 — June 1 is a Monday
+    expect(weeks[0]!.start).toBe('2026-06-01')
+    const lastWeek = weeks[weeks.length - 1]!
+    expect(lastWeek.start).toBe('2026-06-29')
+    expect(lastWeek.end).toBe('2026-07-05') // spills into July, still counted as June's last week
+  })
+
+  it('the following month does not re-count the week that already belongs to the previous month', () => {
+    const july = weeksInMonth(2026, 6)
+    expect(july[0]!.start).toBe('2026-07-06') // not 2026-06-29 — that belongs to June
+  })
+})
+
+describe('weekOrdinalInMonth', () => {
+  it('returns the 1-based position of a week within its month', () => {
+    // June 2026: 06-01 (1st), 06-08 (2nd), 06-15 (3rd), 06-22 (4th), 06-29 (5th)
+    expect(weekOrdinalInMonth('2026-06-01')).toBe(1)
+    expect(weekOrdinalInMonth('2026-06-08')).toBe(2)
+    expect(weekOrdinalInMonth('2026-06-15')).toBe(3)
+    expect(weekOrdinalInMonth('2026-06-22')).toBe(4)
+    expect(weekOrdinalInMonth('2026-06-29')).toBe(5)
+  })
+
+  it('attributes a week spilling into the next month to the starting month', () => {
+    // 2026-06-29 belongs to June (5th week), not July
+    expect(weekOrdinalInMonth('2026-06-29')).toBe(5)
+  })
+})
+
+describe('formatWeekOrdinal', () => {
+  it('formats 1 through 5 with Spanish ordinal abbreviations', () => {
+    expect(formatWeekOrdinal(1)).toBe('1ra')
+    expect(formatWeekOrdinal(2)).toBe('2da')
+    expect(formatWeekOrdinal(3)).toBe('3ra')
+    expect(formatWeekOrdinal(4)).toBe('4ta')
+    expect(formatWeekOrdinal(5)).toBe('5ta')
+  })
+})
+
+describe('formatWeekTitle', () => {
+  it('combines month ordinal, month name, year week number, and date range', () => {
+    // 2026-06-15 is June's 3rd week and the year's 24th week
+    const title = formatWeekTitle('2026-06-15', '2026-06-21')
+    expect(title).toBe('3ra sem. de Jun. [24] - 15 jun – 21 jun 2026')
+  })
+})

--- a/code/webapp/src/lib/__tests__/week.test.ts
+++ b/code/webapp/src/lib/__tests__/week.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import {
   currentWeekRange,
   weekRangeContaining,
@@ -11,6 +11,11 @@ import {
   formatWeekOrdinal,
   formatWeekTitle,
 } from '../week'
+
+// Mock the timezone module to use CDMX timezone for deterministic tests
+vi.mock('../timezone', () => ({
+  getFrontendTimezone: () => 'America/Mexico_City',
+}))
 
 describe('addDays', () => {
   it('adds days within the same month', () => {
@@ -51,9 +56,22 @@ describe('formatWeekLabel', () => {
 })
 
 describe('currentWeekRange', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('returns a 6-day span between start and end', () => {
     const { start, end } = currentWeekRange()
     expect(addDays(start, 6)).toBe(end)
+  })
+
+  it('uses the CDMX date, not the UTC date, during evening hours', () => {
+    // Sunday 2026-06-21 19:00 CDMX = Monday 2026-06-22 01:00 UTC.
+    // A UTC-based date extraction would wrongly land on Monday, the *next* week.
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-22T01:00:00Z'))
+
+    expect(currentWeekRange()).toEqual({ start: '2026-06-15', end: '2026-06-21' })
   })
 })
 

--- a/code/webapp/src/lib/week.ts
+++ b/code/webapp/src/lib/week.ts
@@ -22,14 +22,27 @@ import { getFrontendTimezone } from './timezone'
 
 const WEEK_START_DAY = Number.parseInt(import.meta.env.VITE_WEEK_START_DAY ?? '1', 10)
 
-/** Formats a Date as "YYYY-MM-DD" in the local/business timezone — never UTC, to avoid day-shift near midnight. */
+/**
+ * Formats a Date as "YYYY-MM-DD" via plain UTC extraction. Only correct when
+ * `d` was itself constructed as system-local midnight of a known calendar
+ * date (as every caller in this file does) — local midnight and its UTC
+ * calendar day always agree, regardless of the runtime's timezone, so this
+ * stays self-consistent with `new Date(dateStr + 'T00:00:00')` construction.
+ * Do NOT use this to extract "today" from `new Date()` (the current instant)
+ * — that needs `todayInBusinessTz()` below instead.
+ */
 function toIsoDate(d: Date): string {
+  return d.toISOString().substring(0, 10)
+}
+
+/** Today's date as observed in the business timezone — "YYYY-MM-DD". */
+function todayInBusinessTz(): string {
   return new Intl.DateTimeFormat('en-CA', {
     timeZone: getFrontendTimezone(),
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',
-  }).format(d)
+  }).format(new Date())
 }
 
 /** Shifts a `YYYY-MM-DD` date string by `n` days (negative to go back). */
@@ -51,7 +64,7 @@ export function weekRangeContaining(dateStr: string): { start: string; end: stri
 
 /** Returns the Monday (or configured start day) and Sunday of the current week. */
 export function currentWeekRange(): { start: string; end: string } {
-  return weekRangeContaining(toIsoDate(new Date()))
+  return weekRangeContaining(todayInBusinessTz())
 }
 
 /** Formats a week range as "16 jun – 22 jun 2026" for display. */

--- a/code/webapp/src/lib/week.ts
+++ b/code/webapp/src/lib/week.ts
@@ -1,0 +1,169 @@
+/**
+ * Payroll week boundaries.
+ *
+ * WEEK_START_DAY follows ISO weekday numbering: 1=Monday … 7=Sunday.
+ * Configured via VITE_WEEK_START_DAY; defaults to 1 (Monday).
+ *
+ * SushiGo convention: weeks run Monday–Sunday. Cut-off is end of Sunday;
+ * payments are issued on Monday of the following week.
+ *
+ * Two numbering/grouping schemes coexist here:
+ *  - `weeksInYear` / `weekNumberForDate` — the week's ordinal position within
+ *    the YEAR (1..52/53), used for payroll reference. Week 1 starts on the
+ *    first Monday (or configured start day) ON OR AFTER Jan 1 — days before
+ *    that belong to no week of this year.
+ *  - `weeksInMonth` / `weekOrdinalInMonth` — a week's ordinal position within
+ *    the MONTH it starts in (1st..5th), for calendar-navigation display. A
+ *    week belongs to whichever month it starts in, even if it runs into the
+ *    next month.
+ */
+
+const WEEK_START_DAY = parseInt(import.meta.env.VITE_WEEK_START_DAY ?? '1', 10)
+
+function toIsoDate(d: Date): string {
+  return d.toISOString().substring(0, 10)
+}
+
+/** Shifts a `YYYY-MM-DD` date string by `n` days (negative to go back). */
+export function addDays(dateStr: string, n: number): string {
+  const d = new Date(dateStr + 'T00:00:00')
+  d.setDate(d.getDate() + n)
+  return toIsoDate(d)
+}
+
+/** Returns the Monday (or configured start day) – Sunday range containing `dateStr`. */
+export function weekRangeContaining(dateStr: string): { start: string; end: string } {
+  const date = new Date(dateStr + 'T00:00:00')
+  const jsDay = date.getDay() // 0=Sun … 6=Sat
+  const isoDay = jsDay === 0 ? 7 : jsDay // 1=Mon … 7=Sun
+  const daysFromStart = (isoDay - WEEK_START_DAY + 7) % 7
+  const start = addDays(dateStr, -daysFromStart)
+  return { start, end: addDays(start, 6) }
+}
+
+/** Returns the Monday (or configured start day) and Sunday of the current week. */
+export function currentWeekRange(): { start: string; end: string } {
+  return weekRangeContaining(toIsoDate(new Date()))
+}
+
+/** Formats a week range as "16 jun – 22 jun 2026" for display. */
+export function formatWeekLabel(start: string, end: string): string {
+  const shortDate = (dateStr: string) =>
+    new Date(dateStr + 'T00:00:00').toLocaleDateString('es-MX', { day: 'numeric', month: 'short' })
+  const endYear = new Date(end + 'T00:00:00').getFullYear()
+  return `${shortDate(start)} – ${shortDate(end)} ${endYear}`
+}
+
+/** Start date (Mon, or configured start day) of the first week belonging to `year`-`month` (0-based). */
+function firstWeekStart(year: number, month: number): string {
+  const day1 = new Date(year, month, 1)
+  const jsDay = day1.getDay()
+  const isoDay = jsDay === 0 ? 7 : jsDay
+  const daysToAdd = (WEEK_START_DAY - isoDay + 7) % 7
+  const d = new Date(day1)
+  d.setDate(day1.getDate() + daysToAdd)
+  return toIsoDate(d)
+}
+
+// ── Week-of-year numbering (payroll reference number) ───────────────────────────
+
+export interface WeekOption {
+  weekNumber: number
+  start: string
+  end: string
+}
+
+/**
+ * Enumerates every payroll week (Mon–Sun, or configured start day) in `year`.
+ * Week 1 starts on the first Monday on/after Jan 1 (days before that belong
+ * to no week of this year). The week containing next year's Jan 1 belongs to
+ * that next year instead — each week is assigned to exactly one year.
+ */
+export function weeksInYear(year: number): WeekOption[] {
+  let cursor = firstWeekStart(year, 0)
+  const nextYearStart = firstWeekStart(year + 1, 0)
+
+  const weeks: WeekOption[] = []
+  let weekNumber = 1
+  while (cursor !== nextYearStart) {
+    weeks.push({ weekNumber, start: cursor, end: addDays(cursor, 6) })
+    cursor = addDays(cursor, 7)
+    weekNumber++
+  }
+  return weeks
+}
+
+/** Resolves which (year, weekNumber) a week-start date belongs to, per `weeksInYear`. */
+export function weekNumberForDate(dateStr: string): { year: number; weekNumber: number } {
+  const year = Number(dateStr.slice(0, 4))
+  for (const candidateYear of [year, year + 1]) {
+    const match = weeksInYear(candidateYear).find((w) => w.start === dateStr)
+    if (match) return { year: candidateYear, weekNumber: match.weekNumber }
+  }
+  return { year, weekNumber: 1 }
+}
+
+// ── Week-of-month position (calendar navigation + display) ─────────────────────
+
+export interface MonthWeek {
+  start: string
+  end: string
+}
+
+/**
+ * Enumerates every payroll week (Mon–Sun, or configured start day) belonging to
+ * `year`-`month` (0-based, per JS `Date`), for calendar display purposes. A
+ * week belongs to the month it starts in — the week containing next month's
+ * day 1 belongs to that next month instead, so each week is assigned to
+ * exactly one month, never both.
+ */
+export function weeksInMonth(year: number, month: number): MonthWeek[] {
+  let cursor = firstWeekStart(year, month)
+  const nextMonthStart = month === 11 ? firstWeekStart(year + 1, 0) : firstWeekStart(year, month + 1)
+
+  const weeks: MonthWeek[] = []
+  while (cursor !== nextMonthStart) {
+    weeks.push({ start: cursor, end: addDays(cursor, 6) })
+    cursor = addDays(cursor, 7)
+  }
+  return weeks
+}
+
+/** Resolves a week-start date's 1-based position (1st..5th) within the month it belongs to. */
+export function weekOrdinalInMonth(dateStr: string): number {
+  const d = new Date(dateStr + 'T00:00:00')
+  const year = d.getFullYear()
+  const month = d.getMonth()
+  const candidates: Array<[number, number]> = [
+    [year, month],
+    month === 11 ? [year + 1, 0] : [year, month + 1],
+    month === 0 ? [year - 1, 11] : [year, month - 1],
+  ]
+  for (const [y, m] of candidates) {
+    const index = weeksInMonth(y, m).findIndex((w) => w.start === dateStr)
+    if (index !== -1) return index + 1
+  }
+  return 1
+}
+
+const WEEK_ORDINAL_LABELS = ['1ra', '2da', '3ra', '4ta', '5ta']
+
+/** Spanish ordinal abbreviation for a week's position within its month ("1ra", "2da", …). */
+export function formatWeekOrdinal(ordinal: number): string {
+  return WEEK_ORDINAL_LABELS[ordinal - 1] ?? `${ordinal}ta`
+}
+
+export const MONTH_NAMES = [
+  'Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio',
+  'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre',
+]
+
+export const MONTH_NAMES_SHORT = ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic']
+
+/** Formats a full week title: "3ra sem. de Jun. [24] - 15 jun – 21 jun 2026". */
+export function formatWeekTitle(start: string, end: string): string {
+  const ordinal = formatWeekOrdinal(weekOrdinalInMonth(start))
+  const { weekNumber } = weekNumberForDate(start)
+  const monthAbbr = MONTH_NAMES_SHORT[new Date(`${start}T00:00:00`).getMonth()]
+  return `${ordinal} sem. de ${monthAbbr}. [${weekNumber}] - ${formatWeekLabel(start, end)}`
+}

--- a/code/webapp/src/lib/week.ts
+++ b/code/webapp/src/lib/week.ts
@@ -18,10 +18,18 @@
  *    next month.
  */
 
+import { getFrontendTimezone } from './timezone'
+
 const WEEK_START_DAY = Number.parseInt(import.meta.env.VITE_WEEK_START_DAY ?? '1', 10)
 
+/** Formats a Date as "YYYY-MM-DD" in the local/business timezone — never UTC, to avoid day-shift near midnight. */
 function toIsoDate(d: Date): string {
-  return d.toISOString().substring(0, 10)
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: getFrontendTimezone(),
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(d)
 }
 
 /** Shifts a `YYYY-MM-DD` date string by `n` days (negative to go back). */

--- a/code/webapp/src/lib/week.ts
+++ b/code/webapp/src/lib/week.ts
@@ -23,16 +23,23 @@ import { getFrontendTimezone } from './timezone'
 const WEEK_START_DAY = Number.parseInt(import.meta.env.VITE_WEEK_START_DAY ?? '1', 10)
 
 /**
- * Formats a Date as "YYYY-MM-DD" via plain UTC extraction. Only correct when
- * `d` was itself constructed as system-local midnight of a known calendar
- * date (as every caller in this file does) — local midnight and its UTC
- * calendar day always agree, regardless of the runtime's timezone, so this
- * stays self-consistent with `new Date(dateStr + 'T00:00:00')` construction.
- * Do NOT use this to extract "today" from `new Date()` (the current instant)
- * — that needs `todayInBusinessTz()` below instead.
+ * Formats a Date as "YYYY-MM-DD" using its LOCAL (system-timezone) calendar
+ * components, not UTC. Every caller in this file constructs `d` as
+ * system-local midnight of a known calendar date (`new Date(dateStr +
+ * 'T00:00:00')` or `new Date(year, month, day)`), so reading it back via
+ * local components is always self-consistent regardless of the runtime's
+ * UTC offset — unlike `toISOString()`, which shifts the date by one day for
+ * any timezone that isn't exactly UTC-0 at construction time (behind UTC:
+ * local midnight reads as the previous UTC day; ahead of UTC: the same
+ * construction reads as the next UTC day). Do NOT use this to extract
+ * "today" from `new Date()` (the current instant) — that needs
+ * `todayInBusinessTz()` below instead.
  */
 function toIsoDate(d: Date): string {
-  return d.toISOString().substring(0, 10)
+  const year = d.getFullYear()
+  const month = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
 }
 
 /** Today's date as observed in the business timezone — "YYYY-MM-DD". */

--- a/code/webapp/src/lib/week.ts
+++ b/code/webapp/src/lib/week.ts
@@ -18,7 +18,7 @@
  *    next month.
  */
 
-const WEEK_START_DAY = parseInt(import.meta.env.VITE_WEEK_START_DAY ?? '1', 10)
+const WEEK_START_DAY = Number.parseInt(import.meta.env.VITE_WEEK_START_DAY ?? '1', 10)
 
 function toIsoDate(d: Date): string {
   return d.toISOString().substring(0, 10)

--- a/code/webapp/src/pages/attendance/index.tsx
+++ b/code/webapp/src/pages/attendance/index.tsx
@@ -18,6 +18,8 @@ import {
   useCloseDayPanel,
 } from '@/components/attendance'
 import { ExtraDayNegotiationDialog } from '@/components/attendance/ExtraDayNegotiationDialog'
+import { WeeklySummaryDialog } from '@/components/attendance/WeeklySummaryDialog'
+import { useWeeklySummaryDialog } from '@/components/attendance/use-weekly-summary-dialog'
 import { useAttendancePermissions } from '@/components/attendance/use-attendance-permissions'
 import { useTodayAttendancePage } from './-use-today-attendance-page'
 import { useApplicationTimeLabel } from '@/hooks/use-application-time-label'
@@ -144,8 +146,10 @@ export function AttendancePage() {
   const maxTime = useApplicationTimeLabel()
   const closeDayPanel = useCloseDayPanel(rows, branchId, maxTime)
   const isAdmin = useAuthStore(s => s.isAdmin)
+  const { can } = useAuthStore()
   const today = useBusinessDate() ?? todayDateCdmx()
   const { canEdit, requiresReason } = useAttendancePermissions(selectedDate)
+  const weeklySummary = useWeeklySummaryDialog()
 
   // Feed bulk overtime decisions from the close-day panel into the queue
   const { overtimePending, clearOvertimePending } = closeDayPanel
@@ -233,6 +237,9 @@ export function AttendancePage() {
                 onCheckOut={openCheckOut}
                 onOvertimeDecision={openOvertimeDecision}
                 onMarkDayStatus={markDayStatus}
+                onWeeklySummary={can('reports.weekly-summary')
+                  ? (emp) => weeklySummary.open(emp.id, `${emp.last_name}, ${emp.first_name}`)
+                  : undefined}
               />
             ))}
           </div>
@@ -323,6 +330,25 @@ export function AttendancePage() {
           onCancel={closeExtraDay}
         />
       )}
+
+      {/* Weekly Summary Slide Panel */}
+      <WeeklySummaryDialog
+        isOpen={weeklySummary.isOpen}
+        onClose={weeklySummary.close}
+        employeeName={weeklySummary.employeeName}
+        periodStart={weeklySummary.periodStart}
+        periodEnd={weeklySummary.periodEnd}
+        onPrevWeek={weeklySummary.prevWeek}
+        onNextWeek={weeklySummary.nextWeek}
+        onJumpToDate={weeklySummary.jumpToDate}
+        isCurrentWeek={weeklySummary.isCurrentWeek}
+        isEarliestWeek={weeklySummary.isEarliestWeek}
+        earliestWeekStart={weeklySummary.earliestWeekStart}
+        onGoToCurrentWeek={weeklySummary.goToCurrentWeek}
+        summary={weeklySummary.summary}
+        isLoading={weeklySummary.isLoading}
+        isError={weeklySummary.isError}
+      />
     </PageContainer>
   )
 }

--- a/code/webapp/src/pages/attendance/payroll/use-close-preview.ts
+++ b/code/webapp/src/pages/attendance/payroll/use-close-preview.ts
@@ -3,20 +3,7 @@ import { useAuthStore } from '@/stores/auth.store'
 import { useClosePreview, type ClosePreviewRange } from '@/services/payroll-hooks'
 import { getApiErrorMessage } from '@/lib/api-error'
 import type { PayPeriodEmployeePreview } from '@/types/attendance-payroll'
-
-function currentWeekRange(): ClosePreviewRange {
-  const now = new Date()
-  const day = now.getDay()
-  const diffToMonday = (day === 0 ? -6 : 1 - day)
-  const monday = new Date(now)
-  monday.setDate(now.getDate() + diffToMonday)
-  const sunday = new Date(monday)
-  sunday.setDate(monday.getDate() + 6)
-
-  const fmt = (d: Date) =>
-    `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
-  return { periodStart: fmt(monday), periodEnd: fmt(sunday) }
-}
+import { currentWeekRange as getWeekRange } from '@/lib/week'
 
 export interface UseClosePreviewResult {
   range: ClosePreviewRange
@@ -34,7 +21,8 @@ export function useClosePreviewPage(): UseClosePreviewResult {
   const currentBranch = useAuthStore(s => s.currentBranch)
   const branchId = currentBranch?.id ?? null
 
-  const defaultRange = currentWeekRange()
+  const { start, end } = getWeekRange()
+  const defaultRange: ClosePreviewRange = { periodStart: start, periodEnd: end }
   const [pendingRange, setPendingRange] = useState<ClosePreviewRange>(defaultRange)
   const [activeRange, setActiveRange] = useState<ClosePreviewRange | null>(null)
 

--- a/code/webapp/src/services/__tests__/report-api.test.ts
+++ b/code/webapp/src/services/__tests__/report-api.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { WeeklySummaryResponse } from '@/types/report'
 import { reportApi } from '@/services/report.service'
 
 vi.mock('@/lib/api-client', () => ({
@@ -64,6 +65,61 @@ describe('reportApi.getToday', () => {
     await reportApi.getToday(1)
     expect(apiClient.get).toHaveBeenCalledWith('/reports/today', {
       params: { branch_id: 1 },
+    })
+  })
+})
+
+// ── reportApi.getWeeklySummary ─────────────────────────────────────────────────
+
+const mockWeeklySummary: WeeklySummaryResponse = {
+  employee_id: 'emp-ulid-001',
+  period_start: '2026-06-16',
+  period_end: '2026-06-22',
+  base_pay: 1120.0,
+  late_deductions: 20.0,
+  unpaid_leave_deductions: 0.0,
+  overtime_pay: 0.0,
+  extra_day_pay: 0.0,
+  holiday_pay: 0.0,
+  punctuality_bonus: 110.0,
+  free_hours_earned: 1.0,
+  total_pay: 1210.0,
+  daily_evidence: [],
+}
+
+describe('reportApi.getWeeklySummary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('calls GET /reports/weekly-summary with correct params', async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce({
+      data: { status: 200, data: mockWeeklySummary },
+    } as never)
+
+    const result = await reportApi.getWeeklySummary('emp-ulid-001', '2026-06-16', '2026-06-22')
+
+    expect(apiClient.get).toHaveBeenCalledWith('/reports/weekly-summary', {
+      params: {
+        employee_id: 'emp-ulid-001',
+        period_start: '2026-06-16',
+        period_end: '2026-06-22',
+      },
+    })
+    expect(result).toEqual({ data: { status: 200, data: mockWeeklySummary } })
+  })
+
+  it('passes different employee ids and date ranges', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({ data: {} } as never)
+
+    await reportApi.getWeeklySummary('emp-ulid-002', '2026-06-09', '2026-06-15')
+
+    expect(apiClient.get).toHaveBeenCalledWith('/reports/weekly-summary', {
+      params: {
+        employee_id: 'emp-ulid-002',
+        period_start: '2026-06-09',
+        period_end: '2026-06-15',
+      },
     })
   })
 })

--- a/code/webapp/src/services/__tests__/report-hooks.test.ts
+++ b/code/webapp/src/services/__tests__/report-hooks.test.ts
@@ -13,7 +13,8 @@ vi.mock('@/lib/api-client', () => ({
 }))
 
 import { apiClient } from '@/lib/api-client'
-import { useTodayReport } from '@/services/report.service'
+import { useTodayReport, useWeeklySummary } from '@/services/report.service'
+import type { WeeklySummaryResponse } from '@/types/report'
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -127,5 +128,107 @@ describe('useTodayReport', () => {
     expect(employees[0]!.employee_id).toBe('emp-001')
     expect(employees[0]!.status).toBe('arrived')
     expect(employees[1]!.status).toBe('not_arrived')
+  })
+})
+
+// ── useWeeklySummary ───────────────────────────────────────────────────────────
+
+const mockWeeklySummary: WeeklySummaryResponse = {
+  employee_id: 'emp-ulid-001',
+  period_start: '2026-06-16',
+  period_end: '2026-06-22',
+  base_pay: 1120.0,
+  late_deductions: 20.0,
+  unpaid_leave_deductions: 0.0,
+  overtime_pay: 0.0,
+  extra_day_pay: 0.0,
+  holiday_pay: 0.0,
+  punctuality_bonus: 110.0,
+  free_hours_earned: 1.0,
+  total_pay: 1210.0,
+  daily_evidence: [
+    {
+      date: '2026-06-16',
+      check_in: '2026-06-16T09:00:00+00:00',
+      check_out: '2026-06-16T18:00:00+00:00',
+      day_status: 'WORKED',
+      late_minutes: 0,
+      deducted_minutes: 0,
+      partial_leaves: [],
+      overtime_minutes: 0,
+      overtime_authorized: false,
+    },
+  ],
+}
+
+describe('useWeeklySummary', () => {
+  beforeEach(() => {
+    vi.mocked(apiClient.get).mockResolvedValue({
+      data: { status: 200, data: mockWeeklySummary },
+    } as never)
+  })
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns undefined when any param is null (query disabled)', async () => {
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(
+      () => useWeeklySummary(null, '2026-06-16', '2026-06-22'),
+      { wrapper },
+    )
+
+    expect(result.current.data).toBeUndefined()
+    expect(apiClient.get).not.toHaveBeenCalled()
+  })
+
+  it('fetches weekly summary when all params are provided', async () => {
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(
+      () => useWeeklySummary('emp-ulid-001', '2026-06-16', '2026-06-22'),
+      { wrapper },
+    )
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    expect(apiClient.get).toHaveBeenCalledWith('/reports/weekly-summary', {
+      params: {
+        employee_id: 'emp-ulid-001',
+        period_start: '2026-06-16',
+        period_end: '2026-06-22',
+      },
+    })
+    expect(result.current.data?.base_pay).toBe(1120.0)
+    expect(result.current.data?.total_pay).toBe(1210.0)
+  })
+
+  it('returns daily_evidence with correct structure', async () => {
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(
+      () => useWeeklySummary('emp-ulid-001', '2026-06-16', '2026-06-22'),
+      { wrapper },
+    )
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    const evidence = result.current.data?.daily_evidence ?? []
+    expect(evidence).toHaveLength(1)
+    expect(evidence[0]!.day_status).toBe('WORKED')
+    expect(evidence[0]!.late_minutes).toBe(0)
+  })
+
+  it('remains disabled when period_end is null', async () => {
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(
+      () => useWeeklySummary('emp-ulid-001', '2026-06-16', null),
+      { wrapper },
+    )
+
+    expect(result.current.data).toBeUndefined()
+    expect(apiClient.get).not.toHaveBeenCalled()
   })
 })

--- a/code/webapp/src/services/report.service.ts
+++ b/code/webapp/src/services/report.service.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { apiClient } from '@/lib/api-client'
-import type { TodayReportResponse } from '@/types/report'
+import type { TodayReportResponse, WeeklySummaryResponse } from '@/types/report'
 
 // ── API layer ──────────────────────────────────────────────────────────────────
 
@@ -12,6 +12,15 @@ export const reportApi = {
   getToday: (branchId: number) =>
     apiClient.get<{ status: number; data: TodayReportResponse }>('/reports/today', {
       params: { branch_id: branchId },
+    }),
+
+  /**
+   * GET /reports/weekly-summary?employee_id=<ulid>&period_start=<date>&period_end=<date>
+   * Returns the full payroll breakdown for one employee over a week.
+   */
+  getWeeklySummary: (employeeId: string, periodStart: string, periodEnd: string) =>
+    apiClient.get<{ status: number; data: WeeklySummaryResponse }>('/reports/weekly-summary', {
+      params: { employee_id: employeeId, period_start: periodStart, period_end: periodEnd },
     }),
 }
 
@@ -34,5 +43,28 @@ export function useTodayReport(branchId: number | null) {
     enabled: !!branchId,
     refetchInterval: 2 * 60 * 1000,  // 2 minutes — as specified in issue #067
     staleTime: 60 * 1000,
+  })
+}
+
+/**
+ * Fetch the weekly payroll summary for one employee.
+ *
+ * @param employeeId   ULID public_id of the employee
+ * @param periodStart  ISO date string (YYYY-MM-DD)
+ * @param periodEnd    ISO date string (YYYY-MM-DD)
+ */
+export function useWeeklySummary(
+  employeeId: string | null,
+  periodStart: string | null,
+  periodEnd: string | null,
+) {
+  return useQuery<WeeklySummaryResponse>({
+    queryKey: ['reports', 'weekly-summary', employeeId, periodStart, periodEnd],
+    queryFn: async () => {
+      const response = await reportApi.getWeeklySummary(employeeId!, periodStart!, periodEnd!)
+      return response.data.data
+    },
+    enabled: !!employeeId && !!periodStart && !!periodEnd,
+    staleTime: 5 * 60 * 1000,
   })
 }

--- a/code/webapp/src/types/employee.ts
+++ b/code/webapp/src/types/employee.ts
@@ -29,6 +29,8 @@ export interface Employee {
   last_name: string
   roles: EmployeePositionRole[]
   is_active: boolean
+  /** True for roles (e.g. admin, super-admin) that do not check in/out — excluded from the attendance list */
+  attendance_exempt: boolean
   has_active_period?: boolean | null
   has_user: boolean
   email?: string | null
@@ -75,6 +77,7 @@ export interface EmployeeFormData {
   meta?: Record<string, any>
   branch_id?: number
   start_date?: string
+  attendance_exempt?: boolean
 }
 
 export interface DeactivateEmployeeData {
@@ -94,6 +97,7 @@ export interface EmployeeUpdateData {
   email?: string
   phone?: string
   meta?: Record<string, any>
+  attendance_exempt?: boolean
 }
 
 // ============================================================================

--- a/code/webapp/src/types/report.ts
+++ b/code/webapp/src/types/report.ts
@@ -42,3 +42,39 @@ export interface TodayReportResponse {
   summary: TodayReportSummary
   employees: TodayReportEmployee[]
 }
+
+// ── Weekly Summary ─────────────────────────────────────────────────────────────
+
+export interface PartialLeaveItem {
+  is_paid: boolean
+  duration_minutes: number
+}
+
+export interface DailyEvidenceItem {
+  date: string
+  check_in: string | null
+  check_out: string | null
+  day_status: string | null   // null when no attendance record exists for this date yet
+  late_minutes: number
+  deducted_minutes: number
+  partial_leaves: PartialLeaveItem[]
+  overtime_minutes: number
+  overtime_authorized: boolean
+}
+
+/** Full response payload for GET /api/v1/reports/weekly-summary. */
+export interface WeeklySummaryResponse {
+  employee_id: string
+  period_start: string
+  period_end: string
+  base_pay: number
+  late_deductions: number
+  unpaid_leave_deductions: number
+  overtime_pay: number
+  extra_day_pay: number
+  holiday_pay: number
+  punctuality_bonus: number
+  free_hours_earned: number
+  total_pay: number
+  daily_evidence: DailyEvidenceItem[]
+}

--- a/doc/tasks/2026-06/068-weekly-summary-report.md
+++ b/doc/tasks/2026-06/068-weekly-summary-report.md
@@ -44,6 +44,27 @@ Como Manager, quiero ver el resumen semanal completo por empleado (pago base, de
 
 ---
 
-## ⏱️ Estimates
+## ⏱️ Time
 
-- **Optimistic:** `5h` · **Pessimistic:** `9h`
+### 📊 Estimates
+- **Optimistic:** `5h` · **Pessimistic:** `9h` · **Tracked:** `8h`
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-06-24", "start": "10:00", "end": "14:00", "duration": "4h" },
+  { "date": "2026-06-24", "start": "17:00", "end": "21:00", "duration": "4h" }
+]
+```
+
+---
+
+## 📊 Retrospective
+
+**Tracked vs Estimated:** 8h tracked, 5–9h estimated. Within range.
+
+**Scope expansion:** Issue #068 required AP-020 (PartialLeave), AP-026 (PunctualityService), AP-034 (OvertimeBankMovement) as prerequisites. This added 3 migrations, 4 enums, 3 models, and a full PunctualityService — roughly 3h extra that was unaccounted in the original estimate.
+
+**Key blocker:** PostgreSQL deadlock when creating multiple FK constraints to `users` in a single `Schema::create()` transaction. Solved by separating FK creation into a subsequent `Schema::table()` call. Also required manually recreating the test DB after a partial migration left it in inconsistent state.
+
+**Rest-day formula:** User confirmed proration formula — `base_pay = worked_days × daily_rate × (1 + 1/scheduled_working_days)` — which correctly distributes the rest day proportionally by days actually worked. Implemented exactly as specified.


### PR DESCRIPTION
## Summary
- Implements `GET /api/v1/reports/weekly-summary` with complete payroll breakdown: base pay (with proportional rest day), late deductions, unpaid leave, extra days, holiday pay, punctuality bonus, overtime, and daily evidence per day
- Adds prerequisite models AP-020 (PartialLeave), AP-026 (PunctualityService), AP-034 (OvertimeBankMovement) with 3 migrations, 4 enums, 3 models
- Frontend page at `/attendance/reports/weekly`: form with employee ID + date range, payroll concepts breakdown card, daily evidence table

## Test plan
- [ ] PHPUnit: `php artisan test --filter=WeeklySummaryApiTest` (11 tests)
- [ ] PHPUnit: `php artisan test --filter=PunctualityServiceTest` (15 tests)
- [ ] PHPUnit: `php artisan test --filter=PayrollCalculatorTest` (18 tests)
- [ ] Vitest: `npx vitest run src/services/__tests__/report-api.test.ts src/services/__tests__/report-hooks.test.ts src/pages/attendance/reports/__tests__/use-weekly-summary-page.test.ts` (18 tests)
- [ ] Cypress E2E: `make cypress-run SPEC=attendance-weekly-summary`
- [ ] Linters: Pint ✅ · ESLint ✅ · TypeScript ✅

## Closes
Closes #068

## Workspace
`sushigo-a` — `feature/068-weekly-summary-report`

🤖 Generated with [Claude Code](https://claude.com/claude-code)