### PR TITLE
✨ [#071][a] - Register manual overtime bank movement ✅

### DIFF
--- a/code/api/app/Actions/Employee/CreateManualOvertimeMovementAction.php
+++ b/code/api/app/Actions/Employee/CreateManualOvertimeMovementAction.php
@@ -32,7 +32,7 @@ class CreateManualOvertimeMovementAction
                 ]);
             }
 
-            return OvertimeBankMovement::create([
+            $movement = OvertimeBankMovement::create([
                 'employee_id' => $employee->id,
                 'date' => $data['date'],
                 'movement_type' => $data['movement_type'],
@@ -42,6 +42,10 @@ class CreateManualOvertimeMovementAction
                 'authorized_at' => now(),
                 'reason' => $data['reason'],
             ]);
+
+            $movement->setRelation('authorizedBy', $authorizedBy);
+
+            return $movement;
         });
     }
 }

--- a/code/api/app/Actions/Employee/CreateManualOvertimeMovementAction.php
+++ b/code/api/app/Actions/Employee/CreateManualOvertimeMovementAction.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Actions\Employee;
+
+use App\Enums\OvertimeMovementType;
+use App\Enums\OvertimeOrigin;
+use App\Models\Employee;
+use App\Models\OvertimeBankMovement;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+class CreateManualOvertimeMovementAction
+{
+    /**
+     * @param  array{date: string, movement_type: OvertimeMovementType, minutes: int, reason: string}  $data
+     *
+     * @throws ValidationException
+     */
+    public function __invoke(Employee $employee, array $data, User $authorizedBy): OvertimeBankMovement
+    {
+        return DB::transaction(function () use ($employee, $data, $authorizedBy) {
+            $movements = OvertimeBankMovement::where('employee_id', $employee->id)
+                ->lockForUpdate()
+                ->get();
+
+            $currentBalance = $movements->sum(fn (OvertimeBankMovement $movement) => $movement->balanceImpact());
+
+            if ($data['movement_type'] === OvertimeMovementType::USED && $data['minutes'] > $currentBalance) {
+                throw ValidationException::withMessages([
+                    'minutes' => 'El empleado no tiene saldo de horas extra suficiente para este movimiento.',
+                ]);
+            }
+
+            return OvertimeBankMovement::create([
+                'employee_id' => $employee->id,
+                'date' => $data['date'],
+                'movement_type' => $data['movement_type'],
+                'origin' => OvertimeOrigin::MANUAL,
+                'minutes' => $data['minutes'],
+                'authorized_by' => $authorizedBy->id,
+                'authorized_at' => now(),
+                'reason' => $data['reason'],
+            ]);
+        });
+    }
+}

--- a/code/api/app/Http/Controllers/Api/V1/Employees/CreateManualOvertimeMovementController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Employees/CreateManualOvertimeMovementController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Employees;
+
+use App\Actions\Employee\CreateManualOvertimeMovementAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Employees\StoreManualOvertimeMovementRequest;
+use App\Http\Resources\Employees\OvertimeBankMovementResource;
+use App\Http\Responses\Common\ResponseEntity;
+use App\Models\Employee;
+
+/**
+ * @OA\Post(
+ *   path="/api/v1/employees/{employee}/overtime-bank/movements",
+ *   summary="Register a manual USED or ADJUSTMENT overtime bank movement",
+ *   tags={"Employees"},
+ *   security={{"passport": {}}},
+ *
+ *   @OA\Parameter(name="employee", in="path", required=true, @OA\Schema(type="string"), description="Employee public_id (ULID)"),
+ *
+ *   @OA\RequestBody(
+ *     required=true,
+ *
+ *     @OA\JsonContent(
+ *       required={"date", "movement_type", "minutes", "reason"},
+ *
+ *       @OA\Property(property="date", type="string", format="date"),
+ *       @OA\Property(property="movement_type", type="string", enum={"USED", "ADJUSTMENT"}),
+ *       @OA\Property(property="minutes", type="integer"),
+ *       @OA\Property(property="reason", type="string")
+ *     )
+ *   ),
+ *
+ *   @OA\Response(response=201, description="Movement created"),
+ *   @OA\Response(response=401, description="Unauthenticated"),
+ *   @OA\Response(response=403, description="Forbidden"),
+ *   @OA\Response(response=422, description="Validation error")
+ * )
+ */
+class CreateManualOvertimeMovementController extends Controller
+{
+    public function __invoke(
+        StoreManualOvertimeMovementRequest $request,
+        Employee $employee,
+        CreateManualOvertimeMovementAction $action
+    ): ResponseEntity {
+        $movement = ($action)($employee, $request->manualMovementData(), $request->user());
+
+        return new ResponseEntity(data: (new OvertimeBankMovementResource($movement))->toArray($request), status: 201);
+    }
+}

--- a/code/api/app/Http/Requests/Employees/StoreManualOvertimeMovementRequest.php
+++ b/code/api/app/Http/Requests/Employees/StoreManualOvertimeMovementRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Requests\Employees;
+
+use App\Enums\OvertimeMovementType;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreManualOvertimeMovementRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return (bool) $this->user()?->can('employees.update');
+    }
+
+    public function rules(): array
+    {
+        return [
+            'date' => ['required', 'date'],
+            'movement_type' => ['required', Rule::in([
+                OvertimeMovementType::USED->value,
+                OvertimeMovementType::ADJUSTMENT->value,
+            ])],
+            'minutes' => [
+                'required',
+                'integer',
+                $this->input('movement_type') === OvertimeMovementType::USED->value ? 'min:1' : 'not_in:0',
+            ],
+            'reason' => ['required', 'string', 'max:500'],
+        ];
+    }
+
+    public function manualMovementData(): array
+    {
+        $data = $this->validated();
+        $data['movement_type'] = OvertimeMovementType::from($data['movement_type']);
+
+        return $data;
+    }
+}

--- a/code/api/routes/api.php
+++ b/code/api/routes/api.php
@@ -32,6 +32,7 @@ use App\Http\Controllers\Api\V1\EmployeeRequests\ListEmployeeRequestsController;
 use App\Http\Controllers\Api\V1\EmployeeRequests\RejectEmployeeRequestController;
 use App\Http\Controllers\Api\V1\Employees\AssignableRolesController;
 use App\Http\Controllers\Api\V1\Employees\CreateEmployeeController;
+use App\Http\Controllers\Api\V1\Employees\CreateManualOvertimeMovementController;
 use App\Http\Controllers\Api\V1\Employees\CreateWageController;
 use App\Http\Controllers\Api\V1\Employees\DeactivateEmployeeController;
 use App\Http\Controllers\Api\V1\Employees\GetMyEmployeeController;
