### PR TITLE
🐛 [#233][a] - Fix malformed Swagger enum crashing doc generation 📖

### DIFF
--- a/.github/workflows/api-swagger.yml
+++ b/.github/workflows/api-swagger.yml
@@ -1,0 +1,50 @@
+name: API Swagger Docs
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  api-swagger:
+    name: api-swagger
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: code/api
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect changes in code/api
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            api:
+              - 'code/api/**'
+
+      - name: Setup PHP 8.5
+        if: steps.changes.outputs.api == 'true'
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          coverage: none
+
+      - name: Install Composer dependencies
+        if: steps.changes.outputs.api == 'true'
+        run: composer install --prefer-dist --no-interaction --no-progress --no-scripts --ignore-platform-req=php
+
+      - name: Copy .env and generate app key
+        if: steps.changes.outputs.api == 'true'
+        run: |
+          cp .env.example .env
+          php artisan key:generate --ansi
+          php artisan passport:keys --ansi
+
+      - name: Generate Swagger docs
+        if: steps.changes.outputs.api == 'true'
+        run: php artisan l5-swagger:generate

--- a/code/api/app/Http/Controllers/Api/V1/AuditLogs/ListAuditLogsController.php
+++ b/code/api/app/Http/Controllers/Api/V1/AuditLogs/ListAuditLogsController.php
@@ -18,7 +18,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
  *   tags={"AuditLogs"},
  *   security={{"passport": {}}},
  *
- *   @OA\Parameter(name="auditable_type", in="query", @OA\Schema(type="string", enum={"App\\Models\\Attendance", "App\\Models\\Employee"})),
+ *   @OA\Parameter(name="auditable_type", in="query", @OA\Schema(type="string", enum={"App\Models\Attendance", "App\Models\Employee"})),
  *   @OA\Parameter(name="auditable_id", in="query", @OA\Schema(type="string"), description="Public ID (ULID) of the audited record"),
  *   @OA\Parameter(name="employee_id", in="query", @OA\Schema(type="string"), description="Employee public_id (ULID)"),
  *   @OA\Parameter(name="date_from", in="query", @OA\Schema(type="string", format="date")),


### PR DESCRIPTION
## Summary
Closes #233

- `php artisan l5-swagger:generate` fatally crashed on `main` with `Cannot declare class App\Models\Attendance, because the name is already in use`, reproducing identically on PHP 8.3 and 8.5
- Root cause: `ListAuditLogsController.php`'s `auditable_type` parameter documented example values with double-escaped backslashes (`"App\\Models\\Attendance"` — two literal backslash characters). swagger-php's `ExpandEnums` processor calls `enum_exists()` on every string in an `enum` list; the malformed name still resolved through Composer's autoloader to the real `Attendance.php` file, which got `include()`d a second time after already being loaded earlier in the same process — hence the redeclare fatal
- Fixed by using a single backslash, matching the actual FQCN string (`App\Models\Attendance`) — once the class is already loaded, `enum_exists()` on the correctly-spelled name short-circuits instead of re-including the file
- Added an `api-swagger` GitHub Actions workflow that runs `l5-swagger:generate` on every PR touching `code/api`, so this class of bug is caught in CI instead of surfacing only when someone provisions a new environment

## Test plan
- [x] `./vendor/bin/pint --test` passes on the changed file
- [x] `php artisan l5-swagger:generate` completes successfully (previously fatal)
- [x] Verified end-to-end via `sushigo-dev-lab`: rebuilt 3 fresh workspaces from this branch, all 3 provisioned and Swagger docs generated without error

## Manual Testing
1. `cd code/api`
2. `php artisan l5-swagger:generate`
3. Expected: command exits cleanly with `Regenerating docs default` and no fatal error (previously: `PHP Fatal error: Cannot declare class App\Models\Attendance...`)
4. Optionally, visit `http://localhost:8080/api/documentation` (or your workspace's Swagger UI port) and confirm the `auditable_type` parameter on `GET /api/v1/audit-logs` still lists `App\Models\Attendance` and `App\Models\Employee` as example values

## Workspace
`sushigo-a` — `fix/233-swagger-enum-backslash`

🤖 Generated with [Claude Code](https://claude.com/claude-code)