### PR TITLE
🔧 [#131][e] - Centralize seeder passwords in config with env overrides 🔐

### DIFF
--- a/code/api/.env.example
+++ b/code/api/.env.example
@@ -108,3 +108,11 @@ PAYROLL_SEED_ENABLED=false
 # ISO weekday on which the payroll week begins: 1=Monday … 7=Sunday
 # SushiGo convention: weeks run Monday–Sunday (cut-off end of Sunday).
 WEEK_START_DAY=1
+
+# Seeder Credentials
+# ------------------
+# Passwords used by dev/test/production seeders. Override for custom
+# dev environments without touching seeder source code.
+SEEDER_ADMIN_PASSWORD=admin123456
+SEEDER_EMPLOYEE_PASSWORD=employee123456
+SEEDER_INVENTORY_PASSWORD=inventory123456

--- a/code/api/config/seeders.php
+++ b/code/api/config/seeders.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+|--------------------------------------------------------------------------
+| Seeder Passwords
+|--------------------------------------------------------------------------
+|
+| Single source of truth for passwords used by dev/test/production
+| seeders. Override via env vars without touching seeder source code.
+| Declared here (not inline in the returned array) so every config key
+| below — including development_users/development_employees — can
+| reference the same values and stay in sync with env overrides.
+|
+*/
+$seederPasswords = [
+    'admin' => env('SEEDER_ADMIN_PASSWORD', 'admin123456'),
+    'employee' => env('SEEDER_EMPLOYEE_PASSWORD', 'employee123456'),
+    'inventory' => env('SEEDER_INVENTORY_PASSWORD', 'inventory123456'),
+];
+
 return [
 
     /*
@@ -22,21 +40,7 @@ return [
         'testing' => Database\Seeders\Development\DevelopmentSeeder::class,
     ],
 
-    /*
-    |--------------------------------------------------------------------------
-    | Seeder Passwords
-    |--------------------------------------------------------------------------
-    |
-    | Single source of truth for passwords used by dev/test/production
-    | seeders. Override via env vars without touching seeder source code.
-    |
-    */
-
-    'passwords' => [
-        'admin' => env('SEEDER_ADMIN_PASSWORD', 'admin123456'),
-        'employee' => env('SEEDER_EMPLOYEE_PASSWORD', 'employee123456'),
-        'inventory' => env('SEEDER_INVENTORY_PASSWORD', 'inventory123456'),
-    ],
+    'passwords' => $seederPasswords,
 
     /*
     |--------------------------------------------------------------------------
@@ -51,14 +55,14 @@ return [
         [
             'name' => 'Super Admin',
             'email' => 'superadmin@sushigo.com',
-            'password' => 'admin123456',
+            'password' => $seederPasswords['admin'],
             'role' => 'super-admin',
             // super-admin is not an employee — system-level account only
         ],
         [
             'name' => 'Admin User',
             'email' => 'admin@sushigo.com',
-            'password' => 'admin123456',
+            'password' => $seederPasswords['admin'],
             'role' => 'admin',
             'employee' => [
                 'code' => 'ADM-001',
@@ -72,7 +76,7 @@ return [
         [
             'name' => 'Inventory Manager',
             'email' => 'inventory@sushigo.com',
-            'password' => 'inventory123456',
+            'password' => $seederPasswords['inventory'],
             'role' => 'inventory-manager',
             'employee' => [
                 'code' => 'ADM-002',
@@ -102,7 +106,7 @@ return [
             'roles' => ['manager'],
             'email' => 'carlos.mendoza@sushigo.com',
             'phone' => '5512340001',
-            'password' => 'employee123456',
+            'password' => $seederPasswords['employee'],
         ],
         [
             'code' => 'EMP-002',
@@ -111,7 +115,7 @@ return [
             'roles' => ['cook'],
             'email' => 'maria.garcia@sushigo.com',
             'phone' => '5512340002',
-            'password' => 'employee123456',
+            'password' => $seederPasswords['employee'],
         ],
         [
             'code' => 'EMP-003',
@@ -120,7 +124,7 @@ return [
             'roles' => ['kitchen-assistant'],
             'email' => 'pedro.lopez@sushigo.com',
             'phone' => '5512340003',
-            'password' => 'employee123456',
+            'password' => $seederPasswords['employee'],
         ],
         [
             'code' => 'EMP-004',
@@ -129,7 +133,7 @@ return [
             'roles' => ['delivery-driver'],
             'email' => 'ana.ramirez@sushigo.com',
             'phone' => '5512340004',
-            'password' => 'employee123456',
+            'password' => $seederPasswords['employee'],
         ],
         [
             'code' => 'EMP-005',
@@ -138,7 +142,7 @@ return [
             'roles' => ['cook'],
             'email' => 'roberto.sanchez@sushigo.com',
             'phone' => '5512340005',
-            'password' => 'employee123456',
+            'password' => $seederPasswords['employee'],
             'meta' => ['notes' => 'Part-time employee'],
         ],
         [
@@ -148,7 +152,7 @@ return [
             'roles' => ['cook'],
             'email' => 'laura.torres@sushigo.com',
             'phone' => '5512340006',
-            'password' => 'employee123456',
+            'password' => $seederPasswords['employee'],
         ],
         [
             'code' => 'EMP-007',
@@ -157,7 +161,7 @@ return [
             'roles' => ['kitchen-assistant'],
             'email' => 'miguel.flores@sushigo.com',
             'phone' => '5512340007',
-            'password' => 'employee123456',
+            'password' => $seederPasswords['employee'],
         ],
         [
             'code' => 'EMP-008',
@@ -166,7 +170,7 @@ return [
             'roles' => ['delivery-driver'],
             'email' => 'sofia.vargas@sushigo.com',
             'phone' => '5512340008',
-            'password' => 'employee123456',
+            'password' => $seederPasswords['employee'],
         ],
     ],
 

--- a/code/api/config/seeders.php
+++ b/code/api/config/seeders.php
@@ -24,6 +24,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Seeder Passwords
+    |--------------------------------------------------------------------------
+    |
+    | Single source of truth for passwords used by dev/test/production
+    | seeders. Override via env vars without touching seeder source code.
+    |
+    */
+
+    'passwords' => [
+        'admin' => env('SEEDER_ADMIN_PASSWORD', 'admin123456'),
+        'employee' => env('SEEDER_EMPLOYEE_PASSWORD', 'employee123456'),
+        'inventory' => env('SEEDER_INVENTORY_PASSWORD', 'inventory123456'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Development Users
     |--------------------------------------------------------------------------
     |

--- a/code/api/database/seeders/Development/EmployeeSeeder.php
+++ b/code/api/database/seeders/Development/EmployeeSeeder.php
@@ -118,7 +118,7 @@ class EmployeeSeeder extends OnceSeeder
             'roles' => ['cook'],
             'email' => 'luis.reingresos2@sushigo.com',
             'phone' => '5512349902',
-            'password' => 'employee123456',
+            'password' => config('seeders.passwords.employee'),
             'branch_id' => $branch->id,
             'start_date' => $firstHire->toDateString(),
         ]);
@@ -183,7 +183,7 @@ class EmployeeSeeder extends OnceSeeder
             'roles' => ['kitchen-assistant'],
             'email' => 'sofia.reingresos3@sushigo.com',
             'phone' => '5512349903',
-            'password' => 'employee123456',
+            'password' => config('seeders.passwords.employee'),
             'branch_id' => $branch->id,
             'start_date' => $firstHire->toDateString(),
         ]);

