### PR TITLE
✨ [#070][a] - View overtime bank balance 🏦

### DIFF
--- a/code/api/app/Actions/Attendances/RegisterCheckOutAction.php
+++ b/code/api/app/Actions/Attendances/RegisterCheckOutAction.php
@@ -3,8 +3,12 @@
 namespace App\Actions\Attendances;
 
 use App\Actions\Attendances\Concerns\ResolvesEffectiveScheduleDay;
+use App\Enums\OvertimeMovementType;
+use App\Enums\OvertimeOrigin;
 use App\Models\Attendance;
+use App\Models\OvertimeBankMovement;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 
 /**
@@ -20,10 +24,11 @@ use Illuminate\Validation\ValidationException;
  *      If the schedule cannot be resolved, overtime_minutes = 0 (non-blocking)
  *      ScheduleDayOverride takes precedence over the base ScheduleDay when present
  *   5. Persists check_out, net_worked_minutes, overtime_minutes
+ *   6. If overtime_minutes > 0, auto-creates an EARNED OvertimeBankMovement (origin=AUTO)
  *
  * All business rule violations are surfaced as 422 ValidationException.
  *
- * @see AP-015, RF-12, RF-14, RF-42
+ * @see AP-015, AP-034, RF-12, RF-14, RF-42
  */
 class RegisterCheckOutAction
 {
@@ -46,14 +51,27 @@ class RegisterCheckOutAction
         $netWorkedMinutes = $this->calculateNetWorkedMinutes($attendance, $checkOut);
         $overtimeMinutes = $this->calculateOvertimeMinutes($attendance, $checkOut, $checkOutLocal);
 
-        $attendance->auditReason = $data['reason'] ?? null;
-        $attendance->update([
-            'check_out' => $checkOut,
-            'net_worked_minutes' => $netWorkedMinutes,
-            'overtime_minutes' => $overtimeMinutes,
-        ]);
+        return DB::transaction(function () use ($attendance, $data, $checkOut, $netWorkedMinutes, $overtimeMinutes) {
+            $attendance->auditReason = $data['reason'] ?? null;
+            $attendance->update([
+                'check_out' => $checkOut,
+                'net_worked_minutes' => $netWorkedMinutes,
+                'overtime_minutes' => $overtimeMinutes,
+            ]);
 
-        return $attendance->load('employee');
+            if ($overtimeMinutes > 0) {
+                OvertimeBankMovement::create([
+                    'employee_id' => $attendance->employee_id,
+                    'attendance_id' => $attendance->id,
+                    'date' => $attendance->date,
+                    'movement_type' => OvertimeMovementType::EARNED,
+                    'origin' => OvertimeOrigin::AUTO,
+                    'minutes' => $overtimeMinutes,
+                ]);
+            }
+
+            return $attendance->load('employee');
+        });
     }
 
     /**

--- a/code/api/app/Actions/Payroll/CreateOvertimePaidMovementsAction.php
+++ b/code/api/app/Actions/Payroll/CreateOvertimePaidMovementsAction.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Actions\Payroll;
+
+use App\Enums\OvertimeMovementType;
+use App\Enums\OvertimeOrigin;
+use App\Models\Employee;
+use App\Models\OvertimeBankMovement;
+
+/**
+ * Create PAID overtime bank movements at payroll close time.
+ *
+ * For every EARNED movement in the period whose attendance overtime was authorized
+ * (AP-016) and that doesn't already have a matching PAID movement, creates a PAID
+ * movement reusing the valuation already computed on the Attendance row by
+ * ResolveOvertimeValuationAction — there is no separate per-employee pay config.
+ *
+ * @see AP-038, AP-039
+ */
+class CreateOvertimePaidMovementsAction
+{
+    public function __invoke(Employee $employee, string $periodStart, string $periodEnd): void
+    {
+        $earnedMovements = OvertimeBankMovement::where('employee_id', $employee->id)
+            ->where('movement_type', OvertimeMovementType::EARNED)
+            ->whereBetween('date', [$periodStart, $periodEnd])
+            ->whereHas('attendance', fn ($q) => $q->where('overtime_authorized', true))
+            ->with('attendance')
+            ->get();
+
+        foreach ($earnedMovements as $movement) {
+            $attendance = $movement->attendance;
+
+            $alreadyPaid = OvertimeBankMovement::where('attendance_id', $attendance->id)
+                ->where('movement_type', OvertimeMovementType::PAID)
+                ->exists();
+
+            if ($alreadyPaid) {
+                continue;
+            }
+
+            OvertimeBankMovement::create([
+                'employee_id' => $employee->id,
+                'attendance_id' => $attendance->id,
+                'date' => $attendance->date,
+                'movement_type' => OvertimeMovementType::PAID,
+                'origin' => OvertimeOrigin::AUTO,
+                'minutes' => $movement->minutes,
+                'valuation_method' => $attendance->overtime_valuation_method?->value,
+                'applied_rate' => $attendance->overtime_rate_applied,
+                'amount' => $attendance->overtime_amount,
+                'authorized_by' => $attendance->overtime_authorized_by,
+                'authorized_at' => $attendance->overtime_authorized_at,
+            ]);
+        }
+    }
+}

--- a/code/api/app/Console/Commands/TestReset.php
+++ b/code/api/app/Console/Commands/TestReset.php
@@ -13,6 +13,7 @@ use Database\Seeders\Testing\CloseDayHappyPathSeeder;
 use Database\Seeders\Testing\CloseDayPendingLunchSeeder;
 use Database\Seeders\Testing\CoreTestSeeder;
 use Database\Seeders\Testing\NegotiatedExtraDaysSeeder;
+use Database\Seeders\Testing\OvertimeBankTestSeeder;
 use Database\Seeders\Testing\PayrollPreviewSeeder;
 use Database\Seeders\Testing\ScheduleSummaryOverrideSeeder;
 use Database\Seeders\Testing\TodayReportStatusSeeder;
@@ -81,6 +82,10 @@ class TestReset extends Command
         ],
         'payroll-preview' => [
             PayrollPreviewSeeder::class,
+        ],
+        'overtime-bank' => [
+            AttendanceTestSeeder::class,
+            OvertimeBankTestSeeder::class,
         ],
     ];
 

--- a/code/api/app/Http/Controllers/Api/V1/Employees/ShowOvertimeBankController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Employees/ShowOvertimeBankController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Employees;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Employees\OvertimeBankMovementResource;
+use App\Http\Responses\Common\ResponseEntity;
+use App\Models\Employee;
+
+/**
+ * @OA\Get(
+ *   path="/api/v1/employees/{employee}/overtime-bank",
+ *   summary="View an employee's overtime bank balance and movement history",
+ *   tags={"Employees"},
+ *   security={{"passport": {}}},
+ *
+ *   @OA\Parameter(name="employee", in="path", required=true, @OA\Schema(type="string"), description="Employee public_id (ULID)"),
+ *
+ *   @OA\Response(response=200, description="Overtime bank balance and movements"),
+ *   @OA\Response(response=401, description="Unauthenticated"),
+ *   @OA\Response(response=403, description="Forbidden")
+ * )
+ */
+class ShowOvertimeBankController extends Controller
+{
+    public function __invoke(Employee $employee): ResponseEntity
+    {
+        $user = auth()->user();
+        abort_unless($user->can('employees.view') || $employee->user_id === $user->id, 403);
+
+        $movements = $employee->overtimeBankMovements()->with('authorizedBy')->get();
+
+        $balanceMinutes = $movements->sum(fn ($movement) => $movement->balanceImpact());
+
+        return new ResponseEntity(
+            data: OvertimeBankMovementResource::collection($movements)->toArray(request()),
+            meta: [
+                'balance_minutes' => $balanceMinutes,
+                'balance_formatted' => $this->formatMinutes($balanceMinutes),
+            ],
+        );
+    }
+
+    private function formatMinutes(int $minutes): string
+    {
+        $sign = $minutes < 0 ? '-' : '';
+        $absMinutes = abs($minutes);
+        $hours = intdiv($absMinutes, 60);
+        $remainder = $absMinutes % 60;
+
+        return sprintf('%s%d:%02d', $sign, $hours, $remainder);
+    }
+}

--- a/code/api/app/Http/Controllers/Api/V1/PayPeriods/ConfirmCloseController.php
+++ b/code/api/app/Http/Controllers/Api/V1/PayPeriods/ConfirmCloseController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\V1\PayPeriods;
 
+use App\Actions\Payroll\CreateOvertimePaidMovementsAction;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\PayPeriods\ConfirmClosePayPeriodRequest;
 use App\Http\Responses\Common\ResponseEntity;
