### PR TITLE
🔧 [#082][c] - Close out task #082 time tracking after merge 📊

### DIFF
--- a/doc/tasks/2026-07/082-vacation-request.md
+++ b/doc/tasks/2026-07/082-vacation-request.md
@@ -52,20 +52,37 @@ Como Manager, quiero crear una solicitud de vacaciones para un empleado y aproba
 ## ⏱️ Time
 
 ### 📊 Estimates
-- **Optimistic:** `3h` · **Pessimistic:** `5h` · **Tracked:** `6h 23m`
+- **Optimistic:** `3h` · **Pessimistic:** `5h` · **Tracked:** `20h 5m`
 
 ### 📅 Sessions
 ```json
 [
-  { "date": "2026-07-03", "start": "02:13", "end": "08:36" }
+  { "date": "2026-07-03", "start": "02:13", "end": "08:36" },
+  { "date": "2026-07-09", "start": "20:25", "end": "23:59" },
+  { "date": "2026-07-10", "start": "00:00", "end": "00:49" },
+  { "date": "2026-07-10", "start": "16:50", "end": "23:59" },
+  { "date": "2026-07-11", "start": "00:00", "end": "00:15" },
+  { "date": "2026-07-11", "start": "15:20", "end": "17:15" }
 ]
 ```
 
 ## 📊 Retrospective
-- **Actual total:** 6h 23m (383 min)
-- **vs optimistic:** +3h 23m
-- **vs pessimistic:** +1h 23m
+- **Actual total:** 20h 5m (1205 min = 383 + 214 + 49 + 429 + 15 + 115)
+- **vs optimistic:** +17h 5m
+- **vs pessimistic:** +15h 5m
 
 **Justification:**
 
-The overrun came from the full-stack scope required by strict TDD: backend (migration, model, enum, FormRequest, guards trait, 3 actions, 3 controllers, a list controller, route wiring, and permission seeding across 3 seeder files) plus frontend (types, service, hooks, a two-date-range request dialog, and requests list wired into the existing Vacaciones section) — each written from scratch by mirroring the closest existing precedent (the `Leave` module). Two things weren't in the original estimate: (1) extending two pre-existing Vitest suites (`use-vacation-section` and `vacation-section`) whose mocked hook contracts broke once the hook gained new fields, requiring test updates beyond the new feature's own tests; (2) verifying the mandatory Cypress E2E spec against the real dev-lab E2E stack, which required building the `sushigo-c` E2E container from scratch and debugging one flaky assertion caused by the Dev Debugger overlay re-appearing after navigation.
+The original 3–5h estimate assumed a single straightforward CRUD-style feature mirroring the `Leave` module, and the first session delivered exactly that (migration, model, actions, controllers, permission seeding, request dialog, requests list — see the original retrospective text below). Everything after that session was scope discovered only after using the feature, driven by two forces:
+
+1. **A mid-project architecture pivot.** After the first session shipped, manual testing surfaced that self-service vacation requests didn't appear in the manager's unified "Pendientes de aprobación" queue the way `Permiso` requests do. Fixing this properly meant rerouting self-service vacation requests through the existing `EmployeeRequest` polymorphic system instead of the standalone `VacationRequest` flow — a genuine redesign, not a bug fix: new `VacationRequestHandler`, `SoftDeletes` + balance-reversion on cancel, permission model rework (`vacation-requests.request` → `.schedule`, restricted to admin/super-admin), plus a full replacement of the date-range picker with the day-by-day `MultiDateCalendar` (matching `Permiso`'s UX) and a new `vacation_request_dates` table.
+2. **A chain of bugs only visible once real usage started.** Wrong label in "Mis solicitudes", vacation entitlement lookup breaking across calendar-year boundaries, dark-mode contrast in the calendar, and — most notably — `SeniorityService` reading the real OS clock instead of the app's simulated Application Clock, which silently broke entitlement generation for any QA/demo session using time-travel.
+3. **The mandatory PR review + SonarCloud gate before merge** (2026-07-11 afternoon): Copilot's automated review flagged 4 issues on the original code shape; 2 were genuine bugs that survived the later refactors in a different form (balance not re-validated at approval time; vacation dates could silently span two entitlement years) and required real fixes with regression tests. SonarCloud's webapp gate then failed on new-code coverage (65.3%, needed ≥80% — the admin scheduling dialog had zero tests) and duplication (9.0%, needed ≤3% — three genuine copy-paste blocks against sibling dialogs/hooks). Closing both required real test-writing and a small dedup refactor, not just tweaking thresholds.
+
+**Note on session reconstruction:** sessions 2–6 were reconstructed from `[#082]` commit timestamps (clustered by gaps, split at midnight) since work-session start/close commands weren't run again after the first session. Session 6's start time is an estimate — the Application Clock verification and PR-review comment analysis that preceded its first commit produced no commits of their own, so the true start is inferred from conversation structure rather than a logged marker. This likely undercounts slightly rather than overcounts.
+
+---
+
+*Original first-session retrospective (2026-07-03), preserved for context:*
+
+> The overrun came from the full-stack scope required by strict TDD: backend (migration, model, enum, FormRequest, guards trait, 3 actions, 3 controllers, a list controller, route wiring, and permission seeding across 3 seeder files) plus frontend (types, service, hooks, a two-date-range request dialog, and requests list wired into the existing Vacaciones section) — each written from scratch by mirroring the closest existing precedent (the `Leave` module). Two things weren't in the original estimate: (1) extending two pre-existing Vitest suites (`use-vacation-section` and `vacation-section`) whose mocked hook contracts broke once the hook gained new fields, requiring test updates beyond the new feature's own tests; (2) verifying the mandatory Cypress E2E spec against the real dev-lab E2E stack, which required building the `sushigo-c` E2E container from scratch and debugging one flaky assertion caused by the Dev Debugger overlay re-appearing after navigation.


### PR DESCRIPTION
## Summary
- PR #220 (task #082) merged without the mandatory task-closing time-tracking update having been re-run after the first work session — `Tracked` and the Retrospective only reflected the very first session (6h 23m), not the substantial additional work that followed (architecture pivot to route self-service requests through `EmployeeRequest`, several bug fixes found through real usage, and the PR review + SonarCloud remediation before merge).
- Reconstructs sessions 2–6 from `[#082]` commit timestamps (clustered by gaps, split at midnight) since work-session start/close commands weren't re-run for the later work — `Tracked` updated to 20h 5m.
- Rewrites the Retrospective to explain the full overrun, preserving the original first-session retrospective text for context.
- GitHub issue #82's body was already synced separately with the same sessions/retrospective content (issue stays closed).

## Test plan
- [x] Docs-only change — no code affected, no tests apply

## Manual Testing
- Open `doc/tasks/2026-07/082-vacation-request.md` on this branch (or the rendered file on GitHub) and confirm the Sessions JSON is valid and the Retrospective reads coherently against [issue #82](https://github.com/pakodiazdev/sushigo/issues/82)

## Workspace
`sushigo-c` — `chore/082-close-task-tracking`

🤖 Generated with [Claude Code](https://claude.com/claude-code)