### PR TITLE
✨ [#069][b] - Configure overtime payment method per employee ⏱️

### DIFF
--- a/code/api/app/Http/Controllers/Api/V1/Overtime/GetOvertimeConfigController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Overtime/GetOvertimeConfigController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Overtime;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Overtime\OvertimePayConfigResource;
+use App\Http\Responses\Common\ResponseEntity;
+use App\Models\Employee;
+
+class GetOvertimeConfigController extends Controller
+{
+    public function __invoke(Employee $employee): ResponseEntity
+    {
+        $configs = $employee->overtimePayConfigs()
+            ->orderBy('effective_from', 'desc')
+            ->get();
+
+        $data = OvertimePayConfigResource::collection($configs)->resolve();
+
+        return new ResponseEntity(data: $data);
+    }
+}

--- a/code/api/app/Http/Controllers/Api/V1/Overtime/SetOvertimeConfigController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Overtime/SetOvertimeConfigController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Overtime;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Overtime\SetOvertimeConfigRequest;
+use App\Http\Resources\Overtime\OvertimePayConfigResource;
+use App\Models\Employee;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+
+class SetOvertimeConfigController extends Controller
+{
+    public function __invoke(SetOvertimeConfigRequest $request, Employee $employee): OvertimePayConfigResource
+    {
+        $effectiveFrom = Carbon::parse($request->effective_from)->startOfDay();
+
+        $config = DB::transaction(function () use ($request, $employee, $effectiveFrom) {
+            // Delete all configs starting on or after the new date (open or already closed by a later assignment)
+            $employee->overtimePayConfigs()
+                ->where('effective_from', '>=', $effectiveFrom->toDateString())
+                ->delete();
+
+            // Lock and close the single open config that started before the new effective date
+            $employee->overtimePayConfigs()
+                ->whereNull('effective_to')
+                ->where('effective_from', '<', $effectiveFrom->toDateString())
+                ->lockForUpdate()
+                ->update(['effective_to' => $effectiveFrom->copy()->subDay()->toDateString()]);
+
+            return $employee->overtimePayConfigs()->create([
+                'valuation_method' => $request->valuation_method,
+                'lft_factor' => $request->lft_factor,
+                'hourly_rate' => $request->hourly_rate,
+                'effective_from' => $effectiveFrom->toDateString(),
+                'effective_to' => null,
+            ]);
+        });
+
+        return (new OvertimePayConfigResource($config))->setStatusCode(201);
+    }
+}

--- a/code/api/app/Http/Requests/Overtime/SetOvertimeConfigRequest.php
+++ b/code/api/app/Http/Requests/Overtime/SetOvertimeConfigRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests\Overtime;
+
+use App\Enums\OvertimeValuationMethod;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class SetOvertimeConfigRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'valuation_method' => ['required', Rule::enum(OvertimeValuationMethod::class)],
+            'lft_factor' => ['required_if:valuation_method,LFT_PROPORTIONAL', 'nullable', 'numeric', 'gt:0'],
+            'hourly_rate' => ['required_if:valuation_method,AGREED_RATE', 'nullable', 'numeric', 'gt:0'],
+            'effective_from' => ['required', 'date'],
+        ];
+    }
+}

--- a/code/api/app/Http/Resources/Overtime/OvertimePayConfigResource.php
+++ b/code/api/app/Http/Resources/Overtime/OvertimePayConfigResource.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Resources\Overtime;
+
+use App\Http\Resources\BaseResource;
+use App\Models\OvertimePayConfig;
+
+/**
+ * @mixin OvertimePayConfig
+ *
+ * @OA\Schema(
+ *     schema="OvertimePayConfigResponse",
+ *     title="Overtime Pay Config Response",
+ *
+ *     @OA\Property(property="id", type="string", example="01HXYZ"),
+ *     @OA\Property(property="valuation_method", type="string", enum={"LFT_PROPORTIONAL", "AGREED_RATE"}, example="AGREED_RATE"),
+ *     @OA\Property(property="lft_factor", type="number", format="float", nullable=true, example=null),
+ *     @OA\Property(property="hourly_rate", type="number", format="float", nullable=true, example=90.00),
+ *     @OA\Property(property="effective_from", type="string", format="date", example="2026-05-01"),
+ *     @OA\Property(property="effective_to", type="string", format="date", nullable=true, example=null)
+ * )
+ */
+class OvertimePayConfigResource extends BaseResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->public_id,
+            'valuation_method' => $this->valuation_method->value,
+            'lft_factor' => $this->lft_factor !== null ? (float) $this->lft_factor : null,
+            'hourly_rate' => $this->hourly_rate !== null ? (float) $this->hourly_rate : null,
+            'effective_from' => $this->effective_from->toDateString(),
+            'effective_to' => $this->effective_to?->toDateString(),
+        ];
+    }
+}

--- a/code/api/app/Models/Employee.php
+++ b/code/api/app/Models/Employee.php
@@ -141,6 +141,11 @@ class Employee extends Model
         return $this->hasMany(EmployeeBonusConfig::class)->orderBy('effective_from', 'desc');
     }
 
+    public function overtimePayConfigs(): HasMany
+    {
+        return $this->hasMany(OvertimePayConfig::class)->orderBy('effective_from', 'desc');
+    }
+
     /**
      * All schedules for this employee, via their employment periods.
      * For the active schedule use:

--- a/code/api/app/Models/OvertimePayConfig.php
+++ b/code/api/app/Models/OvertimePayConfig.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\OvertimeValuationMethod;
+use App\Support\Traits\HasPublicId;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class OvertimePayConfig extends Model
+{
+    use HasFactory, HasPublicId;
+
+    protected $fillable = [
+        'employee_id',
+        'valuation_method',
+        'lft_factor',
+        'hourly_rate',
+        'effective_from',
+        'effective_to',
+    ];
+
+    protected $casts = [
+        'valuation_method' => OvertimeValuationMethod::class,
+        'lft_factor' => 'decimal:2',
+        'hourly_rate' => 'decimal:2',
+        'effective_from' => 'date',
+        'effective_to' => 'date',
+    ];
+
+    public function employee(): BelongsTo
+    {
+        return $this->belongsTo(Employee::class);
+    }
+
+    /** Returns the config active on a given date (effective_from ≤ date, effective_to is null or ≥ date). */
+    public function scopeEffective(Builder $query, Carbon $date): Builder
+    {
+        return $query
+            ->where('effective_from', '<=', $date->toDateString())
+            ->where(function (Builder $q) use ($date) {
+                $q->whereNull('effective_to')
+                    ->orWhere('effective_to', '>=', $date->toDateString());
+            });
+    }
+
+    /**
+     * Calculate the overtime pay for a number of minutes, given the method configured.
+     *
+     * LFT_PROPORTIONAL: (dailyWage / 8 / 60) × lft_factor × minutes
+     * AGREED_RATE: (hourly_rate / 60) × minutes
+     */
+    public function calculatePay(int $minutes, float $dailyWage): float
+    {
+        return match ($this->valuation_method) {
+            OvertimeValuationMethod::LFT_PROPORTIONAL => ($dailyWage / 8 / 60) * (float) $this->lft_factor * $minutes,
+            OvertimeValuationMethod::AGREED_RATE => ((float) $this->hourly_rate / 60) * $minutes,
+        };
+    }
+}