@@ -48,7 +49,10 @@ class ConfirmCloseController extends Controller
 {
     private const DUPLICATE_PERIOD_MESSAGE = 'Ya existe un cierre para este periodo.';
 
-    public function __construct(private PayPeriodPreviewService $previewService) {}
+    public function __construct(
+        private PayPeriodPreviewService $previewService,
+        private CreateOvertimePaidMovementsAction $createOvertimePaidMovements,
+    ) {}
 
     public function __invoke(ConfirmClosePayPeriodRequest $request): ResponseEntity
     {
@@ -92,6 +96,8 @@ class ConfirmCloseController extends Controller
                 ]);
 
                 foreach ($employees as $employee) {
+                    ($this->createOvertimePaidMovements)($employee, $periodStart, $periodEnd);
+
                     $preview = $this->previewService->buildEmployeePreview(
                         $employee,
                         $periodStart,

--- a/code/api/app/Http/Resources/Employees/OvertimeBankMovementResource.php
+++ b/code/api/app/Http/Resources/Employees/OvertimeBankMovementResource.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Resources\Employees;
+
+use App\Http\Resources\BaseResource;
+use App\Models\OvertimeBankMovement;
+
+/**
+ * @mixin OvertimeBankMovement
+ */
+class OvertimeBankMovementResource extends BaseResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->public_id,
+            'date' => $this->date->toDateString(),
+            'movement_type' => $this->movement_type->value,
+            'origin' => $this->origin->value,
+            'minutes' => $this->minutes,
+            'valuation_method' => $this->valuation_method?->value,
+            'applied_rate' => $this->applied_rate !== null ? (float) $this->applied_rate : null,
+            'amount' => $this->amount !== null ? (float) $this->amount : null,
+            'authorized_by' => $this->authorizedBy?->name,
+            'authorized_at' => $this->authorized_at?->toIso8601String(),
+            'reason' => $this->reason,
+        ];
+    }
+}

--- a/code/api/app/Models/OvertimeBankMovement.php
+++ b/code/api/app/Models/OvertimeBankMovement.php
@@ -2,6 +2,9 @@
 
 namespace App\Models;
 
+use App\Enums\OvertimeMovementType;
+use App\Enums\OvertimeOrigin;
+use App\Enums\OvertimeValuationMethod;
 use App\Support\Traits\HasPublicId;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -13,27 +16,32 @@ class OvertimeBankMovement extends Model
     use HasFactory;
     use HasPublicId;
 
-    const TYPE_EARNED = 'EARNED';
-
-    const TYPE_PAID = 'PAID';
-
-    const TYPE_EXPIRED = 'EXPIRED';
-
-    const TYPE_TRANSFERRED = 'TRANSFERRED';
-
     protected $fillable = [
         'employee_id',
         'attendance_id',
         'date',
-        'type',
+        'movement_type',
+        'origin',
         'minutes',
+        'valuation_method',
+        'applied_rate',
+        'amount',
+        'authorized_by',
+        'authorized_at',
+        'reason',
         'reference',
         'meta',
     ];
 
     protected $casts = [
         'date' => 'date',
+        'movement_type' => OvertimeMovementType::class,
+        'origin' => OvertimeOrigin::class,
         'minutes' => 'integer',
+        'valuation_method' => OvertimeValuationMethod::class,
+        'applied_rate' => 'decimal:2',
+        'amount' => 'decimal:2',
+        'authorized_at' => 'datetime',
         'meta' => 'array',
     ];
 
@@ -47,14 +55,25 @@ class OvertimeBankMovement extends Model
         return $this->belongsTo(Attendance::class);
     }
 
+    public function authorizedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'authorized_by');
+    }
+
+    /** Positive impact = minutes added to the bank; negative = minutes removed. */
+    public function balanceImpact(): int
+    {
+        return $this->movement_type->balanceImpact((int) $this->minutes);
+    }
+
     public function scopePaid(Builder $query): Builder
     {
-        return $query->where('type', self::TYPE_PAID);
+        return $query->where('movement_type', OvertimeMovementType::PAID);
     }
 
     public function scopeEarned(Builder $query): Builder
     {
-        return $query->where('type', self::TYPE_EARNED);
+        return $query->where('movement_type', OvertimeMovementType::EARNED);
     }
 
     public function scopeInPeriod(Builder $query, string $start, string $end): Builder

--- a/code/api/app/Services/PayPeriodPreviewService.php
+++ b/code/api/app/Services/PayPeriodPreviewService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Enums\OvertimeMovementType;
 use App\Models\Employee;
 use App\Models\EmployeeBonusConfig;
 use App\Models\EmployeeSchedule;
