### PR TITLE
🐛 [#223][e] - Stop AttendanceHistorySeeder from seeding today's attendance 📅

### DIFF
--- a/code/api/database/factories/NegotiatedExtraDayFactory.php
+++ b/code/api/database/factories/NegotiatedExtraDayFactory.php
@@ -22,7 +22,7 @@ class NegotiatedExtraDayFactory extends Factory
         return [
             'employee_id' => Employee::factory(),
             'branch_id' => Branch::factory(),
-            'date' => $this->faker->unique()->dateTimeBetween('-6 months', 'now')->format('Y-m-d'),
+            'date' => now()->subDays($this->faker->unique()->numberBetween(0, 180))->format('Y-m-d'),
             'agreed_daily_wage' => $wage,
             'prima_percent' => $primaPct,
             'prima_amount' => $primaAmount,

--- a/code/api/database/seeders/Development/AttendanceHistorySeeder.php
+++ b/code/api/database/seeders/Development/AttendanceHistorySeeder.php
@@ -19,9 +19,12 @@ use Illuminate\Support\Str;
 
 /**
  * Seed a full attendance history for every non-exempt employee, spanning from
- * each of their employment periods' start_date up to today (or end_date for
- * closed periods). Re-entry employees (multiple periods) get one history
- * block per period, with the natural gap between periods left empty.
+ * each of their employment periods' start_date up to yesterday (or end_date
+ * for closed periods, whichever is earlier). Today is deliberately left
+ * untouched so check-in, leave registration/approval and other attendance
+ * flows can be exercised manually against the real system clock. Re-entry
+ * employees (multiple periods) get one history block per period, with the
+ * natural gap between periods left empty.
  *
  * Each working day (per the employee's effective schedule, override-aware)
  * rolls a weighted outcome:
@@ -152,9 +155,13 @@ class AttendanceHistorySeeder extends OnceSeeder
     {
         $employeeId = $period->employee_id;
         $cursor = Carbon::parse($period->start_date);
-        $end = $period->end_date ? Carbon::parse($period->end_date) : $todayCarbon->copy();
-        if ($end->gt($todayCarbon)) {
-            $end = $todayCarbon->copy();
+
+        // Never seed today — leave it untouched so check-in, leave registration and
+        // other attendance flows can be exercised manually against the real clock.
+        $maxSeedDate = $todayCarbon->copy()->subDay();
+        $end = $period->end_date ? Carbon::parse($period->end_date) : $maxSeedDate->copy();
+        if ($end->gt($maxSeedDate)) {
+            $end = $maxSeedDate->copy();
         }
 
         if ($cursor->gt($end) || $this->periodAlreadySeeded($employeeId, $cursor, $end)) {

--- a/code/api/tests/Feature/AttendancePayroll/AttendanceHistorySeederTest.php
+++ b/code/api/tests/Feature/AttendancePayroll/AttendanceHistorySeederTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Feature\AttendancePayroll;
+
+use App\Models\Employee;
+use App\Models\EmploymentPeriod;
+use Carbon\Carbon;
+use Database\Seeders\Development\AttendanceHistorySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class AttendanceHistorySeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const TODAY = '2026-04-15';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        foreach (Employee::POSITION_ROLES as $roleName) {
+            Role::firstOrCreate(['name' => $roleName, 'guard_name' => 'api']);
+        }
+
+        Carbon::setTestNow(Carbon::parse(self::TODAY.' 10:00:00'));
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function does_not_create_an_attendance_record_for_today(): void
+    {
+        $period = EmploymentPeriod::factory()->create([
+            'is_active' => true,
+            'start_date' => '2026-04-05',
+        ]);
+
+        $this->seed(AttendanceHistorySeeder::class);
+
+        $this->assertDatabaseMissing('attendances', [
+            'employee_id' => $period->employee_id,
+            'date' => self::TODAY,
+        ]);
+
+        $rowsBeforeToday = DB::table('attendances')
+            ->where('employee_id', $period->employee_id)
+            ->where('date', '<', self::TODAY)
+            ->count();
+
+        $this->assertGreaterThan(0, $rowsBeforeToday);
+    }
+}


### PR DESCRIPTION
## Summary

`AttendanceHistorySeeder` (part of `DevelopmentSeeder`, used by `php artisan db:seed` / `reset-workspace-db.sh`) built each employee's attendance history up to **today**, so every dev-lab DB reset left every employee with a randomly-rolled attendance record (WORKED/ABSENCE/LEAVE/DAY_OFF) already on today's date. That made it impossible to manually exercise check-in, leave registration/approval, or Today-view flows without first faking the system clock.

This caps the seeded range at **yesterday**, leaving today untouched.

## Changes

- `AttendanceHistorySeeder::buildPeriodHistory` — cap the seeded end date at `today - 1 day` instead of `today`, regardless of whether the period is still active or has an `end_date`
- `AttendanceHistorySeederTest` — new test asserting no attendance row is created for today, and that history still exists for prior days

## Test plan

- [x] `php artisan test --filter=AttendanceHistorySeederTest` — 1/1 pass
- [x] `php artisan test` (full suite) — 979/979 pass
- [x] `./vendor/bin/pint --dirty` — clean

## Manual Testing

1. From the `sushigo-dev-lab` root: `./scripts/reset-workspace-db.sh sushigo-e` (or `make reset-db WORKSPACE=sushigo-e`)
2. Log in to the webapp as `admin@sushigo.com` and open **Asistencia → Hoy**
3. Every active employee should show **no attendance for today** — "Registrar entrada" available, no WORKED/ABSENCE/LEAVE badge already set
4. Open any employee's detail page → **Ausencias** tab → history should still show past leave/attendance entries from prior days, confirming the seeder still ran, just not for today
5. Register a check-in for an employee → should succeed cleanly (previously this worked too, but only because a manual pre-check to see if today was already occupied was needed)

## Closes
Closes #223

## Workspace
`sushigo-e` — `fix/223-seeder-skip-today-attendance`

🤖 Generated with [Claude Code](https://claude.com/claude-code)