@@ -310,6 +311,7 @@ Route::prefix('v1')->group(function () {
         Route::get('/{employee}/vacation-requests', ListEmployeeVacationRequestsController::class)->name('employees.vacation-requests.list')->middleware('permission:employees.view|employee-requests.create');
         // Overtime bank balance + movement history (same self-service scoping as above)
         Route::get('/{employee}/overtime-bank', ShowOvertimeBankController::class)->name('employees.overtime-bank.show')->middleware('permission:employees.view|employee-requests.create');
+        Route::post('/{employee}/overtime-bank/movements', CreateManualOvertimeMovementController::class)->name('employees.overtime-bank.movements.create')->middleware('permission:employees.update');
         // Direct permission management
         Route::get('/{employee}/permissions', GetUserPermissionsController::class)->name('employees.permissions.get')->middleware('permission:users.show');
         Route::put('/{employee}/permissions', SyncUserDirectPermissionsController::class)->name('employees.permissions.sync')->middleware('permission:users.update');

--- a/code/api/tests/Feature/AttendancePayroll/ManualOvertimeMovementApiTest.php
+++ b/code/api/tests/Feature/AttendancePayroll/ManualOvertimeMovementApiTest.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace Tests\Feature\AttendancePayroll;
+
+use App\Enums\OvertimeMovementType;
+use App\Enums\OvertimeOrigin;
+use App\Models\Employee;
+use App\Models\OvertimeBankMovement;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+class ManualOvertimeMovementApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        app()[PermissionRegistrar::class]->forgetCachedPermissions();
+
+        Permission::create(['name' => 'employees.view', 'guard_name' => 'api']);
+        Permission::create(['name' => 'employees.update', 'guard_name' => 'api']);
+        Permission::create(['name' => 'employee-requests.create', 'guard_name' => 'api']);
+
+        $adminRole = Role::create(['name' => 'admin', 'guard_name' => 'api']);
+        $adminRole->givePermissionTo(['employees.view', 'employees.update']);
+
+        $selfServiceRole = Role::create(['name' => 'employee', 'guard_name' => 'api']);
+        $selfServiceRole->givePermissionTo('employee-requests.create');
+
+        foreach (Employee::POSITION_ROLES as $roleName) {
+            Role::firstOrCreate(['name' => $roleName, 'guard_name' => 'api']);
+        }
+
+        $this->admin = User::factory()->create();
+        $this->admin->assignRole('admin');
+
+        Passport::actingAs($this->admin);
+    }
+
+    private function endpoint(Employee $employee): string
+    {
+        return "/api/v1/employees/{$employee->public_id}/overtime-bank/movements";
+    }
+
+    #[Test]
+    public function admin_can_register_a_used_movement(): void
+    {
+        $employee = Employee::factory()->create();
+
+        OvertimeBankMovement::factory()->earned()->create([
+            'employee_id' => $employee->id,
+            'minutes' => 120,
+        ]);
+
+        $response = $this->postJson($this->endpoint($employee), [
+            'date' => '2026-07-13',
+            'minutes' => 60,
+            'movement_type' => 'USED',
+            'reason' => 'Redeemed for time off',
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertSame('USED', $response->json('data.movement_type'));
+        $this->assertSame('MANUAL', $response->json('data.origin'));
+        $this->assertSame(60, $response->json('data.minutes'));
+        $this->assertSame($this->admin->name, $response->json('data.authorized_by'));
+        $this->assertSame('Redeemed for time off', $response->json('data.reason'));
+
+        $this->assertDatabaseHas('overtime_bank_movements', [
+            'employee_id' => $employee->id,
+            'movement_type' => OvertimeMovementType::USED->value,
+            'origin' => OvertimeOrigin::MANUAL->value,
+            'minutes' => 60,
+            'authorized_by' => $this->admin->id,
+        ]);
+    }
+
+    #[Test]
+    public function admin_can_register_a_positive_adjustment_movement(): void
+    {
+        $employee = Employee::factory()->create();
+
+        $response = $this->postJson($this->endpoint($employee), [
+            'date' => '2026-07-13',
+            'minutes' => 45,
+            'movement_type' => 'ADJUSTMENT',
+            'reason' => 'Correcting under-counted balance',
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertSame(45, $response->json('data.minutes'));
+
+        $balance = $this->getJson("/api/v1/employees/{$employee->public_id}/overtime-bank");
+        $this->assertSame(45, $balance->json('meta.balance_minutes'));
+    }
+
+    #[Test]
+    public function admin_can_register_a_negative_adjustment_movement(): void
+    {
+        $employee = Employee::factory()->create();
+
+        OvertimeBankMovement::factory()->earned()->create([
+            'employee_id' => $employee->id,
+            'minutes' => 120,
+        ]);
+
+        $response = $this->postJson($this->endpoint($employee), [
+            'date' => '2026-07-13',
+            'minutes' => -30,
+            'movement_type' => 'ADJUSTMENT',
+            'reason' => 'Correcting over-counted balance',
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertSame(-30, $response->json('data.minutes'));
+
+        $balance = $this->getJson("/api/v1/employees/{$employee->public_id}/overtime-bank");
+        $this->assertSame(90, $balance->json('meta.balance_minutes'));
+    }
+
+    #[Test]
+    public function used_movement_is_rejected_when_balance_would_go_negative(): void
+    {
+        $employee = Employee::factory()->create();
+
+        OvertimeBankMovement::factory()->earned()->create([
+            'employee_id' => $employee->id,
+            'minutes' => 30,
+        ]);
+
+        $response = $this->postJson($this->endpoint($employee), [
+            'date' => '2026-07-13',
+            'minutes' => 60,
+            'movement_type' => 'USED',
+            'reason' => 'Attempting to redeem more than available',
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['minutes']);
+
+        $this->assertDatabaseMissing('overtime_bank_movements', [
+            'employee_id' => $employee->id,
+            'movement_type' => OvertimeMovementType::USED->value,
+        ]);
+    }
+
+    #[Test]
+    public function it_validates_required_fields(): void
+    {
+        $employee = Employee::factory()->create();
+
+        $response = $this->postJson($this->endpoint($employee), []);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['date', 'minutes', 'movement_type', 'reason']);
+    }
+
+    #[Test]
+    public function it_rejects_earned_and_paid_movement_types(): void
+    {
+        $employee = Employee::factory()->create();
+
+        $response = $this->postJson($this->endpoint($employee), [
+            'date' => '2026-07-13',
+            'minutes' => 60,
+            'movement_type' => 'EARNED',
+            'reason' => 'Should not be allowed manually',
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['movement_type']);
+    }
+
+    #[Test]
+    public function it_returns_403_for_user_without_employees_update_permission(): void
+    {
+        $employee = Employee::factory()->create();
+        Passport::actingAs(User::factory()->create());
+
+        $response = $this->postJson($this->endpoint($employee), [
+            'date' => '2026-07-13',
+            'minutes' => 60,
+            'movement_type' => 'ADJUSTMENT',
+            'reason' => 'Should be forbidden',
+        ]);
+
+        $response->assertStatus(403);
+    }
+}

--- a/code/webapp/cypress/e2e/employee-overtime-manual-movement.cy.ts
+++ b/code/webapp/cypress/e2e/employee-overtime-manual-movement.cy.ts
@@ -1,0 +1,73 @@
+/**
+ * Manual Overtime Bank Movement — E2E happy path (Task #071)
+ *
+ * Verifies that an admin can register a manual ADJUSTMENT movement from the
+ * Overtime Bank section of the Employee Detail panel, and that the balance and
+ * movement history refresh immediately after saving.
+ *
+ * Reuses OvertimeBankTestSeeder (Task #070) — EMP-001 starts with a net balance
+ * of 0 min (90 EARNED - 90 PAID), so the +30 min adjustment registered here is
+ * unambiguous in the assertions below.
+ *
+ * To run only this file:
+ *   make cypress-spec SPEC=employee-overtime-manual-movement
+ */
+
+import users from '../fixtures/users.json'
+
+const { email, password } = users.admin
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function openEmp001Detail() {
+  cy.contains('tr', 'EMP-001', { timeout: 10_000 })
+    .find('button[title="Ver detalle"]')
+    .click()
+  cy.contains('h2', 'Detalle de Empleado', { timeout: 10_000 }).should('be.visible')
+}
+
+function scrollToOvertimeBank() {
+  cy.get('[data-testid="overtime-bank-section"]', { timeout: 10_000 })
+    .scrollIntoView()
+    .should('be.visible')
+}
+
+// ── Suite setup ───────────────────────────────────────────────────────────────
+
+before(() => {
+  cy.task('test:reset', 'overtime-bank', { timeout: 60_000 })
+})
+
+beforeEach(() => {
+  cy.loginByApi(email, password)
+  cy.visitWithAuth('/employees')
+  cy.contains('tr', 'EMP-001', { timeout: 10_000 })
+  cy.closeDevDebugger()
+})
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+it('registers a manual adjustment movement and refreshes balance + history', () => {
+  openEmp001Detail()
+  cy.closeDevDebugger()
+  scrollToOvertimeBank()
+
+  cy.get('[data-testid="overtime-bank-section"]').within(() => {
+    cy.contains('Saldo actual (0 min)').should('be.visible')
+    cy.contains('button', 'Movimiento manual').click()
+  })
+
+  cy.contains('h3', 'Movimiento manual', { timeout: 10_000 }).should('be.visible')
+
+  cy.get('select[name="movement_type"]').select('ADJUSTMENT')
+  cy.get('input[name="minutes"]').clear().type('30')
+  cy.get('textarea[name="reason"]').type('Corrección de saldo por error de captura')
+  cy.contains('button', 'Registrar movimiento').click()
+
+  cy.contains('h3', 'Movimiento manual').should('not.exist')
+
+  cy.get('[data-testid="overtime-bank-section"]').within(() => {
+    cy.contains('Saldo actual (30 min)').should('be.visible')
+    cy.contains('tr', 'Ajuste').should('be.visible').and('contain.text', 'Manual').and('contain.text', '30 min')
+  })
+})

--- a/code/webapp/src/components/employees/ManualOvertimeMovementDialog.tsx
+++ b/code/webapp/src/components/employees/ManualOvertimeMovementDialog.tsx
@@ -1,0 +1,158 @@
+import { Loader2, X } from 'lucide-react'
+import { createPortal } from 'react-dom'
+import { Button } from '@/components/ui/button'
+import { FormField, Select, Textarea } from '@/components/ui/form-fields'
+import { Input } from '@/components/ui/input'
+import { useDialogAnimation } from './use-dialog-animation'
+import { useManualOvertimeMovementDialog } from './use-manual-overtime-movement-dialog'
+import type { ManualOvertimeMovementEmployee } from './use-manual-overtime-movement-dialog'
+
+// ── Props ───────────────────────────────────────────────────────────────────────
+
+export interface ManualOvertimeMovementDialogProps {
+  isOpen: boolean
+  employee: ManualOvertimeMovementEmployee | null
+  onClose: () => void
+}
+
+// ── Component ───────────────────────────────────────────────────────────────────
+
+export function ManualOvertimeMovementDialog({
+  isOpen,
+  employee,
+  onClose,
+}: Readonly<ManualOvertimeMovementDialogProps>) {
+  const { form, isPending, handleSubmit, handleClose } = useManualOvertimeMovementDialog({
+    employee,
+    onSuccess: onClose,
+  })
+
+  const { register, formState: { errors } } = form
+
+  const close = () => {
+    if (isPending) return
+    handleClose()
+    onClose()
+  }
+
+  const { visible, backdropCls, panelCls } = useDialogAnimation(isOpen, close)
+
+  if (!visible) return null
+
+  const employeeName = employee
+    ? `${employee.last_name}, ${employee.first_name}`
+    : ''
+
+  const content = (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center">
+      {/* Backdrop */}
+      <button
+        type="button"
+        className={`absolute inset-0 bg-black/50 ${backdropCls} cursor-default appearance-none border-none p-0`}
+        onClick={close}
+        aria-label="Cerrar diálogo"
+      />
+
+      {/* Dialog */}
+      <dialog
+        open
+        aria-labelledby="manual-overtime-movement-title"
+        className={`relative z-10 w-full max-w-lg rounded-lg border border-border bg-background shadow-xl ${panelCls}`}
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between gap-2 border-b border-border px-6 py-4">
+          <div>
+            <h3
+              id="manual-overtime-movement-title"
+              className="text-base font-semibold text-foreground"
+            >
+              Movimiento manual
+            </h3>
+            <p className="mt-0.5 text-sm text-muted-foreground">{employeeName}</p>
+          </div>
+          <button
+            type="button"
+            onClick={close}
+            disabled={isPending}
+            className="rounded p-1 text-muted-foreground hover:text-foreground disabled:opacity-50"
+            aria-label="Cerrar"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4 px-6 py-5">
+          <FormField
+            label="Tipo de movimiento"
+            error={errors.movement_type?.message}
+            required
+          >
+            <Select {...register('movement_type')} error={!!errors.movement_type} disabled={isPending}>
+              <option value="USED">Usado</option>
+              <option value="ADJUSTMENT">Ajuste</option>
+            </Select>
+          </FormField>
+
+          <FormField
+            label="Fecha"
+            error={errors.date?.message}
+            required
+          >
+            <Input type="date" disabled={isPending} {...register('date')} error={!!errors.date} />
+          </FormField>
+
+          <FormField
+            label="Minutos"
+            error={errors.minutes?.message}
+            hint="Para un ajuste negativo, ingresa un número negativo"
+            required
+          >
+            <Input
+              type="number"
+              step={1}
+              disabled={isPending}
+              {...register('minutes', { valueAsNumber: true })}
+              error={!!errors.minutes}
+            />
+          </FormField>
+
+          <FormField
+            label="Motivo"
+            error={errors.reason?.message}
+            required
+          >
+            <Textarea
+              placeholder="Motivo del movimiento..."
+              disabled={isPending}
+              {...register('reason')}
+              error={!!errors.reason}
+            />
+          </FormField>
+
+          {/* Actions */}
+          <div className="flex justify-end gap-3 pt-1">
+            <Button
+              type="button"
+              onClick={close}
+              disabled={isPending}
+              className="bg-gray-200 text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+            >
+              Cancelar
+            </Button>
+            <Button
+              type="submit"
+              disabled={isPending}
+              className="bg-amber-600 text-white hover:bg-amber-700"
+            >
+              {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Registrar movimiento
+            </Button>
+          </div>
+        </form>
+      </dialog>
+    </div>
+  )
+
+  return createPortal(content, document.body)
+}

--- a/code/webapp/src/components/employees/__tests__/ManualOvertimeMovementDialog.test.tsx
+++ b/code/webapp/src/components/employees/__tests__/ManualOvertimeMovementDialog.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { render, cleanup, fireEvent } from '@testing-library/react'
+import { ManualOvertimeMovementDialog } from '../ManualOvertimeMovementDialog'
+import type { UseManualOvertimeMovementDialogResult, ManualOvertimeMovementEmployee } from '../use-manual-overtime-movement-dialog'
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockHandleSubmit = vi.fn((e?: React.BaseSyntheticEvent) => {
+    e?.preventDefault?.()
+})
+const mockHandleClose = vi.fn()
+const mockRegister = vi.fn((name: string) => ({ name }))
+
+const defaultHookResult: UseManualOvertimeMovementDialogResult = {
+    form: {
+        register: mockRegister,
+        formState: { errors: {} },
+        reset: vi.fn(),
+    } as unknown as UseManualOvertimeMovementDialogResult['form'],
+    isPending: false,
+    handleSubmit: mockHandleSubmit,
+    handleClose: mockHandleClose,
+}
+
+let currentHookResult = { ...defaultHookResult }
+
+vi.mock('../use-manual-overtime-movement-dialog', () => ({
+    useManualOvertimeMovementDialog: () => currentHookResult,
+}))
+
+// ── Test data ──────────────────────────────────────────────────────────────────
+
+const mockEmployee: ManualOvertimeMovementEmployee = {
+    id: 'emp-1',
+    first_name: 'Carlos',
+    last_name: 'Mendoza',
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('ManualOvertimeMovementDialog', () => {
+    beforeEach(() => {
+        currentHookResult = { ...defaultHookResult }
+    })
+
+    afterEach(() => {
+        cleanup()
+        vi.clearAllMocks()
+    })
+
+    it('renders nothing when isOpen is false', () => {
+        const { container } = render(
+            <ManualOvertimeMovementDialog isOpen={false} employee={mockEmployee} onClose={vi.fn()} />
+        )
+        expect(container.innerHTML).toBe('')
+    })
+
+    it('renders dialog when isOpen is true', () => {
+        render(
+            <ManualOvertimeMovementDialog isOpen={true} employee={mockEmployee} onClose={vi.fn()} />
+        )
+        const dialog = document.querySelector('dialog')
+        expect(dialog).not.toBeNull()
+    })
+
+    it('displays "Movimiento manual" title', () => {
+        render(
+            <ManualOvertimeMovementDialog isOpen={true} employee={mockEmployee} onClose={vi.fn()} />
+        )
+        expect(document.body.textContent).toContain('Movimiento manual')
+    })
+
+    it('displays employee name', () => {
+        render(
+            <ManualOvertimeMovementDialog isOpen={true} employee={mockEmployee} onClose={vi.fn()} />
+        )
+        expect(document.body.textContent).toContain('Mendoza, Carlos')
+    })
+
+    it('renders movement type, date, minutes and reason fields', () => {
+        render(
+            <ManualOvertimeMovementDialog isOpen={true} employee={mockEmployee} onClose={vi.fn()} />
+        )
+        expect(document.body.textContent).toContain('Tipo de movimiento')
+        expect(document.body.textContent).toContain('Fecha')
+        expect(document.body.textContent).toContain('Minutos')
+        expect(document.body.textContent).toContain('Motivo')
+    })
+
+    it('calls handleSubmit on form submission', () => {
+        render(
+            <ManualOvertimeMovementDialog isOpen={true} employee={mockEmployee} onClose={vi.fn()} />
+        )
+        const form = document.querySelector('form')
+        expect(form).not.toBeNull()
+        fireEvent.submit(form!)
+        expect(mockHandleSubmit).toHaveBeenCalled()
+    })
+
+    it('calls onClose when Cancelar is clicked', () => {
+        const onClose = vi.fn()
+        render(
+            <ManualOvertimeMovementDialog isOpen={true} employee={mockEmployee} onClose={onClose} />
+        )
+        const buttons = document.querySelectorAll('button')
+        const cancelBtn = Array.from(buttons).find((b) => b.textContent === 'Cancelar')
+        expect(cancelBtn).toBeDefined()
+        fireEvent.click(cancelBtn!)
+        expect(onClose).toHaveBeenCalled()
+    })
+
+    it('calls onClose when close (X) button is clicked', () => {
+        const onClose = vi.fn()
+        render(
+            <ManualOvertimeMovementDialog isOpen={true} employee={mockEmployee} onClose={onClose} />
+        )
+        const closeBtn = document.querySelector('button[aria-label="Cerrar"]')
+        expect(closeBtn).not.toBeNull()
+        fireEvent.click(closeBtn!)
+        expect(onClose).toHaveBeenCalled()
+    })
+
+    it('calls onClose when backdrop is clicked', () => {
+        const onClose = vi.fn()
+        render(
+            <ManualOvertimeMovementDialog isOpen={true} employee={mockEmployee} onClose={onClose} />
+        )
+        const backdrop = document.querySelector('.bg-black\\/50')
+        expect(backdrop).not.toBeNull()
+        fireEvent.click(backdrop!)
+        expect(onClose).toHaveBeenCalled()
+    })
+
+    it('does not call onClose on backdrop click when isPending', () => {
+        currentHookResult = { ...defaultHookResult, isPending: true }
+        const onClose = vi.fn()
+        render(
+            <ManualOvertimeMovementDialog isOpen={true} employee={mockEmployee} onClose={onClose} />
+        )
+        const backdrop = document.querySelector('.bg-black\\/50')
+        fireEvent.click(backdrop!)
+        expect(onClose).not.toHaveBeenCalled()
+    })
+
+    it('disables the submit button while pending', () => {
+        currentHookResult = { ...defaultHookResult, isPending: true }
+        render(
+            <ManualOvertimeMovementDialog isOpen={true} employee={mockEmployee} onClose={vi.fn()} />
+        )
+        const submitBtn = Array.from(document.querySelectorAll('button')).find((b) => b.type === 'submit')
+        expect(submitBtn?.disabled).toBe(true)
+    })
+
+    it('handles empty employee gracefully', () => {
+        render(
+            <ManualOvertimeMovementDialog isOpen={true} employee={null} onClose={vi.fn()} />
+        )
+        const dialog = document.querySelector('dialog')
+        expect(dialog).not.toBeNull()
+    })
+
+    it('has aria-labelledby pointing to title', () => {
+        render(
+            <ManualOvertimeMovementDialog isOpen={true} employee={mockEmployee} onClose={vi.fn()} />
+        )
+        const dialog = document.querySelector('dialog')
+        expect(dialog?.getAttribute('aria-labelledby')).toBe('manual-overtime-movement-title')
+        const title = document.getElementById('manual-overtime-movement-title')
+        expect(title).not.toBeNull()
+    })
+})

--- a/code/webapp/src/components/employees/__tests__/overtime-bank-section.test.tsx
+++ b/code/webapp/src/components/employees/__tests__/overtime-bank-section.test.tsx
@@ -7,17 +7,40 @@ let mockState = {
   movements: [] as OvertimeBankMovement[],
   summary: null as OvertimeBankSummary | null,
   isLoading: false,
+  showManualMovementDialog: false,
+  manualMovementEmployee: null,
+  openManualMovementDialog: vi.fn(),
+  closeManualMovementDialog: vi.fn(),
 }
 
 vi.mock('@/components/employees/use-overtime-bank-section', () => ({
   useOvertimeBankSection: () => mockState,
 }))
 
+vi.mock('@/components/employees/ManualOvertimeMovementDialog', () => ({
+  ManualOvertimeMovementDialog: () => null,
+}))
+
+const mockCan = vi.fn().mockReturnValue(true)
+
+vi.mock('@/stores/auth.store', () => ({
+  useAuthStore: () => ({ can: mockCan }),
+}))
+
 import { OvertimeBankSection } from '@/components/employees/overtime-bank-section'
 
 beforeEach(() => {
   vi.clearAllMocks()
-  mockState = { movements: [], summary: null, isLoading: false }
+  mockCan.mockReturnValue(true)
+  mockState = {
+    movements: [],
+    summary: null,
+    isLoading: false,
+    showManualMovementDialog: false,
+    manualMovementEmployee: null,
+    openManualMovementDialog: vi.fn(),
+    closeManualMovementDialog: vi.fn(),
+  }
 })
 
 afterEach(() => {
@@ -123,5 +146,27 @@ describe('OvertimeBankSection', () => {
 
     expect(screen.getByText('Manual')).toBeTruthy()
     expect(screen.getByText('Ajuste')).toBeTruthy()
+  })
+
+  it('shows the "Movimiento manual" button when the actor can update employees', () => {
+    mockCan.mockReturnValue(true)
+    render(<OvertimeBankSection employeeId="emp-001" />)
+
+    expect(screen.getByText('Movimiento manual')).toBeTruthy()
+  })
+
+  it('hides the "Movimiento manual" button when the actor cannot update employees', () => {
+    mockCan.mockReturnValue(false)
+    render(<OvertimeBankSection employeeId="emp-001" />)
+
+    expect(screen.queryByText('Movimiento manual')).toBeNull()
+  })
+
+  it('calls openManualMovementDialog when the button is clicked', () => {
+    render(<OvertimeBankSection employeeId="emp-001" />)
+
+    screen.getByText('Movimiento manual').click()
+
+    expect(mockState.openManualMovementDialog).toHaveBeenCalledOnce()
   })
 })

--- a/code/webapp/src/components/employees/__tests__/use-manual-overtime-movement-dialog.test.ts
+++ b/code/webapp/src/components/employees/__tests__/use-manual-overtime-movement-dialog.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { useManualOvertimeMovementDialog } from '../use-manual-overtime-movement-dialog'
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockMutate = vi.fn()
+
+vi.mock('@/services/overtime-bank-hooks', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/overtime-bank-hooks')>()
+  return {
+    ...actual,
+    useCreateManualOvertimeMovement: () => ({ mutate: mockMutate, isPending: false }),
+  }
+})
+
+const mockEmployee = { id: 'emp-1', first_name: 'Carlos', last_name: 'Mendoza' }
+
+describe('useManualOvertimeMovementDialog', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('defaults movement_type to USED and minutes to 0', () => {
+    const { result } = renderHook(() =>
+      useManualOvertimeMovementDialog({ employee: mockEmployee, onSuccess: vi.fn() })
+    )
+    expect(result.current.form.getValues('movement_type')).toBe('USED')
+    expect(result.current.form.getValues('minutes')).toBe(0)
+  })
+
+  it('defaults date to today', () => {
+    const today = new Date().toISOString().slice(0, 10)
+    const { result } = renderHook(() =>
+      useManualOvertimeMovementDialog({ employee: mockEmployee, onSuccess: vi.fn() })
+    )
+    expect(result.current.form.getValues('date')).toBe(today)
+  })
+
+  it('submits the movement payload and calls onSuccess', async () => {
+    const onSuccess = vi.fn()
+    const { result } = renderHook(() =>
+      useManualOvertimeMovementDialog({ employee: mockEmployee, onSuccess })
+    )
+
+    act(() => {
+      result.current.form.setValue('movement_type', 'ADJUSTMENT')
+      result.current.form.setValue('minutes', -30)
+      result.current.form.setValue('reason', 'Correcting balance')
+    })
+
+    await act(async () => {
+      await result.current.handleSubmit()
+    })
+
+    await waitFor(() => expect(mockMutate).toHaveBeenCalledOnce())
+
+    const [payload, options] = mockMutate.mock.calls[0] as [Record<string, unknown>, { onSuccess: () => void }]
+    expect(payload).toMatchObject({
+      movement_type: 'ADJUSTMENT',
+      minutes: -30,
+      reason: 'Correcting balance',
+    })
+
+    options.onSuccess()
+    expect(onSuccess).toHaveBeenCalledOnce()
+  })
+
+  it('does not submit when employee is null', async () => {
+    const { result } = renderHook(() =>
+      useManualOvertimeMovementDialog({ employee: null, onSuccess: vi.fn() })
+    )
+
+    act(() => {
+      result.current.form.setValue('minutes', 30)
+      result.current.form.setValue('reason', 'Some reason')
+    })
+
+    await act(async () => {
+      await result.current.handleSubmit()
+    })
+
+    expect(mockMutate).not.toHaveBeenCalled()
+  })
+
+  it('rejects a USED movement with zero or negative minutes', async () => {
+    const { result } = renderHook(() =>
+      useManualOvertimeMovementDialog({ employee: mockEmployee, onSuccess: vi.fn() })
+    )
+
+    act(() => {
+      result.current.form.setValue('movement_type', 'USED')
+      result.current.form.setValue('minutes', 0)
+      result.current.form.setValue('reason', 'Some reason')
+    })
+
+    await act(async () => {
+      await result.current.handleSubmit()
+    })
+
+    expect(mockMutate).not.toHaveBeenCalled()
+  })
+
+  it('rejects an ADJUSTMENT movement with zero minutes', async () => {
+    const { result } = renderHook(() =>
+      useManualOvertimeMovementDialog({ employee: mockEmployee, onSuccess: vi.fn() })
+    )
+
+    act(() => {
+      result.current.form.setValue('movement_type', 'ADJUSTMENT')
+      result.current.form.setValue('minutes', 0)
+      result.current.form.setValue('reason', 'Some reason')
+    })
+
+    await act(async () => {
+      await result.current.handleSubmit()
+    })
+
+    expect(mockMutate).not.toHaveBeenCalled()
+  })
+
+  it('handleClose resets the form', () => {
+    const { result } = renderHook(() =>
+      useManualOvertimeMovementDialog({ employee: mockEmployee, onSuccess: vi.fn() })
+    )
+
+    act(() => result.current.form.setValue('reason', 'Some reason'))
+    act(() => result.current.handleClose())
+
+    expect(result.current.form.getValues('reason')).toBe('')
+  })
+})

--- a/code/webapp/src/components/employees/employee-detail-view.tsx
+++ b/code/webapp/src/components/employees/employee-detail-view.tsx
@@ -109,7 +109,7 @@ export function EmployeeDetailView({
       <hr className="border-border" />
 
       {/* Overtime bank balance + movement history */}
-      <OvertimeBankSection employeeId={employee.id} />
+      <OvertimeBankSection employeeId={employee.id} employee={employee} />
 
       <hr className="border-border" />
 

--- a/code/webapp/src/components/employees/overtime-bank-section.tsx
+++ b/code/webapp/src/components/employees/overtime-bank-section.tsx
@@ -1,10 +1,15 @@
-import { Clock3, Loader2 } from 'lucide-react'
+import { Clock3, Loader2, Plus } from 'lucide-react'
 import type { OvertimeBankMovement } from '@/types/attendance-payroll'
+import { Button } from '@/components/ui/button'
+import { useAuthStore } from '@/stores/auth.store'
 import { useOvertimeBankSection } from './use-overtime-bank-section'
 import { OvertimeMovementTypeBadge, OvertimeOriginBadge } from './overtime-movement-badges'
+import { ManualOvertimeMovementDialog } from './ManualOvertimeMovementDialog'
+import type { ManualOvertimeMovementEmployee } from './use-manual-overtime-movement-dialog'
 
 interface OvertimeBankSectionProps {
   readonly employeeId: string
+  readonly employee?: ManualOvertimeMovementEmployee
 }
 
 function formatDate(dateString: string): string {
@@ -40,13 +45,30 @@ function MovementRow({ movement }: { readonly movement: OvertimeBankMovement }) 
   )
 }
 
-export function OvertimeBankSection({ employeeId }: OvertimeBankSectionProps) {
-  const { movements, summary, isLoading } = useOvertimeBankSection(employeeId)
+export function OvertimeBankSection({ employeeId, employee }: OvertimeBankSectionProps) {
+  const {
+    movements,
+    summary,
+    isLoading,
+    showManualMovementDialog,
+    manualMovementEmployee,
+    openManualMovementDialog,
+    closeManualMovementDialog,
+  } = useOvertimeBankSection(employeeId, employee)
+
+  const { can } = useAuthStore()
+  const canRegisterManualMovement = can('employees.update')
 
   return (
     <div className="space-y-4" data-testid="overtime-bank-section">
-      <div className="flex items-center gap-2">
+      <div className="flex items-center justify-between">
         <h3 className="text-sm font-semibold text-foreground">Banco de horas extra</h3>
+        {canRegisterManualMovement && (
+          <Button size="sm" variant="ghost" onClick={openManualMovementDialog} className="h-7 gap-1 px-2 text-xs">
+            <Plus className="h-3.5 w-3.5" />
+            Movimiento manual
+          </Button>
+        )}
       </div>
 
       {isLoading && (
@@ -94,6 +116,12 @@ export function OvertimeBankSection({ employeeId }: OvertimeBankSectionProps) {
           </table>
         </div>
       )}
+
+      <ManualOvertimeMovementDialog
+        isOpen={showManualMovementDialog}
+        employee={manualMovementEmployee}
+        onClose={closeManualMovementDialog}
+      />
     </div>
   )
 }

--- a/code/webapp/src/components/employees/use-manual-overtime-movement-dialog.ts
+++ b/code/webapp/src/components/employees/use-manual-overtime-movement-dialog.ts
@@ -1,0 +1,82 @@
+import { useForm } from 'react-hook-form'
+import type { UseFormReturn } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { useCreateManualOvertimeMovement } from '@/services/overtime-bank-hooks'
+
+const schema = z
+  .object({
+    date: z.string().min(1, 'La fecha es requerida'),
+    movement_type: z.enum(['USED', 'ADJUSTMENT']),
+    minutes: z.number({ error: 'Los minutos son requeridos' }).int('Debe ser un número entero'),
+    reason: z.string().min(1, 'El motivo es requerido').max(500, 'Máximo 500 caracteres'),
+  })
+  .refine((data) => data.movement_type !== 'USED' || data.minutes > 0, {
+    message: 'Los minutos deben ser mayores a 0 para un movimiento de uso',
+    path: ['minutes'],
+  })
+  .refine((data) => data.movement_type !== 'ADJUSTMENT' || data.minutes !== 0, {
+    message: 'El ajuste no puede ser 0',
+    path: ['minutes'],
+  })
+
+export type ManualOvertimeMovementFormValues = z.infer<typeof schema>
+
+export interface ManualOvertimeMovementEmployee {
+  id: string
+  first_name: string
+  last_name: string
+}
+
+export interface UseManualOvertimeMovementDialogProps {
+  employee: ManualOvertimeMovementEmployee | null
+  onSuccess: () => void
+}
+
+export interface UseManualOvertimeMovementDialogResult {
+  form: UseFormReturn<ManualOvertimeMovementFormValues>
+  isPending: boolean
+  handleSubmit: () => void
+  handleClose: () => void
+}
+
+export function useManualOvertimeMovementDialog({
+  employee,
+  onSuccess,
+}: UseManualOvertimeMovementDialogProps): UseManualOvertimeMovementDialogResult {
+  const mutation = useCreateManualOvertimeMovement(employee?.id ?? '')
+
+  const today = new Date().toISOString().slice(0, 10)
+
+  const form = useForm<ManualOvertimeMovementFormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      date: today,
+      movement_type: 'USED',
+      minutes: 0,
+      reason: '',
+    },
+  })
+
+  const handleSubmit = form.handleSubmit((values) => {
+    if (!employee) return
+
+    mutation.mutate(values, {
+      onSuccess: () => {
+        form.reset()
+        onSuccess()
+      },
+    })
+  })
+
+  const handleClose = () => {
+    form.reset()
+  }
+
+  return {
+    form,
+    isPending: mutation.isPending,
+    handleSubmit,
+    handleClose,
+  }
+}

--- a/code/webapp/src/components/employees/use-manual-overtime-movement-dialog.ts
+++ b/code/webapp/src/components/employees/use-manual-overtime-movement-dialog.ts
@@ -8,7 +8,7 @@ const schema = z
   .object({
     date: z.string().min(1, 'La fecha es requerida'),
     movement_type: z.enum(['USED', 'ADJUSTMENT']),
-    minutes: z.number({ error: 'Los minutos son requeridos' }).int('Debe ser un número entero'),
+    minutes: z.number().int('Debe ser un número entero'),
     reason: z.string().min(1, 'El motivo es requerido').max(500, 'Máximo 500 caracteres'),
   })
   .refine((data) => data.movement_type !== 'USED' || data.minutes > 0, {

--- a/code/webapp/src/components/employees/use-overtime-bank-section.ts
+++ b/code/webapp/src/components/employees/use-overtime-bank-section.ts
@@ -1,11 +1,28 @@
+import { useState } from 'react'
 import { useOvertimeBank } from '@/services/overtime-bank-hooks'
+import type { ManualOvertimeMovementEmployee } from './use-manual-overtime-movement-dialog'
 
-export function useOvertimeBankSection(employeeId: string) {
+export function useOvertimeBankSection(employeeId: string, employee?: ManualOvertimeMovementEmployee) {
   const { data, isLoading } = useOvertimeBank(employeeId)
+
+  const [showManualMovementDialog, setShowManualMovementDialog] = useState(false)
+
+  function openManualMovementDialog() {
+    if (!employee) return
+    setShowManualMovementDialog(true)
+  }
+
+  function closeManualMovementDialog() {
+    setShowManualMovementDialog(false)
+  }
 
   return {
     movements: data?.movements ?? [],
     summary: data?.summary ?? null,
     isLoading,
+    showManualMovementDialog,
+    manualMovementEmployee: employee ?? null,
+    openManualMovementDialog,
+    closeManualMovementDialog,
   }
 }

--- a/code/webapp/src/services/__tests__/overtime-bank-api.test.ts
+++ b/code/webapp/src/services/__tests__/overtime-bank-api.test.ts
@@ -27,3 +27,33 @@ describe('overtimeBankApi.getBank', () => {
     expect(result).toEqual(mockResponse)
   })
 })
+
+describe('overtimeBankApi.createManualMovement', () => {
+  it('calls POST /employees/{employeeId}/overtime-bank/movements', async () => {
+    const payload = { date: '2026-07-13', movement_type: 'USED' as const, minutes: 60, reason: 'Time off' }
+    const mockResponse = {
+      data: {
+        status: 201,
+        data: {
+          id: 'mov-1',
+          date: '2026-07-13',
+          movement_type: 'USED',
+          origin: 'MANUAL',
+          minutes: 60,
+          valuation_method: null,
+          applied_rate: null,
+          amount: null,
+          authorized_by: 'Admin',
+          authorized_at: '2026-07-13T18:00:00Z',
+          reason: 'Time off',
+        },
+      },
+    }
+    vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
+
+    const result = await overtimeBankApi.createManualMovement('emp-123', payload)
+
+    expect(apiClient.post).toHaveBeenCalledWith('/employees/emp-123/overtime-bank/movements', payload)
+    expect(result).toEqual(mockResponse)
+  })
+})

--- a/code/webapp/src/services/__tests__/overtime-bank-hooks.test.tsx
+++ b/code/webapp/src/services/__tests__/overtime-bank-hooks.test.tsx
@@ -7,14 +7,22 @@ import React from 'react'
 import type { OvertimeBankMovement, OvertimeBankSummary } from '@/types/attendance-payroll'
 
 const mockGetBank = vi.fn()
+const mockCreateManualMovement = vi.fn()
+const mockShowSuccess = vi.fn()
+const mockShowError = vi.fn()
 
 vi.mock('@/services/overtime-bank-api', () => ({
   overtimeBankApi: {
     getBank: (...args: unknown[]) => mockGetBank(...args),
+    createManualMovement: (...args: unknown[]) => mockCreateManualMovement(...args),
   },
 }))
 
-import { useOvertimeBank } from '../overtime-bank-hooks'
+vi.mock('@/components/ui/toast-context', () => ({
+  useToast: () => ({ showSuccess: mockShowSuccess, showError: mockShowError }),
+}))
+
+import { useOvertimeBank, useCreateManualOvertimeMovement } from '../overtime-bank-hooks'
 
 function makeWrapper() {
   const qc = new QueryClient({
@@ -65,5 +73,32 @@ describe('useOvertimeBank', () => {
     const { result } = renderHook(() => useOvertimeBank(''), { wrapper: makeWrapper() })
     expect(result.current.fetchStatus).toBe('idle')
     expect(mockGetBank).not.toHaveBeenCalled()
+  })
+})
+
+describe('useCreateManualOvertimeMovement', () => {
+  const payload = { date: '2026-07-13', movement_type: 'USED' as const, minutes: 60, reason: 'Time off' }
+
+  it('calls createManualMovement with the employeeId and payload, then shows a success toast', async () => {
+    mockCreateManualMovement.mockResolvedValue({ data: { data: { ...fakeMovement, ...payload } } })
+
+    const { result } = renderHook(() => useCreateManualOvertimeMovement('emp-123'), { wrapper: makeWrapper() })
+
+    result.current.mutate(payload)
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockCreateManualMovement).toHaveBeenCalledWith('emp-123', payload)
+    expect(mockShowSuccess).toHaveBeenCalled()
+  })
+
+  it('shows an error toast when the request fails', async () => {
+    mockCreateManualMovement.mockRejectedValue(new Error('boom'))
+
+    const { result } = renderHook(() => useCreateManualOvertimeMovement('emp-123'), { wrapper: makeWrapper() })
+
+    result.current.mutate(payload)
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(mockShowError).toHaveBeenCalled()
   })
 })

--- a/code/webapp/src/services/overtime-bank-api.ts
+++ b/code/webapp/src/services/overtime-bank-api.ts
@@ -1,5 +1,5 @@
 import { apiClient } from '@/lib/api-client'
-import type { OvertimeBankMovement, OvertimeBankSummary } from '@/types/attendance-payroll'
+import type { CreateManualOvertimeMovementData, OvertimeBankMovement, OvertimeBankSummary } from '@/types/attendance-payroll'
 
 interface OvertimeBankResponse {
   data: OvertimeBankMovement[]
@@ -7,7 +7,14 @@ interface OvertimeBankResponse {
   meta: OvertimeBankSummary
 }
 
+interface CreateManualOvertimeMovementResponse {
+  data: OvertimeBankMovement
+  status: number
+}
+
 export const overtimeBankApi = {
   getBank: (employeeId: string) =>
     apiClient.get<OvertimeBankResponse>(`/employees/${employeeId}/overtime-bank`),
+  createManualMovement: (employeeId: string, data: CreateManualOvertimeMovementData) =>
+    apiClient.post<CreateManualOvertimeMovementResponse>(`/employees/${employeeId}/overtime-bank/movements`, data),
 }

--- a/code/webapp/src/services/overtime-bank-hooks.ts
+++ b/code/webapp/src/services/overtime-bank-hooks.ts
@@ -1,13 +1,38 @@
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { overtimeBankApi } from '@/services/overtime-bank-api'
+import { useToast } from '@/components/ui/toast-context'
+import { getApiErrorMessage } from '@/lib/api-error'
+import type { CreateManualOvertimeMovementData } from '@/types/attendance-payroll'
+
+const QUERY_KEY = (employeeId: string) => ['overtime-bank', employeeId]
 
 export function useOvertimeBank(employeeId: string) {
   return useQuery({
-    queryKey: ['overtime-bank', employeeId],
+    queryKey: QUERY_KEY(employeeId),
     queryFn: async () => {
       const response = await overtimeBankApi.getBank(employeeId)
       return { movements: response.data.data, summary: response.data.meta }
     },
     enabled: !!employeeId,
+  })
+}
+
+export function useCreateManualOvertimeMovement(employeeId: string) {
+  const queryClient = useQueryClient()
+  const { showSuccess, showError } = useToast()
+
+  return useMutation({
+    mutationFn: (data: CreateManualOvertimeMovementData) =>
+      overtimeBankApi.createManualMovement(employeeId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY(employeeId) })
+      showSuccess('Movimiento registrado correctamente.', 'Movimiento manual')
+    },
+    onError: (error: unknown) => {
+      showError(
+        getApiErrorMessage(error, 'No se pudo registrar el movimiento.'),
+        'Error al registrar movimiento'
+      )
+    },
   })
 }

--- a/code/webapp/src/types/attendance-payroll.ts
+++ b/code/webapp/src/types/attendance-payroll.ts
@@ -187,6 +187,15 @@ export interface OvertimeBankSummary {
   balance_formatted: string
 }
 
+export type ManualOvertimeMovementType = Extract<OvertimeMovementType, 'USED' | 'ADJUSTMENT'>
+
+export interface CreateManualOvertimeMovementData {
+  date: string
+  movement_type: ManualOvertimeMovementType
+  minutes: number
+  reason: string
+}
+
 // ── Vacation Request ─────────────────────────────────────────────────────────
 
 export type VacationRequestStatus = 'PENDING' | 'APPROVED' | 'REJECTED' | 'CANCELLED'

--- a/doc/tasks/2026-07/071-overtime-manual-movement.md
+++ b/doc/tasks/2026-07/071-overtime-manual-movement.md
@@ -41,6 +41,14 @@ Como Admin, quiero registrar un movimiento manual USADO o AJUSTE en el banco de 
 
 ---
 
-## ⏱️ Estimates
+## ⏱️ Time
 
-- **Optimistic:** `1h` · **Pessimistic:** `2h`
+### 📊 Estimates
+- **Optimistic:** `1h` · **Pessimistic:** `2h` · **Tracked:** _in progress_
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-07-13", "start": "18:58", "end": "?" }
+]
+```

--- a/doc/tasks/2026-07/071-overtime-manual-movement.md
+++ b/doc/tasks/2026-07/071-overtime-manual-movement.md
@@ -12,26 +12,26 @@ Como Admin, quiero registrar un movimiento manual USADO o AJUSTE en el banco de 
 
 ## ✅ Backend Tasks
 
-- [ ] 🌐 `POST /api/v1/employees/{id}/overtime-bank/movements` — ManualOvertimeMovementController
-- [ ] 📝 Request — `{ date, minutes, movement_type: USED|ADJUSTMENT, reason }`; origin = MANUAL; authorized_by = auth user
-- [ ] 🔧 Validation: if USED, resulting balance cannot be negative
-- [ ] 🧪 Feature tests: USED movement, ADJUSTMENT (positive/negative), USED rejected if balance insufficient
+- [x] 🌐 `POST /api/v1/employees/{id}/overtime-bank/movements` — CreateManualOvertimeMovementController
+- [x] 📝 Request — `{ date, minutes, movement_type: USED|ADJUSTMENT, reason }`; origin = MANUAL; authorized_by = auth user
+- [x] 🔧 Validation: if USED, resulting balance cannot be negative
+- [x] 🧪 Feature tests: USED movement, ADJUSTMENT (positive/negative), USED rejected if balance insufficient
 
 ## ✅ Frontend Tasks
 
-- [ ] 🔧 `createManualMovement(employeeId, data)` in `src/services/overtime.service.ts`
-- [ ] 📱 **"Movimiento manual" button** in the Overtime Bank section (#070) — opens modal (admin only)
-- [ ] 📱 **Manual movement modal** (react-hook-form + zod) — movement_type selector, minutes, date, reason
-- [ ] 📱 After save: balance and movements table refresh
-- [ ] 🔧 Mutation added to `useOvertimeBank` hook
+- [x] 🔧 `createManualMovement(employeeId, data)` in `src/services/overtime-bank-api.ts` (existing #070 service file, not `overtime.service.ts` as originally noted)
+- [x] 📱 **"Movimiento manual" button** in the Overtime Bank section (#070) — opens modal (admin only)
+- [x] 📱 **Manual movement modal** (react-hook-form + zod) — movement_type selector, minutes, date, reason
+- [x] 📱 After save: balance and movements table refresh
+- [x] 🔧 Mutation added via new `useCreateManualOvertimeMovement` hook in `overtime-bank-hooks.ts`
 
 ---
 
 ## 🎯 Acceptance Criteria
 
-- [ ] Admin can register USED or ADJUSTMENT movements with a reason
-- [ ] Form shows an error if a USED movement would make the balance negative
-- [ ] Balance updates immediately after saving
+- [x] Admin can register USED or ADJUSTMENT movements with a reason
+- [x] Form shows an error if a USED movement would make the balance negative
+- [x] Balance updates immediately after saving
 
 ---
 
@@ -44,11 +44,18 @@ Como Admin, quiero registrar un movimiento manual USADO o AJUSTE en el banco de 
 ## ⏱️ Time
 
 ### 📊 Estimates
-- **Optimistic:** `1h` · **Pessimistic:** `2h` · **Tracked:** _in progress_
+- **Optimistic:** `1h` · **Pessimistic:** `2h` · **Tracked:** `1h08m`
 
 ### 📅 Sessions
 ```json
 [
-  { "date": "2026-07-13", "start": "18:58", "end": "?" }
+  { "date": "2026-07-13", "start": "18:58", "end": "20:06" }
 ]
 ```
+
+## 📊 Retrospective
+- **Actual total:** 1h 08m (68m)
+- **vs optimistic:** +8m
+- **vs pessimistic:** −52m
+
+**Justification:** Landed close to the optimistic estimate. The schema and enum values from #070 already covered USED/ADJUSTMENT, so no migration was needed, and the closest existing UI/backend analogs (RegisterVacationRequestDialog, CreateWageController, VacationRequestGuards) gave a direct pattern to follow for the request/action/dialog/hook, which kept implementation and test-writing straightforward with no unplanned rework.


### PR DESCRIPTION
## Summary
Closes #071

- Add `POST /api/v1/employees/{id}/overtime-bank/movements` letting an admin register a manual `USED` or `ADJUSTMENT` overtime bank movement with a reason
- Guard `USED` movements against driving the balance negative, checked under a row lock in `CreateManualOvertimeMovementAction`
- Add an admin-only "Movimiento manual" button + react-hook-form/zod modal to the Overtime Bank section (#070), refreshing balance and movement history on save

## Test plan
- [x] PHPUnit: `php artisan test --filter=ManualOvertimeMovementApiTest` (7 passed)
- [x] PHPUnit regression: `php artisan test --filter=Overtime` (88 passed)
- [x] Vitest: `npx vitest run` (full suite, 3274 passed)
- [x] Cypress E2E: `employee-overtime-manual-movement.cy.ts` (1 passed, run against dev-lab E2E stack)
- [x] Linters: Pint ✅ · ESLint ✅ · TypeScript ✅

## Manual Testing
1. Log in as `admin@sushigo.com` and open an employee's detail view.
2. Scroll to the "Banco de horas extra" section and click **Movimiento manual**.
3. Select movement type **Ajuste**, enter minutes (e.g. `30`), a reason, and submit — confirm the balance and movement table update immediately with a "Manual" / "Ajuste" row.
4. Repeat with movement type **Usado** and a minutes value greater than the current balance — confirm the API returns a validation error and no movement is created.
5. Log in as a non-admin user (e.g. `manager@sushigo.com`) and confirm the "Movimiento manual" button is not shown.

## Workspace
`sushigo-a` — `feature/071-overtime-manual-movement`

🤖 Generated with [Claude Code](https://claude.com/claude-code)