@@ -222,7 +223,7 @@ class PayPeriodPreviewService
         }
 
         foreach ($overtimeMovements as $movement) {
-            if ($movement->type === OvertimeBankMovement::TYPE_PAID) {
+            if ($movement->movement_type === OvertimeMovementType::PAID) {
                 $amount = round((int) $movement->minutes * $ctx['minuteRate'], 2);
                 $lines[] = [
                     'date' => $movement->date->toDateString(),

--- a/code/api/app/Services/PayrollCalculator.php
+++ b/code/api/app/Services/PayrollCalculator.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Enums\OvertimeMovementType;
 use App\Models\Holiday;
 use Illuminate\Support\Collection;
 
@@ -83,7 +84,7 @@ class PayrollCalculator
         $total = 0.0;
 
         foreach ($overtimeMovements as $movement) {
-            if ($movement->type === 'PAID') {
+            if ($movement->movement_type === OvertimeMovementType::PAID) {
                 $total += (int) $movement->minutes * $minuteRate;
             }
         }
@@ -115,7 +116,7 @@ class PayrollCalculator
         $minutes = 0;
 
         foreach ($overtimeMovements as $movement) {
-            if ($movement->type === 'EARNED') {
+            if ($movement->movement_type === OvertimeMovementType::EARNED) {
                 $minutes += (int) $movement->minutes;
             }
         }

--- a/code/api/app/Services/PayrollSeedService.php
+++ b/code/api/app/Services/PayrollSeedService.php
@@ -3,6 +3,8 @@
 namespace App\Services;
 
 use App\Enums\DayStatus;
+use App\Enums\OvertimeMovementType;
+use App\Enums\OvertimeOrigin;
 use App\Enums\SeedScenario;
 use App\Models\Attendance;
 use App\Models\Employee;
@@ -211,7 +213,8 @@ class PayrollSeedService
                 ],
                 'partial_leave' => null,
                 'overtime' => [
-                    'type' => OvertimeBankMovement::TYPE_PAID,
+                    'movement_type' => OvertimeMovementType::PAID,
+                    'origin' => OvertimeOrigin::AUTO,
                     'minutes' => self::OVERTIME_MINUTES,
                     'reference' => 'payroll-seed',
                 ],
@@ -339,7 +342,8 @@ class PayrollSeedService
                 ],
                 'partial_leave' => null,
                 'overtime' => [
-                    'type' => OvertimeBankMovement::TYPE_PAID,
+                    'movement_type' => OvertimeMovementType::PAID,
+                    'origin' => OvertimeOrigin::AUTO,
                     'minutes' => self::OVERTIME_MINUTES,
                     'reference' => 'payroll-seed',
                 ],

--- a/code/api/database/factories/OvertimeBankMovementFactory.php
+++ b/code/api/database/factories/OvertimeBankMovementFactory.php
@@ -2,6 +2,8 @@
 
 namespace Database\Factories;
 
+use App\Enums\OvertimeMovementType;
+use App\Enums\OvertimeOrigin;
 use App\Models\Employee;
 use App\Models\OvertimeBankMovement;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -17,8 +19,15 @@ class OvertimeBankMovementFactory extends Factory
             'employee_id' => Employee::factory(),
             'attendance_id' => null,
             'date' => now()->toDateString(),
-            'type' => OvertimeBankMovement::TYPE_EARNED,
+            'movement_type' => OvertimeMovementType::EARNED,
+            'origin' => OvertimeOrigin::AUTO,
             'minutes' => fake()->numberBetween(15, 120),
+            'valuation_method' => null,
+            'applied_rate' => null,
+            'amount' => null,
+            'authorized_by' => null,
+            'authorized_at' => null,
+            'reason' => null,
             'reference' => null,
             'meta' => null,
         ];
@@ -26,11 +35,11 @@ class OvertimeBankMovementFactory extends Factory
 
     public function paid(): static
     {
-        return $this->state(['type' => OvertimeBankMovement::TYPE_PAID]);
+        return $this->state(['movement_type' => OvertimeMovementType::PAID]);
     }
 
     public function earned(): static
     {
-        return $this->state(['type' => OvertimeBankMovement::TYPE_EARNED]);
+        return $this->state(['movement_type' => OvertimeMovementType::EARNED]);
     }
 }

--- a/code/api/database/migrations/2026_07_12_000001_add_overtime_bank_movement_details.php
+++ b/code/api/database/migrations/2026_07_12_000001_add_overtime_bank_movement_details.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // The original enum('type', ['EARNED', 'PAID', 'EXPIRED', 'TRANSFERRED']) is enforced
+        // via a Postgres CHECK constraint that keeps its auto-generated name across the rename
+        // below, so it must be dropped before movement_type can hold the full
+        // OvertimeMovementType set (EARNED|USED|PAID|ADJUSTMENT).
+        DB::statement('ALTER TABLE overtime_bank_movements DROP CONSTRAINT IF EXISTS overtime_bank_movements_type_check');
+
+        Schema::table('overtime_bank_movements', function (Blueprint $table) {
+            $table->renameColumn('type', 'movement_type');
+            $table->string('origin')->default('AUTO')->after('movement_type');
+            $table->string('valuation_method')->nullable()->after('minutes');
+            $table->decimal('applied_rate', 8, 2)->nullable()->after('valuation_method');
+            $table->decimal('amount', 10, 2)->nullable()->after('applied_rate');
+            $table->foreignId('authorized_by')->nullable()->after('amount')->constrained('users')->nullOnDelete();
+            $table->dateTime('authorized_at')->nullable()->after('authorized_by');
+            $table->string('reason')->nullable()->after('authorized_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('overtime_bank_movements', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('authorized_by');
+            $table->dropColumn(['origin', 'valuation_method', 'applied_rate', 'amount', 'authorized_at', 'reason']);
+            $table->renameColumn('movement_type', 'type');
+        });
+
+        DB::statement("ALTER TABLE overtime_bank_movements ADD CONSTRAINT overtime_bank_movements_type_check CHECK (type IN ('EARNED', 'PAID', 'EXPIRED', 'TRANSFERRED'))");
+    }
+};

--- a/code/api/database/migrations/2026_07_12_000001_add_overtime_bank_movement_details.php
+++ b/code/api/database/migrations/2026_07_12_000001_add_overtime_bank_movement_details.php
@@ -9,6 +9,13 @@ return new class extends Migration
 {
     public function up(): void
     {
+        // OvertimeMovementType has no EXPIRED/TRANSFERRED case — remap any legacy rows before the
+        // column is cast to that enum, otherwise reading them back would throw a ValueError.
+        // EXPIRED (minutes removed from the bank) maps to USED; TRANSFERRED (moved elsewhere) maps
+        // to ADJUSTMENT, the closest equivalent in the new vocabulary.
+        DB::table('overtime_bank_movements')->where('type', 'EXPIRED')->update(['type' => 'USED']);
+        DB::table('overtime_bank_movements')->where('type', 'TRANSFERRED')->update(['type' => 'ADJUSTMENT']);
+
         // The original enum('type', ['EARNED', 'PAID', 'EXPIRED', 'TRANSFERRED']) is enforced
         // via a Postgres CHECK constraint that keeps its auto-generated name across the rename
         // below, so it must be dropped before movement_type can hold the full
@@ -25,6 +32,12 @@ return new class extends Migration
             $table->dateTime('authorized_at')->nullable()->after('authorized_by');
             $table->string('reason')->nullable()->after('authorized_at');
         });
+
+        // Note: `minutes` stays as-is (originally unsignedInteger). Postgres has no native unsigned
+        // integer type, so Laravel's grammar already compiles unsignedInteger() to a plain signed
+        // `integer` here with no CHECK constraint — confirmed negative values (needed by
+        // OvertimeMovementType::ADJUSTMENT, which passes minutes through signed) are already
+        // storable, no column type change required.
     }
 
     public function down(): void
@@ -34,6 +47,12 @@ return new class extends Migration
             $table->dropColumn(['origin', 'valuation_method', 'applied_rate', 'amount', 'authorized_at', 'reason']);
             $table->renameColumn('movement_type', 'type');
         });
+
+        // USED/ADJUSTMENT rows created after this migration ran have no equivalent in the legacy
+        // set — remapped back to their closest original meaning so the restored CHECK constraint
+        // doesn't reject them (this is a best-effort revert, not a lossless one).
+        DB::table('overtime_bank_movements')->where('type', 'USED')->update(['type' => 'EXPIRED']);
+        DB::table('overtime_bank_movements')->where('type', 'ADJUSTMENT')->update(['type' => 'TRANSFERRED']);
 
         DB::statement("ALTER TABLE overtime_bank_movements ADD CONSTRAINT overtime_bank_movements_type_check CHECK (type IN ('EARNED', 'PAID', 'EXPIRED', 'TRANSFERRED'))");
     }