--- a/code/api/database/factories/OvertimePayConfigFactory.php
+++ b/code/api/database/factories/OvertimePayConfigFactory.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Employee;
+use App\Models\OvertimePayConfig;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/** @extends Factory<OvertimePayConfig> */
+class OvertimePayConfigFactory extends Factory
+{
+    protected $model = OvertimePayConfig::class;
+
+    public function definition(): array
+    {
+        $effectiveFrom = fake()->dateTimeBetween('-2 years', '-1 month');
+
+        return [
+            'public_id' => (string) Str::ulid(),
+            'employee_id' => Employee::factory(),
+            'valuation_method' => 'LFT_PROPORTIONAL',
+            'lft_factor' => fake()->randomElement(['2.00', '3.00']),
+            'hourly_rate' => null,
+            'effective_from' => $effectiveFrom,
+            'effective_to' => null, // open-ended (current)
+        ];
+    }
+
+    /**
+     * Configure this record as an agreed hourly rate config instead of LFT proportional.
+     */
+    public function agreedRate(float $hourlyRate = 90.00): static
+    {
+        return $this->state(fn () => [
+            'valuation_method' => 'AGREED_RATE',
+            'lft_factor' => null,
+            'hourly_rate' => $hourlyRate,
+        ]);
+    }
+
+    /**
+     * A config that has already been superseded (closed).
+     */
+    public function closed(): static
+    {
+        return $this->state(function (array $attributes) {
+            $from = $attributes['effective_from'];
+            $to = fake()->dateTimeBetween($from, '-1 day');
+
+            return ['effective_to' => $to];
+        });
+    }
+
+    /**
+     * Explicitly mark this record as the currently active config.
+     */
+    public function current(): static
+    {
+        return $this->state(fn () => ['effective_to' => null]);
+    }
+
+    /**
+     * Pin the effective range to a known period for deterministic tests.
+     */
+    public function effectiveBetween(string $from, ?string $to = null): static
+    {
+        return $this->state(fn () => [
+            'effective_from' => $from,
+            'effective_to' => $to,
+        ]);
+    }
+}

--- a/code/api/database/migrations/2026_07_03_000001_create_overtime_pay_configs_table.php
+++ b/code/api/database/migrations/2026_07_03_000001_create_overtime_pay_configs_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('overtime_pay_configs', function (Blueprint $table) {
+            $table->id();
+            $table->string('public_id', 26)->unique();
+            $table->foreignId('employee_id')->constrained()->cascadeOnDelete();
+            $table->enum('valuation_method', ['LFT_PROPORTIONAL', 'AGREED_RATE']);
+            $table->decimal('lft_factor', 8, 2)->nullable();
+            $table->decimal('hourly_rate', 8, 2)->nullable();
+            $table->date('effective_from');
+            $table->date('effective_to')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('overtime_pay_configs');
+    }
+};

--- a/code/api/routes/api.php
+++ b/code/api/routes/api.php
@@ -85,6 +85,8 @@ use App\Http\Controllers\Api\V1\OperatingUnit\UpdateOperatingUnitController;
 use App\Http\Controllers\Api\V1\OperatingUnitUser\AddUserToOperatingUnitController;
 use App\Http\Controllers\Api\V1\OperatingUnitUser\ListOperatingUnitUsersController;
 use App\Http\Controllers\Api\V1\OperatingUnitUser\RemoveUserFromOperatingUnitController;
+use App\Http\Controllers\Api\V1\Overtime\GetOvertimeConfigController;
+use App\Http\Controllers\Api\V1\Overtime\SetOvertimeConfigController;
 use App\Http\Controllers\Api\V1\Punctuality\AssignBonusConfigController;
 use App\Http\Controllers\Api\V1\Punctuality\CreatePunctualityBonusGroupController;
 use App\Http\Controllers\Api\V1\Punctuality\GetEmployeeBonusConfigController;
@@ -300,6 +302,9 @@ Route::prefix('v1')->group(function () {
         // Bonus config
         Route::get('/{employee}/bonus-config', GetEmployeeBonusConfigController::class)->name('employees.bonus-config.get')->middleware('permission:employees.view');
         Route::post('/{employee}/bonus-config', AssignBonusConfigController::class)->name('employees.bonus-config.assign')->middleware('permission:employees.update');
+        // Overtime pay config
+        Route::get('/{employee}/overtime-config', GetOvertimeConfigController::class)->name('employees.overtime-config.get')->middleware('permission:employees.view');
+        Route::post('/{employee}/overtime-config', SetOvertimeConfigController::class)->name('employees.overtime-config.set')->middleware('permission:employees.update');
     });
 
     // Employment Periods — Schedules (All Protected)