--- a/code/api/database/seeders/Production/UserSeeder.php
+++ b/code/api/database/seeders/Production/UserSeeder.php
@@ -32,7 +32,7 @@ class UserSeeder extends OnceSeeder
             [
                 'name' => 'Sistema Admin',
                 'email' => 'admin@sushigo.com',
-                'password' => 'Admin123!', // ⚠️ Change this password immediately after first login
+                'password' => config('seeders.passwords.admin'), // ⚠️ Change this password immediately after first login
                 'role' => 'super-admin',
             ],
         ];

--- a/code/api/database/seeders/Testing/AttendanceTestSeeder.php
+++ b/code/api/database/seeders/Testing/AttendanceTestSeeder.php
@@ -43,7 +43,7 @@ class AttendanceTestSeeder extends Seeder
     {
         $now = now();
         $hireDate = $now->copy()->subYear()->toDateString();
-        $hashedPassword = Hash::make('employee123456');
+        $hashedPassword = Hash::make(config('seeders.passwords.employee'));
 
         $branchId = DB::table('branches')->where('code', 'MAIN')->value('id');
         $roleMap = DB::table('roles')->where('guard_name', 'api')->pluck('id', 'name')->toArray();

--- a/code/api/database/seeders/Testing/CoreTestSeeder.php
+++ b/code/api/database/seeders/Testing/CoreTestSeeder.php
@@ -336,9 +336,9 @@ class CoreTestSeeder extends Seeder
     private function seedUsers(array $roleMap, array $unitIds): void
     {
         $now = now();
-        $adminHash = Hash::make('admin123456');
-        $inventoryHash = Hash::make('inventory123456');
-        $employeeHash = Hash::make('employee123456');
+        $adminHash = Hash::make(config('seeders.passwords.admin'));
+        $inventoryHash = Hash::make(config('seeders.passwords.inventory'));
+        $employeeHash = Hash::make(config('seeders.passwords.employee'));
 
         $userModel = User::class;
         $allUnitIds = array_values($unitIds);

--- a/code/api/database/seeders/Testing/PayrollPreviewSeeder.php
+++ b/code/api/database/seeders/Testing/PayrollPreviewSeeder.php
@@ -50,7 +50,7 @@ class PayrollPreviewSeeder extends Seeder
         $now = now();
         $branchId = DB::table('branches')->where('code', 'MAIN')->value('id');
         $roleMap = DB::table('roles')->where('guard_name', 'api')->pluck('id', 'name')->toArray();
-        $hashedPassword = Hash::make('employee123456');
+        $hashedPassword = Hash::make(config('seeders.passwords.employee'));
 
         $employees = [
             ['code' => 'PAY-001', 'first_name' => 'Ana',    'last_name' => 'Payroll',   'email' => 'pay001@sushigo.com'],

--- a/doc/tasks/2026-07/131-seeder-passwords-config.md
+++ b/doc/tasks/2026-07/131-seeder-passwords-config.md
@@ -1,0 +1,89 @@
+# 🔧 Task #131: Seeder Passwords — Centralize in Config and Parameterize via Env
+
+## 📖 Story
+
+As a developer, I want seeder passwords to be defined in a single place and overridable via environment variables, so that dev/test credentials are never scattered across multiple files and can be changed without touching source code.
+
+---
+
+## 🧠 Context
+
+Seeder passwords are hardcoded as string literals in multiple files with no single source of truth:
+
+| File | Hardcoded password |
+|---|---|
+| `database/seeders/Development/EmployeeSeeder.php` (×2) | `'employee123456'` |
+| `database/seeders/Testing/CoreTestSeeder.php` (×3) | `'admin123456'`, `'inventory123456'`, `'employee123456'` |
+| `database/seeders/Testing/AttendanceTestSeeder.php` | `'employee123456'` |
+| `database/seeders/Testing/PayrollPreviewSeeder.php` | `'employee123456'` (found during implementation, not in original issue list) |
+| `database/seeders/Production/UserSeeder.php` | `'Admin123!'` |
+
+`Development/UserSeeder.php` already reads credentials from `config/seeders.php` (`development_users` array) — that's the correct pattern being extended here.
+
+---
+
+## 🔧 Implementation
+
+### 1. `config/seeders.php` — add passwords with env fallback
+
+```php
+'passwords' => [
+    'admin'     => env('SEEDER_ADMIN_PASSWORD',     'admin123456'),
+    'employee'  => env('SEEDER_EMPLOYEE_PASSWORD',  'employee123456'),
+    'inventory' => env('SEEDER_INVENTORY_PASSWORD', 'inventory123456'),
+],
+```
+
+### 2. Migrate all hardcoded passwords to read from config
+
+- `Development/EmployeeSeeder.php` → `config('seeders.passwords.employee')`
+- `Testing/CoreTestSeeder.php` → `config('seeders.passwords.admin|inventory|employee')`
+- `Testing/AttendanceTestSeeder.php` → `config('seeders.passwords.employee')`
+- `Testing/PayrollPreviewSeeder.php` → `config('seeders.passwords.employee')`
+- `Production/UserSeeder.php` → `config('seeders.passwords.admin')` — **note:** this changes the production default from `'Admin123!'` to `'admin123456'` when `SEEDER_ADMIN_PASSWORD` is unset (confirmed acceptable — single shared `admin` key/env var across all environments)
+
+### 3. Document in `.env.example`
+
+```dotenv
+# Seeder credentials (override for custom dev environments)
+SEEDER_ADMIN_PASSWORD=admin123456
+SEEDER_EMPLOYEE_PASSWORD=employee123456
+SEEDER_INVENTORY_PASSWORD=inventory123456
+```
+
+---
+
+## ✅ Acceptance Criteria
+
+- [ ] `config/seeders.php` defines the 3 passwords with `env()` and fallback
+- [ ] No seeder contains a password as a string literal
+- [ ] `.env.example` documents the 3 variables
+- [ ] `php artisan db:seed` in dev produces the same result as before
+- [ ] `php artisan test` passes with no changes to existing tests
+- [ ] Pint passes with 0 errors
+
+---
+
+## 🔗 Additional Context
+
+Detected during code review of PR #130 in `Testing/CoreTestSeeder.php:315` when adding the `manager@sushigo.com` user.
+
+---
+
+## ⏱️ Estimates
+
+- **Optimistic:** `30min` · **Pessimistic:** `1h`
+
+---
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `30min` · **Pessimistic:** `1h` · **Tracked:** _in progress_
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-07-14", "start": "02:11", "end": "?" }
+]
+```

--- a/doc/tasks/2026-07/131-seeder-passwords-config.md
+++ b/doc/tasks/2026-07/131-seeder-passwords-config.md
@@ -79,11 +79,21 @@ Detected during code review of PR #130 in `Testing/CoreTestSeeder.php:315` when 
 ## ⏱️ Time
 
 ### 📊 Estimates
-- **Optimistic:** `30min` · **Pessimistic:** `1h` · **Tracked:** _in progress_
+- **Optimistic:** `30min` · **Pessimistic:** `1h` · **Tracked:** `~5h`
 
 ### 📅 Sessions
 ```json
 [
-  { "date": "2026-07-14", "start": "02:11", "end": "?" }
+  { "date": "2026-07-14", "start": "02:11", "end": "07:10" }
 ]
 ```
+
+---
+
+## 📊 Retrospective
+
+**Estimated:** 30min–1h · **Tracked:** ~5h · **Variance:** +4h over pessimistic
+
+The implementation itself (adding `config('seeders.passwords.*')`, migrating 6 seeder files, `.env.example`) matched the estimate — well under an hour. The overrun came entirely from test verification: `code/api/phpunit.xml` hardcodes `DB_DATABASE=mydb_test` (not workspace-suffixed), so this dev-lab's shared Postgres instance is contended by every workspace's test runs. Mid-verification, another workspace's `migrate:fresh` ran concurrently against the same `mydb_test` database, producing cascading deadlocks and "relation does not exist" failures (173 failed on one full-suite run) that looked like regressions but were pure cross-workspace contention. Confirmed via `ps aux` (caught the other workspace's `migrate:fresh --force` mid-run) and by re-running the same targeted tests in isolation once that process cleared — all passed cleanly (`LoginTest`, `TestResetCommandTest`, `CoreTestSeeder`/`AttendanceTestSeeder`/`PayrollPreviewSeeder` consumers). Pint was clean with zero changes needed.
+
+**Follow-up worth a separate issue:** `phpunit.xml`'s shared `mydb_test` name causes this contention for every workspace, every time two agents run tests concurrently — worth namespacing the test DB per workspace (e.g. reading from `.env` like the dev DB already does) to stop future sessions from losing time diagnosing false regressions.


### PR DESCRIPTION
## Summary
- Add `config('seeders.passwords.*')` (admin/employee/inventory) with `SEEDER_*_PASSWORD` env overrides and sane defaults matching the previous hardcoded values
- Migrate every seeder that hardcoded a password literal to read from config instead: `Development/EmployeeSeeder`, `Testing/CoreTestSeeder`, `Testing/AttendanceTestSeeder`, `Testing/PayrollPreviewSeeder` (found during implementation, not in original issue list), `Production/UserSeeder`
- Document the 3 new env vars in `.env.example`

**Note on `Production/UserSeeder.php`:** its default password changes from `Admin123!` to `admin123456` when `SEEDER_ADMIN_PASSWORD` is unset, unifying to a single shared `admin` password key/env var across all environments — confirmed intentional during planning.

## Test plan
- [x] Pint: 0 errors, 0 changes needed
- [x] PHPUnit: `php artisan test --filter="CoreTestSeeder|AttendanceTestSeeder|PayrollPreview|TestResetCommandTest|AttendanceHistorySeederTest"` — 16 passed, 64 assertions
- [x] PHPUnit: `php artisan test --filter=LoginTest` — 12 passed, 49 assertions (confirms login still works against config-driven seeded passwords)
- [x] `php artisan db:seed` in dev — completes without error

## Manual Testing
1. `cd code/api && php artisan test --filter=TestResetCommandTest` — exercises `CoreTestSeeder` (admin/inventory/employee passwords) end-to-end on a fresh DB
2. `cd code/api && php artisan db:seed` — confirm no errors, and login still works with `admin@sushigo.com` (password unchanged, see Test Users table in CLAUDE.md)
3. Optional override check: set `SEEDER_ADMIN_PASSWORD=custom123` in `.env`, re-seed, confirm the admin user's password becomes the overridden value

## Closes
Closes #131

## Workspace
`sushigo-e` — `chore/131-seeder-passwords-config`

🤖 Generated with [Claude Code](https://claude.com/claude-code)