--- a/code/api/database/seeders/Testing/OvertimeBankTestSeeder.php
+++ b/code/api/database/seeders/Testing/OvertimeBankTestSeeder.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Database\Seeders\Testing;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+/**
+ * Overtime bank test seeder — deterministic data for the Overtime Bank Cypress spec.
+ *
+ * Requires AttendanceTestSeeder to have run first (creates EMP-001 with schedule).
+ * Gives EMP-001 one authorized-overtime attendance, mirroring the real checkout
+ * (EARNED) + payroll close (PAID) flow so the balance and movement history render.
+ */
+class OvertimeBankTestSeeder extends Seeder
+{
+    private const DATE = '2026-06-24';
+
+    private const OVERTIME_MINUTES = 90;
+
+    private const HOURLY_RATE_APPLIED = 90.00;
+
+    public function run(): void
+    {
+        $now = now();
+
+        $employeeId = DB::table('employees')->where('code', 'EMP-001')->value('id');
+        $managerId = DB::table('users')->where('email', 'admin@sushigo.com')->value('id');
+
+        $attendanceId = DB::table('attendances')->insertGetId([
+            'public_id' => Str::ulid()->toString(),
+            'employee_id' => $employeeId,
+            'date' => self::DATE,
+            'check_in' => self::DATE.' 13:00:00',
+            'check_out' => self::DATE.' 23:30:00',
+            'lunch_start' => self::DATE.' 18:00:00',
+            'lunch_end' => self::DATE.' 18:30:00',
+            'entry_late_seconds' => 0,
+            'lunch_late_seconds' => 0,
+            'net_worked_minutes' => 570,
+            'overtime_minutes' => self::OVERTIME_MINUTES,
+            'overtime_authorized' => true,
+            'overtime_authorized_by' => $managerId,
+            'overtime_authorized_at' => self::DATE.' 23:35:00',
+            'overtime_valuation_method' => 'AGREED_RATE',
+            'overtime_rate_applied' => self::HOURLY_RATE_APPLIED,
+            'overtime_amount' => round(self::OVERTIME_MINUTES / 60 * self::HOURLY_RATE_APPLIED, 2),
+            'day_status' => 'WORKED',
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        DB::table('overtime_bank_movements')->insert([
+            [
+                'public_id' => Str::ulid()->toString(),
+                'employee_id' => $employeeId,
+                'attendance_id' => $attendanceId,
+                'date' => self::DATE,
+                'movement_type' => 'EARNED',
+                'origin' => 'AUTO',
+                'minutes' => self::OVERTIME_MINUTES,
+                'valuation_method' => null,
+                'applied_rate' => null,
+                'amount' => null,
+                'authorized_by' => null,
+                'authorized_at' => null,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+            [
+                'public_id' => Str::ulid()->toString(),
+                'employee_id' => $employeeId,
+                'attendance_id' => $attendanceId,
+                'date' => self::DATE,
+                'movement_type' => 'PAID',
+                'origin' => 'AUTO',
+                'minutes' => self::OVERTIME_MINUTES,
+                'valuation_method' => 'AGREED_RATE',
+                'applied_rate' => self::HOURLY_RATE_APPLIED,
+                'amount' => round(self::OVERTIME_MINUTES / 60 * self::HOURLY_RATE_APPLIED, 2),
+                'authorized_by' => $managerId,
+                'authorized_at' => self::DATE.' 23:35:00',
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+        ]);
+    }
+}

--- a/code/api/routes/api.php
+++ b/code/api/routes/api.php
@@ -43,6 +43,7 @@ use App\Http\Controllers\Api\V1\Employees\ListVacationEntitlementsController;
 use App\Http\Controllers\Api\V1\Employees\ListWagesController;
 use App\Http\Controllers\Api\V1\Employees\RehireEmployeeController;
 use App\Http\Controllers\Api\V1\Employees\ShowEmployeeController;
+use App\Http\Controllers\Api\V1\Employees\ShowOvertimeBankController;
 use App\Http\Controllers\Api\V1\Employees\SuggestEmployeeCodeController;
 use App\Http\Controllers\Api\V1\Employees\SyncUserDirectPermissionsController;
 use App\Http\Controllers\Api\V1\Employees\ToggleEmployeeActiveController;
@@ -307,6 +308,8 @@ Route::prefix('v1')->group(function () {
         Route::get('/{employee}/vacation-entitlements', ListVacationEntitlementsController::class)->name('employees.vacation-entitlements.list')->middleware('permission:employees.view|employee-requests.create');
         // Vacation request history endpoints (same self-service scoping as above)
         Route::get('/{employee}/vacation-requests', ListEmployeeVacationRequestsController::class)->name('employees.vacation-requests.list')->middleware('permission:employees.view|employee-requests.create');
+        // Overtime bank balance + movement history (same self-service scoping as above)
+        Route::get('/{employee}/overtime-bank', ShowOvertimeBankController::class)->name('employees.overtime-bank.show')->middleware('permission:employees.view|employee-requests.create');
         // Direct permission management
         Route::get('/{employee}/permissions', GetUserPermissionsController::class)->name('employees.permissions.get')->middleware('permission:users.show');
         Route::put('/{employee}/permissions', SyncUserDirectPermissionsController::class)->name('employees.permissions.sync')->middleware('permission:users.update');

--- a/code/api/tests/Feature/AttendancePayroll/CheckOutApiTest.php
+++ b/code/api/tests/Feature/AttendancePayroll/CheckOutApiTest.php
@@ -2,10 +2,13 @@
 
 namespace Tests\Feature\AttendancePayroll;
 
+use App\Enums\OvertimeMovementType;
+use App\Enums\OvertimeOrigin;
 use App\Models\Attendance;
 use App\Models\Employee;
 use App\Models\EmployeeSchedule;
 use App\Models\EmploymentPeriod;
+use App\Models\OvertimeBankMovement;
 use App\Models\ScheduleDay;
 use App\Models\User;
 use Carbon\Carbon;
@@ -187,6 +190,43 @@ class CheckOutApiTest extends TestCase
             ]);
 
         $this->assertEquals(26, strlen($response->json('data.id')));
+    }
+
+    // #endregion
+
+    // #region Overtime bank
+
+    #[Test]
+    public function checkout_with_overtime_creates_earned_bank_movement(): void
+    {
+        ['attendance' => $attendance, 'employee' => $employee] = $this->makeAttendanceWithLunch();
+
+        $this->patchJson(
+            "/api/v1/attendances/{$attendance->public_id}/check-out",
+            ['check_out' => '2026-02-23T17:35:00'],
+        )->assertStatus(200);
+
+        $this->assertDatabaseCount('overtime_bank_movements', 1);
+
+        $movement = OvertimeBankMovement::first();
+        $this->assertSame($employee->id, $movement->employee_id);
+        $this->assertSame($attendance->id, $movement->attendance_id);
+        $this->assertSame(OvertimeMovementType::EARNED, $movement->movement_type);
+        $this->assertSame(OvertimeOrigin::AUTO, $movement->origin);
+        $this->assertSame(35, $movement->minutes);
+    }
+
+    #[Test]
+    public function checkout_without_overtime_creates_no_bank_movement(): void
+    {
+        ['attendance' => $attendance] = $this->makeAttendanceWithLunch();
+
+        $this->patchJson(
+            "/api/v1/attendances/{$attendance->public_id}/check-out",
+            ['check_out' => '2026-02-23T17:00:00'],
+        )->assertStatus(200);
+
+        $this->assertDatabaseCount('overtime_bank_movements', 0);
     }
 
     // #endregion

--- a/code/api/tests/Feature/AttendancePayroll/ConfirmCloseApiTest.php
+++ b/code/api/tests/Feature/AttendancePayroll/ConfirmCloseApiTest.php
@@ -2,11 +2,13 @@
 
 namespace Tests\Feature\AttendancePayroll;
 
+use App\Enums\OvertimeValuationMethod;
 use App\Models\Attendance;
 use App\Models\Branch;
 use App\Models\Employee;
 use App\Models\EmployeeSchedule;
 use App\Models\EmploymentPeriod;
+use App\Models\OvertimeBankMovement;
 use App\Models\PayPeriod;
 use App\Models\PayPeriodLine;
 use App\Models\ScheduleDay;
@@ -116,6 +118,71 @@ class ConfirmCloseApiTest extends TestCase
         $this->assertTrue($payPeriod->isClosed());
         $this->assertEquals($this->user->id, $payPeriod->closed_by);
         $this->assertNotNull($payPeriod->closed_at);
+    }
+
+    public function test_confirm_close_creates_paid_overtime_movement_for_authorized_overtime(): void
+    {
+        $employee = $this->createActiveEmployee();
+        $manager = User::factory()->create();
+
+        $attendance = Attendance::where('employee_id', $employee->id)->first();
+        $attendance->update([
+            'overtime_minutes' => 60,
+            'overtime_authorized' => true,
+            'overtime_authorized_by' => $manager->id,
+            'overtime_authorized_at' => now(),
+            'overtime_valuation_method' => OvertimeValuationMethod::AGREED_RATE->value,
+            'overtime_rate_applied' => 90.00,
+            'overtime_amount' => 90.00,
+        ]);
+
+        OvertimeBankMovement::factory()->earned()->create([
+            'employee_id' => $employee->id,
+            'attendance_id' => $attendance->id,
+            'date' => $attendance->date,
+            'minutes' => 60,
+        ]);
+
+        $response = $this->postJson('/api/v1/pay-periods', [
+            'branch_id' => $this->branch->id,
+            'period_start' => '2026-06-22',
+            'period_end' => '2026-06-28',
+        ]);
+
+        $response->assertStatus(201);
+
+        $this->assertDatabaseCount('overtime_bank_movements', 2);
+        $this->assertDatabaseHas('overtime_bank_movements', [
+            'employee_id' => $employee->id,
+            'attendance_id' => $attendance->id,
+            'movement_type' => 'PAID',
+            'minutes' => 60,
+            'amount' => 90.00,
+            'authorized_by' => $manager->id,
+        ]);
+    }
+
+    public function test_confirm_close_does_not_create_paid_movement_for_unauthorized_overtime(): void
+    {
+        $employee = $this->createActiveEmployee();
+
+        $attendance = Attendance::where('employee_id', $employee->id)->first();
+        $attendance->update(['overtime_minutes' => 60]);
+
+        OvertimeBankMovement::factory()->earned()->create([
+            'employee_id' => $employee->id,
+            'attendance_id' => $attendance->id,
+            'date' => $attendance->date,
+            'minutes' => 60,
+        ]);
+
+        $this->postJson('/api/v1/pay-periods', [
+            'branch_id' => $this->branch->id,
+            'period_start' => '2026-06-22',
+            'period_end' => '2026-06-28',
+        ])->assertStatus(201);
+
+        $this->assertDatabaseCount('overtime_bank_movements', 1);
     }
 
     public function test_confirm_close_rejects_duplicate_period_for_same_branch(): void

--- a/code/api/tests/Feature/AttendancePayroll/OvertimeBankApiTest.php
+++ b/code/api/tests/Feature/AttendancePayroll/OvertimeBankApiTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Tests\Feature\AttendancePayroll;
+
+use App\Models\Employee;
+use App\Models\OvertimeBankMovement;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+class OvertimeBankApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        app()[PermissionRegistrar::class]->forgetCachedPermissions();
+
+        Permission::create(['name' => 'employees.view', 'guard_name' => 'api']);
+        Permission::create(['name' => 'employee-requests.create', 'guard_name' => 'api']);
+
+        $adminRole = Role::create(['name' => 'admin', 'guard_name' => 'api']);
+        $adminRole->givePermissionTo('employees.view');
+
+        $selfServiceRole = Role::create(['name' => 'employee', 'guard_name' => 'api']);
+        $selfServiceRole->givePermissionTo('employee-requests.create');
+
+        foreach (Employee::POSITION_ROLES as $roleName) {
+            Role::firstOrCreate(['name' => $roleName, 'guard_name' => 'api']);
+        }
+
+        $this->admin = User::factory()->create();
+        $this->admin->assignRole('admin');
+
+        Passport::actingAs($this->admin);
+    }
+
+    #[Test]
+    public function it_returns_balance_and_movements_for_employee(): void
+    {
+        $employee = Employee::factory()->create();
+
+        OvertimeBankMovement::factory()->earned()->create([
+            'employee_id' => $employee->id,
+            'date' => '2026-06-10',
+            'minutes' => 120,
+        ]);
+
+        OvertimeBankMovement::factory()->paid()->create([
+            'employee_id' => $employee->id,
+            'date' => '2026-06-12',
+            'minutes' => 60,
+        ]);
+
+        $response = $this->getJson("/api/v1/employees/{$employee->public_id}/overtime-bank");
+
+        $response->assertStatus(200);
+        $this->assertCount(2, $response->json('data'));
+        $this->assertSame(60, $response->json('meta.balance_minutes'));
+        $this->assertSame('1:00', $response->json('meta.balance_formatted'));
+    }
+
+    #[Test]
+    public function it_includes_authorized_by_name_for_paid_movements(): void
+    {
+        $employee = Employee::factory()->create();
+        $manager = User::factory()->create(['name' => 'Jane Manager']);
+
+        OvertimeBankMovement::factory()->paid()->create([
+            'employee_id' => $employee->id,
+            'minutes' => 60,
+            'authorized_by' => $manager->id,
+        ]);
+
+        $response = $this->getJson("/api/v1/employees/{$employee->public_id}/overtime-bank");
+
+        $response->assertStatus(200);
+        $this->assertSame('Jane Manager', $response->json('data.0.authorized_by'));
+    }
+
+    #[Test]
+    public function it_returns_empty_movements_and_zero_balance_for_employee_with_no_movements(): void
+    {
+        $employee = Employee::factory()->create();
+
+        $response = $this->getJson("/api/v1/employees/{$employee->public_id}/overtime-bank");
+
+        $response->assertStatus(200);
+        $this->assertCount(0, $response->json('data'));
+        $this->assertSame(0, $response->json('meta.balance_minutes'));
+    }
+
+    #[Test]
+    public function it_returns_403_for_unauthorized_request(): void
+    {
+        $employee = Employee::factory()->create();
+        Passport::actingAs(User::factory()->create());
+
+        $response = $this->getJson("/api/v1/employees/{$employee->public_id}/overtime-bank");
+
+        $response->assertStatus(403);
+    }
+
+    #[Test]
+    public function self_service_user_can_view_their_own_overtime_bank(): void
+    {
+        $employee = Employee::factory()->create();
+        $user = User::factory()->create();
+        $user->assignRole('employee');
+        $employee->update(['user_id' => $user->id]);
+
+        Passport::actingAs($user);
+
+        $response = $this->getJson("/api/v1/employees/{$employee->public_id}/overtime-bank");
+
+        $response->assertStatus(200);
+    }
+
+    #[Test]
+    public function self_service_user_cannot_view_another_employees_overtime_bank(): void
+    {
+        $employee = Employee::factory()->create();
+        $user = User::factory()->create();
+        $user->assignRole('employee');
+        // Note: $user is not linked to $employee (no matching user_id)
+
+        Passport::actingAs($user);
+
+        $response = $this->getJson("/api/v1/employees/{$employee->public_id}/overtime-bank");
+
+        $response->assertStatus(403);
+    }
+}

