### PR TITLE
🐛 [#229][c] - Apply overtime valuation dialog to day-close batch flow 🔁

### DIFF
--- a/code/webapp/cypress/e2e/attendance-close-day-overtime.cy.ts
+++ b/code/webapp/cypress/e2e/attendance-close-day-overtime.cy.ts
@@ -109,8 +109,12 @@ describe("Close day with overtime — decision queue after bulk close", () => {
     cy.contains("Decisión de horas extra", { timeout: 10_000 }).should("be.visible");
     cy.contains("35 min extra").should("be.visible");
 
-    // ── First employee: Authorize (Pagar) ──
+    // ── First employee: Authorize (Pagar) → advances to valuation-method step ──
     cy.get("[data-testid='btn-authorize-overtime']").should("be.visible").click();
+    cy.contains("Método de valoración").should("be.visible");
+
+    // LFT_PROPORTIONAL is the default selection — just confirm
+    cy.get("[data-testid='btn-confirm-valuation']").click();
 
     cy.wait("@overtimeDecision", { timeout: 10_000 })
       .its("response.statusCode")

--- a/code/webapp/src/components/attendance/__tests__/use-overtime-decision-dialog.test.ts
+++ b/code/webapp/src/components/attendance/__tests__/use-overtime-decision-dialog.test.ts
@@ -46,6 +46,18 @@ describe('useOvertimeDecisionDialog', () => {
     expect(result.current.step).toBe('confirm')
   })
 
+  it('resets to confirm step when attendanceId changes while isOpen stays true (bulk queue advancing)', () => {
+    const { result, rerender } = renderHook(
+      ({ attendanceId }) => useOvertimeDecisionDialog({ isOpen: true, attendanceId, onAuthorize: vi.fn() }),
+      { initialProps: { attendanceId: 'att-1' } },
+    )
+    act(() => { result.current.handlePagar() })
+    expect(result.current.step).toBe('method')
+
+    rerender({ attendanceId: 'att-2' })
+    expect(result.current.step).toBe('confirm')
+  })
+
   it('onSubmitMethod calls onAuthorize with LFT_PROPORTIONAL and no rate/factor', async () => {
     const onAuthorize = vi.fn()
     const { result } = renderHook(() =>

--- a/code/webapp/src/components/attendance/use-overtime-decision-dialog.ts
+++ b/code/webapp/src/components/attendance/use-overtime-decision-dialog.ts
@@ -49,14 +49,15 @@ export function useOvertimeDecisionDialog({ isOpen, attendanceId, onAuthorize }:
     defaultValues: { valuation_method: 'LFT_PROPORTIONAL', agreed_rate: '', agreed_factor: '' },
   })
 
-  // Reset to the first step and clear the form whenever a new decision opens.
+  // Reset to the first step whenever a new decision opens, and also when the
+  // bulk queue advances to the next attendanceId while isOpen stays true.
   useEffect(() => {
     if (isOpen) {
       setStep('confirm')
       form.reset({ valuation_method: 'LFT_PROPORTIONAL', agreed_rate: '', agreed_factor: '' })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen])
+  }, [isOpen, attendanceId])
 
   const handlePagar = () => setStep('method')
   const handleBack = () => setStep('confirm')

--- a/doc/tasks/2026-07/229-day-close-overtime-dialog.md
+++ b/doc/tasks/2026-07/229-day-close-overtime-dialog.md
@@ -1,0 +1,73 @@
+# ⚙️ Task #229: Apply overtime valuation dialog to the day-close batch flow
+
+## 📖 Story
+
+**English:** As an Admin closing the day for a branch, when the system flags pending overtime decisions (`overtime_pending`), I want the same two-step decision (authorize + valuation method, with its live cost preview) available in the batch flow, so I don't have to leave day-close to decide each one individually on the attendance screen.
+
+**Español:** Como Admin cerrando el día de una sucursal, cuando el sistema marca decisiones de hora extra pendientes (`overtime_pending`), quiero contar con la misma decisión de dos pasos (autorizar + método de valoración, con su preview de costo en vivo) dentro del flujo de cierre de día, para no tener que salir de esa pantalla a decidir cada una individualmente en la pantalla de asistencia.
+
+---
+
+## 🔍 Investigation finding
+
+The frontend reuse required by this issue is **already structurally in place**, as a side effect of two earlier tasks:
+
+- **#101** unified the individual and bulk overtime-decision flows onto one shared `OvertimeDecisionDialog` instance in `pages/attendance/index.tsx`, fed by `resolveOvertimeDialog()` (individual pending decision takes priority over the bulk queue).
+- **#228** extended that *same* shared dialog with the two-step authorize → valuation-method UI (LFT / agreed rate / salary factor + live preview). Because #228 modified the shared component instead of duplicating it, the bulk/day-close queue automatically inherited the two-step flow.
+
+**The actual gap**: `code/webapp/cypress/e2e/attendance-close-day-overtime.cy.ts` (written for the bulk flow in #101) was never updated for the two-step dialog introduced by #228. It still clicks `btn-authorize-overtime` and expects the `overtime-decision` PATCH to fire immediately — but since #228, that button only advances to the method-selection step. The PATCH now only fires after `btn-confirm-valuation`. This spec is stale.
+
+## ✅ Backend Tasks
+
+- [x] None — confirmed no backend changes needed (`CloseDayAction` already returns `overtime_pending`, endpoint/decision action already extended by #228)
+
+## ✅ Frontend Tasks
+
+- [x] None — reuse already complete via shared `OvertimeDecisionDialog` + `resolveOvertimeDialog` + bulk queue in `pages/attendance/index.tsx` / `-use-today-attendance-page.ts`
+
+## ✅ Tests
+
+- [x] 🐛 Fix `attendance-close-day-overtime.cy.ts` — drive the authorize decision through the two-step dialog, matching the pattern in `attendance-overtime-decision.cy.ts`
+
+## 🐛 Bug found during E2E fix
+
+Running the corrected spec surfaced a real bug: `useOvertimeDecisionDialog`'s step-reset effect only depended on `isOpen`, but in the bulk day-close queue `isOpen` stays `true` continuously as `resolveOvertimeDialog` (pages/attendance/index.tsx) advances through pending employees — only `attendanceId` changes. The dialog for employee 2+ opened directly on the "Método de valoración" step instead of resetting to "Decisión de horas extra". Fixed by adding `attendanceId` to the effect's dependency array (`code/webapp/src/components/attendance/use-overtime-decision-dialog.ts`), with a new hook test covering the scenario.
+
+---
+
+## 🎯 Acceptance Criteria
+
+- [x] Al cerrar el día, cada hora extra pendiente se puede autorizar (con método de valoración y su preview de costo) o rechazar desde el mismo flujo de cierre, sin salir a la pantalla de asistencia individual — already true via shared component
+- [x] No se duplica lógica de negocio — se reutiliza el endpoint y componentes de #228 — confirmed, single dialog/mutation instance
+
+---
+
+## 🔗 References
+
+- Depende de #228 (completado)
+- Relacionado con #101 (unificación original del diálogo compartido)
+
+---
+
+## ⏱️ Estimates
+
+- **Optimistic:** `1h` · **Pessimistic:** `2h`
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `1h` · **Pessimistic:** `2h` · **Tracked:** `1h05m`
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-07-14", "start": "02:10", "end": "03:15" }
+]
+```
+
+## 📊 Retrospective
+- **Actual total:** 1h 05m
+- **vs optimistic:** +5m
+- **vs pessimistic:** -55m
+
+**Justification:** The frontend reuse was already structurally complete from #101/#228 — no new component work needed. The E2E spec was stale (still asserting the old one-step click), and fixing it surfaced a genuine bug: the shared dialog's step state didn't reset when the bulk queue advanced to the next employee (`isOpen` stays `true` across the queue, only `attendanceId` changes). Fixed with a one-line dependency-array change plus a targeted hook test. Landed within the original estimate.


### PR DESCRIPTION
## Summary
- Confirmed the frontend reuse required by this issue was already structurally in place: since #101, the individual and bulk (day-close) overtime-decision flows share a single `OvertimeDecisionDialog` instance, so #228's two-step authorize→valuation-method UI was already inherited by the day-close batch flow — no new component/hook work needed
- Found and fixed a real bug surfaced while updating the stale E2E spec: `useOvertimeDecisionDialog`'s step-reset effect only depended on `isOpen`, but in the bulk queue `isOpen` stays `true` continuously as pending employees advance (only `attendanceId` changes) — so the 2nd+ employee's dialog opened directly on "Método de valoración" instead of resetting to "Decisión de horas extra"
- Fixed by adding `attendanceId` to the effect's dependency array, with a new hook test covering the exact scenario
- Updated `attendance-close-day-overtime.cy.ts`, which still asserted the pre-#228 one-step click, to drive the two-step flow

## Test plan
- [x] Vitest: `npx vitest run src/components/attendance/__tests__/use-overtime-decision-dialog.test.ts src/components/attendance/__tests__/OvertimeDecisionDialog.test.tsx` — 38 passing
- [x] Vitest (full attendance regression): `npx vitest run src/components/attendance src/pages/attendance` — 457 passing
- [x] Cypress E2E: `make cypress-devlab-run-spec SPEC=attendance-close-day-overtime` — 1 passing
- [x] Cypress E2E (regression): `make cypress-devlab-run-spec SPEC=attendance-overtime-decision` — 4 passing
- [x] Linters: ESLint ✅ (0 errors, 2 pre-existing warnings unrelated to this change) · TypeScript ✅

## Manual Testing
1. Log in as `admin@sushigo.com` and go to Asistencia
2. Check in, send to lunch, return from lunch, and check out 2+ employees past their shift end (e.g. 35 min late) so both accrue overtime, without recording an overtime decision for either
3. Click "Cerrar día" and confirm the close at a time past both employees' shift end
4. The overtime decision dialog appears for the first pending employee — click "Pagar horas extra", confirm a valuation method (e.g. leave the LFT default and click Confirmar)
5. The dialog should advance to the second employee and show the initial "Decisión de horas extra ¿Se pagan?" step (not jump straight to "Método de valoración") — this is the bug this PR fixes
6. Reject or authorize the second employee; confirm no more dialogs appear once the queue is empty

## Closes
Closes #229

## Workspace
`sushigo-c` — `fix/229-day-close-overtime-e2e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)