### PR TITLE
📚 [#070][a] - Close out task #070 time tracking 📊

### DIFF
--- a/doc/tasks/2026-07/070-overtime-bank-balance.md
+++ b/doc/tasks/2026-07/070-overtime-bank-balance.md
@@ -51,11 +51,24 @@ Como Manager o Admin, quiero ver el saldo del banco de horas extra de un emplead
 ## ⏱️ Time
 
 ### 📊 Estimates
-- **Optimistic:** `3h` · **Pessimistic:** `5h` · **Tracked:** `~4h42m`
+- **Optimistic:** `3h` · **Pessimistic:** `5h` · **Tracked:** `~5h47m`
 
 ### 📅 Sessions
 ```json
 [
-  { "date": "2026-07-12", "start": "17:15", "end": "21:57" }
+  { "date": "2026-07-12", "start": "17:15", "end": "21:57" },
+  { "date": "2026-07-13", "start": "00:05", "end": "01:00" },
+  { "date": "2026-07-13", "start": "16:40", "end": "16:50" }
 ]
 ```
+
+## 📊 Retrospective
+- **Actual total:** 5h 47m (282m + 55m + 10m)
+- **vs optimistic:** +2h 47m
+- **vs pessimistic:** +47m
+
+**Justification:**
+
+The core implementation (session 1, 4h42m) ran close to the pessimistic estimate on its own. Two things drove that: first, the `overtime_bank_movements` table already existed from an earlier PR with a schema that conflicted with what the issue described (`type` enum `EARNED|PAID|EXPIRED|TRANSFERRED` vs. the issue's `movement_type`/`origin` vocabulary), which required a design discussion with the user before writing any code, plus a more involved `ALTER TABLE` migration than a plain `CREATE` would have been. Second, `PayPeriodPreviewService` was already silently expecting `PAID` movements to exist for its payroll calculations, but nothing in the codebase ever created them for real — tracing that and deciding PAID creation belongs at payroll-close time (not at overtime authorization) took extra investigation. Real end-to-end browser verification (API smoke test + a from-scratch Cypress spec against the E2E stack, since none existed for this endpoint) also added time, including debugging a DevDebugger-overlay/`cy.contains()`-scoping flakiness that turned out to be a genuine `cy.contains('0:00')` ambiguous-match bug in the spec itself.
+
+Sessions 2–3 (1h05m) were not part of the original implementation estimate: session 2 addressed two automated Copilot review comments post-PR (a legacy-enum-value migration safety fix and a Cypress Dev Debugger timing fix) plus SonarCloud quality gate verification for both `api` and `webapp` projects — both gates passed clean on the first check, no additional fixes needed there. Session 3 is this closing pass (task file + issue update) after the user merged the PR.


### PR DESCRIPTION
## Summary
- 📊 Record final session breakdown and retrospective for task #070 (View Overtime Bank Balance), now merged in #237
- ⏱️ Tracked ~5h47m across 3 sessions vs. 3–5h estimate — see retrospective in the task file for the justification

## Test plan
- [x] Documentation-only change, no code touched

## Workspace
`sushigo-a` — `docs/070-close-task-retrospective`

🤖 Generated with [Claude Code](https://claude.com/claude-code)