--- a/code/api/tests/Feature/AttendancePayroll/PreviewPayPeriodApiTest.php
+++ b/code/api/tests/Feature/AttendancePayroll/PreviewPayPeriodApiTest.php
@@ -262,10 +262,9 @@ class PreviewPayPeriodApiTest extends TestCase
             'employee_id' => $employee->id,
             'hourly_rate' => 60.00,
         ]);
-        OvertimeBankMovement::factory()->create([
+        OvertimeBankMovement::factory()->paid()->create([
             'employee_id' => $employee->id,
             'date' => '2026-06-22',
-            'type' => OvertimeBankMovement::TYPE_PAID,
             'minutes' => 60,
         ]);
 

--- a/code/api/tests/Feature/Devtools/SeedPayrollEndpointTest.php
+++ b/code/api/tests/Feature/Devtools/SeedPayrollEndpointTest.php
@@ -187,11 +187,11 @@ class SeedPayrollEndpointTest extends TestCase
             'scenario' => 'with_overtime',
         ])->assertOk();
 
-        // Tue, Thu, Fri (3 days) get OvertimeBankMovement TYPE_PAID
+        // Tue, Thu, Fri (3 days) get OvertimeBankMovement PAID
         $this->assertDatabaseCount('overtime_bank_movements', 3);
         $this->assertDatabaseHas('overtime_bank_movements', [
             'employee_id' => $employee->id,
-            'type' => 'PAID',
+            'movement_type' => 'PAID',
             'minutes' => 120,
         ]);
     }

--- a/code/api/tests/Unit/Models/OvertimeBankMovementTest.php
+++ b/code/api/tests/Unit/Models/OvertimeBankMovementTest.php
@@ -2,16 +2,41 @@
 
 namespace Tests\Unit\Models;
 
+use App\Enums\OvertimeMovementType;
+use App\Enums\OvertimeOrigin;
 use App\Models\OvertimeBankMovement;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 class OvertimeBankMovementTest extends TestCase
 {
-    public function test_type_constants_have_expected_values(): void
+    #[Test]
+    #[DataProvider('balanceImpactCases')]
+    public function balance_impact_reflects_movement_type(OvertimeMovementType $type, int $minutes, int $expected): void
     {
-        $this->assertSame('EARNED', OvertimeBankMovement::TYPE_EARNED);
-        $this->assertSame('PAID', OvertimeBankMovement::TYPE_PAID);
-        $this->assertSame('EXPIRED', OvertimeBankMovement::TYPE_EXPIRED);
-        $this->assertSame('TRANSFERRED', OvertimeBankMovement::TYPE_TRANSFERRED);
+        $movement = new OvertimeBankMovement;
+        $movement->movement_type = $type;
+        $movement->minutes = $minutes;
+
+        $this->assertSame($expected, $movement->balanceImpact());
+    }
+
+    public static function balanceImpactCases(): array
+    {
+        return [
+            'earned adds minutes' => [OvertimeMovementType::EARNED, 60, 60],
+            'used subtracts minutes' => [OvertimeMovementType::USED, 30, -30],
+            'paid subtracts minutes' => [OvertimeMovementType::PAID, 45, -45],
+            'adjustment keeps positive sign' => [OvertimeMovementType::ADJUSTMENT, 15, 15],
+            'adjustment keeps negative sign' => [OvertimeMovementType::ADJUSTMENT, -15, -15],
+        ];
+    }
+
+    #[Test]
+    public function origin_enum_has_auto_and_manual(): void
+    {
+        $this->assertSame('AUTO', OvertimeOrigin::AUTO->value);
+        $this->assertSame('MANUAL', OvertimeOrigin::MANUAL->value);
     }
 }

--- a/code/api/tests/Unit/Services/PayrollCalculatorTest.php
+++ b/code/api/tests/Unit/Services/PayrollCalculatorTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services;
 
+use App\Enums\OvertimeMovementType;
 use App\Models\Holiday;
 use App\Services\PayrollCalculator;
 use Carbon\Carbon;
@@ -284,7 +285,7 @@ class PayrollCalculatorTest extends TestCase
     #[Test]
     public function sums_paid_overtime_movements(): void
     {
-        $movement = (object) ['type' => 'PAID', 'minutes' => 120];
+        $movement = (object) ['movement_type' => OvertimeMovementType::PAID, 'minutes' => 120];
 
         $result = PayrollCalculator::calculateOvertimePay(collect([$movement]), 2.0);
 
@@ -292,11 +293,11 @@ class PayrollCalculatorTest extends TestCase
     }
 
     #[Test]