--- a/code/api/tests/Feature/Overtime/OvertimePayConfigTest.php
+++ b/code/api/tests/Feature/Overtime/OvertimePayConfigTest.php
@@ -1,0 +1,291 @@
+<?php
+
+namespace Tests\Feature\Overtime;
+
+use App\Models\Employee;
+use App\Models\OvertimePayConfig;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+class OvertimePayConfigTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected Employee $employee;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        app()[PermissionRegistrar::class]->forgetCachedPermissions();
+
+        Permission::create(['name' => 'employees.view', 'guard_name' => 'api']);
+        Permission::create(['name' => 'employees.update', 'guard_name' => 'api']);
+        $admin = Role::create(['name' => 'admin', 'guard_name' => 'api']);
+        $admin->givePermissionTo(['employees.view', 'employees.update']);
+
+        foreach (Employee::POSITION_ROLES as $roleName) {
+            Role::firstOrCreate(['name' => $roleName, 'guard_name' => 'api']);
+        }
+
+        $this->employee = Employee::factory()->create();
+    }
+
+    private function adminUser(): User
+    {
+        $user = User::factory()->create();
+        $user->assignRole('admin');
+
+        return $user;
+    }
+
+    // ── GET /api/v1/employees/{id}/overtime-config ─────────────────────────────
+
+    #[Test]
+    public function admin_can_get_empty_overtime_config_history(): void
+    {
+        Passport::actingAs($this->adminUser());
+
+        $this->getJson("/api/v1/employees/{$this->employee->public_id}/overtime-config")
+            ->assertOk()
+            ->assertJsonPath('data', []);
+    }
+
+    #[Test]
+    public function admin_can_get_overtime_config_history(): void
+    {
+        Passport::actingAs($this->adminUser());
+
+        OvertimePayConfig::create([
+            'public_id' => '01CFGTEST01234567890123',
+            'employee_id' => $this->employee->id,
+            'valuation_method' => 'LFT_PROPORTIONAL',
+            'lft_factor' => '2.00',
+            'hourly_rate' => null,
+            'effective_from' => '2026-01-01',
+            'effective_to' => null,
+        ]);
+
+        $this->getJson("/api/v1/employees/{$this->employee->public_id}/overtime-config")
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.valuation_method', 'LFT_PROPORTIONAL')
+            ->assertJsonPath('data.0.lft_factor', 2)
+            ->assertJsonPath('data.0.hourly_rate', null)
+            ->assertJsonPath('data.0.effective_from', '2026-01-01')
+            ->assertJsonPath('data.0.effective_to', null);
+    }
+
+    #[Test]
+    public function get_overtime_config_requires_authentication(): void
+    {
+        $this->getJson("/api/v1/employees/{$this->employee->public_id}/overtime-config")
+            ->assertUnauthorized();
+    }
+
+    #[Test]
+    public function get_overtime_config_requires_employees_view_permission(): void
+    {
+        $user = User::factory()->create();
+        Passport::actingAs($user);
+
+        $this->getJson("/api/v1/employees/{$this->employee->public_id}/overtime-config")
+            ->assertForbidden();
+    }
+
+    // ── POST /api/v1/employees/{id}/overtime-config ────────────────────────────
+
+    #[Test]
+    public function admin_can_set_lft_proportional_config(): void
+    {
+        Passport::actingAs($this->adminUser());
+
+        $payload = [
+            'valuation_method' => 'LFT_PROPORTIONAL',
+            'lft_factor' => 2.00,
+            'effective_from' => '2026-05-01',
+        ];
+
+        $this->postJson("/api/v1/employees/{$this->employee->public_id}/overtime-config", $payload)
+            ->assertCreated()
+            ->assertJsonPath('data.valuation_method', 'LFT_PROPORTIONAL')
+            ->assertJsonPath('data.lft_factor', 2)
+            ->assertJsonPath('data.hourly_rate', null)
+            ->assertJsonPath('data.effective_from', '2026-05-01')
+            ->assertJsonPath('data.effective_to', null);
+
+        $this->assertDatabaseHas('overtime_pay_configs', [
+            'employee_id' => $this->employee->id,
+            'valuation_method' => 'LFT_PROPORTIONAL',
+            'effective_from' => '2026-05-01',
+            'effective_to' => null,
+        ]);
+    }
+
+    #[Test]
+    public function admin_can_set_agreed_rate_config(): void
+    {
+        Passport::actingAs($this->adminUser());
+
+        $payload = [
+            'valuation_method' => 'AGREED_RATE',
+            'hourly_rate' => 85.50,
+            'effective_from' => '2026-05-01',
+        ];
+
+        $this->postJson("/api/v1/employees/{$this->employee->public_id}/overtime-config", $payload)
+            ->assertCreated()
+            ->assertJsonPath('data.valuation_method', 'AGREED_RATE')
+            ->assertJsonPath('data.hourly_rate', 85.5)
+            ->assertJsonPath('data.lft_factor', null);
+    }
+
+    #[Test]
+    public function setting_new_config_auto_closes_previous_open_config(): void
+    {
+        Passport::actingAs($this->adminUser());
+
+        $previousConfig = OvertimePayConfig::create([
+            'public_id' => '01CFGTEST01234567890125',
+            'employee_id' => $this->employee->id,
+            'valuation_method' => 'LFT_PROPORTIONAL',
+            'lft_factor' => '2.00',
+            'hourly_rate' => null,
+            'effective_from' => '2026-01-01',
+            'effective_to' => null,
+        ]);
+
+        $this->postJson("/api/v1/employees/{$this->employee->public_id}/overtime-config", [
+            'valuation_method' => 'AGREED_RATE',
+            'hourly_rate' => 90.00,
+            'effective_from' => '2026-05-01',
+        ])->assertCreated();
+
+        $this->assertDatabaseHas('overtime_pay_configs', [
+            'id' => $previousConfig->id,
+            'effective_to' => '2026-04-30',
+        ]);
+    }
+
+    #[Test]
+    public function setting_with_earlier_date_deletes_future_open_configs(): void
+    {
+        Passport::actingAs($this->adminUser());
+
+        $futureConfig = OvertimePayConfig::create([
+            'public_id' => '01CFGTEST01234567890126',
+            'employee_id' => $this->employee->id,
+            'valuation_method' => 'LFT_PROPORTIONAL',
+            'lft_factor' => '2.00',
+            'hourly_rate' => null,
+            'effective_from' => '2026-06-01',
+            'effective_to' => null,
+        ]);
+
+        $this->postJson("/api/v1/employees/{$this->employee->public_id}/overtime-config", [
+            'valuation_method' => 'AGREED_RATE',
+            'hourly_rate' => 90.00,
+            'effective_from' => '2026-05-01',
+        ])->assertCreated();
+
+        $this->assertDatabaseMissing('overtime_pay_configs', ['id' => $futureConfig->id]);
+
+        $this->assertDatabaseHas('overtime_pay_configs', [
+            'employee_id' => $this->employee->id,
+            'effective_from' => '2026-05-01',
+            'effective_to' => null,
+        ]);
+    }
+
+    #[Test]
+    public function response_status_field_matches_http_201(): void
+    {
+        Passport::actingAs($this->adminUser());
+
+        $this->postJson("/api/v1/employees/{$this->employee->public_id}/overtime-config", [
+            'valuation_method' => 'LFT_PROPORTIONAL',
+            'lft_factor' => 2.00,
+            'effective_from' => '2026-05-01',
+        ])
+            ->assertCreated()
+            ->assertJsonPath('status', 201);
+    }
+
+    #[Test]
+    public function set_overtime_config_requires_authentication(): void
+    {
+        $this->postJson("/api/v1/employees/{$this->employee->public_id}/overtime-config", [
+            'valuation_method' => 'LFT_PROPORTIONAL',
+            'lft_factor' => 2.00,
+            'effective_from' => '2026-05-01',
+        ])->assertUnauthorized();
+    }
+
+    #[Test]
+    public function set_overtime_config_requires_employees_update_permission(): void
+    {
+        $user = User::factory()->create();
+        Passport::actingAs($user);
+
+        $this->postJson("/api/v1/employees/{$this->employee->public_id}/overtime-config", [
+            'valuation_method' => 'LFT_PROPORTIONAL',
+            'lft_factor' => 2.00,
+            'effective_from' => '2026-05-01',
+        ])->assertForbidden();
+    }
+
+    #[Test]
+    public function set_overtime_config_rejects_missing_fields(): void
+    {
+        Passport::actingAs($this->adminUser());
+
+        $this->postJson("/api/v1/employees/{$this->employee->public_id}/overtime-config", [])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['valuation_method', 'effective_from']);
+    }
+
+    #[Test]
+    public function set_overtime_config_requires_lft_factor_when_lft_proportional(): void
+    {
+        Passport::actingAs($this->adminUser());
+
+        $this->postJson("/api/v1/employees/{$this->employee->public_id}/overtime-config", [
+            'valuation_method' => 'LFT_PROPORTIONAL',
+            'effective_from' => '2026-05-01',
+        ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['lft_factor']);
+    }
+
+    #[Test]
+    public function set_overtime_config_requires_hourly_rate_when_agreed_rate(): void
+    {
+        Passport::actingAs($this->adminUser());
+
+        $this->postJson("/api/v1/employees/{$this->employee->public_id}/overtime-config", [
+            'valuation_method' => 'AGREED_RATE',
+            'effective_from' => '2026-05-01',
+        ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['hourly_rate']);
+    }
+
+    #[Test]
+    public function set_overtime_config_rejects_invalid_valuation_method(): void
+    {
+        Passport::actingAs($this->adminUser());
+
+        $this->postJson("/api/v1/employees/{$this->employee->public_id}/overtime-config", [
+            'valuation_method' => 'INVALID_METHOD',
+            'effective_from' => '2026-05-01',
+        ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['valuation_method']);
+    }
+}

--- a/code/api/tests/Unit/Models/OvertimePayConfigCalculatePayTest.php
+++ b/code/api/tests/Unit/Models/OvertimePayConfigCalculatePayTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\OvertimePayConfig;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class OvertimePayConfigCalculatePayTest extends TestCase
+{
+    private static function lftConfig(string $factor): OvertimePayConfig
+    {
+        $config = new OvertimePayConfig;
+        $config->valuation_method = 'LFT_PROPORTIONAL';
+        $config->lft_factor = $factor;
+
+        return $config;
+    }
+
+    private static function agreedConfig(string $hourlyRate): OvertimePayConfig
+    {
+        $config = new OvertimePayConfig;
+        $config->valuation_method = 'AGREED_RATE';
+        $config->hourly_rate = $hourlyRate;
+
+        return $config;
+    }
+
+    public static function lftProportionalProvider(): array
+    {
+        return [
+            'daily $240, factor 2, 60 min' => ['240.00', '2.00', 60, 60.00],
+            'daily $200, factor 3, 30 min' => ['200.00', '3.00', 30, 37.50],
+            'daily $160, factor 2, 15 min' => ['160.00', '2.00', 15, 10.00],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('lftProportionalProvider')]
+    public function calculates_pay_for_lft_proportional_method(
+        string $dailyWage,
+        string $factor,
+        int $minutes,
+        float $expected,
+    ): void {
+        $config = self::lftConfig($factor);
+
+        $this->assertEqualsWithDelta($expected, $config->calculatePay($minutes, (float) $dailyWage), 0.01);
+    }
+
+    public static function agreedRateProvider(): array
+    {
+        return [
+            'rate $90/hr, 60 min' => ['90.00', 60, 90.00],
+            'rate $120/hr, 30 min' => ['120.00', 30, 60.00],
+            'rate $60/hr, 15 min' => ['60.00', 15, 15.00],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('agreedRateProvider')]
+    public function calculates_pay_for_agreed_rate_method(
+        string $hourlyRate,
+        int $minutes,
+        float $expected,
+    ): void {
+        $config = self::agreedConfig($hourlyRate);
+
+        $this->assertEqualsWithDelta($expected, $config->calculatePay($minutes, 0.0), 0.01);
+    }
+}

--- a/code/webapp/cypress/e2e/employee-overtime-config.cy.ts
+++ b/code/webapp/cypress/e2e/employee-overtime-config.cy.ts
@@ -1,0 +1,80 @@
+/**
+ * Employee Overtime Pay Config — E2E happy path
+ *
+ * Verifies that an admin can configure how overtime is valued for an
+ * employee (agreed hourly rate) and see the current configuration
+ * displayed in the employee detail panel.
+ *
+ * Seeder group: 'attendance' — creates EMP-002 María García (cook).
+ *
+ * Happy path:
+ *   1. Admin navigates to /employees and opens María García's detail panel.
+ *   2. "Pago de Horas Extra" section is visible with no config set.
+ *   3. Admin clicks "Configurar", selects "Tarifa acordada", sets a rate
+ *      and a date, submits.
+ *   4. Success toast appears.
+ *   5. Current config card shows the method and rate.
+ *
+ * For running only this file:
+ *   make cypress-spec SPEC=employee-overtime-config
+ *   make cypress-debug SPEC=employee-overtime-config
+ */
+
+import users from '../fixtures/users.json'
+
+const { email: adminEmail, password: adminPassword } = users.admin
+
+const EMPLOYEE_NAME = 'María García'
+
+before(() => {
+  cy.task('test:reset', 'attendance', { timeout: 60_000 })
+})
+
+describe('Employee Overtime Pay Config — admin happy path', () => {
+  beforeEach(() => {
+    cy.login(adminEmail, adminPassword)
+    cy.url().should('not.include', '/login', { timeout: 10_000 })
+    cy.visit('/employees')
+    cy.url().should('include', '/employees', { timeout: 10_000 })
+    cy.get('table', { timeout: 10_000 }).should('exist')
+    cy.closeDevDebugger()
+  })
+
+  it('shows no overtime config initially and allows setting agreed rate', () => {
+    cy.contains(EMPLOYEE_NAME).closest('tr').find('button[aria-label="Ver detalle"]').click()
+    cy.contains('Pago de Horas Extra').scrollIntoView().should('be.visible')
+
+    // No config set yet
+    cy.contains('Sin configuración de horas extra').should('be.visible')
+
+    // Open the config form
+    cy.contains('button', 'Configurar').click()
+
+    // Select "Tarifa acordada" (native select + dispatchEvent for React 17+ delegation)
+    cy.get('select#valuation_method').should('be.visible').should('not.be.disabled').then(($select) => {
+      const select = $select[0] as HTMLSelectElement
+      const win = select.ownerDocument.defaultView as Window
+      select.value = 'AGREED_RATE'
+      select.dispatchEvent(new win.Event('change', { bubbles: true }))
+    })
+
+    // Fill hourly rate
+    cy.get('input#hourly_rate').should('be.visible').type('95.50')
+
+    // Set effective date
+    const today = new Date().toISOString().slice(0, 10)
+    cy.get('input#effective_from').type(today)
+
+    // Submit
+    cy.contains('button', 'Guardar').click()
+
+    // Toast should appear
+    cy.contains('Configuración de horas extra guardada').should('be.visible')
+
+    // The current config card is now shown
+    cy.get('[data-testid="current-overtime-config"]').scrollIntoView().should('be.visible')
+    cy.get('[data-testid="current-overtime-config"]').contains('Tarifa acordada').should('be.visible')
+    cy.get('[data-testid="current-overtime-config"]').contains('Activo').should('be.visible')
+    cy.contains('Sin configuración de horas extra').should('not.exist')
+  })
+})

--- a/code/webapp/src/components/employees/__tests__/employee-detail-view.test.tsx
+++ b/code/webapp/src/components/employees/__tests__/employee-detail-view.test.tsx
@@ -68,6 +68,10 @@ vi.mock('@/components/employees/vacation-section', () => ({
   VacationSection: () => <div>VacationSection</div>,
 }))
 
+vi.mock('@/components/employees/overtime-config-section', () => ({
+  OvertimeConfigSection: () => <div>OvertimeConfigSection</div>,
+}))
+
 vi.mock('@/components/employees/use-employee-detail-actions', () => ({
   useEmployeeDetailActions: () => ({
     hasActivePeriod: true,

--- a/code/webapp/src/components/employees/__tests__/overtime-config-section.test.tsx
+++ b/code/webapp/src/components/employees/__tests__/overtime-config-section.test.tsx
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import type { OvertimePayConfig } from '@/types/attendance-payroll'
+import type { UseFormReturn } from 'react-hook-form'
+import type { SetConfigFormValues } from '../use-overtime-config-section'
+
+const mockSetShowForm = vi.fn()
+const mockOnSubmit = vi.fn()
+const mockWatch = vi.fn(() => 'LFT_PROPORTIONAL')
+
+const fakeConfig: OvertimePayConfig = {
+  id: 'cfg-1', valuation_method: 'AGREED_RATE', lft_factor: null, hourly_rate: 90,
+  effective_from: '2026-01-01', effective_to: null,
+}
+
+const baseHook = {
+  current: null,
+  configs: [],
+  isLoadingConfigs: false,
+  showForm: false,
+  setShowForm: mockSetShowForm,
+  form: {
+    register: vi.fn(() => ({})),
+    watch: mockWatch,
+    handleSubmit: (fn: (v: SetConfigFormValues) => void) => (e: React.FormEvent) => {
+      e.preventDefault()
+      fn({ valuation_method: 'LFT_PROPORTIONAL', lft_factor: '2.00', hourly_rate: '', effective_from: '2026-05-01' })
+    },
+    formState: { errors: {} },
+  } as unknown as UseFormReturn<SetConfigFormValues>,
+  onSubmit: mockOnSubmit,
+  isPending: false,
+}
+
+vi.mock('../use-overtime-config-section', () => ({
+  useOvertimeConfigSection: vi.fn(() => baseHook),
+}))
+
+import { OvertimeConfigSection } from '../overtime-config-section'
+import * as sectionHook from '../use-overtime-config-section'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockWatch.mockReturnValue('LFT_PROPORTIONAL')
+  vi.mocked(sectionHook.useOvertimeConfigSection).mockReturnValue(baseHook)
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('OvertimeConfigSection', () => {
+  it('shows "Sin configuración de horas extra" when no current config', () => {
+    render(<OvertimeConfigSection employeeId="emp-1" />)
+    expect(screen.getByText('Sin configuración de horas extra')).toBeTruthy()
+  })
+
+  it('shows "Configurar" button when no current config', () => {
+    render(<OvertimeConfigSection employeeId="emp-1" />)
+    expect(screen.getByRole('button', { name: /configurar/i })).toBeTruthy()
+  })
+
+  it('clicking "Configurar" calls setShowForm(true)', () => {
+    render(<OvertimeConfigSection employeeId="emp-1" />)
+    fireEvent.click(screen.getByRole('button', { name: /configurar/i }))
+    expect(mockSetShowForm).toHaveBeenCalledWith(true)
+  })
+
+  it('shows the config form when showForm is true', () => {
+    vi.mocked(sectionHook.useOvertimeConfigSection).mockReturnValue({ ...baseHook, showForm: true })
+    render(<OvertimeConfigSection employeeId="emp-1" />)
+    expect(screen.getByLabelText(/método de valoración/i)).toBeTruthy()
+    expect(screen.getByLabelText(/fecha de vigencia/i)).toBeTruthy()
+  })
+
+  it('shows lft_factor field when method is LFT_PROPORTIONAL', () => {
+    mockWatch.mockReturnValue('LFT_PROPORTIONAL')
+    vi.mocked(sectionHook.useOvertimeConfigSection).mockReturnValue({ ...baseHook, showForm: true })
+    render(<OvertimeConfigSection employeeId="emp-1" />)
+    expect(screen.getByLabelText(/factor lft/i)).toBeTruthy()
+  })
+
+  it('shows hourly_rate field when method is AGREED_RATE', () => {
+    mockWatch.mockReturnValue('AGREED_RATE')
+    vi.mocked(sectionHook.useOvertimeConfigSection).mockReturnValue({ ...baseHook, showForm: true })
+    render(<OvertimeConfigSection employeeId="emp-1" />)
+    expect(screen.getByLabelText(/tarifa por hora/i)).toBeTruthy()
+  })
+
+  it('shows current config card with method and rate', () => {
+    vi.mocked(sectionHook.useOvertimeConfigSection).mockReturnValue({
+      ...baseHook, current: fakeConfig, configs: [fakeConfig],
+    })
+    render(<OvertimeConfigSection employeeId="emp-1" />)
+    expect(screen.getByText('Tarifa acordada')).toBeTruthy()
+    expect(screen.getByText('Activo')).toBeTruthy()
+  })
+
+  it('shows "Cambiar configuración" button when a config exists', () => {
+    vi.mocked(sectionHook.useOvertimeConfigSection).mockReturnValue({
+      ...baseHook, current: fakeConfig, configs: [fakeConfig],
+    })
+    render(<OvertimeConfigSection employeeId="emp-1" />)
+    expect(screen.getByRole('button', { name: /cambiar configuración/i })).toBeTruthy()
+  })
+
+  it('shows loading spinner when isLoadingConfigs is true', () => {
+    vi.mocked(sectionHook.useOvertimeConfigSection).mockReturnValue({ ...baseHook, isLoadingConfigs: true })
+    render(<OvertimeConfigSection employeeId="emp-1" />)
+    expect(document.querySelector('.animate-spin')).toBeTruthy()
+  })
+
+  it('shows history for past configs (slice(1))', () => {
+    const pastConfig: OvertimePayConfig = {
+      ...fakeConfig, id: 'cfg-2', effective_from: '2025-01-01', effective_to: '2025-12-31',
+    }
+    vi.mocked(sectionHook.useOvertimeConfigSection).mockReturnValue({
+      ...baseHook, current: fakeConfig, configs: [fakeConfig, pastConfig],
+    })
+    render(<OvertimeConfigSection employeeId="emp-1" />)
+    expect(screen.getByText('Historial')).toBeTruthy()
+  })
+
+  it('clicking Cancelar in the form calls setShowForm(false)', () => {
+    vi.mocked(sectionHook.useOvertimeConfigSection).mockReturnValue({ ...baseHook, showForm: true })
+    render(<OvertimeConfigSection employeeId="emp-1" />)
+    fireEvent.click(screen.getByRole('button', { name: /cancelar/i }))
+    expect(mockSetShowForm).toHaveBeenCalledWith(false)
+  })
+
+  it('shows spinner on submit button when isPending is true', () => {
+    vi.mocked(sectionHook.useOvertimeConfigSection).mockReturnValue({ ...baseHook, showForm: true, isPending: true })
+    render(<OvertimeConfigSection employeeId="emp-1" />)
+    expect(document.querySelector('.animate-spin')).toBeTruthy()
+  })
+
+  it('shows validation error for lft_factor when present', () => {
+    vi.mocked(sectionHook.useOvertimeConfigSection).mockReturnValue({
+      ...baseHook,
+      showForm: true,
+      form: {
+        ...baseHook.form,
+        formState: { errors: { lft_factor: { message: 'El factor LFT es requerido', type: 'custom' } } },
+      } as unknown as typeof baseHook.form,
+    })
+    render(<OvertimeConfigSection employeeId="emp-1" />)
+    expect(screen.getByText('El factor LFT es requerido')).toBeTruthy()
+  })
+
+  it('shows validation error for effective_from when present', () => {
+    vi.mocked(sectionHook.useOvertimeConfigSection).mockReturnValue({
+      ...baseHook,
+      showForm: true,
+      form: {
+        ...baseHook.form,
+        formState: { errors: { effective_from: { message: 'La fecha de vigencia es requerida', type: 'required' } } },
+      } as unknown as typeof baseHook.form,
+    })
+    render(<OvertimeConfigSection employeeId="emp-1" />)
+    expect(screen.getByText('La fecha de vigencia es requerida')).toBeTruthy()
+  })
+
+  it('history shows dash when effective_to is null', () => {
+    const pastConfig: OvertimePayConfig = {
+      ...fakeConfig, id: 'cfg-2', effective_from: '2025-01-01', effective_to: null,
+    }
+    vi.mocked(sectionHook.useOvertimeConfigSection).mockReturnValue({
+      ...baseHook, current: fakeConfig, configs: [fakeConfig, pastConfig],
+    })
+    render(<OvertimeConfigSection employeeId="emp-1" />)
+    expect(screen.getByText(/→\s*—/)).toBeTruthy()
+  })
+})

--- a/code/webapp/src/components/employees/__tests__/use-overtime-config-section.test.tsx
+++ b/code/webapp/src/components/employees/__tests__/use-overtime-config-section.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import type { OvertimePayConfig } from '@/types/attendance-payroll'
+
+const mockConfigs: OvertimePayConfig[] = [
+  {
+    id: 'cfg-1',
+    valuation_method: 'AGREED_RATE',
+    lft_factor: null,
+    hourly_rate: 90,
+    effective_from: '2026-01-01',
+    effective_to: null,
+  },
+]
+
+const mockMutate = vi.fn()
+
+vi.mock('@/services/overtime-hooks', () => ({
+  useOvertimeConfig: vi.fn(() => ({ data: mockConfigs, isLoading: false })),
+  useSetOvertimeConfig: vi.fn(() => ({ mutate: mockMutate, isPending: false })),
+}))
+
+import { useOvertimeConfigSection } from '../use-overtime-config-section'
+import * as hooks from '@/services/overtime-hooks'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(hooks.useOvertimeConfig).mockReturnValue({ data: mockConfigs, isLoading: false } as unknown as ReturnType<typeof hooks.useOvertimeConfig>)
+  vi.mocked(hooks.useSetOvertimeConfig).mockReturnValue({ mutate: mockMutate, isPending: false } as unknown as ReturnType<typeof hooks.useSetOvertimeConfig>)
+})
+
+describe('useOvertimeConfigSection', () => {
+  it('exposes the config active today as current', () => {
+    const { result } = renderHook(() => useOvertimeConfigSection('emp-1'))
+    expect(result.current.current).toEqual(mockConfigs[0])
+  })
+
+  it('returns null for current when configs is empty', () => {
+    vi.mocked(hooks.useOvertimeConfig).mockReturnValue({ data: [], isLoading: false } as unknown as ReturnType<typeof hooks.useOvertimeConfig>)
+    const { result } = renderHook(() => useOvertimeConfigSection('emp-1'))
+    expect(result.current.current).toBeNull()
+  })
+
+  it('returns null when the only config is in the future', () => {
+    const futureConfig = { ...mockConfigs[0], effective_from: '2099-01-01', effective_to: null }
+    vi.mocked(hooks.useOvertimeConfig).mockReturnValue({ data: [futureConfig], isLoading: false } as unknown as ReturnType<typeof hooks.useOvertimeConfig>)
+    const { result } = renderHook(() => useOvertimeConfigSection('emp-1'))
+    expect(result.current.current).toBeNull()
+  })
+
+  it('returns null when all configs are expired', () => {
+    const expiredConfig = { ...mockConfigs[0], effective_from: '2020-01-01', effective_to: '2020-12-31' }
+    vi.mocked(hooks.useOvertimeConfig).mockReturnValue({ data: [expiredConfig], isLoading: false } as unknown as ReturnType<typeof hooks.useOvertimeConfig>)
+    const { result } = renderHook(() => useOvertimeConfigSection('emp-1'))
+    expect(result.current.current).toBeNull()
+  })
+
+  it('starts with showForm = false', () => {
+    const { result } = renderHook(() => useOvertimeConfigSection('emp-1'))
+    expect(result.current.showForm).toBe(false)
+  })
+
+  it('setShowForm toggles the form visibility', () => {
+    const { result } = renderHook(() => useOvertimeConfigSection('emp-1'))
+    act(() => { result.current.setShowForm(true) })
+    expect(result.current.showForm).toBe(true)
+  })
+
+  it('onSubmit sends lft_factor and omits hourly_rate for LFT_PROPORTIONAL', () => {
+    const { result } = renderHook(() => useOvertimeConfigSection('emp-1'))
+    act(() => {
+      result.current.onSubmit({
+        valuation_method: 'LFT_PROPORTIONAL',
+        lft_factor: '2.00',
+        hourly_rate: '',
+        effective_from: '2026-05-01',
+      })
+    })
+    expect(mockMutate).toHaveBeenCalledWith(
+      { valuation_method: 'LFT_PROPORTIONAL', lft_factor: 2, hourly_rate: undefined, effective_from: '2026-05-01' },
+      expect.any(Object),
+    )
+  })
+
+  it('onSubmit sends hourly_rate and omits lft_factor for AGREED_RATE', () => {
+    const { result } = renderHook(() => useOvertimeConfigSection('emp-1'))
+    act(() => {
+      result.current.onSubmit({
+        valuation_method: 'AGREED_RATE',
+        lft_factor: '',
+        hourly_rate: '90.00',
+        effective_from: '2026-05-01',
+      })
+    })
+    expect(mockMutate).toHaveBeenCalledWith(
+      { valuation_method: 'AGREED_RATE', lft_factor: undefined, hourly_rate: 90, effective_from: '2026-05-01' },
+      expect.any(Object),
+    )
+  })
+
+  it('isPending reflects setConfig.isPending', () => {
+    const { result } = renderHook(() => useOvertimeConfigSection('emp-1'))
+    expect(result.current.isPending).toBe(false)
+  })
+
+  it('isLoadingConfigs is true when query is loading', () => {
+    vi.mocked(hooks.useOvertimeConfig).mockReturnValue({ data: undefined, isLoading: true } as unknown as ReturnType<typeof hooks.useOvertimeConfig>)
+    const { result } = renderHook(() => useOvertimeConfigSection('emp-1'))
+    expect(result.current.isLoadingConfigs).toBe(true)
+  })
+
+  it('onSubmit onSuccess hides the form and resets it', () => {
+    let capturedOnSuccess: (() => void) | undefined
+    vi.mocked(hooks.useSetOvertimeConfig).mockReturnValue({
+      mutate: vi.fn((_, opts) => { capturedOnSuccess = opts?.onSuccess }),
+      isPending: false,
+    } as unknown as ReturnType<typeof hooks.useSetOvertimeConfig>)
+
+    const { result } = renderHook(() => useOvertimeConfigSection('emp-1'))
+    act(() => { result.current.setShowForm(true) })
+    expect(result.current.showForm).toBe(true)
+
+    act(() => {
+      result.current.onSubmit({
+        valuation_method: 'AGREED_RATE',
+        lft_factor: '',
+        hourly_rate: '90.00',
+        effective_from: '2026-05-01',
+      })
+    })
+    act(() => { capturedOnSuccess?.() })
+
+    expect(result.current.showForm).toBe(false)
+  })
+})

--- a/code/webapp/src/components/employees/employee-detail-view.tsx
+++ b/code/webapp/src/components/employees/employee-detail-view.tsx
@@ -15,6 +15,7 @@ import { ExtraDaySection } from './extra-day-section'
 import { usePermissionManager } from './use-permission-manager'
 import { PermissionManagerDialog } from './permission-manager-dialog'
 import { BonusConfigSection } from './bonus-config-section'
+import { OvertimeConfigSection } from './overtime-config-section'
 import { VacationSection } from './vacation-section'
 
 // ─── Props ───────────────────────────────────────────────────────────────────
@@ -109,6 +110,11 @@ export function EmployeeDetailView({
 
       {/* Punctuality bonus group assignment */}
       <BonusConfigSection employeeId={employee.id} />
+
+      <hr className="border-border" />
+
+      {/* Overtime pay valuation method */}
+      <OvertimeConfigSection employeeId={employee.id} />
 
       <hr className="border-border" />
 

--- a/code/webapp/src/components/employees/overtime-config-section.tsx
+++ b/code/webapp/src/components/employees/overtime-config-section.tsx
@@ -1,0 +1,185 @@
+import { Loader2, Clock, Plus, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { useOvertimeConfigSection } from './use-overtime-config-section'
+
+interface OvertimeConfigSectionProps {
+  readonly employeeId: string
+}
+
+function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('es-MX', { style: 'currency', currency: 'MXN' }).format(amount)
+}
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr + 'T00:00:00').toLocaleDateString('es-MX', {
+    year: 'numeric', month: 'short', day: 'numeric',
+  })
+}
+
+function methodLabel(method: 'LFT_PROPORTIONAL' | 'AGREED_RATE'): string {
+  return method === 'LFT_PROPORTIONAL' ? 'Proporcional LFT' : 'Tarifa acordada'
+}
+
+export function OvertimeConfigSection({ employeeId }: OvertimeConfigSectionProps) {
+  const {
+    current,
+    configs,
+    isLoadingConfigs,
+    showForm,
+    setShowForm,
+    form,
+    onSubmit,
+    isPending,
+  } = useOvertimeConfigSection(employeeId)
+
+  const { register, handleSubmit, watch, formState: { errors } } = form
+  const selectedMethod = watch('valuation_method')
+
+  if (isLoadingConfigs) {
+    return (
+      <div className="flex items-center justify-center py-6">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-foreground">Pago de Horas Extra</h3>
+        {!showForm && (
+          <Button type="button" size="sm" variant="outline" onClick={() => setShowForm(true)}>
+            <Plus className="mr-1 h-4 w-4" />
+            {current ? 'Cambiar configuración' : 'Configurar'}
+          </Button>
+        )}
+      </div>
+
+      {/* Current configuration */}
+      {current ? (
+        <div className="rounded-md border border-border p-3 space-y-1" data-testid="current-overtime-config">
+          <div className="flex items-center gap-2">
+            <Clock className="h-4 w-4 text-amber-500" />
+            <span className="text-sm font-medium">{methodLabel(current.valuation_method)}</span>
+            <Badge variant="success" className="text-xs">Activo</Badge>
+          </div>
+          <div className="text-xs text-muted-foreground">
+            {current.valuation_method === 'LFT_PROPORTIONAL'
+              ? `Factor ${current.lft_factor}`
+              : `${formatCurrency(current.hourly_rate ?? 0)}/hr`}
+          </div>
+          <div className="text-xs text-muted-foreground">
+            Desde {formatDate(current.effective_from)}
+          </div>
+        </div>
+      ) : (
+        !showForm && (
+          <div className="flex flex-col items-center justify-center py-6 text-muted-foreground">
+            <Clock className="h-8 w-8 mb-2" />
+            <p className="text-sm">Sin configuración de horas extra</p>
+          </div>
+        )
+      )}
+
+      {/* Config form */}
+      {showForm && (
+        <form onSubmit={handleSubmit(onSubmit)} className="rounded-md border border-border p-4 space-y-3">
+          <div className="space-y-1">
+            <label htmlFor="valuation_method" className="text-sm font-medium">Método de valoración</label>
+            <select
+              id="valuation_method"
+              {...register('valuation_method')}
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              disabled={isPending}
+            >
+              <option value="LFT_PROPORTIONAL">Proporcional LFT</option>
+              <option value="AGREED_RATE">Tarifa acordada</option>
+            </select>
+            {errors.valuation_method && (
+              <p className="text-xs text-destructive">{errors.valuation_method.message}</p>
+            )}
+          </div>
+
+          {selectedMethod === 'LFT_PROPORTIONAL' ? (
+            <div className="space-y-1">
+              <label htmlFor="lft_factor" className="text-sm font-medium">Factor LFT</label>
+              <input
+                id="lft_factor"
+                type="number"
+                step="0.01"
+                {...register('lft_factor')}
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                disabled={isPending}
+              />
+              {errors.lft_factor && (
+                <p className="text-xs text-destructive">{errors.lft_factor.message}</p>
+              )}
+            </div>
+          ) : (
+            <div className="space-y-1">
+              <label htmlFor="hourly_rate" className="text-sm font-medium">Tarifa por hora</label>
+              <input
+                id="hourly_rate"
+                type="number"
+                step="0.01"
+                {...register('hourly_rate')}
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                disabled={isPending}
+              />
+              {errors.hourly_rate && (
+                <p className="text-xs text-destructive">{errors.hourly_rate.message}</p>
+              )}
+            </div>
+          )}
+
+          <div className="space-y-1">
+            <label htmlFor="effective_from" className="text-sm font-medium">Fecha de vigencia</label>
+            <input
+              id="effective_from"
+              type="date"
+              {...register('effective_from')}
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              disabled={isPending}
+            />
+            {errors.effective_from && (
+              <p className="text-xs text-destructive">{errors.effective_from.message}</p>
+            )}
+          </div>
+
+          <div className="flex gap-2">
+            <Button type="submit" size="sm" disabled={isPending} className="bg-blue-600 text-white hover:bg-blue-700">
+              {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Guardar
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => setShowForm(false)}
+              disabled={isPending}
+            >
+              <X className="mr-1 h-4 w-4" />
+              Cancelar
+            </Button>
+          </div>
+        </form>
+      )}
+
+      {/* History */}
+      {configs && configs.length > 1 && (
+        <div className="space-y-2">
+          <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Historial</h4>
+          {configs.slice(1).map((cfg) => (
+            <div key={cfg.id} className="rounded-md border border-border px-3 py-2 text-xs text-muted-foreground space-y-0.5">
+              <div className="font-medium text-foreground">{methodLabel(cfg.valuation_method)}</div>
+              <div>
+                {formatDate(cfg.effective_from)} → {cfg.effective_to ? formatDate(cfg.effective_to) : '—'}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/code/webapp/src/components/employees/use-overtime-config-section.ts
+++ b/code/webapp/src/components/employees/use-overtime-config-section.ts
@@ -1,0 +1,71 @@
+import { useState } from 'react'
+import { useForm, type SubmitHandler } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { useOvertimeConfig, useSetOvertimeConfig } from '@/services/overtime-hooks'
+
+const setConfigSchema = z
+  .object({
+    valuation_method: z.enum(['LFT_PROPORTIONAL', 'AGREED_RATE'], {
+      message: 'Selecciona un método de valoración',
+    }),
+    lft_factor: z.string().optional(),
+    hourly_rate: z.string().optional(),
+    effective_from: z.string().min(1, 'La fecha de vigencia es requerida'),
+  })
+  .refine(
+    (data) => data.valuation_method !== 'LFT_PROPORTIONAL' || Number(data.lft_factor) > 0,
+    { message: 'El factor LFT es requerido', path: ['lft_factor'] },
+  )
+  .refine(
+    (data) => data.valuation_method !== 'AGREED_RATE' || Number(data.hourly_rate) > 0,
+    { message: 'La tarifa por hora es requerida', path: ['hourly_rate'] },
+  )
+
+export type SetConfigFormValues = z.infer<typeof setConfigSchema>
+
+export function useOvertimeConfigSection(employeeId: string) {
+  const [showForm, setShowForm] = useState(false)
+
+  const { data: configs, isLoading: isLoadingConfigs } = useOvertimeConfig(employeeId)
+  const setConfig = useSetOvertimeConfig(employeeId)
+
+  const form = useForm<SetConfigFormValues>({
+    resolver: zodResolver(setConfigSchema),
+    defaultValues: { valuation_method: 'LFT_PROPORTIONAL', lft_factor: '', hourly_rate: '', effective_from: '' },
+  })
+
+  const today = new Date().toISOString().slice(0, 10)
+  const current =
+    configs?.find(
+      (c) => c.effective_from <= today && (c.effective_to === null || c.effective_to >= today),
+    ) ?? null
+
+  const onSubmit: SubmitHandler<SetConfigFormValues> = (values) => {
+    setConfig.mutate(
+      {
+        valuation_method: values.valuation_method,
+        lft_factor: values.valuation_method === 'LFT_PROPORTIONAL' ? Number(values.lft_factor) : undefined,
+        hourly_rate: values.valuation_method === 'AGREED_RATE' ? Number(values.hourly_rate) : undefined,
+        effective_from: values.effective_from,
+      },
+      {
+        onSuccess: () => {
+          setShowForm(false)
+          form.reset()
+        },
+      },
+    )
+  }
+
+  return {
+    current,
+    configs,
+    isLoadingConfigs,
+    showForm,
+    setShowForm,
+    form,
+    onSubmit,
+    isPending: setConfig.isPending,
+  }
+}

--- a/code/webapp/src/services/__tests__/overtime-hooks.test.tsx
+++ b/code/webapp/src/services/__tests__/overtime-hooks.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import React from 'react'
+import type { OvertimePayConfig } from '@/types/attendance-payroll'
+
+const mockGetOvertimeConfig = vi.fn()
+const mockSetOvertimeConfig = vi.fn()
+const mockShowSuccess = vi.fn()
+const mockShowError = vi.fn()
+
+vi.mock('@/services/overtime.service', () => ({
+  overtimeConfigApi: {
+    getOvertimeConfig: (...args: unknown[]) => mockGetOvertimeConfig(...args),
+    setOvertimeConfig: (...args: unknown[]) => mockSetOvertimeConfig(...args),
+  },
+}))
+
+vi.mock('@/components/ui/toast-context', () => ({
+  useToast: () => ({ showSuccess: mockShowSuccess, showError: mockShowError }),
+}))
+
+import { useOvertimeConfig, useSetOvertimeConfig } from '../overtime-hooks'
+
+function makeWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children)
+}
+
+const fakeConfig: OvertimePayConfig = {
+  id: 'cfg-1',
+  valuation_method: 'AGREED_RATE',
+  lft_factor: null,
+  hourly_rate: 90,
+  effective_from: '2026-01-01',
+  effective_to: null,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('useOvertimeConfig', () => {
+  it('returns config data for employee', async () => {
+    mockGetOvertimeConfig.mockResolvedValue({ data: { data: [fakeConfig] } })
+    const { result } = renderHook(() => useOvertimeConfig('emp-1'), { wrapper: makeWrapper() })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual([fakeConfig])
+    expect(mockGetOvertimeConfig).toHaveBeenCalledWith('emp-1')
+  })
+
+  it('starts with data undefined', () => {
+    mockGetOvertimeConfig.mockReturnValue(new Promise(() => {}))
+    const { result } = renderHook(() => useOvertimeConfig('emp-1'), { wrapper: makeWrapper() })
+    expect(result.current.data).toBeUndefined()
+  })
+})
+
+describe('useSetOvertimeConfig', () => {
+  const payload = { valuation_method: 'AGREED_RATE' as const, hourly_rate: 90, effective_from: '2026-05-01' }
+
+  it('calls setOvertimeConfig with employeeId and payload', async () => {
+    mockSetOvertimeConfig.mockResolvedValue({ data: { data: fakeConfig } })
+    const { result } = renderHook(() => useSetOvertimeConfig('emp-1'), { wrapper: makeWrapper() })
+
+    act(() => { result.current.mutate(payload) })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockSetOvertimeConfig).toHaveBeenCalledWith('emp-1', payload)
+  })
+
+  it('shows success toast on success', async () => {
+    mockSetOvertimeConfig.mockResolvedValue({ data: { data: fakeConfig } })
+    const { result } = renderHook(() => useSetOvertimeConfig('emp-1'), { wrapper: makeWrapper() })
+
+    act(() => { result.current.mutate(payload) })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockShowSuccess).toHaveBeenCalled()
+  })
+
+  it('shows error toast on failure', async () => {
+    mockSetOvertimeConfig.mockRejectedValue(new Error('Network error'))
+    const { result } = renderHook(() => useSetOvertimeConfig('emp-1'), { wrapper: makeWrapper() })
+
+    act(() => { result.current.mutate(payload) })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(mockShowError).toHaveBeenCalled()
+  })
+
+  it('starts with isPending false', () => {
+    const { result } = renderHook(() => useSetOvertimeConfig('emp-1'), { wrapper: makeWrapper() })
+    expect(result.current.isPending).toBe(false)
+  })
+})

--- a/code/webapp/src/services/__tests__/overtime.service.test.ts
+++ b/code/webapp/src/services/__tests__/overtime.service.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { overtimeConfigApi } from '../overtime.service'
+
+vi.mock('@/lib/api-client', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+import { apiClient } from '@/lib/api-client'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('overtimeConfigApi.getOvertimeConfig', () => {
+  it('calls GET /employees/:id/overtime-config', async () => {
+    const mockResponse = { data: { status: 200, data: [] } }
+    vi.mocked(apiClient.get).mockResolvedValue(mockResponse)
+
+    const result = await overtimeConfigApi.getOvertimeConfig('emp-123')
+
+    expect(apiClient.get).toHaveBeenCalledWith('/employees/emp-123/overtime-config')
+    expect(result).toEqual(mockResponse)
+  })
+})
+
+describe('overtimeConfigApi.setOvertimeConfig', () => {
+  it('calls POST /employees/:id/overtime-config with payload', async () => {
+    const payload = { valuation_method: 'AGREED_RATE' as const, hourly_rate: 90, effective_from: '2026-05-01' }
+    const mockResponse = { data: { status: 201, data: {} } }
+    vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
+
+    const result = await overtimeConfigApi.setOvertimeConfig('emp-123', payload)
+
+    expect(apiClient.post).toHaveBeenCalledWith('/employees/emp-123/overtime-config', payload)
+    expect(result).toEqual(mockResponse)
+  })
+})

--- a/code/webapp/src/services/overtime-hooks.ts
+++ b/code/webapp/src/services/overtime-hooks.ts
@@ -1,0 +1,33 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { getApiErrorMessage } from '@/lib/api-error'
+import { useToast } from '@/components/ui/toast-context'
+import type { OvertimePayConfig, SetOvertimeConfigPayload } from '@/types/attendance-payroll'
+import { overtimeConfigApi } from './overtime.service'
+
+export function useOvertimeConfig(employeeId: string) {
+  return useQuery<OvertimePayConfig[]>({
+    queryKey: ['overtime-config', employeeId],
+    queryFn: async () => {
+      const response = await overtimeConfigApi.getOvertimeConfig(employeeId)
+      return response.data.data
+    },
+    staleTime: 2 * 60_000,
+  })
+}
+
+export function useSetOvertimeConfig(employeeId: string) {
+  const queryClient = useQueryClient()
+  const { showSuccess, showError } = useToast()
+
+  return useMutation({
+    mutationFn: (payload: SetOvertimeConfigPayload) =>
+      overtimeConfigApi.setOvertimeConfig(employeeId, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['overtime-config', employeeId] })
+      showSuccess('Configuración de horas extra guardada.', 'Horas extra')
+    },
+    onError: (error: unknown) => {
+      showError(getApiErrorMessage(error, 'Error al guardar la configuración.'), 'Horas extra')
+    },
+  })
+}

--- a/code/webapp/src/services/overtime.service.ts
+++ b/code/webapp/src/services/overtime.service.ts
@@ -1,0 +1,10 @@
+import { apiClient } from '@/lib/api-client'
+import type { OvertimePayConfig, SetOvertimeConfigPayload } from '@/types/attendance-payroll'
+
+export const overtimeConfigApi = {
+  getOvertimeConfig: (employeeId: string) =>
+    apiClient.get<{ status: number; data: OvertimePayConfig[] }>(`/employees/${employeeId}/overtime-config`),
+
+  setOvertimeConfig: (employeeId: string, payload: SetOvertimeConfigPayload) =>
+    apiClient.post<{ status: number; data: OvertimePayConfig }>(`/employees/${employeeId}/overtime-config`, payload),
+}

--- a/code/webapp/src/types/attendance-payroll.ts
+++ b/code/webapp/src/types/attendance-payroll.ts
@@ -132,3 +132,23 @@ export interface VacationSummary {
   seniority_years: number
   next_anniversary_date: string | null
 }
+
+// ── Overtime Pay Config ─────────────────────────────────────────────────────────
+
+export type OvertimeValuationMethod = 'LFT_PROPORTIONAL' | 'AGREED_RATE'
+
+export interface OvertimePayConfig {
+  id: string
+  valuation_method: OvertimeValuationMethod
+  lft_factor: number | null
+  hourly_rate: number | null
+  effective_from: string
+  effective_to: string | null
+}
+
+export interface SetOvertimeConfigPayload {
+  valuation_method: OvertimeValuationMethod
+  lft_factor?: number
+  hourly_rate?: number
+  effective_from: string
+}

--- a/doc/tasks/2026-07/069-overtime-config.md
+++ b/doc/tasks/2026-07/069-overtime-config.md
@@ -49,11 +49,11 @@ Como Admin, quiero configurar cómo se valoran las horas extra de cada empleado 
 ## ⏱️ Time
 
 ### 📊 Estimates
-- **Optimistic:** `2h` · **Pessimistic:** `4h` · **Tracked:** _in progress_
+- **Optimistic:** `2h` · **Pessimistic:** `4h` · **Tracked:** `6h46m`
 
 ### 📅 Sessions
 ```json
 [
-  { "date": "2026-07-03", "start": "02:18", "end": "?" }
+  { "date": "2026-07-03", "start": "02:18", "end": "09:04" }
 ]
 ```

--- a/doc/tasks/2026-07/069-overtime-config.md
+++ b/doc/tasks/2026-07/069-overtime-config.md
@@ -45,3 +45,15 @@ Como Admin, quiero configurar cómo se valoran las horas extra de cada empleado 
 ## ⏱️ Estimates
 
 - **Optimistic:** `2h` · **Pessimistic:** `4h`
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `2h` · **Pessimistic:** `4h` · **Tracked:** _in progress_
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-07-03", "start": "02:18", "end": "?" }
+]
+```


### PR DESCRIPTION
## Summary
- Add `overtime_pay_configs` table + `OvertimePayConfig` model with `effective()` scope and `calculatePay(minutes, dailyWage)` (LFT proportional or agreed hourly rate)
- Add `POST /employees/{id}/overtime-config` (auto-closes the previous open config) and `GET /employees/{id}/overtime-config` (current + history)
- Add an "Pago de Horas Extra" section to Employee Detail with a method selector and conditional fields (LFT factor vs hourly rate)

## Test plan
- [x] PHPUnit Feature: `php artisan test --filter=OvertimePayConfigTest` (15 tests)
- [x] PHPUnit Unit: `php artisan test --filter=OvertimePayConfigCalculatePayTest` (6 tests)
- [x] Vitest: `overtime.service`, `overtime-hooks`, `use-overtime-config-section`, `overtime-config-section` (34 tests) + full suite regression (3008 passed)
- [x] Cypress E2E: `cypress/e2e/employee-overtime-config.cy.ts` (1/1 passed, verified against the full local E2E suite)
- [x] Linters: Pint ✅ · ESLint ✅ · TypeScript ✅

## Manual Testing
1. Run `php artisan migrate` in `code/api` to create the `overtime_pay_configs` table
2. Log in as `admin@sushigo.com` and open any employee's detail page (`/employees` → click a row)
3. Scroll to "Pago de Horas Extra" — should show "Sin configuración de horas extra"
4. Click "Configurar", select "Tarifa acordada", enter an hourly rate (e.g. `95.50`), pick today's date, submit
5. A success toast appears and the current config card shows "Tarifa acordada" with the rate and "Activo"
6. Click "Cambiar configuración", select "Proporcional LFT", enter a factor (e.g. `2.00`), pick a later date, submit — the previous config moves into "Historial" with an `effective_to` one day before the new one

## Closes
Closes #069

## Workspace
`sushigo-b` — `feature/069-overtime-pay-config`

🤖 Generated with [Claude Code](https://claude.com/claude-code)