-    public function skips_earned_and_expired_overtime_movements(): void
+    public function skips_earned_and_used_overtime_movements(): void
     {
         $movements = collect([
-            (object) ['type' => 'EARNED', 'minutes' => 60],
-            (object) ['type' => 'EXPIRED', 'minutes' => 60],
+            (object) ['movement_type' => OvertimeMovementType::EARNED, 'minutes' => 60],
+            (object) ['movement_type' => OvertimeMovementType::USED, 'minutes' => 60],
         ]);
 
         $result = PayrollCalculator::calculateOvertimePay($movements, 2.0);

--- a/code/webapp/cypress/e2e/employee-overtime-bank.cy.ts
+++ b/code/webapp/cypress/e2e/employee-overtime-bank.cy.ts
@@ -52,6 +52,10 @@ before(() => {
 beforeEach(() => {
   cy.loginByApi(email, password)
   cy.visitWithAuth('/employees')
+  // Wait for the employee table (meaningful page content) before closing the debugger —
+  // closeDevDebugger() takes a synchronous DOM snapshot and can no-op if it runs before
+  // the DevDebugger has mounted.
+  cy.contains('tr', 'EMP-001', { timeout: 10_000 })
   cy.closeDevDebugger()
 })
 

--- a/code/webapp/cypress/e2e/employee-overtime-bank.cy.ts
+++ b/code/webapp/cypress/e2e/employee-overtime-bank.cy.ts
@@ -1,0 +1,73 @@
+/**
+ * Overtime Bank — E2E happy path (Task #070)
+ *
+ * Verifies that an employee's overtime bank balance and movement history render
+ * in the Employee Detail panel after a checkout (EARNED) + payroll close (PAID)
+ * cycle — seeded deterministically by OvertimeBankTestSeeder so the spec doesn't
+ * depend on driving the full checkout/authorization/payroll-close flow through
+ * the UI.
+ *
+ * All assertions are scoped inside [data-testid="overtime-bank-section"] —
+ * unscoped cy.contains() text matching (e.g. "0:00") can accidentally match
+ * unrelated content elsewhere in the panel (e.g. "10:00" in the Schedule
+ * section above), so every check below is confined to this section only.
+ *
+ * DB reset strategy
+ * ─────────────────
+ * • before() → cy.task('test:reset', 'overtime-bank') ONCE per file.
+ *   Gives EMP-001 one attendance with 90 min of authorized overtime, an EARNED
+ *   movement (from checkout) and a PAID movement (from payroll close) — balance
+ *   nets to 0 min, which is the correct, expected state once overtime has been
+ *   both earned and paid out.
+ *
+ * To run only this file:
+ *   make cypress-spec SPEC=employee-overtime-bank
+ */
+
+import users from '../fixtures/users.json'
+
+const { email, password } = users.admin
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function openEmp001Detail() {
+  cy.contains('tr', 'EMP-001', { timeout: 10_000 })
+    .find('button[title="Ver detalle"]')
+    .click()
+  cy.contains('h2', 'Detalle de Empleado', { timeout: 10_000 }).should('be.visible')
+}
+
+function scrollToOvertimeBank() {
+  cy.get('[data-testid="overtime-bank-section"]', { timeout: 10_000 })
+    .scrollIntoView()
+    .should('be.visible')
+}
+
+// ── Suite setup ───────────────────────────────────────────────────────────────
+
+before(() => {
+  cy.task('test:reset', 'overtime-bank', { timeout: 60_000 })
+})
+
+beforeEach(() => {
+  cy.loginByApi(email, password)
+  cy.visitWithAuth('/employees')
+  cy.closeDevDebugger()
+})
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+it('shows the overtime bank balance and both EARNED/PAID movements', () => {
+  openEmp001Detail()
+  cy.closeDevDebugger()
+  scrollToOvertimeBank()
+
+  cy.get('[data-testid="overtime-bank-section"]').within(() => {
+    // Balance card — EARNED (+90) then PAID (-90) nets to 0:00
+    cy.contains('Saldo actual (0 min)').should('be.visible')
+
+    // Movement history — both the checkout-generated EARNED and the payroll-close PAID movement
+    cy.contains('tr', 'Ganado').should('be.visible').and('contain.text', '90 min')
+    cy.contains('tr', 'Pagado').should('be.visible').and('contain.text', 'Admin User')
+  })
+})

--- a/code/webapp/src/components/employees/__tests__/employee-detail-view.test.tsx
+++ b/code/webapp/src/components/employees/__tests__/employee-detail-view.test.tsx
@@ -68,6 +68,10 @@ vi.mock('@/components/employees/vacation-section', () => ({
   VacationSection: () => <div>VacationSection</div>,
 }))
 
+vi.mock('@/components/employees/overtime-bank-section', () => ({
+  OvertimeBankSection: () => <div>OvertimeBankSection</div>,
+}))
+
 vi.mock('@/components/employees/use-employee-detail-actions', () => ({
   useEmployeeDetailActions: () => ({
     hasActivePeriod: true,

--- a/code/webapp/src/components/employees/__tests__/overtime-bank-section.test.tsx
+++ b/code/webapp/src/components/employees/__tests__/overtime-bank-section.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import type { OvertimeBankMovement, OvertimeBankSummary } from '@/types/attendance-payroll'
+
+let mockState = {
+  movements: [] as OvertimeBankMovement[],
+  summary: null as OvertimeBankSummary | null,
+  isLoading: false,
+}
+
+vi.mock('@/components/employees/use-overtime-bank-section', () => ({
+  useOvertimeBankSection: () => mockState,
+}))
+
+import { OvertimeBankSection } from '@/components/employees/overtime-bank-section'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockState = { movements: [], summary: null, isLoading: false }
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('OvertimeBankSection', () => {
+  it('renders the section header', () => {
+    render(<OvertimeBankSection employeeId="emp-001" />)
+
+    expect(screen.getByText('Banco de horas extra')).toBeTruthy()
+  })
+
+  it('shows loading spinner when isLoading is true', () => {
+    mockState = { ...mockState, isLoading: true }
+    const { container } = render(<OvertimeBankSection employeeId="emp-001" />)
+
+    expect(container.querySelector('.animate-spin')).toBeTruthy()
+  })
+
+  it('shows empty state when there are no movements', () => {
+    render(<OvertimeBankSection employeeId="emp-001" />)
+
+    expect(screen.getByText('Sin movimientos de horas extra registrados')).toBeTruthy()
+  })
+
+  it('renders the balance card with formatted balance', () => {
+    mockState = { ...mockState, summary: { balance_minutes: 90, balance_formatted: '1:30' } }
+    render(<OvertimeBankSection employeeId="emp-001" />)
+
+    expect(screen.getByText('1:30')).toBeTruthy()
+    expect(screen.getByText('Saldo actual (90 min)')).toBeTruthy()
+  })
+
+  it('applies destructive class when balance is negative', () => {
+    mockState = { ...mockState, summary: { balance_minutes: -30, balance_formatted: '-0:30' } }
+    const { container } = render(<OvertimeBankSection employeeId="emp-001" />)
+
+    expect(container.querySelector('.text-destructive')).toBeTruthy()
+  })
+
+  it('renders movements table with type, origin, and authorized_by', () => {
+    mockState = {
+      ...mockState,
+      movements: [
+        {
+          id: 'mov-1',
+          date: '2026-06-10',
+          movement_type: 'EARNED',
+          origin: 'AUTO',
+          minutes: 60,
+          valuation_method: null,
+          applied_rate: null,
+          amount: null,
+          authorized_by: null,
+          authorized_at: null,
+          reason: null,
+        },
+        {
+          id: 'mov-2',
+          date: '2026-06-14',
+          movement_type: 'PAID',
+          origin: 'AUTO',
+          minutes: 60,
+          valuation_method: 'AGREED_RATE',
+          applied_rate: 90,
+          amount: 90,
+          authorized_by: 'Jane Manager',
+          authorized_at: '2026-06-14T20:00:00+00:00',
+          reason: null,
+        },
+      ],
+    }
+    render(<OvertimeBankSection employeeId="emp-001" />)
+
+    expect(screen.getByText('Ganado')).toBeTruthy()
+    expect(screen.getByText('Pagado')).toBeTruthy()
+    expect(screen.getAllByText('Automático')).toHaveLength(2)
+    expect(screen.getByText('Jane Manager')).toBeTruthy()
+    expect(screen.getByText('$90.00')).toBeTruthy()
+  })
+
+  it('distinguishes MANUAL movements from AUTO ones', () => {
+    mockState = {
+      ...mockState,
+      movements: [
+        {
+          id: 'mov-1',
+          date: '2026-06-10',
+          movement_type: 'ADJUSTMENT',
+          origin: 'MANUAL',
+          minutes: 15,
+          valuation_method: null,
+          applied_rate: null,
+          amount: null,
+          authorized_by: null,
+          authorized_at: null,
+          reason: 'Correction',
+        },
+      ],
+    }
+    render(<OvertimeBankSection employeeId="emp-001" />)
+
+    expect(screen.getByText('Manual')).toBeTruthy()
+    expect(screen.getByText('Ajuste')).toBeTruthy()
+  })
+})

--- a/code/webapp/src/components/employees/employee-detail-view.tsx
+++ b/code/webapp/src/components/employees/employee-detail-view.tsx
@@ -16,6 +16,7 @@ import { usePermissionManager } from './use-permission-manager'
 import { PermissionManagerDialog } from './permission-manager-dialog'
 import { BonusConfigSection } from './bonus-config-section'
 import { VacationSection } from './vacation-section'
+import { OvertimeBankSection } from './overtime-bank-section'
 
 // ─── Props ───────────────────────────────────────────────────────────────────
 
@@ -104,6 +105,11 @@ export function EmployeeDetailView({
 
       {/* Vacation entitlements */}
       <VacationSection employeeId={employee.id} employee={employee} />
+
+      <hr className="border-border" />
+
+      {/* Overtime bank balance + movement history */}
+      <OvertimeBankSection employeeId={employee.id} />
 
       <hr className="border-border" />
 

--- a/code/webapp/src/components/employees/overtime-bank-section.tsx
+++ b/code/webapp/src/components/employees/overtime-bank-section.tsx
@@ -1,0 +1,99 @@
+import { Clock3, Loader2 } from 'lucide-react'
+import type { OvertimeBankMovement } from '@/types/attendance-payroll'
+import { useOvertimeBankSection } from './use-overtime-bank-section'
+import { OvertimeMovementTypeBadge, OvertimeOriginBadge } from './overtime-movement-badges'
+
+interface OvertimeBankSectionProps {
+  readonly employeeId: string
+}
+
+function formatDate(dateString: string): string {
+  return new Date(`${dateString}T00:00:00`).toLocaleDateString('es-MX', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('es-MX', { style: 'currency', currency: 'MXN' }).format(amount)
+}
+
+function balanceClass(minutes: number): string {
+  if (minutes < 0) return 'text-destructive'
+  if (minutes === 0) return 'text-muted-foreground'
+  return 'text-foreground'
+}
+
+function MovementRow({ movement }: { readonly movement: OvertimeBankMovement }) {
+  return (
+    <tr className="border-b last:border-0">
+      <td className="py-2 pr-3 text-sm whitespace-nowrap">{formatDate(movement.date)}</td>
+      <td className="py-2 pr-3"><OvertimeMovementTypeBadge type={movement.movement_type} /></td>
+      <td className="py-2 pr-3"><OvertimeOriginBadge origin={movement.origin} /></td>
+      <td className="py-2 pr-3 text-sm tabular-nums">{movement.minutes} min</td>
+      <td className="py-2 pr-3 text-sm tabular-nums">
+        {movement.amount !== null ? formatCurrency(movement.amount) : '—'}
+      </td>
+      <td className="py-2 text-sm">{movement.authorized_by ?? '—'}</td>
+    </tr>
+  )
+}
+
+export function OvertimeBankSection({ employeeId }: OvertimeBankSectionProps) {
+  const { movements, summary, isLoading } = useOvertimeBankSection(employeeId)
+
+  return (
+    <div className="space-y-4" data-testid="overtime-bank-section">
+      <div className="flex items-center gap-2">
+        <h3 className="text-sm font-semibold text-foreground">Banco de horas extra</h3>
+      </div>
+
+      {isLoading && (
+        <div className="flex items-center justify-center py-6">
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+        </div>
+      )}
+
+      {!isLoading && summary && (
+        <div className="rounded-lg border bg-card p-4 text-center">
+          <div className="flex items-center justify-center gap-2">
+            <Clock3 className="h-5 w-5 text-muted-foreground" />
+            <p className={`text-3xl font-bold tabular-nums ${balanceClass(summary.balance_minutes)}`}>
+              {summary.balance_formatted}
+            </p>
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Saldo actual ({summary.balance_minutes} min)
+          </p>
+        </div>
+      )}
+
+      {!isLoading && movements.length === 0 && (
+        <p className="text-xs text-muted-foreground italic">Sin movimientos de horas extra registrados</p>
+      )}
+
+      {!isLoading && movements.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-left text-xs font-medium text-muted-foreground">
+                <th className="py-2 pr-3">Fecha</th>
+                <th className="py-2 pr-3">Tipo</th>
+                <th className="py-2 pr-3">Origen</th>
+                <th className="py-2 pr-3">Minutos</th>
+                <th className="py-2 pr-3">Monto</th>
+                <th className="py-2">Autorizado por</th>
+              </tr>
+            </thead>
+            <tbody>
+              {movements.map((movement) => (
+                <MovementRow key={movement.id} movement={movement} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/code/webapp/src/components/employees/overtime-movement-badges.tsx
+++ b/code/webapp/src/components/employees/overtime-movement-badges.tsx
@@ -1,0 +1,25 @@
+import type { OvertimeMovementType, OvertimeOrigin } from '@/types/attendance-payroll'
+
+const TYPE_MAP: Record<OvertimeMovementType, { text: string; cls: string }> = {
+  EARNED: { text: 'Ganado', cls: 'bg-green-100 text-green-800' },
+  USED: { text: 'Usado', cls: 'bg-gray-100 text-gray-700' },
+  PAID: { text: 'Pagado', cls: 'bg-blue-100 text-blue-800' },
+  ADJUSTMENT: { text: 'Ajuste', cls: 'bg-purple-100 text-purple-800' },
+}
+
+const ORIGIN_MAP: Record<OvertimeOrigin, { text: string; cls: string }> = {
+  AUTO: { text: 'Automático', cls: 'bg-gray-100 text-gray-600' },
+  MANUAL: { text: 'Manual', cls: 'bg-amber-100 text-amber-800' },
+}
+
+/** Movement-type pill used in the Employee panel's Overtime Bank section. */
+export function OvertimeMovementTypeBadge({ type }: { readonly type: OvertimeMovementType }) {
+  const s = TYPE_MAP[type]
+  return <span className={`rounded px-2 py-0.5 text-xs font-medium ${s.cls}`}>{s.text}</span>
+}
+
+/** Origin pill (AUTO vs MANUAL) used in the Employee panel's Overtime Bank section. */
+export function OvertimeOriginBadge({ origin }: { readonly origin: OvertimeOrigin }) {
+  const s = ORIGIN_MAP[origin]
+  return <span className={`rounded px-2 py-0.5 text-xs font-medium ${s.cls}`}>{s.text}</span>
+}

--- a/code/webapp/src/components/employees/use-overtime-bank-section.ts
+++ b/code/webapp/src/components/employees/use-overtime-bank-section.ts
@@ -1,0 +1,11 @@
+import { useOvertimeBank } from '@/services/overtime-bank-hooks'
+
+export function useOvertimeBankSection(employeeId: string) {
+  const { data, isLoading } = useOvertimeBank(employeeId)
+
+  return {
+    movements: data?.movements ?? [],
+    summary: data?.summary ?? null,
+    isLoading,
+  }
+}

--- a/code/webapp/src/services/__tests__/overtime-bank-api.test.ts
+++ b/code/webapp/src/services/__tests__/overtime-bank-api.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { overtimeBankApi } from '../overtime-bank-api'
+
+vi.mock('@/lib/api-client', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+import { apiClient } from '@/lib/api-client'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('overtimeBankApi.getBank', () => {
+  it('calls GET /employees/{employeeId}/overtime-bank', async () => {
+    const mockResponse = { data: { status: 200, data: [], meta: { balance_minutes: 0, balance_formatted: '0:00' } } }
+    vi.mocked(apiClient.get).mockResolvedValue(mockResponse)
+
+    const result = await overtimeBankApi.getBank('emp-123')
+
+    expect(apiClient.get).toHaveBeenCalledWith('/employees/emp-123/overtime-bank')
+    expect(result).toEqual(mockResponse)
+  })
+})

--- a/code/webapp/src/services/__tests__/overtime-bank-hooks.test.tsx
+++ b/code/webapp/src/services/__tests__/overtime-bank-hooks.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import React from 'react'
+import type { OvertimeBankMovement, OvertimeBankSummary } from '@/types/attendance-payroll'
+
+const mockGetBank = vi.fn()
+
+vi.mock('@/services/overtime-bank-api', () => ({
+  overtimeBankApi: {
+    getBank: (...args: unknown[]) => mockGetBank(...args),
+  },
+}))
+
+import { useOvertimeBank } from '../overtime-bank-hooks'
+
+function makeWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children)
+}
+
+const fakeMovement: OvertimeBankMovement = {
+  id: 'mov-1',
+  date: '2026-06-10',
+  movement_type: 'EARNED',
+  origin: 'AUTO',
+  minutes: 60,
+  valuation_method: null,
+  applied_rate: null,
+  amount: null,
+  authorized_by: null,
+  authorized_at: null,
+  reason: null,
+}
+
+const fakeSummary: OvertimeBankSummary = { balance_minutes: 60, balance_formatted: '1:00' }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('useOvertimeBank', () => {
+  it('returns movements and summary from the response', async () => {
+    mockGetBank.mockResolvedValue({ data: { data: [fakeMovement], meta: fakeSummary } })
+
+    const { result } = renderHook(() => useOvertimeBank('emp-123'), { wrapper: makeWrapper() })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual({ movements: [fakeMovement], summary: fakeSummary })
+    expect(mockGetBank).toHaveBeenCalledWith('emp-123')
+  })
+
+  it('starts with data undefined before resolving', () => {
+    mockGetBank.mockReturnValue(new Promise(() => {}))
+    const { result } = renderHook(() => useOvertimeBank('emp-123'), { wrapper: makeWrapper() })
+    expect(result.current.data).toBeUndefined()
+  })
+
+  it('is disabled when employeeId is empty', () => {
+    const { result } = renderHook(() => useOvertimeBank(''), { wrapper: makeWrapper() })
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(mockGetBank).not.toHaveBeenCalled()
+  })
+})

--- a/code/webapp/src/services/overtime-bank-api.ts
+++ b/code/webapp/src/services/overtime-bank-api.ts
@@ -1,0 +1,13 @@
+import { apiClient } from '@/lib/api-client'
+import type { OvertimeBankMovement, OvertimeBankSummary } from '@/types/attendance-payroll'
+
+interface OvertimeBankResponse {
+  data: OvertimeBankMovement[]
+  status: number
+  meta: OvertimeBankSummary
+}
+
+export const overtimeBankApi = {
+  getBank: (employeeId: string) =>
+    apiClient.get<OvertimeBankResponse>(`/employees/${employeeId}/overtime-bank`),
+}

--- a/code/webapp/src/services/overtime-bank-hooks.ts
+++ b/code/webapp/src/services/overtime-bank-hooks.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query'
+import { overtimeBankApi } from '@/services/overtime-bank-api'
+
+export function useOvertimeBank(employeeId: string) {
+  return useQuery({
+    queryKey: ['overtime-bank', employeeId],
+    queryFn: async () => {
+      const response = await overtimeBankApi.getBank(employeeId)
+      return { movements: response.data.data, summary: response.data.meta }
+    },
+    enabled: !!employeeId,
+  })
+}

--- a/code/webapp/src/types/attendance-payroll.ts
+++ b/code/webapp/src/types/attendance-payroll.ts
@@ -163,6 +163,30 @@ export interface UpdateOvertimeLftTiersPayload {
   tiers: { factor: number; up_to_hours: number | null }[]
 }
 
+// ── Overtime Bank ───────────────────────────────────────────────────────────
+
+export type OvertimeMovementType = 'EARNED' | 'USED' | 'PAID' | 'ADJUSTMENT'
+export type OvertimeOrigin = 'AUTO' | 'MANUAL'
+
+export interface OvertimeBankMovement {
+  id: string
+  date: string
+  movement_type: OvertimeMovementType
+  origin: OvertimeOrigin
+  minutes: number
+  valuation_method: string | null
+  applied_rate: number | null
+  amount: number | null
+  authorized_by: string | null
+  authorized_at: string | null
+  reason: string | null
+}
+
+export interface OvertimeBankSummary {
+  balance_minutes: number
+  balance_formatted: string
+}
+
 // ── Vacation Request ─────────────────────────────────────────────────────────
 
 export type VacationRequestStatus = 'PENDING' | 'APPROVED' | 'REJECTED' | 'CANCELLED'

--- a/doc/tasks/2026-07/070-overtime-bank-balance.md
+++ b/doc/tasks/2026-07/070-overtime-bank-balance.md
@@ -51,11 +51,11 @@ Como Manager o Admin, quiero ver el saldo del banco de horas extra de un emplead
 ## ⏱️ Time
 
 ### 📊 Estimates
-- **Optimistic:** `3h` · **Pessimistic:** `5h` · **Tracked:** _in progress_
+- **Optimistic:** `3h` · **Pessimistic:** `5h` · **Tracked:** `~4h42m`
 
 ### 📅 Sessions
 ```json
 [
-  { "date": "2026-07-12", "start": "17:15", "end": "?" }
+  { "date": "2026-07-12", "start": "17:15", "end": "21:57" }
 ]
 ```

--- a/doc/tasks/2026-07/070-overtime-bank-balance.md
+++ b/doc/tasks/2026-07/070-overtime-bank-balance.md
@@ -45,3 +45,17 @@ Como Manager o Admin, quiero ver el saldo del banco de horas extra de un emplead
 ## ⏱️ Estimates
 
 - **Optimistic:** `3h` · **Pessimistic:** `5h`
+
+---
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `3h` · **Pessimistic:** `5h` · **Tracked:** _in progress_
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-07-12", "start": "17:15", "end": "?" }
+]
+```


### PR DESCRIPTION
## Summary
Closes #70

- 📂 Extended `overtime_bank_movements` with `movement_type`/`origin`/`authorized_by`/`amount` fields, adopting the already-built `OvertimeMovementType`/`OvertimeOrigin` enums
- 🔧 Checkout auto-creates an `EARNED` movement (origin=AUTO) when `overtime_minutes > 0`
- 🔧 Payroll close auto-creates `PAID` movements for authorized overtime, reusing the valuation already computed on `Attendance` (no separate per-employee pay config)
- 🌐 New `GET /api/v1/employees/{id}/overtime-bank` — balance + movement history. Self-service: no permission needed to view your own record, `employees.view` required to view another employee's
- 📱 New "Banco de horas extra" section in Employee Detail: balance card (h:mm) + movements table with type/origin badges

### Design decisions (see issue discussion)
- Extended the existing `overtime_bank_movements` table instead of replacing it — kept `EARNED|PAID` semantics but adopted the unused `OvertimeMovementType`/`OvertimeOrigin` enums for the full `EARNED|USED|PAID|ADJUSTMENT` / `AUTO|MANUAL` vocabulary
- `PAID` movements are created at **payroll close**, not at overtime authorization time (matches how `PayPeriodPreviewService` already consumes `PAID` movements for payroll calculations)
- No `OvertimePayConfig` — reused `overtime_amount`/`overtime_rate_applied`/`overtime_valuation_method` already computed on `Attendance` by `ResolveOvertimeValuationAction`

## Test plan
- [x] PHPUnit Unit: `php artisan test --filter=OvertimeBankMovementTest` (balanceImpact per movement type)
- [x] PHPUnit Feature: `php artisan test --filter=CheckOutApiTest` (EARNED movement on checkout)
- [x] PHPUnit Feature: `php artisan test --filter=ConfirmCloseApiTest` (PAID movement on payroll close)
- [x] PHPUnit Feature: `php artisan test --filter=OvertimeBankApiTest` (balance endpoint, self-service scoping)
- [x] Full backend suite: `php artisan test` — 1107 passing (5 pre-existing, unrelated failures in `VacationEntitlementApiTest`/`GenerateAnniversaryEntitlementsTest`, both untouched by this branch — a date-dependent flake tied to today's date)
- [x] Vitest: `npx vitest run` — 3252 tests passing
- [x] Cypress: `cypress/e2e/employee-overtime-bank.cy.ts` — happy path (balance card + EARNED/PAID movements)
- [x] Linters: Pint ✅ · ESLint ✅ · TypeScript ✅
- [x] `l5-swagger:generate` verified — no crash from the new `@OA\Get` docblock

## Manual Testing
1. Seed overtime data (devtools, local/testing env only): `POST /api/v1/devtools/payroll/seed` with `{"branch_id": 1, "period_start": "2026-07-06", "period_end": "2026-07-12", "scenario": "with_overtime"}`
2. Log in as `admin@sushigo.com`, go to **Empleados**, open any employee that was seeded with overtime (e.g. any employee shown in the seed response)
3. Scroll to the **Banco de horas extra** section — balance card shows the h:mm total, movements table lists EARNED/PAID rows with type badge, origin badge, minutes, amount, and who authorized it
4. To see the real flow end-to-end: check an employee out with overtime (`PATCH /attendances/{id}/check-out`) → confirm an `EARNED` movement appears; authorize the overtime (`PATCH /attendances/{id}/overtime-decision`) then close payroll for that period (`POST /pay-periods`) → confirm a `PAID` movement appears and the balance nets accordingly

## Workspace
`sushigo-a` — `feature/070-overtime-bank-balance`

🤖 Generated with [Claude Code](https://claude.com/claude-code)