### PR TITLE
🔀 [#214][d] - Add configurable vacation entitlement policies beyond LFT minimum ✨

### DIFF
--- a/code/api/app/Contracts/VacationEntitlementRule.php
+++ b/code/api/app/Contracts/VacationEntitlementRule.php
@@ -14,6 +14,14 @@ interface VacationEntitlementRule
     public function label(): string;
 
     /**
+     * Stable identifier persisted as VacationEntitlement.rule_key and used by
+     * the resolver to tell apart instances of the same strategy class
+     * configured at different scopes (e.g. CustomVacationPolicy at the
+     * tenant vs. employee level).
+     */
+    public function key(): string;
+
+    /**
      * Return the full entitlement table as rows of ['years' => string, 'days' => int].
      * Used for the "Reglas aplicables" info panel in the frontend.
      *

--- a/code/api/app/Http/Controllers/Api/V1/Employees/UpdateEmployeeVacationPolicyController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Employees/UpdateEmployeeVacationPolicyController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Employees;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Employees\UpdateEmployeeVacationPolicyRequest;
+use App\Http\Responses\Common\ResponseEntity;
+use App\Models\Employee;
+use App\Services\VacationEntitlementResolver;
+
+/**
+ * @OA\Put(
+ *   path="/api/v1/employees/{employee}/vacation-policy-override",
+ *   summary="Set or clear an employee's contractual vacation policy override",
+ *   description="A non-null rule_key takes precedence over the tenant-wide vacation rule for this employee. Passing rule_key=null clears the override.",
+ *   tags={"Employees"},
+ *   security={{"passport": {}}},
+ *
+ *   @OA\RequestBody(required=true, @OA\JsonContent(ref="#/components/schemas/UpdateEmployeeVacationPolicyRequest")),
+ *
+ *   @OA\Response(response=200, description="Override updated successfully"),
+ *   @OA\Response(response=401, description="Unauthenticated"),
+ *   @OA\Response(response=403, description="Forbidden"),
+ *   @OA\Response(response=422, description="Validation Error", @OA\JsonContent(ref="#/components/schemas/ResponseError"))
+ * )
+ */
+class UpdateEmployeeVacationPolicyController extends Controller
+{
+    public function __invoke(
+        UpdateEmployeeVacationPolicyRequest $request,
+        Employee $employee,
+        VacationEntitlementResolver $resolver,
+    ): ResponseEntity {
+        $ruleKey = $request->input('rule_key');
+
+        $employee->update([
+            'vacation_entitlement_rule_key' => $ruleKey,
+            'vacation_entitlement_custom_table' => $ruleKey === 'ContractualPolicy' ? $request->input('tiers') : null,
+        ]);
+
+        return new ResponseEntity(data: [
+            'rule_key' => $employee->vacation_entitlement_rule_key,
+            'tiers' => $employee->vacation_entitlement_custom_table ?? [],
+            'active_rule_label' => $resolver->resolve($employee)->label(),
+        ]);
+    }
+}

--- a/code/api/app/Http/Controllers/Api/V1/Employees/UpdateEmployeeVacationPolicyController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Employees/UpdateEmployeeVacationPolicyController.php
@@ -31,12 +31,7 @@ class UpdateEmployeeVacationPolicyController extends Controller
         Employee $employee,
         VacationEntitlementResolver $resolver,
     ): ResponseEntity {
-        $ruleKey = $request->input('rule_key');
-
-        $employee->update([
-            'vacation_entitlement_rule_key' => $ruleKey,
-            'vacation_entitlement_custom_table' => $ruleKey === 'ContractualPolicy' ? $request->input('tiers') : null,
-        ]);
+        $employee->update($request->updateData());
 
         return new ResponseEntity(data: [
             'rule_key' => $employee->vacation_entitlement_rule_key,

--- a/code/api/app/Http/Controllers/Api/V1/VacationPolicy/ListVacationPolicyController.php
+++ b/code/api/app/Http/Controllers/Api/V1/VacationPolicy/ListVacationPolicyController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\VacationPolicy;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\VacationPolicy\VacationPolicyTierResource;
+use App\Http\Responses\Common\ResponseEntity;
+use App\Models\VacationPolicySetting;
+use App\Models\VacationPolicyTier;
+use App\Services\VacationEntitlementResolver;
+
+/**
+ * @OA\Get(
+ *   path="/api/v1/vacation-policy",
+ *   summary="Get Vacation Policy Settings",
+ *   description="Returns the active tenant-level vacation entitlement rule and its custom tiers (if any).",
+ *   tags={"Vacation Policy"},
+ *   security={{"passport": {}}},
+ *
+ *   @OA\Response(response=200, description="Settings retrieved successfully"),
+ *   @OA\Response(response=401, description="Unauthenticated"),
+ *   @OA\Response(response=403, description="Forbidden")
+ * )
+ */
+class ListVacationPolicyController extends Controller
+{
+    public function __invoke(VacationEntitlementResolver $resolver): ResponseEntity
+    {
+        $settings = VacationPolicySetting::current();
+
+        $tiers = VacationPolicyTier::orderBy('years_from')->get();
+
+        return new ResponseEntity(data: [
+            'active_rule_key' => $settings->active_rule_key,
+            'active_rule_label' => $resolver->resolveTenantDefault()->label(),
+            'tiers' => VacationPolicyTierResource::collection($tiers)->toArray(request()),
+        ]);
+    }
+}

--- a/code/api/app/Http/Controllers/Api/V1/VacationPolicy/UpdateVacationPolicyController.php
+++ b/code/api/app/Http/Controllers/Api/V1/VacationPolicy/UpdateVacationPolicyController.php
@@ -6,10 +6,9 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\VacationPolicy\UpdateVacationPolicyRequest;
 use App\Http\Resources\VacationPolicy\VacationPolicyTierResource;
 use App\Http\Responses\Common\ResponseEntity;
-use App\Models\VacationPolicySetting;
 use App\Models\VacationPolicyTier;
 use App\Services\VacationEntitlementResolver;
-use Illuminate\Support\Facades\DB;
+use App\Services\VacationPolicySettingService;
 
 /**
  * @OA\Put(
@@ -29,30 +28,19 @@ use Illuminate\Support\Facades\DB;
  */
 class UpdateVacationPolicyController extends Controller
 {
-    public function __invoke(UpdateVacationPolicyRequest $request, VacationEntitlementResolver $resolver): ResponseEntity
-    {
-        $activeRuleKey = $request->input('active_rule_key');
+    public function __invoke(
+        UpdateVacationPolicyRequest $request,
+        VacationEntitlementResolver $resolver,
+        VacationPolicySettingService $policyService,
+    ): ResponseEntity {
+        $data = $request->policyData();
 
-        DB::transaction(function () use ($request, $activeRuleKey) {
-            VacationPolicySetting::current()->update(['active_rule_key' => $activeRuleKey]);
-
-            if ($activeRuleKey === 'CustomCompanyPolicy') {
-                $sorted = collect($request->input('tiers'))->sortBy('years_from')->values();
-
-                VacationPolicyTier::query()->delete();
-
-                $sorted->each(fn (array $item, int $index) => VacationPolicyTier::create([
-                    'years_from' => $item['years_from'],
-                    'days' => $item['days'],
-                    'sort_order' => $index + 1,
-                ]));
-            }
-        });
+        $policyService->update($data['active_rule_key'], $data['tiers']);
 
         $tiers = VacationPolicyTier::orderBy('years_from')->get();
 
         return new ResponseEntity(data: [
-            'active_rule_key' => $activeRuleKey,
+            'active_rule_key' => $data['active_rule_key'],
             'active_rule_label' => $resolver->resolveTenantDefault()->label(),
             'tiers' => VacationPolicyTierResource::collection($tiers)->toArray(request()),
         ]);

--- a/code/api/app/Http/Controllers/Api/V1/VacationPolicy/UpdateVacationPolicyController.php
+++ b/code/api/app/Http/Controllers/Api/V1/VacationPolicy/UpdateVacationPolicyController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\VacationPolicy;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\VacationPolicy\UpdateVacationPolicyRequest;
+use App\Http\Resources\VacationPolicy\VacationPolicyTierResource;
+use App\Http\Responses\Common\ResponseEntity;
+use App\Models\VacationPolicySetting;
+use App\Models\VacationPolicyTier;
+use App\Services\VacationEntitlementResolver;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * @OA\Put(
+ *   path="/api/v1/vacation-policy",
+ *   summary="Update Vacation Policy Settings",
+ *   description="Sets the active tenant-level vacation rule. When switching to CustomCompanyPolicy, atomically replaces the custom tiers with the provided list. Switching back to VacationsLFTMX preserves any existing custom tiers so they are available if re-enabled later.",
+ *   tags={"Vacation Policy"},
+ *   security={{"passport": {}}},
+ *
+ *   @OA\RequestBody(required=true, @OA\JsonContent(ref="#/components/schemas/UpdateVacationPolicyRequest")),
+ *
+ *   @OA\Response(response=200, description="Settings updated successfully"),
+ *   @OA\Response(response=401, description="Unauthenticated"),
+ *   @OA\Response(response=403, description="Forbidden"),
+ *   @OA\Response(response=422, description="Validation Error", @OA\JsonContent(ref="#/components/schemas/ResponseError"))
+ * )
+ */
+class UpdateVacationPolicyController extends Controller
+{
+    public function __invoke(UpdateVacationPolicyRequest $request, VacationEntitlementResolver $resolver): ResponseEntity
+    {
+        $activeRuleKey = $request->input('active_rule_key');
+
+        DB::transaction(function () use ($request, $activeRuleKey) {
+            VacationPolicySetting::current()->update(['active_rule_key' => $activeRuleKey]);
+
+            if ($activeRuleKey === 'CustomCompanyPolicy') {
+                $sorted = collect($request->input('tiers'))->sortBy('years_from')->values();
+
+                VacationPolicyTier::query()->delete();
+
+                $sorted->each(fn (array $item, int $index) => VacationPolicyTier::create([
+                    'years_from' => $item['years_from'],
+                    'days' => $item['days'],
+                    'sort_order' => $index + 1,
+                ]));
+            }
+        });
+
+        $tiers = VacationPolicyTier::orderBy('years_from')->get();
+
+        return new ResponseEntity(data: [
+            'active_rule_key' => $activeRuleKey,
+            'active_rule_label' => $resolver->resolveTenantDefault()->label(),
+            'tiers' => VacationPolicyTierResource::collection($tiers)->toArray(request()),
+        ]);
+    }
+}

--- a/code/api/app/Http/Requests/Concerns/ValidatesVacationPolicyTiers.php
+++ b/code/api/app/Http/Requests/Concerns/ValidatesVacationPolicyTiers.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\Concerns;
+
+use Illuminate\Validation\Validator;
+
+/**
+ * Shared "years_from → days" tiers validation, used by both
+ * UpdateVacationPolicyRequest (tenant default) and
+ * UpdateEmployeeVacationPolicyRequest (per-employee override).
+ */
+trait ValidatesVacationPolicyTiers
+{
+    protected function vacationPolicyTierRules(string $gateField, string $gateValue): array
+    {
+        return [
+            'tiers' => ["required_if:{$gateField},{$gateValue}", 'nullable', 'array', 'min:1'],
+            'tiers.*.years_from' => ['required', 'integer', 'min:1'],
+            'tiers.*.days' => ['required', 'integer', 'min:0'],
+        ];
+    }
+
+    protected function validateUniqueTierYears(Validator $validator, string $gateField, string $gateValue): void
+    {
+        $validator->after(function (Validator $v) use ($gateField, $gateValue) {
+            if ($this->input($gateField) !== $gateValue) {
+                return;
+            }
+
+            $yearsFrom = collect($this->input('tiers', []))->pluck('years_from');
+
+            if ($yearsFrom->duplicates()->isNotEmpty()) {
+                $v->errors()->add('tiers', 'Los valores de years_from deben ser únicos.');
+            }
+        });
+    }
+}

--- a/code/api/app/Http/Requests/Employees/UpdateEmployeeVacationPolicyRequest.php
+++ b/code/api/app/Http/Requests/Employees/UpdateEmployeeVacationPolicyRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Employees;
 
+use App\Http\Requests\Concerns\ValidatesVacationPolicyTiers;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Validator;
@@ -27,6 +28,8 @@ use Illuminate\Validation\Validator;
  */
 class UpdateEmployeeVacationPolicyRequest extends FormRequest
 {
+    use ValidatesVacationPolicyTiers;
+
     public function authorize(): bool
     {
         return $this->user()->can('employees.update');
@@ -34,26 +37,14 @@ class UpdateEmployeeVacationPolicyRequest extends FormRequest
 
     public function rules(): array
     {
-        return [
-            'rule_key' => ['nullable', 'string', Rule::in(['ContractualPolicy'])],
-            'tiers' => ['required_if:rule_key,ContractualPolicy', 'nullable', 'array', 'min:1'],
-            'tiers.*.years_from' => ['required', 'integer', 'min:1'],
-            'tiers.*.days' => ['required', 'integer', 'min:0'],
-        ];
+        return array_merge(
+            ['rule_key' => ['nullable', 'string', Rule::in(['ContractualPolicy'])]],
+            $this->vacationPolicyTierRules('rule_key', 'ContractualPolicy'),
+        );
     }
 
     public function withValidator(Validator $validator): void
     {
-        $validator->after(function (Validator $v) {
-            if ($this->input('rule_key') !== 'ContractualPolicy') {
-                return;
-            }
-
-            $yearsFrom = collect($this->input('tiers', []))->pluck('years_from');
-
-            if ($yearsFrom->duplicates()->isNotEmpty()) {
-                $v->errors()->add('tiers', 'Los valores de years_from deben ser únicos.');
-            }
-        });
+        $this->validateUniqueTierYears($validator, 'rule_key', 'ContractualPolicy');
     }
 }

--- a/code/api/app/Http/Requests/Employees/UpdateEmployeeVacationPolicyRequest.php
+++ b/code/api/app/Http/Requests/Employees/UpdateEmployeeVacationPolicyRequest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Requests\Employees;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
+
+/**
+ * @OA\Schema(
+ *     schema="UpdateEmployeeVacationPolicyRequest",
+ *     title="Update Employee Vacation Policy Override Request",
+ *
+ *     @OA\Property(property="rule_key", type="string", nullable=true, enum={"ContractualPolicy"}, example="ContractualPolicy", description="null clears the override and falls back to the tenant default"),
+ *     @OA\Property(
+ *         property="tiers",
+ *         type="array",
+ *         description="Required when rule_key is ContractualPolicy. Ignored otherwise.",
+ *
+ *         @OA\Items(
+ *
+ *             @OA\Property(property="years_from", type="integer", minimum=1, example=1),
+ *             @OA\Property(property="days", type="integer", minimum=0, example=30)
+ *         )
+ *     )
+ * )
+ */
+class UpdateEmployeeVacationPolicyRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()->can('employees.update');
+    }
+
+    public function rules(): array
+    {
+        return [
+            'rule_key' => ['nullable', 'string', Rule::in(['ContractualPolicy'])],
+            'tiers' => ['required_if:rule_key,ContractualPolicy', 'nullable', 'array', 'min:1'],
+            'tiers.*.years_from' => ['required', 'integer', 'min:1'],
+            'tiers.*.days' => ['required', 'integer', 'min:0'],
+        ];
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $v) {
+            if ($this->input('rule_key') !== 'ContractualPolicy') {
+                return;
+            }
+
+            $yearsFrom = collect($this->input('tiers', []))->pluck('years_from');
+
+            if ($yearsFrom->duplicates()->isNotEmpty()) {
+                $v->errors()->add('tiers', 'Los valores de years_from deben ser únicos.');
+            }
+        });
+    }
+}

--- a/code/api/app/Http/Requests/Employees/UpdateEmployeeVacationPolicyRequest.php
+++ b/code/api/app/Http/Requests/Employees/UpdateEmployeeVacationPolicyRequest.php
@@ -47,4 +47,19 @@ class UpdateEmployeeVacationPolicyRequest extends FormRequest
     {
         $this->validateUniqueTierYears($validator, 'rule_key', 'ContractualPolicy');
     }
+
+    /**
+     * Ready-to-persist employee data: the override rule key, and its custom
+     * table (null when the override is cleared or not ContractualPolicy).
+     */
+    public function updateData(): array
+    {
+        $data = $this->validated();
+        $ruleKey = $data['rule_key'] ?? null;
+
+        return [
+            'vacation_entitlement_rule_key' => $ruleKey,
+            'vacation_entitlement_custom_table' => $ruleKey === 'ContractualPolicy' ? ($data['tiers'] ?? null) : null,
+        ];
+    }
 }

--- a/code/api/app/Http/Requests/VacationPolicy/UpdateVacationPolicyRequest.php
+++ b/code/api/app/Http/Requests/VacationPolicy/UpdateVacationPolicyRequest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Requests\VacationPolicy;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
+
+/**
+ * @OA\Schema(
+ *     schema="UpdateVacationPolicyRequest",
+ *     title="Update Vacation Policy Request",
+ *     required={"active_rule_key"},
+ *
+ *     @OA\Property(property="active_rule_key", type="string", enum={"VacationsLFTMX", "CustomCompanyPolicy"}, example="CustomCompanyPolicy"),
+ *     @OA\Property(
+ *         property="tiers",
+ *         type="array",
+ *         description="Required when active_rule_key is CustomCompanyPolicy. Ignored otherwise.",
+ *
+ *         @OA\Items(
+ *
+ *             @OA\Property(property="years_from", type="integer", minimum=1, example=1),
+ *             @OA\Property(property="days", type="integer", minimum=0, example=18)
+ *         )
+ *     )
+ * )
+ */
+class UpdateVacationPolicyRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()->can('vacation-policy.manage');
+    }
+
+    public function rules(): array
+    {
+        return [
+            'active_rule_key' => ['required', 'string', Rule::in(['VacationsLFTMX', 'CustomCompanyPolicy'])],
+            'tiers' => ['required_if:active_rule_key,CustomCompanyPolicy', 'nullable', 'array', 'min:1'],
+            'tiers.*.years_from' => ['required', 'integer', 'min:1'],
+            'tiers.*.days' => ['required', 'integer', 'min:0'],
+        ];
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $v) {
+            if ($this->input('active_rule_key') !== 'CustomCompanyPolicy') {
+                return;
+            }
+
+            $yearsFrom = collect($this->input('tiers', []))->pluck('years_from');
+
+            if ($yearsFrom->duplicates()->isNotEmpty()) {
+                $v->errors()->add('tiers', 'Los valores de years_from deben ser únicos.');
+            }
+        });
+    }
+}

--- a/code/api/app/Http/Requests/VacationPolicy/UpdateVacationPolicyRequest.php
+++ b/code/api/app/Http/Requests/VacationPolicy/UpdateVacationPolicyRequest.php
@@ -48,4 +48,20 @@ class UpdateVacationPolicyRequest extends FormRequest
     {
         $this->validateUniqueTierYears($validator, 'active_rule_key', 'CustomCompanyPolicy');
     }
+
+    /**
+     * Ready-to-persist policy data: the active rule key, and the tiers sorted
+     * by years_from (null when the tenant isn't switching to a custom policy).
+     */
+    public function policyData(): array
+    {
+        $data = $this->validated();
+
+        return [
+            'active_rule_key' => $data['active_rule_key'],
+            'tiers' => $data['active_rule_key'] === 'CustomCompanyPolicy'
+                ? collect($data['tiers'])->sortBy('years_from')->values()->all()
+                : null,
+        ];
+    }
 }

--- a/code/api/app/Http/Requests/VacationPolicy/UpdateVacationPolicyRequest.php
+++ b/code/api/app/Http/Requests/VacationPolicy/UpdateVacationPolicyRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\VacationPolicy;
 
+use App\Http\Requests\Concerns\ValidatesVacationPolicyTiers;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Validator;
@@ -28,6 +29,8 @@ use Illuminate\Validation\Validator;
  */
 class UpdateVacationPolicyRequest extends FormRequest
 {
+    use ValidatesVacationPolicyTiers;
+
     public function authorize(): bool
     {
         return $this->user()->can('vacation-policy.manage');
@@ -35,26 +38,14 @@ class UpdateVacationPolicyRequest extends FormRequest
 
     public function rules(): array
     {
-        return [
-            'active_rule_key' => ['required', 'string', Rule::in(['VacationsLFTMX', 'CustomCompanyPolicy'])],
-            'tiers' => ['required_if:active_rule_key,CustomCompanyPolicy', 'nullable', 'array', 'min:1'],
-            'tiers.*.years_from' => ['required', 'integer', 'min:1'],
-            'tiers.*.days' => ['required', 'integer', 'min:0'],
-        ];
+        return array_merge(
+            ['active_rule_key' => ['required', 'string', Rule::in(['VacationsLFTMX', 'CustomCompanyPolicy'])]],
+            $this->vacationPolicyTierRules('active_rule_key', 'CustomCompanyPolicy'),
+        );
     }
 
     public function withValidator(Validator $validator): void
     {
-        $validator->after(function (Validator $v) {
-            if ($this->input('active_rule_key') !== 'CustomCompanyPolicy') {
-                return;
-            }
-
-            $yearsFrom = collect($this->input('tiers', []))->pluck('years_from');
-
-            if ($yearsFrom->duplicates()->isNotEmpty()) {
-                $v->errors()->add('tiers', 'Los valores de years_from deben ser únicos.');
-            }
-        });
+        $this->validateUniqueTierYears($validator, 'active_rule_key', 'CustomCompanyPolicy');
     }
 }

--- a/code/api/app/Http/Resources/Employee/EmployeeResource.php
+++ b/code/api/app/Http/Resources/Employee/EmployeeResource.php
@@ -16,6 +16,8 @@ use App\Http\Resources\BaseResource;
  *     @OA\Property(property="roles", type="array", @OA\Items(type="string", enum={"manager", "cook", "kitchen-assistant", "delivery-driver", "acting-manager"}), example={"cook"}, description="Position roles"),
  *     @OA\Property(property="is_active", type="boolean", example=true),
  *     @OA\Property(property="attendance_exempt", type="boolean", example=false, description="True for roles (e.g. admin, super-admin) that do not check in/out — excluded from the attendance list"),
+ *     @OA\Property(property="vacation_entitlement_rule_key", type="string", nullable=true, example="ContractualPolicy", description="null = inherits the tenant-wide vacation policy"),
+ *     @OA\Property(property="vacation_entitlement_custom_table", type="array", nullable=true, @OA\Items(@OA\Property(property="years_from", type="integer"), @OA\Property(property="days", type="integer"))),
  *     @OA\Property(property="has_active_period", type="boolean", nullable=true, example=true, description="True when employee has at least one active employment period"),
  *     @OA\Property(property="has_user", type="boolean", example=true, description="Whether the employee has a linked user account"),
  *     @OA\Property(property="email", type="string", format="email", nullable=true, example="juan@sushigo.com"),
@@ -54,6 +56,8 @@ class EmployeeResource extends BaseResource
             'roles' => $this->getPositionRoles(),
             'is_active' => $this->is_active,
             'attendance_exempt' => $this->attendance_exempt,
+            'vacation_entitlement_rule_key' => $this->vacation_entitlement_rule_key,
+            'vacation_entitlement_custom_table' => $this->vacation_entitlement_custom_table,
             'has_active_period' => $this->active_employment_periods_count !== null
                 ? $this->active_employment_periods_count > 0
                 : ($this->relationLoaded('employmentPeriods')

--- a/code/api/app/Http/Resources/VacationPolicy/VacationPolicyTierResource.php
+++ b/code/api/app/Http/Resources/VacationPolicy/VacationPolicyTierResource.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Resources\VacationPolicy;
+
+use App\Http\Resources\BaseResource;
+use App\Models\VacationPolicyTier;
+
+/**
+ * @mixin VacationPolicyTier
+ *
+ * @OA\Schema(
+ *     schema="VacationPolicyTierResponse",
+ *     title="Vacation Policy Tier Response",
+ *
+ *     @OA\Property(property="id", type="string", example="01HXYZ"),
+ *     @OA\Property(property="years_from", type="integer", example=1),
+ *     @OA\Property(property="days", type="integer", example=18),
+ *     @OA\Property(property="sort_order", type="integer", example=1)
+ * )
+ */
+class VacationPolicyTierResource extends BaseResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->public_id,
+            'years_from' => $this->years_from,
+            'days' => $this->days,
+            'sort_order' => $this->sort_order,
+        ];
+    }
+}

--- a/code/api/app/Models/Employee.php
+++ b/code/api/app/Models/Employee.php
@@ -79,12 +79,15 @@ class Employee extends Model
         'is_active',
         'attendance_exempt',
         'meta',
+        'vacation_entitlement_rule_key',
+        'vacation_entitlement_custom_table',
     ];
 
     protected $casts = [
         'is_active' => 'boolean',
         'attendance_exempt' => 'boolean',
         'meta' => 'array',
+        'vacation_entitlement_custom_table' => 'array',
     ];
 
     public function user(): BelongsTo

--- a/code/api/app/Models/VacationPolicySetting.php
+++ b/code/api/app/Models/VacationPolicySetting.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Singleton settings row — no tenant_id column. Multi-tenancy is planned as
+ * one database per tenant, so a single global row is sufficient today.
+ */
+class VacationPolicySetting extends Model
+{
+    protected $fillable = [
+        'active_rule_key',
+    ];
+
+    public static function current(): self
+    {
+        return self::query()->first() ?? self::query()->create(['active_rule_key' => 'VacationsLFTMX']);
+    }
+}

--- a/code/api/app/Models/VacationPolicyTier.php
+++ b/code/api/app/Models/VacationPolicyTier.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use App\Support\Traits\HasPublicId;
+use Illuminate\Database\Eloquent\Model;
+
+class VacationPolicyTier extends Model
+{
+    use HasPublicId;
+
+    protected $fillable = [
+        'years_from',
+        'days',
+        'sort_order',
+    ];
+
+    protected $casts = [
+        'years_from' => 'integer',
+        'days' => 'integer',
+        'sort_order' => 'integer',
+    ];
+}

--- a/code/api/app/Providers/AppServiceProvider.php
+++ b/code/api/app/Providers/AppServiceProvider.php
@@ -3,10 +3,8 @@
 namespace App\Providers;
 
 use App\Contracts\PasswordResetTokenRecorder;
-use App\Contracts\VacationEntitlementRule;
 use App\Services\Testing\FileTokenRecorder;
 use App\Services\Testing\NullTokenRecorder;
-use App\Services\VacationRules\VacationsLFTMX;
 use App\Support\Clock\ApplicationClock;
 use App\Support\Clock\DatabaseApplicationClock;
 use Illuminate\Support\ServiceProvider;
@@ -31,8 +29,8 @@ class AppServiceProvider extends ServiceProvider
         // Application Clock: single source of truth for business time
         $this->app->singleton(ApplicationClock::class, DatabaseApplicationClock::class);
 
-        // Active vacation entitlement rule — locked to LFT Mexico 2022 until #214
-        $this->app->bind(VacationEntitlementRule::class, VacationsLFTMX::class);
+        // Active vacation entitlement rule is resolved per-employee by
+        // App\Services\VacationEntitlementResolver — see #214.
     }
 
     /**

--- a/code/api/app/Services/SeniorityService.php
+++ b/code/api/app/Services/SeniorityService.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Services;
 
-use App\Contracts\VacationEntitlementRule;
 use App\Models\Employee;
 use App\Support\Clock\ApplicationClock;
 use Carbon\Carbon;
@@ -12,7 +11,7 @@ use Carbon\Carbon;
 class SeniorityService
 {
     public function __construct(
-        private readonly VacationEntitlementRule $rule,
+        private readonly VacationEntitlementResolver $resolver,
         private readonly ApplicationClock $clock,
     ) {}
 
@@ -75,14 +74,9 @@ class SeniorityService
         return [
             'date' => $nextAnniversaryDate->toDateString(),
             'seniority_year' => $nextSeniorityYear,
-            'entitled_days' => $this->rule->calculate($nextSeniorityYear),
+            'entitled_days' => $this->resolver->resolve($employee)->calculate($nextSeniorityYear),
             'days_until' => (int) $at->diffInDays($nextAnniversaryDate, false),
         ];
-    }
-
-    public function entitledDaysForSeniorityYear(int $year): int
-    {
-        return $this->rule->calculate($year);
     }
 
     /**

--- a/code/api/app/Services/VacationEntitlementResolver.php
+++ b/code/api/app/Services/VacationEntitlementResolver.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Contracts\VacationEntitlementRule;
+use App\Models\Employee;
+use App\Models\VacationPolicySetting;
+use App\Models\VacationPolicyTier;
+use App\Services\VacationRules\CustomVacationPolicy;
+use App\Services\VacationRules\VacationsLFTMX;
+
+/**
+ * Resolution order: employee override → tenant custom policy → LFT default.
+ */
+class VacationEntitlementResolver
+{
+    public function resolve(Employee $employee): VacationEntitlementRule
+    {
+        if ($employee->vacation_entitlement_rule_key === 'ContractualPolicy') {
+            $table = $employee->vacation_entitlement_custom_table;
+
+            if (! empty($table)) {
+                return new CustomVacationPolicy($table, 'Política contractual', 'ContractualPolicy');
+            }
+        }
+
+        return $this->resolveTenantDefault();
+    }
+
+    /**
+     * The rule that applies tenant-wide, ignoring any employee-level override.
+     * Used by the /vacation-policy settings screen to show the currently
+     * active tenant rule regardless of any single employee's contract.
+     */
+    public function resolveTenantDefault(): VacationEntitlementRule
+    {
+        $settings = VacationPolicySetting::current();
+
+        if ($settings->active_rule_key === 'CustomCompanyPolicy') {
+            $tiers = VacationPolicyTier::orderBy('years_from')
+                ->get(['years_from', 'days'])
+                ->map(fn (VacationPolicyTier $tier) => ['years_from' => $tier->years_from, 'days' => $tier->days])
+                ->all();
+
+            if ($tiers !== []) {
+                return new CustomVacationPolicy($tiers, 'Política de la empresa', 'CustomCompanyPolicy');
+            }
+        }
+
+        return new VacationsLFTMX;
+    }
+}

--- a/code/api/app/Services/VacationEntitlementService.php
+++ b/code/api/app/Services/VacationEntitlementService.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Services;
 
-use App\Contracts\VacationEntitlementRule;
 use App\Models\Employee;
 use App\Models\VacationEntitlement;
 use Illuminate\Support\Collection;
@@ -13,7 +12,7 @@ class VacationEntitlementService
 {
     public function __construct(
         private readonly SeniorityService $seniority,
-        private readonly VacationEntitlementRule $rule,
+        private readonly VacationEntitlementResolver $resolver,
     ) {}
 
     /**
@@ -35,6 +34,7 @@ class VacationEntitlementService
 
         $start = $this->seniority->effectiveStartDate($employee);
         $existingYears = VacationEntitlement::where('employee_id', $employee->id)->pluck('year')->all();
+        $rule = $this->resolver->resolve($employee);
 
         $pending = [];
 
@@ -48,7 +48,7 @@ class VacationEntitlementService
             $pending[] = [
                 'calendar_year' => $calendarYear,
                 'seniority_year' => $seniorityYear,
-                'entitled_days' => $this->rule->calculate($seniorityYear),
+                'entitled_days' => $rule->calculate($seniorityYear),
             ];
         }
 
@@ -62,32 +62,39 @@ class VacationEntitlementService
      */
     public function generateMissing(Employee $employee): Collection
     {
+        $ruleKey = $this->resolver->resolve($employee)->key();
+
         return collect($this->pendingAnniversaries($employee))
             ->map(fn (array $pending) => VacationEntitlement::create([
                 'employee_id' => $employee->id,
                 'year' => $pending['calendar_year'],
                 'entitled_days' => $pending['entitled_days'],
                 'used_days' => 0,
-                'rule_key' => class_basename($this->rule),
+                'rule_key' => $ruleKey,
             ]));
     }
 
     /**
-     * Seniority years completed and the employee's next anniversary date.
+     * Seniority years completed, the employee's next anniversary date, and
+     * the label of the vacation rule currently applied to this employee.
      *
-     * @return array{seniority_years: int, next_anniversary_date: ?string}
+     * @return array{seniority_years: int, next_anniversary_date: ?string, active_rule_label: string}
      */
     public function summary(Employee $employee): array
     {
+        $activeRuleLabel = $this->resolver->resolve($employee)->label();
+
         try {
             return [
                 'seniority_years' => $this->seniority->completedYears($employee),
                 'next_anniversary_date' => $this->seniority->nextAnniversary($employee)['date'],
+                'active_rule_label' => $activeRuleLabel,
             ];
         } catch (\LogicException) {
             return [
                 'seniority_years' => 0,
                 'next_anniversary_date' => null,
+                'active_rule_label' => $activeRuleLabel,
             ];
         }
     }

--- a/code/api/app/Services/VacationEntitlementService.php
+++ b/code/api/app/Services/VacationEntitlementService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services;
 
+use App\Contracts\VacationEntitlementRule;
 use App\Models\Employee;
 use App\Models\VacationEntitlement;
 use Illuminate\Support\Collection;
@@ -20,7 +21,7 @@ class VacationEntitlementService
      *
      * @return array<int, array{calendar_year: int, seniority_year: int, entitled_days: int}>
      */
-    public function pendingAnniversaries(Employee $employee): array
+    public function pendingAnniversaries(Employee $employee, ?VacationEntitlementRule $rule = null): array
     {
         try {
             $completedYears = $this->seniority->completedYears($employee);
@@ -34,7 +35,7 @@ class VacationEntitlementService
 
         $start = $this->seniority->effectiveStartDate($employee);
         $existingYears = VacationEntitlement::where('employee_id', $employee->id)->pluck('year')->all();
-        $rule = $this->resolver->resolve($employee);
+        $rule ??= $this->resolver->resolve($employee);
 
         $pending = [];
 
@@ -62,15 +63,15 @@ class VacationEntitlementService
      */
     public function generateMissing(Employee $employee): Collection
     {
-        $ruleKey = $this->resolver->resolve($employee)->key();
+        $rule = $this->resolver->resolve($employee);
 
-        return collect($this->pendingAnniversaries($employee))
+        return collect($this->pendingAnniversaries($employee, $rule))
             ->map(fn (array $pending) => VacationEntitlement::create([
                 'employee_id' => $employee->id,
                 'year' => $pending['calendar_year'],
                 'entitled_days' => $pending['entitled_days'],
                 'used_days' => 0,
-                'rule_key' => $ruleKey,
+                'rule_key' => $rule->key(),
             ]));
     }
 

--- a/code/api/app/Services/VacationPolicySettingService.php
+++ b/code/api/app/Services/VacationPolicySettingService.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\VacationPolicySetting;
+use App\Models\VacationPolicyTier;
+use Illuminate\Support\Facades\DB;
+
+class VacationPolicySettingService
+{
+    /**
+     * Atomically sets the tenant's active vacation rule and, when switching to
+     * CustomCompanyPolicy, replaces the custom tiers with the given list.
+     * Switching back to VacationsLFTMX preserves any existing custom tiers so
+     * they are available if re-enabled later.
+     *
+     * @param  array<int, array{years_from: int, days: int}>|null  $tiers  Already sorted by years_from.
+     */
+    public function update(string $activeRuleKey, ?array $tiers): void
+    {
+        DB::transaction(function () use ($activeRuleKey, $tiers) {
+            VacationPolicySetting::current()->update(['active_rule_key' => $activeRuleKey]);
+
+            if ($activeRuleKey !== 'CustomCompanyPolicy') {
+                return;
+            }
+
+            VacationPolicyTier::query()->delete();
+
+            collect($tiers)->each(fn (array $item, int $index) => VacationPolicyTier::create([
+                'years_from' => $item['years_from'],
+                'days' => $item['days'],
+                'sort_order' => $index + 1,
+            ]));
+        });
+    }
+}

--- a/code/api/app/Services/VacationRules/CustomVacationPolicy.php
+++ b/code/api/app/Services/VacationRules/CustomVacationPolicy.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Services\VacationRules;
+
+use App\Contracts\VacationEntitlementRule;
+use Illuminate\Support\Collection;
+
+/**
+ * Generic table-driven vacation policy — used for both the tenant-level
+ * "CustomCompanyPolicy" and the employee-level "ContractualPolicy" override.
+ * Both scopes share this same runtime strategy; only the source of the
+ * table (tenant settings vs. the employee record) and the injected
+ * label/key differ. See App\Services\VacationEntitlementResolver.
+ */
+class CustomVacationPolicy implements VacationEntitlementRule
+{
+    /**
+     * @param  array<int, array{years_from: int, days: int}>  $tiers
+     */
+    public function __construct(
+        private readonly array $tiers,
+        private readonly string $label,
+        private readonly string $key,
+    ) {}
+
+    public function calculate(int $years): int
+    {
+        $applicable = $this->sortedTiers()
+            ->filter(fn (array $tier) => $tier['years_from'] <= $years)
+            ->last();
+
+        return $applicable['days'] ?? 0;
+    }
+
+    public function label(): string
+    {
+        return $this->label;
+    }
+
+    public function key(): string
+    {
+        return $this->key;
+    }
+
+    public function table(): array
+    {
+        $sorted = $this->sortedTiers()->values();
+
+        return $sorted
+            ->map(function (array $tier, int $index) use ($sorted) {
+                $next = $sorted->get($index + 1);
+
+                return [
+                    'years' => $this->rangeLabel($tier['years_from'], $next['years_from'] ?? null),
+                    'days' => $tier['days'],
+                ];
+            })
+            ->all();
+    }
+
+    private function rangeLabel(int $from, ?int $nextFrom): string
+    {
+        if ($nextFrom === null) {
+            return "{$from}+";
+        }
+
+        $to = $nextFrom - 1;
+
+        return $to === $from ? (string) $from : "{$from}–{$to}";
+    }
+
+    /**
+     * @return Collection<int, array{years_from: int, days: int}>
+     */
+    private function sortedTiers(): Collection
+    {
+        return collect($this->tiers)->sortBy('years_from')->values();
+    }
+}

--- a/code/api/app/Services/VacationRules/VacationsLFTMX.php
+++ b/code/api/app/Services/VacationRules/VacationsLFTMX.php
@@ -32,6 +32,11 @@ class VacationsLFTMX implements VacationEntitlementRule
         return 'LFT México 2022';
     }
 
+    public function key(): string
+    {
+        return 'VacationsLFTMX';
+    }
+
     public function table(): array
     {
         return [

--- a/code/api/database/migrations/2026_07_14_020000_create_vacation_policy_settings_table.php
+++ b/code/api/database/migrations/2026_07_14_020000_create_vacation_policy_settings_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('vacation_policy_settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('active_rule_key')->default('VacationsLFTMX');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('vacation_policy_settings');
+    }
+};

--- a/code/api/database/migrations/2026_07_14_020001_create_vacation_policy_tiers_table.php
+++ b/code/api/database/migrations/2026_07_14_020001_create_vacation_policy_tiers_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('vacation_policy_tiers', function (Blueprint $table) {
+            $table->id();
+            $table->string('public_id', 26)->unique();
+            $table->unsignedSmallInteger('years_from')->unique();
+            $table->unsignedSmallInteger('days');
+            $table->unsignedSmallInteger('sort_order')->unique();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('vacation_policy_tiers');
+    }
+};

--- a/code/api/database/migrations/2026_07_14_020002_add_vacation_entitlement_rule_to_employees_table.php
+++ b/code/api/database/migrations/2026_07_14_020002_add_vacation_entitlement_rule_to_employees_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            // null = inherit the tenant default. Only 'ContractualPolicy' is
+            // a valid non-null value today — see VacationEntitlementResolver.
+            $table->string('vacation_entitlement_rule_key')->nullable()->after('meta');
+            $table->json('vacation_entitlement_custom_table')->nullable()->after('vacation_entitlement_rule_key');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            $table->dropColumn(['vacation_entitlement_rule_key', 'vacation_entitlement_custom_table']);
+        });
+    }
+};

--- a/code/api/database/seeders/Development/PermissionSeeder.php
+++ b/code/api/database/seeders/Development/PermissionSeeder.php
@@ -148,6 +148,7 @@ class PermissionSeeder extends LockedSeeder
             'punctuality.manage' => ['label' => 'Gestionar rangos de puntualidad', 'group' => 'Asistencia'],
             'holidays.manage' => ['label' => 'Gestionar días festivos', 'group' => 'Asistencia'],
             'overtime.manage' => ['label' => 'Gestionar tramos LFT de horas extra', 'group' => 'Asistencia'],
+            'vacation-policy.manage' => ['label' => 'Gestionar reglas de vacaciones', 'group' => 'Asistencia'],
 
             // Configuración del sistema
             'settings.manage' => ['label' => 'Gestionar configuración del sistema', 'group' => 'Configuración'],
@@ -196,7 +197,7 @@ class PermissionSeeder extends LockedSeeder
                             ->orWhere('name', 'like', self::REPORTS_PATTERN)
                             ->orWhere('name', 'like', self::PAYROLL_PATTERN)
                             ->orWhere('name', 'like', 'audit-logs.%')
-                            ->orWhereIn('name', ['punctuality.manage', 'holidays.manage', 'settings.manage', 'overtime.manage']);
+                            ->orWhereIn('name', ['punctuality.manage', 'holidays.manage', 'settings.manage', 'overtime.manage', 'vacation-policy.manage']);
                     })
                     ->get()
             );

--- a/code/api/database/seeders/Production/PermissionSeeder.php
+++ b/code/api/database/seeders/Production/PermissionSeeder.php
@@ -102,6 +102,7 @@ class PermissionSeeder extends LockedSeeder
             'punctuality.manage',
             'holidays.manage',
             'overtime.manage',
+            'vacation-policy.manage',
 
             // Nómina
             'payroll.preview',
@@ -175,7 +176,7 @@ class PermissionSeeder extends LockedSeeder
                             ->orWhere('name', 'like', 'inventory_locations.%')
                             ->orWhere('name', 'like', 'stock.%')
                             ->orWhere('name', 'like', 'audit-logs.%')
-                            ->orWhereIn('name', ['punctuality.manage', 'holidays.manage', 'payroll.preview', 'payroll.close', 'payroll.reopen', 'payroll.reclose', 'overtime.manage']);
+                            ->orWhereIn('name', ['punctuality.manage', 'holidays.manage', 'payroll.preview', 'payroll.close', 'payroll.reopen', 'payroll.reclose', 'overtime.manage', 'vacation-policy.manage']);
                     })
                     ->get()
             );

--- a/code/api/database/seeders/Testing/AttendanceTestSeeder.php
+++ b/code/api/database/seeders/Testing/AttendanceTestSeeder.php
@@ -3,6 +3,8 @@
 namespace Database\Seeders\Testing;
 
 use App\Models\User;
+use App\Support\Clock\ApplicationClock;
+use Carbon\Carbon;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
@@ -21,6 +23,8 @@ use Illuminate\Support\Str;
  */
 class AttendanceTestSeeder extends Seeder
 {
+    public function __construct(private readonly ApplicationClock $clock) {}
+
     /** Staggered lunch templates: 30 min each, every 30 min from 15:00 to 20:00 */
     private const LUNCH_TEMPLATES = [
         ['15:00:00', '15:30:00'],
@@ -42,7 +46,10 @@ class AttendanceTestSeeder extends Seeder
     public function run(): void
     {
         $now = now();
-        $hireDate = $now->copy()->subYear()->toDateString();
+        // Hire date must be exactly one seniority year behind "today" as the business
+        // clock (SeniorityService) sees it, not the raw UTC now() — otherwise a UTC/
+        // business-timezone day-boundary mismatch can leave the anniversary one day away.
+        $hireDate = Carbon::parse($this->clock->todayInBusinessTz())->subYear()->toDateString();
         $hashedPassword = Hash::make(config('seeders.passwords.employee'));
 
         $branchId = DB::table('branches')->where('code', 'MAIN')->value('id');

--- a/code/api/database/seeders/Testing/CoreTestSeeder.php
+++ b/code/api/database/seeders/Testing/CoreTestSeeder.php
@@ -105,6 +105,7 @@ class CoreTestSeeder extends Seeder
         'payroll.reopen',
         'payroll.reclose',
         'overtime.manage',
+        'vacation-policy.manage',
         'audit-logs.view',
     ];
 
@@ -127,7 +128,7 @@ class CoreTestSeeder extends Seeder
     /** role name => permission name prefixes or exact names */
     private const ROLE_PERMISSIONS = [
         'super-admin' => '*',  // all permissions
-        'admin' => ['users.', 'employees.', 'leaves.', 'vacation-requests.', 'employee-requests.', 'items.', 'inventory_locations.', 'stock.', 'attendances.', 'punctuality.', 'reports.', 'holidays.', 'payroll.', 'overtime.', 'audit-logs.'],
+        'admin' => ['users.', 'employees.', 'leaves.', 'vacation-requests.', 'vacation-policy.', 'employee-requests.', 'items.', 'inventory_locations.', 'stock.', 'attendances.', 'punctuality.', 'reports.', 'holidays.', 'payroll.', 'overtime.', 'audit-logs.'],
         'inventory-manager' => ['items.', 'inventory_locations.', 'stock.', ...self::SELF_SERVICE_REQUESTS],
         'manager' => [...self::BASIC_USER_VIEW, 'employees.', 'leaves.', 'employee-requests.', 'attendances.', 'reports.', '=payroll.preview', '=payroll.close'],
         'cook' => [...self::BASIC_USER_VIEW, ...self::SELF_SERVICE_REQUESTS],

--- a/code/api/routes/api.php
+++ b/code/api/routes/api.php
@@ -49,6 +49,7 @@ use App\Http\Controllers\Api\V1\Employees\SuggestEmployeeCodeController;
 use App\Http\Controllers\Api\V1\Employees\SyncUserDirectPermissionsController;
 use App\Http\Controllers\Api\V1\Employees\ToggleEmployeeActiveController;
 use App\Http\Controllers\Api\V1\Employees\UpdateEmployeeController;
+use App\Http\Controllers\Api\V1\Employees\UpdateEmployeeVacationPolicyController;
 use App\Http\Controllers\Api\V1\Holidays\CreateHolidayController;
 use App\Http\Controllers\Api\V1\Holidays\CreateHolidayDefinitionController;
 use App\Http\Controllers\Api\V1\Holidays\DeleteHolidayController;
@@ -120,6 +121,8 @@ use App\Http\Controllers\Api\V1\UnitsOfMeasure\ListUnitsOfMeasureController;
 use App\Http\Controllers\Api\V1\UnitsOfMeasure\ListUomConversionsController;
 use App\Http\Controllers\Api\V1\UnitsOfMeasure\ShowUnitOfMeasureController;
 use App\Http\Controllers\Api\V1\UnitsOfMeasure\UpdateUnitOfMeasureController;
+use App\Http\Controllers\Api\V1\VacationPolicy\ListVacationPolicyController;
+use App\Http\Controllers\Api\V1\VacationPolicy\UpdateVacationPolicyController;
 use App\Http\Controllers\Api\V1\VacationRequests\ApproveVacationRequestController;
 use App\Http\Controllers\Api\V1\VacationRequests\RegisterVacationRequestController;
 use App\Http\Controllers\Api\V1\VacationRequests\RejectVacationRequestController;
@@ -313,6 +316,8 @@ Route::prefix('v1')->group(function () {
         // balance while filling the self-service form — the controller itself
         // restricts those callers to their own linked employee.
         Route::get('/{employee}/vacation-entitlements', ListVacationEntitlementsController::class)->name('employees.vacation-entitlements.list')->middleware('permission:employees.view|employee-requests.create');
+        // Per-employee vacation policy override (contractual entitlement beyond the tenant default)
+        Route::put('/{employee}/vacation-policy-override', UpdateEmployeeVacationPolicyController::class)->name('employees.vacation-policy-override.update')->middleware('permission:employees.update');
         // Vacation request history endpoints (same self-service scoping as above)
         Route::get('/{employee}/vacation-requests', ListEmployeeVacationRequestsController::class)->name('employees.vacation-requests.list')->middleware('permission:employees.view|employee-requests.create');
         // Overtime bank balance + movement history (same self-service scoping as above)
@@ -432,6 +437,12 @@ Route::prefix('v1')->group(function () {
     Route::middleware('auth:api')->prefix('overtime')->name('overtime.')->group(function () {
         Route::get('/lft-tiers', ListOvertimeLftTiersController::class)->name('lft-tiers.index')->middleware('permission:overtime.manage');
         Route::put('/lft-tiers', UpdateOvertimeLftTiersController::class)->name('lft-tiers.update')->middleware('permission:overtime.manage');
+    });
+
+    // Vacation Policy Settings (tenant-level — All Protected)
+    Route::middleware('auth:api')->prefix('vacation-policy')->name('vacation-policy.')->group(function () {
+        Route::get('/', ListVacationPolicyController::class)->name('index')->middleware('permission:vacation-policy.manage');
+        Route::put('/', UpdateVacationPolicyController::class)->name('update')->middleware('permission:vacation-policy.manage');
     });
 
     // Holidays Module (All Protected — requires holidays.manage)

--- a/code/api/tests/Feature/AttendancePayroll/EmployeeVacationPolicyOverrideApiTest.php
+++ b/code/api/tests/Feature/AttendancePayroll/EmployeeVacationPolicyOverrideApiTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Tests\Feature\AttendancePayroll;
+
+use App\Models\Employee;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+class EmployeeVacationPolicyOverrideApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        app()[PermissionRegistrar::class]->forgetCachedPermissions();
+
+        Permission::create(['name' => 'employees.update', 'guard_name' => 'api']);
+        $admin = Role::create(['name' => 'admin', 'guard_name' => 'api']);
+        $admin->givePermissionTo('employees.update');
+
+        foreach (Employee::POSITION_ROLES as $roleName) {
+            Role::firstOrCreate(['name' => $roleName, 'guard_name' => 'api']);
+        }
+    }
+
+    private function adminUser(): User
+    {
+        $user = User::factory()->create();
+        $user->assignRole('admin');
+
+        return $user;
+    }
+
+    #[Test]
+    public function admin_can_set_a_contractual_override(): void
+    {
+        $employee = Employee::factory()->create();
+        Passport::actingAs($this->adminUser());
+
+        $response = $this->putJson("/api/v1/employees/{$employee->public_id}/vacation-policy-override", [
+            'rule_key' => 'ContractualPolicy',
+            'tiers' => [
+                ['years_from' => 1, 'days' => 30],
+            ],
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.rule_key', 'ContractualPolicy')
+            ->assertJsonPath('data.active_rule_label', 'Política contractual')
+            ->assertJsonCount(1, 'data.tiers');
+
+        $employee->refresh();
+        $this->assertSame('ContractualPolicy', $employee->vacation_entitlement_rule_key);
+        $this->assertSame([['years_from' => 1, 'days' => 30]], $employee->vacation_entitlement_custom_table);
+    }
+
+    #[Test]
+    public function admin_can_clear_the_override_back_to_tenant_default(): void
+    {
+        $employee = Employee::factory()->create([
+            'vacation_entitlement_rule_key' => 'ContractualPolicy',
+            'vacation_entitlement_custom_table' => [['years_from' => 1, 'days' => 30]],
+        ]);
+        Passport::actingAs($this->adminUser());
+
+        $response = $this->putJson("/api/v1/employees/{$employee->public_id}/vacation-policy-override", [
+            'rule_key' => null,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.rule_key', null)
+            ->assertJsonPath('data.active_rule_label', 'LFT México 2022')
+            ->assertJsonCount(0, 'data.tiers');
+
+        $employee->refresh();
+        $this->assertNull($employee->vacation_entitlement_rule_key);
+        $this->assertNull($employee->vacation_entitlement_custom_table);
+    }
+
+    #[Test]
+    public function update_rejects_contractual_policy_without_tiers(): void
+    {
+        $employee = Employee::factory()->create();
+        Passport::actingAs($this->adminUser());
+
+        $this->putJson("/api/v1/employees/{$employee->public_id}/vacation-policy-override", [
+            'rule_key' => 'ContractualPolicy',
+        ])->assertUnprocessable();
+    }
+
+    #[Test]
+    public function update_rejects_duplicate_years_from(): void
+    {
+        $employee = Employee::factory()->create();
+        Passport::actingAs($this->adminUser());
+
+        $this->putJson("/api/v1/employees/{$employee->public_id}/vacation-policy-override", [
+            'rule_key' => 'ContractualPolicy',
+            'tiers' => [
+                ['years_from' => 1, 'days' => 20],
+                ['years_from' => 1, 'days' => 25],
+            ],
+        ])->assertUnprocessable();
+    }
+
+    #[Test]
+    public function update_rejects_an_unknown_rule_key(): void
+    {
+        $employee = Employee::factory()->create();
+        Passport::actingAs($this->adminUser());
+
+        $this->putJson("/api/v1/employees/{$employee->public_id}/vacation-policy-override", [
+            'rule_key' => 'SomethingElse',
+        ])->assertUnprocessable();
+    }
+
+    #[Test]
+    public function unauthenticated_cannot_update_override(): void
+    {
+        $employee = Employee::factory()->create();
+
+        $this->putJson("/api/v1/employees/{$employee->public_id}/vacation-policy-override", [
+            'rule_key' => null,
+        ])->assertUnauthorized();
+    }
+
+    #[Test]
+    public function user_without_permission_cannot_update_override(): void
+    {
+        $employee = Employee::factory()->create();
+        Passport::actingAs(User::factory()->create());
+
+        $this->putJson("/api/v1/employees/{$employee->public_id}/vacation-policy-override", [
+            'rule_key' => null,
+        ])->assertForbidden();
+    }
+}

--- a/code/api/tests/Feature/AttendancePayroll/VacationPolicySettingsApiTest.php
+++ b/code/api/tests/Feature/AttendancePayroll/VacationPolicySettingsApiTest.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace Tests\Feature\AttendancePayroll;
+
+use App\Models\User;
+use App\Models\VacationPolicySetting;
+use App\Models\VacationPolicyTier;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+class VacationPolicySettingsApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        app()[PermissionRegistrar::class]->forgetCachedPermissions();
+
+        Permission::create(['name' => 'vacation-policy.manage', 'guard_name' => 'api']);
+        $admin = Role::create(['name' => 'admin', 'guard_name' => 'api']);
+        $admin->givePermissionTo('vacation-policy.manage');
+    }
+
+    private function adminUser(): User
+    {
+        $user = User::factory()->create();
+        $user->assignRole('admin');
+
+        return $user;
+    }
+
+    // ── GET /api/v1/vacation-policy ─────────────────────────────────────────────
+
+    #[Test]
+    public function it_defaults_to_lft_with_no_tiers_configured(): void
+    {
+        Passport::actingAs($this->adminUser());
+
+        $response = $this->getJson('/api/v1/vacation-policy');
+
+        $response->assertOk()
+            ->assertJsonPath('data.active_rule_key', 'VacationsLFTMX')
+            ->assertJsonPath('data.active_rule_label', 'LFT México 2022')
+            ->assertJsonCount(0, 'data.tiers');
+    }
+
+    #[Test]
+    public function it_lists_the_active_custom_policy_and_its_tiers(): void
+    {
+        VacationPolicySetting::query()->create(['active_rule_key' => 'CustomCompanyPolicy']);
+        VacationPolicyTier::insert([
+            ['public_id' => '01A', 'years_from' => 1, 'days' => 18, 'sort_order' => 1, 'created_at' => now(), 'updated_at' => now()],
+            ['public_id' => '01B', 'years_from' => 5, 'days' => 25, 'sort_order' => 2, 'created_at' => now(), 'updated_at' => now()],
+        ]);
+
+        Passport::actingAs($this->adminUser());
+
+        $response = $this->getJson('/api/v1/vacation-policy');
+
+        $response->assertOk()
+            ->assertJsonPath('data.active_rule_key', 'CustomCompanyPolicy')
+            ->assertJsonPath('data.active_rule_label', 'Política de la empresa')
+            ->assertJsonCount(2, 'data.tiers')
+            ->assertJsonPath('data.tiers.0.years_from', 1)
+            ->assertJsonPath('data.tiers.1.days', 25);
+    }
+
+    #[Test]
+    public function unauthenticated_cannot_view_settings(): void
+    {
+        $this->getJson('/api/v1/vacation-policy')->assertUnauthorized();
+    }
+
+    #[Test]
+    public function user_without_permission_cannot_view_settings(): void
+    {
+        Passport::actingAs(User::factory()->create());
+        $this->getJson('/api/v1/vacation-policy')->assertForbidden();
+    }
+
+    // ── PUT /api/v1/vacation-policy — happy path ────────────────────────────────
+
+    #[Test]
+    public function admin_can_switch_to_a_custom_policy_with_tiers(): void
+    {
+        Passport::actingAs($this->adminUser());
+
+        $response = $this->putJson('/api/v1/vacation-policy', [
+            'active_rule_key' => 'CustomCompanyPolicy',
+            'tiers' => [
+                ['years_from' => 1, 'days' => 18],
+                ['years_from' => 5, 'days' => 25],
+            ],
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.active_rule_key', 'CustomCompanyPolicy')
+            ->assertJsonCount(2, 'data.tiers');
+
+        $this->assertDatabaseCount('vacation_policy_tiers', 2);
+        $this->assertDatabaseHas('vacation_policy_tiers', ['years_from' => 1, 'days' => 18, 'sort_order' => 1]);
+        $this->assertDatabaseHas('vacation_policy_tiers', ['years_from' => 5, 'days' => 25, 'sort_order' => 2]);
+        $this->assertSame('CustomCompanyPolicy', VacationPolicySetting::current()->active_rule_key);
+    }
+
+    #[Test]
+    public function tiers_are_sorted_server_side_regardless_of_input_order(): void
+    {
+        Passport::actingAs($this->adminUser());
+
+        $response = $this->putJson('/api/v1/vacation-policy', [
+            'active_rule_key' => 'CustomCompanyPolicy',
+            'tiers' => [
+                ['years_from' => 5, 'days' => 25],
+                ['years_from' => 1, 'days' => 18],
+            ],
+        ])->assertOk();
+
+        $data = $response->json('data.tiers');
+        $this->assertSame([1, 5], array_column($data, 'years_from'));
+        $this->assertSame([1, 2], array_column($data, 'sort_order'));
+    }
+
+    #[Test]
+    public function admin_can_switch_back_to_lft_without_sending_tiers(): void
+    {
+        VacationPolicySetting::query()->create(['active_rule_key' => 'CustomCompanyPolicy']);
+        VacationPolicyTier::create(['years_from' => 1, 'days' => 18, 'sort_order' => 1]);
+
+        Passport::actingAs($this->adminUser());
+
+        $response = $this->putJson('/api/v1/vacation-policy', ['active_rule_key' => 'VacationsLFTMX']);
+
+        $response->assertOk()->assertJsonPath('data.active_rule_key', 'VacationsLFTMX');
+        $this->assertSame('VacationsLFTMX', VacationPolicySetting::current()->active_rule_key);
+        // Existing custom tiers are preserved (not deleted) so re-enabling later keeps them.
+        $this->assertDatabaseCount('vacation_policy_tiers', 1);
+    }
+
+    // ── PUT — validation ─────────────────────────────────────────────────────────
+
+    #[Test]
+    public function update_rejects_missing_active_rule_key(): void
+    {
+        Passport::actingAs($this->adminUser());
+        $this->putJson('/api/v1/vacation-policy', [])->assertUnprocessable();
+    }
+
+    #[Test]
+    public function update_rejects_unknown_active_rule_key(): void
+    {
+        Passport::actingAs($this->adminUser());
+
+        $this->putJson('/api/v1/vacation-policy', ['active_rule_key' => 'SomethingElse'])
+            ->assertUnprocessable();
+    }
+
+    #[Test]
+    public function update_rejects_custom_policy_without_tiers(): void
+    {
+        Passport::actingAs($this->adminUser());
+
+        $this->putJson('/api/v1/vacation-policy', ['active_rule_key' => 'CustomCompanyPolicy'])
+            ->assertUnprocessable();
+    }
+
+    #[Test]
+    public function update_rejects_duplicate_years_from(): void
+    {
+        Passport::actingAs($this->adminUser());
+
+        $this->putJson('/api/v1/vacation-policy', [
+            'active_rule_key' => 'CustomCompanyPolicy',
+            'tiers' => [
+                ['years_from' => 1, 'days' => 12],
+                ['years_from' => 1, 'days' => 15],
+            ],
+        ])->assertUnprocessable();
+    }
+
+    #[Test]
+    public function update_rejects_non_positive_years_from_or_negative_days(): void
+    {
+        Passport::actingAs($this->adminUser());
+
+        $this->putJson('/api/v1/vacation-policy', [
+            'active_rule_key' => 'CustomCompanyPolicy',
+            'tiers' => [['years_from' => 0, 'days' => -1]],
+        ])->assertUnprocessable();
+    }
+
+    #[Test]
+    public function unauthenticated_cannot_update_settings(): void
+    {
+        $this->putJson('/api/v1/vacation-policy', ['active_rule_key' => 'VacationsLFTMX'])
+            ->assertUnauthorized();
+    }
+
+    #[Test]
+    public function user_without_permission_cannot_update_settings(): void
+    {
+        Passport::actingAs(User::factory()->create());
+
+        $this->putJson('/api/v1/vacation-policy', ['active_rule_key' => 'VacationsLFTMX'])
+            ->assertForbidden();
+    }
+}

--- a/code/api/tests/Feature/Console/TestResetCommandTest.php
+++ b/code/api/tests/Feature/Console/TestResetCommandTest.php
@@ -192,6 +192,41 @@ class TestResetCommandTest extends TestCase
         $this->assertDatabaseMissing('employees', ['code' => 'ADM-001']);
     }
 
+    #[Test]
+    public function attendance_seeder_reads_a_sane_clock_even_if_previously_simulated(): void
+    {
+        // Simulate a stale clock left over from a prior manual "time travel" QA
+        // session, pointing 5 years in the past. AttendanceTestSeeder now derives
+        // its hire date from the ApplicationClock (not raw now()), so if test:reset
+        // didn't truncate application_clock_state, the seeder would wrongly derive
+        // the hire date from this stale simulated instant instead of the real "today".
+        DB::table('application_clock_state')->delete();
+        DB::table('application_clock_state')->insert([
+            'mode' => 'simulated',
+            'base_datetime_utc' => now()->subYears(5),
+            'started_real_datetime_utc' => now(),
+            'timezone' => 'America/Mexico_City',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->artisan('test:reset', ['--seeders' => 'attendance'])->assertExitCode(0);
+
+        // The clock table gets truncated and reset to its sane SYSTEM default.
+        $this->assertDatabaseHas('application_clock_state', ['id' => 1, 'mode' => 'system']);
+
+        // EMP-001's hire date must be exactly one seniority year behind the real
+        // "today" in business tz — not the stale simulated date from 5 years ago.
+        $businessTz = config('app.business_timezone', 'America/Mexico_City');
+        $expectedHireDate = now($businessTz)->subYear()->toDateString();
+        $employeeId = DB::table('employees')->where('code', 'EMP-001')->value('id');
+
+        $this->assertDatabaseHas('employment_periods', [
+            'employee_id' => $employeeId,
+            'start_date' => $expectedHireDate,
+        ]);
+    }
+
     // ── Test artifact cleanup ──────────────────────────────────────────────
 
     #[Test]

--- a/code/api/tests/Unit/Services/CustomVacationPolicyTest.php
+++ b/code/api/tests/Unit/Services/CustomVacationPolicyTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\VacationRules\CustomVacationPolicy;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class CustomVacationPolicyTest extends TestCase
+{
+    private function policy(?array $tiers = null): CustomVacationPolicy
+    {
+        $tiers ??= [
+            ['years_from' => 1, 'days' => 15],
+            ['years_from' => 3, 'days' => 20],
+            ['years_from' => 6, 'days' => 25],
+        ];
+
+        return new CustomVacationPolicy($tiers, 'Política de la empresa', 'CustomCompanyPolicy');
+    }
+
+    #[Test]
+    public function it_returns_days_from_the_matching_tier(): void
+    {
+        $policy = $this->policy();
+
+        $this->assertSame(15, $policy->calculate(1));
+        $this->assertSame(15, $policy->calculate(2));
+        $this->assertSame(20, $policy->calculate(3));
+        $this->assertSame(20, $policy->calculate(5));
+        $this->assertSame(25, $policy->calculate(6));
+        $this->assertSame(25, $policy->calculate(50));
+    }
+
+    #[Test]
+    public function it_returns_zero_when_years_are_below_the_lowest_tier(): void
+    {
+        $policy = $this->policy([
+            ['years_from' => 2, 'days' => 15],
+        ]);
+
+        $this->assertSame(0, $policy->calculate(1));
+    }
+
+    #[Test]
+    public function it_returns_zero_for_an_empty_table(): void
+    {
+        $policy = $this->policy([]);
+
+        $this->assertSame(0, $policy->calculate(5));
+    }
+
+    #[Test]
+    public function it_ignores_tier_input_order(): void
+    {
+        $ordered = $this->policy([
+            ['years_from' => 1, 'days' => 12],
+            ['years_from' => 5, 'days' => 20],
+        ]);
+
+        $shuffled = $this->policy([
+            ['years_from' => 5, 'days' => 20],
+            ['years_from' => 1, 'days' => 12],
+        ]);
+
+        $this->assertSame($ordered->calculate(7), $shuffled->calculate(7));
+    }
+
+    #[Test]
+    public function it_exposes_the_injected_label_and_key(): void
+    {
+        $policy = new CustomVacationPolicy([], 'Política contractual', 'ContractualPolicy');
+
+        $this->assertSame('Política contractual', $policy->label());
+        $this->assertSame('ContractualPolicy', $policy->key());
+    }
+
+    #[Test]
+    public function it_builds_a_display_table_with_closed_and_open_ended_ranges(): void
+    {
+        $policy = $this->policy();
+
+        $this->assertSame([
+            ['years' => '1–2', 'days' => 15],
+            ['years' => '3–5', 'days' => 20],
+            ['years' => '6+', 'days' => 25],
+        ], $policy->table());
+    }
+
+    #[Test]
+    public function it_collapses_adjacent_single_year_tiers_in_the_display_table(): void
+    {
+        $policy = $this->policy([
+            ['years_from' => 1, 'days' => 12],
+            ['years_from' => 2, 'days' => 14],
+        ]);
+
+        $this->assertSame([
+            ['years' => '1', 'days' => 12],
+            ['years' => '2+', 'days' => 14],
+        ], $policy->table());
+    }
+
+    #[Test]
+    public function it_returns_an_empty_display_table_for_no_tiers(): void
+    {
+        $this->assertSame([], $this->policy([])->table());
+    }
+}

--- a/code/api/tests/Unit/Services/SeniorityServiceTest.php
+++ b/code/api/tests/Unit/Services/SeniorityServiceTest.php
@@ -9,7 +9,7 @@ use App\Models\Branch;
 use App\Models\Employee;
 use App\Models\EmploymentPeriod;
 use App\Services\SeniorityService;
-use App\Services\VacationRules\VacationsLFTMX;
+use App\Services\VacationEntitlementResolver;
 use App\Support\Clock\ApplicationClock;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -35,7 +35,7 @@ class SeniorityServiceTest extends TestCase
 
         $this->branch = Branch::factory()->create();
 
-        $this->service = new SeniorityService(new VacationsLFTMX, app(ApplicationClock::class));
+        $this->service = new SeniorityService(new VacationEntitlementResolver, app(ApplicationClock::class));
     }
 
     private function employeeWithPeriod(string $startDate, bool $active = true): Employee

--- a/code/api/tests/Unit/Services/VacationEntitlementResolverTest.php
+++ b/code/api/tests/Unit/Services/VacationEntitlementResolverTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Employee;
+use App\Models\VacationPolicySetting;
+use App\Models\VacationPolicyTier;
+use App\Services\VacationEntitlementResolver;
+use App\Services\VacationRules\CustomVacationPolicy;
+use App\Services\VacationRules\VacationsLFTMX;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class VacationEntitlementResolverTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private VacationEntitlementResolver $resolver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        foreach (Employee::POSITION_ROLES as $role) {
+            Role::firstOrCreate(['name' => $role, 'guard_name' => 'api']);
+        }
+
+        $this->resolver = new VacationEntitlementResolver;
+    }
+
+    #[Test]
+    public function it_resolves_lft_by_default_with_no_settings_configured(): void
+    {
+        $employee = Employee::factory()->create();
+
+        $rule = $this->resolver->resolve($employee);
+
+        $this->assertInstanceOf(VacationsLFTMX::class, $rule);
+        $this->assertSame('VacationsLFTMX', $rule->key());
+    }
+
+    #[Test]
+    public function it_resolves_the_tenant_custom_policy_when_active_and_tiers_exist(): void
+    {
+        VacationPolicySetting::query()->create(['active_rule_key' => 'CustomCompanyPolicy']);
+        VacationPolicyTier::create(['years_from' => 1, 'days' => 18, 'sort_order' => 1]);
+        VacationPolicyTier::create(['years_from' => 5, 'days' => 25, 'sort_order' => 2]);
+
+        $employee = Employee::factory()->create();
+
+        $rule = $this->resolver->resolve($employee);
+
+        $this->assertInstanceOf(CustomVacationPolicy::class, $rule);
+        $this->assertSame('CustomCompanyPolicy', $rule->key());
+        $this->assertSame(18, $rule->calculate(1));
+        $this->assertSame(25, $rule->calculate(5));
+    }
+
+    #[Test]
+    public function it_falls_back_to_lft_when_custom_policy_is_active_but_has_no_tiers(): void
+    {
+        VacationPolicySetting::query()->create(['active_rule_key' => 'CustomCompanyPolicy']);
+
+        $employee = Employee::factory()->create();
+
+        $rule = $this->resolver->resolve($employee);
+
+        $this->assertInstanceOf(VacationsLFTMX::class, $rule);
+    }
+
+    #[Test]
+    public function employee_contractual_override_takes_precedence_over_tenant_custom_policy(): void
+    {
+        VacationPolicySetting::query()->create(['active_rule_key' => 'CustomCompanyPolicy']);
+        VacationPolicyTier::create(['years_from' => 1, 'days' => 18, 'sort_order' => 1]);
+
+        $employee = Employee::factory()->create([
+            'vacation_entitlement_rule_key' => 'ContractualPolicy',
+            'vacation_entitlement_custom_table' => [
+                ['years_from' => 1, 'days' => 30],
+            ],
+        ]);
+
+        $rule = $this->resolver->resolve($employee);
+
+        $this->assertInstanceOf(CustomVacationPolicy::class, $rule);
+        $this->assertSame('ContractualPolicy', $rule->key());
+        $this->assertSame(30, $rule->calculate(1));
+    }
+
+    #[Test]
+    public function employee_override_key_without_a_table_falls_back_to_tenant_resolution(): void
+    {
+        $employee = Employee::factory()->create([
+            'vacation_entitlement_rule_key' => 'ContractualPolicy',
+            'vacation_entitlement_custom_table' => null,
+        ]);
+
+        $rule = $this->resolver->resolve($employee);
+
+        $this->assertInstanceOf(VacationsLFTMX::class, $rule);
+    }
+}

--- a/code/webapp/cypress/e2e/vacation-policy-settings.cy.ts
+++ b/code/webapp/cypress/e2e/vacation-policy-settings.cy.ts
@@ -11,12 +11,19 @@
  * auto-generates a year-1 VacationEntitlement using whichever policy is
  * active). 'core' alone has no employees.
  *
- * Happy path:
+ * Happy path (tenant-wide policy):
  *   1. Admin opens /configuracion → "Vacaciones" tab. LFT is selected by default.
  *   2. Admin switches to "Política personalizada", defines a custom table, saves.
  *   3. The change survives a page reload.
  *   4. EMP-001's Vacaciones section badge shows "Política de la empresa" and the
  *      auto-generated year-1 entitlement uses the custom day count.
+ *
+ * Happy path (per-employee override, EMP-002 to avoid clashing with EMP-001 above):
+ *   1. No contractual override by default — checkbox unchecked, no tiers editor.
+ *   2. Admin enables "Política contractual", defines a table, saves — badge
+ *      switches to "Política contractual" and takes precedence over the tenant policy.
+ *   3. The override survives a page reload.
+ *   4. Admin unchecks the override — it falls back to the tenant default policy.
  *
  * For running only this file:
  *   make cypress-spec SPEC=vacation-policy-settings
@@ -87,5 +94,84 @@ describe('Vacation Policy Settings — admin happy path', () => {
         cy.contains('Política de la empresa').should('be.visible')
         cy.contains('tr', '2026').should('contain.text', '20')
       })
+  })
+})
+
+function openEmp002VacationSection() {
+  cy.visitWithAuth('/employees')
+  cy.contains('tr', 'EMP-002', { timeout: 10_000 })
+  cy.closeDevDebugger()
+
+  cy.contains('tr', 'EMP-002').find('button[title="Ver detalle"]').click()
+  cy.contains('h2', 'Detalle de Empleado', { timeout: 10_000 }).should('be.visible')
+  cy.closeDevDebugger()
+
+  cy.get('[data-testid="vacation-section"]', { timeout: 10_000 }).scrollIntoView()
+}
+
+// The checkbox label always reads "Política contractual" regardless of state,
+// so assertions must target the rule badge (sibling of the "Vacaciones" <h3>)
+// specifically rather than matching that text anywhere in the section.
+function vacationRuleBadge() {
+  return cy.get('[data-testid="vacation-section"] h3').parent().find('span').scrollIntoView()
+}
+
+describe('Employee Vacation Policy Override — admin happy path', () => {
+  beforeEach(() => {
+    cy.loginByApi(adminEmail, adminPassword)
+  })
+
+  it('starts without a contractual override', () => {
+    openEmp002VacationSection()
+
+    vacationRuleBadge().should('not.contain.text', 'Política contractual')
+    cy.get('[data-testid="vacation-section"]').within(() => {
+      cy.contains('label', 'Política contractual')
+        .find('input[type="checkbox"]')
+        .should('not.be.checked')
+    })
+    cy.get('[data-testid="vacation-section"]').contains('button', 'Agregar tramo').should('not.exist')
+  })
+
+  it('enables a contractual override, defines a table, and saves', () => {
+    openEmp002VacationSection()
+
+    cy.get('[data-testid="vacation-section"]')
+      .contains('label', 'Política contractual')
+      .find('input[type="checkbox"]')
+      .click()
+
+    cy.get('[data-testid="vacation-section"]').contains('button', 'Agregar tramo').should('be.visible')
+    cy.get('[data-testid="vacation-section"] input[name="tiers.0.days"]').clear().type('30')
+
+    cy.get('[data-testid="vacation-section"]').contains('button', 'Guardar cambios').click()
+    cy.contains('Política de vacaciones del empleado actualizada', { timeout: 10_000 }).should('be.visible')
+
+    vacationRuleBadge().should('contain.text', 'Política contractual')
+  })
+
+  it('persists the override — and its precedence over the tenant policy — after a page reload', () => {
+    openEmp002VacationSection()
+
+    vacationRuleBadge().should('contain.text', 'Política contractual')
+    cy.get('[data-testid="vacation-section"]').within(() => {
+      cy.contains('label', 'Política contractual')
+        .find('input[type="checkbox"]')
+        .should('be.checked')
+      cy.get('input[name="tiers.0.days"]').should('have.value', '30')
+    })
+  })
+
+  it('clears the override back to the tenant default policy', () => {
+    openEmp002VacationSection()
+
+    cy.get('[data-testid="vacation-section"]')
+      .contains('label', 'Política contractual')
+      .find('input[type="checkbox"]')
+      .click()
+    cy.get('[data-testid="vacation-section"]').contains('button', 'Guardar cambios').click()
+    cy.contains('Política de vacaciones del empleado actualizada', { timeout: 10_000 }).should('be.visible')
+
+    vacationRuleBadge().should('not.contain.text', 'Política contractual')
   })
 })

--- a/code/webapp/cypress/e2e/vacation-policy-settings.cy.ts
+++ b/code/webapp/cypress/e2e/vacation-policy-settings.cy.ts
@@ -1,0 +1,91 @@
+/**
+ * Vacation Policy Settings — E2E happy path (Task #214)
+ *
+ * Verifies that an admin can switch the tenant-wide vacation entitlement rule
+ * from the LFT México 2022 default to a custom company policy with its own
+ * years→days table, and that the change is reflected both in the settings
+ * screen and in an employee's Vacaciones section.
+ *
+ * Seeder group: 'attendance' (AttendanceTestSeeder — seeds EMP-001 with a
+ * 1-year-old employment period, which reaches its first anniversary and
+ * auto-generates a year-1 VacationEntitlement using whichever policy is
+ * active). 'core' alone has no employees.
+ *
+ * Happy path:
+ *   1. Admin opens /configuracion → "Vacaciones" tab. LFT is selected by default.
+ *   2. Admin switches to "Política personalizada", defines a custom table, saves.
+ *   3. The change survives a page reload.
+ *   4. EMP-001's Vacaciones section badge shows "Política de la empresa" and the
+ *      auto-generated year-1 entitlement uses the custom day count.
+ *
+ * For running only this file:
+ *   make cypress-spec SPEC=vacation-policy-settings
+ *   make cypress-debug SPEC=vacation-policy-settings
+ */
+
+import users from '../fixtures/users.json'
+
+const { email: adminEmail, password: adminPassword } = users.admin
+
+function visitVacacionesTab() {
+  cy.visitWithAuth('/configuracion')
+  cy.closeDevDebugger()
+  cy.contains('nav button', 'Vacaciones').click()
+}
+
+before(() => {
+  cy.task('test:reset', 'attendance', { timeout: 60_000 })
+})
+
+describe('Vacation Policy Settings — admin happy path', () => {
+  beforeEach(() => {
+    cy.loginByApi(adminEmail, adminPassword)
+  })
+
+  it('opens the Vacaciones tab with LFT selected and no tiers editor', () => {
+    visitVacacionesTab()
+    cy.contains('Reglas aplicables', { timeout: 10_000 }).should('be.visible')
+
+    cy.get('input[type="radio"][value="VacationsLFTMX"]').should('be.checked')
+    cy.contains('button', 'Agregar tramo').should('not.exist')
+  })
+
+  it('switches to a custom policy, defines a table, and saves', () => {
+    visitVacacionesTab()
+    cy.contains('Reglas aplicables', { timeout: 10_000 }).should('be.visible')
+
+    cy.get('input[type="radio"][value="CustomCompanyPolicy"]').click()
+    cy.contains('button', 'Agregar tramo').should('be.visible')
+
+    // Default row: years_from=1, days=12 — bump days to 20 for a visibly different policy
+    cy.get('input[name="tiers.0.days"]').clear().type('20')
+
+    cy.contains('button', 'Guardar cambios').click()
+    cy.contains('Política de vacaciones actualizada', { timeout: 10_000 }).should('be.visible')
+  })
+
+  it('persists the custom policy after a page reload', () => {
+    visitVacacionesTab()
+    cy.contains('Reglas aplicables', { timeout: 10_000 }).should('be.visible')
+
+    cy.get('input[type="radio"][value="CustomCompanyPolicy"]').should('be.checked')
+    cy.get('input[name="tiers.0.days"]').should('have.value', '20')
+  })
+
+  it("reflects the custom policy on EMP-001's Vacaciones section", () => {
+    cy.visitWithAuth('/employees')
+    cy.contains('tr', 'EMP-001', { timeout: 10_000 })
+    cy.closeDevDebugger()
+
+    cy.contains('tr', 'EMP-001').find('button[title="Ver detalle"]').click()
+    cy.contains('h2', 'Detalle de Empleado', { timeout: 10_000 }).should('be.visible')
+    cy.closeDevDebugger()
+
+    cy.get('[data-testid="vacation-section"]', { timeout: 10_000 })
+      .scrollIntoView()
+      .within(() => {
+        cy.contains('Política de la empresa').should('be.visible')
+        cy.contains('tr', '2026').should('contain.text', '20')
+      })
+  })
+})

--- a/code/webapp/cypress/e2e/vacation-policy-settings.cy.ts
+++ b/code/webapp/cypress/e2e/vacation-policy-settings.cy.ts
@@ -36,6 +36,7 @@ const { email: adminEmail, password: adminPassword } = users.admin
 
 function visitVacacionesTab() {
   cy.visitWithAuth('/configuracion')
+  cy.url().should('include', '/configuracion', { timeout: 10_000 })
   cy.closeDevDebugger()
   cy.contains('nav button', 'Vacaciones').click()
 }

--- a/code/webapp/src/components/employees/__tests__/employee-columns.test.tsx
+++ b/code/webapp/src/components/employees/__tests__/employee-columns.test.tsx
@@ -13,6 +13,8 @@ const mockEmployee: Employee = {
     last_name: 'Pérez',
     is_active: true,
     attendance_exempt: false,
+    vacation_entitlement_rule_key: null,
+    vacation_entitlement_custom_table: null,
     has_active_period: true,
     has_user: true,
     roles: ['manager', 'cook'] as EmployeePositionRole[],

--- a/code/webapp/src/components/employees/__tests__/employee-info-header.test.tsx
+++ b/code/webapp/src/components/employees/__tests__/employee-info-header.test.tsx
@@ -20,6 +20,8 @@ const mockEmployee: Employee = {
     phone_country: '+1',
     is_active: true,
     attendance_exempt: false,
+    vacation_entitlement_rule_key: null,
+    vacation_entitlement_custom_table: null,
     has_user: true,
     roles: ['manager', 'cook'],
     meta: null,

--- a/code/webapp/src/components/employees/__tests__/schedule-section.test.tsx
+++ b/code/webapp/src/components/employees/__tests__/schedule-section.test.tsx
@@ -108,6 +108,8 @@ const mockEmployee: Employee = {
   roles: ['cook'],
   is_active: true,
   attendance_exempt: false,
+  vacation_entitlement_rule_key: null,
+  vacation_entitlement_custom_table: null,
   has_user: false,
   meta: null,
   employment_periods: [

--- a/code/webapp/src/components/employees/__tests__/use-employee-detail-actions.test.ts
+++ b/code/webapp/src/components/employees/__tests__/use-employee-detail-actions.test.ts
@@ -31,6 +31,8 @@ const mockEmployee: Employee = {
     roles: ['cook'] as EmployeePositionRole[],
     is_active: true,
     attendance_exempt: false,
+    vacation_entitlement_rule_key: null,
+    vacation_entitlement_custom_table: null,
     has_active_period: true,
     has_user: false,
     meta: null,

--- a/code/webapp/src/components/employees/__tests__/use-employee-form.test.ts
+++ b/code/webapp/src/components/employees/__tests__/use-employee-form.test.ts
@@ -40,6 +40,8 @@ const mockEmployee: Employee = {
   phone: null,
   is_active: true,
   attendance_exempt: false,
+  vacation_entitlement_rule_key: null,
+  vacation_entitlement_custom_table: null,
   has_user: true,
   roles: [],
   meta: null,

--- a/code/webapp/src/components/employees/__tests__/vacation-policy-override.test.tsx
+++ b/code/webapp/src/components/employees/__tests__/vacation-policy-override.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import React from 'react'
+import type { Employee } from '@/types/employee'
+
+const mockUpdateOverride = vi.fn()
+const mockShowSuccess = vi.fn()
+const mockShowError = vi.fn()
+
+vi.mock('@/services/employee-vacation-policy-api', () => ({
+  employeeVacationPolicyApi: {
+    updateOverride: (...args: unknown[]) => mockUpdateOverride(...args),
+  },
+}))
+
+vi.mock('@/components/ui/toast-context', () => ({
+  useToast: () => ({ showSuccess: mockShowSuccess, showError: mockShowError }),
+}))
+
+import { VacationPolicyOverride } from '../vacation-policy-override'
+
+function makeWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children)
+}
+
+const baseEmployee = {
+  id: 'emp-001',
+  vacation_entitlement_rule_key: null,
+  vacation_entitlement_custom_table: null,
+} as Pick<Employee, 'id' | 'vacation_entitlement_rule_key' | 'vacation_entitlement_custom_table'>
+
+function renderOverride(employee = baseEmployee) {
+  return render(<VacationPolicyOverride employee={employee} />, { wrapper: makeWrapper() })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('VacationPolicyOverride', () => {
+  it('starts unchecked and hides the tiers editor when there is no override', () => {
+    renderOverride()
+
+    const toggle = screen.getByLabelText('Política contractual') as HTMLInputElement
+    expect(toggle.checked).toBe(false)
+    expect(screen.queryByText('Agregar tramo')).toBeNull()
+  })
+
+  it('shows the tiers editor pre-filled when an override already exists', () => {
+    renderOverride({
+      id: 'emp-001',
+      vacation_entitlement_rule_key: 'ContractualPolicy',
+      vacation_entitlement_custom_table: [{ years_from: 1, days: 30 }],
+    })
+
+    const toggle = screen.getByLabelText('Política contractual') as HTMLInputElement
+    expect(toggle.checked).toBe(true)
+    expect(screen.getAllByLabelText('Eliminar tramo').length).toBe(1)
+  })
+
+  it('reveals the tiers editor when the toggle is turned on', () => {
+    renderOverride()
+
+    fireEvent.click(screen.getByLabelText('Política contractual'))
+
+    expect(screen.getAllByLabelText('Eliminar tramo').length).toBeGreaterThan(0)
+  })
+
+  it('submits the override with rule_key and tiers when enabled', async () => {
+    mockUpdateOverride.mockResolvedValue({
+      data: { data: { rule_key: 'ContractualPolicy', tiers: [{ years_from: 1, days: 30 }], active_rule_label: 'Política contractual' } },
+    })
+    renderOverride()
+
+    fireEvent.click(screen.getByLabelText('Política contractual'))
+
+    const submitButton = screen.getByText('Guardar cambios').closest('button')
+    await waitFor(() => expect(submitButton?.disabled).toBe(false))
+    fireEvent.click(submitButton!)
+
+    await waitFor(() => expect(mockUpdateOverride).toHaveBeenCalledWith('emp-001', {
+      rule_key: 'ContractualPolicy',
+      tiers: [{ years_from: 1, days: 12 }],
+    }))
+  })
+
+  it('submits rule_key null when turning the override off', async () => {
+    mockUpdateOverride.mockResolvedValue({
+      data: { data: { rule_key: null, tiers: [], active_rule_label: 'LFT México 2022' } },
+    })
+    renderOverride({
+      id: 'emp-001',
+      vacation_entitlement_rule_key: 'ContractualPolicy',
+      vacation_entitlement_custom_table: [{ years_from: 1, days: 30 }],
+    })
+
+    fireEvent.click(screen.getByLabelText('Política contractual'))
+
+    const submitButton = screen.getByText('Guardar cambios').closest('button')
+    await waitFor(() => expect(submitButton?.disabled).toBe(false))
+    fireEvent.click(submitButton!)
+
+    await waitFor(() => expect(mockUpdateOverride).toHaveBeenCalledWith('emp-001', {
+      rule_key: null,
+      tiers: undefined,
+    }))
+  })
+})

--- a/code/webapp/src/components/employees/__tests__/vacation-section.test.tsx
+++ b/code/webapp/src/components/employees/__tests__/vacation-section.test.tsx
@@ -75,6 +75,17 @@ describe('VacationSection', () => {
     expect(screen.getByText('LFT México 2022')).toBeTruthy()
   })
 
+  it('shows the active rule label from summary once loaded', () => {
+    mockState = {
+      ...mockState,
+      summary: { seniority_years: 2, next_anniversary_date: null, active_rule_label: 'Política de la empresa' },
+    }
+    render(<VacationSection employeeId="emp-001" />)
+
+    expect(screen.getByText('Política de la empresa')).toBeTruthy()
+    expect(screen.queryByText('LFT México 2022')).toBeNull()
+  })
+
   it('shows empty state when no entitlements', () => {
     render(<VacationSection employeeId="emp-001" />)
 
@@ -132,7 +143,7 @@ describe('VacationSection', () => {
   it('shows seniority years and next anniversary date when summary is present', () => {
     mockState = {
       ...mockState,
-      summary: { seniority_years: 2, next_anniversary_date: '2027-03-15' },
+      summary: { seniority_years: 2, next_anniversary_date: '2027-03-15', active_rule_label: 'LFT México 2022' },
     }
     render(<VacationSection employeeId="emp-001" />)
 
@@ -143,7 +154,7 @@ describe('VacationSection', () => {
   it('uses singular wording for a single year of seniority', () => {
     mockState = {
       ...mockState,
-      summary: { seniority_years: 1, next_anniversary_date: null },
+      summary: { seniority_years: 1, next_anniversary_date: null, active_rule_label: 'LFT México 2022' },
     }
     render(<VacationSection employeeId="emp-001" />)
 

--- a/code/webapp/src/components/employees/use-vacation-policy-override.ts
+++ b/code/webapp/src/components/employees/use-vacation-policy-override.ts
@@ -61,8 +61,7 @@ export function useVacationPolicyOverride(employee: OverrideEmployee) {
         ? employee.vacation_entitlement_custom_table
         : [DEFAULT_TIER],
     })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [employee.id, employee.vacation_entitlement_rule_key, reset])
+  }, [employee.id, employee.vacation_entitlement_rule_key, employee.vacation_entitlement_custom_table, reset])
 
   const enabled = watch('enabled')
 

--- a/code/webapp/src/components/employees/use-vacation-policy-override.ts
+++ b/code/webapp/src/components/employees/use-vacation-policy-override.ts
@@ -1,0 +1,91 @@
+import { useEffect } from 'react'
+import { useForm, useFieldArray, type SubmitHandler } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { useUpdateEmployeeVacationPolicy } from '@/services/employee-vacation-policy-hooks'
+import type { Employee } from '@/types/employee'
+
+const tierSchema = z.object({
+  years_from: z.number().int().min(1),
+  days: z.number().int().min(0),
+})
+
+export const overrideSchema = z
+  .object({
+    enabled: z.boolean(),
+    tiers: z.array(tierSchema),
+  })
+  .superRefine(({ enabled, tiers }, ctx) => {
+    if (!enabled) return
+
+    if (tiers.length === 0) {
+      ctx.addIssue({ code: 'custom', path: ['tiers'], message: 'Agrega al menos un tramo' })
+      return
+    }
+
+    const seen = new Set<number>()
+    tiers.forEach((tier, i) => {
+      if (seen.has(tier.years_from)) {
+        ctx.addIssue({ code: 'custom', path: ['tiers', i, 'years_from'], message: 'Debe ser único' })
+      }
+      seen.add(tier.years_from)
+    })
+  })
+
+export type OverrideFormValues = z.infer<typeof overrideSchema>
+
+const DEFAULT_TIER = { years_from: 1, days: 12 }
+
+type OverrideEmployee = Pick<Employee, 'id' | 'vacation_entitlement_rule_key' | 'vacation_entitlement_custom_table'>
+
+export function useVacationPolicyOverride(employee: OverrideEmployee) {
+  const update = useUpdateEmployeeVacationPolicy(employee.id)
+
+  const form = useForm<OverrideFormValues>({
+    resolver: zodResolver(overrideSchema),
+    defaultValues: {
+      enabled: employee.vacation_entitlement_rule_key === 'ContractualPolicy',
+      tiers: employee.vacation_entitlement_custom_table && employee.vacation_entitlement_custom_table.length > 0
+        ? employee.vacation_entitlement_custom_table
+        : [DEFAULT_TIER],
+    },
+  })
+
+  const { reset, watch } = form
+  const { fields, append, remove } = useFieldArray({ control: form.control, name: 'tiers' })
+
+  useEffect(() => {
+    reset({
+      enabled: employee.vacation_entitlement_rule_key === 'ContractualPolicy',
+      tiers: employee.vacation_entitlement_custom_table && employee.vacation_entitlement_custom_table.length > 0
+        ? employee.vacation_entitlement_custom_table
+        : [DEFAULT_TIER],
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [employee.id, employee.vacation_entitlement_rule_key, reset])
+
+  const enabled = watch('enabled')
+
+  const onSubmit: SubmitHandler<OverrideFormValues> = (values) => {
+    update.mutate({
+      rule_key: values.enabled ? 'ContractualPolicy' : null,
+      tiers: values.enabled ? values.tiers : undefined,
+    })
+  }
+
+  const addRow = () => {
+    const lastIndex = fields.length - 1
+    const lastYearsFrom = form.getValues(`tiers.${lastIndex}.years_from`) ?? 0
+    append({ years_from: lastYearsFrom + 1, days: 0 })
+  }
+
+  return {
+    form,
+    fields,
+    remove,
+    addRow,
+    onSubmit,
+    enabled,
+    isPending: update.isPending,
+  }
+}

--- a/code/webapp/src/components/employees/vacation-policy-override.tsx
+++ b/code/webapp/src/components/employees/vacation-policy-override.tsx
@@ -1,0 +1,99 @@
+import { Trash2, Plus } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import type { Employee } from '@/types/employee'
+import { useVacationPolicyOverride } from './use-vacation-policy-override'
+
+interface VacationPolicyOverrideProps {
+  readonly employee: Pick<Employee, 'id' | 'vacation_entitlement_rule_key' | 'vacation_entitlement_custom_table'>
+}
+
+export function VacationPolicyOverride({ employee }: VacationPolicyOverrideProps) {
+  const { form, fields, remove, addRow, onSubmit, enabled, isPending } = useVacationPolicyOverride(employee)
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isDirty },
+  } = form
+
+  return (
+    <div className="space-y-3 rounded-lg border border-border p-4">
+      <label className="flex items-center gap-2 text-sm font-medium">
+        <input type="checkbox" {...register('enabled')} />
+        Política contractual
+      </label>
+      <p className="text-xs text-muted-foreground">
+        Activa para otorgar a este empleado un derecho vacacional distinto al de la política de la
+        empresa, tomando precedencia sobre ella.
+      </p>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
+        {enabled && (
+          <div className="space-y-3">
+            <div className="grid grid-cols-[1fr_1fr_40px] gap-3 px-2 text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              <span>Desde año</span>
+              <span>Días</span>
+              <span />
+            </div>
+
+            {fields.map((field, index) => (
+              <div
+                key={field.id}
+                className="grid grid-cols-[1fr_1fr_40px] gap-3 items-start rounded-lg border bg-card px-3 py-2"
+              >
+                <div>
+                  <Input
+                    type="number"
+                    min={1}
+                    step={1}
+                    {...register(`tiers.${index}.years_from`, { valueAsNumber: true })}
+                  />
+                  {errors.tiers?.[index]?.years_from && (
+                    <p className="mt-1 text-xs text-red-600">{errors.tiers[index]?.years_from?.message}</p>
+                  )}
+                </div>
+
+                <div>
+                  <Input
+                    type="number"
+                    min={0}
+                    step={1}
+                    {...register(`tiers.${index}.days`, { valueAsNumber: true })}
+                  />
+                  {errors.tiers?.[index]?.days && (
+                    <p className="mt-1 text-xs text-red-600">{errors.tiers[index]?.days?.message}</p>
+                  )}
+                </div>
+
+                <div className="flex items-center justify-center h-9">
+                  <button
+                    type="button"
+                    onClick={() => remove(index)}
+                    disabled={fields.length === 1}
+                    aria-label="Eliminar tramo"
+                    title="Eliminar tramo"
+                    className="text-muted-foreground hover:text-destructive disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </div>
+              </div>
+            ))}
+
+            <Button type="button" variant="outline" size="sm" onClick={addRow}>
+              <Plus className="h-4 w-4 mr-1" />
+              Agregar tramo
+            </Button>
+          </div>
+        )}
+
+        <div>
+          <Button type="submit" size="sm" disabled={!isDirty || isPending}>
+            {isPending ? 'Guardando...' : 'Guardar cambios'}
+          </Button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/code/webapp/src/components/employees/vacation-policy-override.tsx
+++ b/code/webapp/src/components/employees/vacation-policy-override.tsx
@@ -1,7 +1,10 @@
-import { Trash2, Plus } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
+import {
+  VacationPolicyTiersEditor,
+  type VacationPolicyTiersFormValues,
+} from '@/components/vacation-policy/vacation-policy-tiers-editor'
 import type { Employee } from '@/types/employee'
+import type { FieldArrayWithId, FieldErrors, UseFormRegister } from 'react-hook-form'
 import { useVacationPolicyOverride } from './use-vacation-policy-override'
 
 interface VacationPolicyOverrideProps {
@@ -20,7 +23,7 @@ export function VacationPolicyOverride({ employee }: VacationPolicyOverrideProps
   return (
     <div className="space-y-3 rounded-lg border border-border p-4">
       <label className="flex items-center gap-2 text-sm font-medium">
-        <input type="checkbox" {...register('enabled')} />
+        <input type="checkbox" {...register('enabled')} />{' '}
         Política contractual
       </label>
       <p className="text-xs text-muted-foreground">
@@ -30,62 +33,13 @@ export function VacationPolicyOverride({ employee }: VacationPolicyOverrideProps
 
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
         {enabled && (
-          <div className="space-y-3">
-            <div className="grid grid-cols-[1fr_1fr_40px] gap-3 px-2 text-xs font-medium text-muted-foreground uppercase tracking-wide">
-              <span>Desde año</span>
-              <span>Días</span>
-              <span />
-            </div>
-
-            {fields.map((field, index) => (
-              <div
-                key={field.id}
-                className="grid grid-cols-[1fr_1fr_40px] gap-3 items-start rounded-lg border bg-card px-3 py-2"
-              >
-                <div>
-                  <Input
-                    type="number"
-                    min={1}
-                    step={1}
-                    {...register(`tiers.${index}.years_from`, { valueAsNumber: true })}
-                  />
-                  {errors.tiers?.[index]?.years_from && (
-                    <p className="mt-1 text-xs text-red-600">{errors.tiers[index]?.years_from?.message}</p>
-                  )}
-                </div>
-
-                <div>
-                  <Input
-                    type="number"
-                    min={0}
-                    step={1}
-                    {...register(`tiers.${index}.days`, { valueAsNumber: true })}
-                  />
-                  {errors.tiers?.[index]?.days && (
-                    <p className="mt-1 text-xs text-red-600">{errors.tiers[index]?.days?.message}</p>
-                  )}
-                </div>
-
-                <div className="flex items-center justify-center h-9">
-                  <button
-                    type="button"
-                    onClick={() => remove(index)}
-                    disabled={fields.length === 1}
-                    aria-label="Eliminar tramo"
-                    title="Eliminar tramo"
-                    className="text-muted-foreground hover:text-destructive disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </button>
-                </div>
-              </div>
-            ))}
-
-            <Button type="button" variant="outline" size="sm" onClick={addRow}>
-              <Plus className="h-4 w-4 mr-1" />
-              Agregar tramo
-            </Button>
-          </div>
+          <VacationPolicyTiersEditor
+            fields={fields as unknown as FieldArrayWithId<VacationPolicyTiersFormValues, 'tiers', 'id'>[]}
+            register={register as unknown as UseFormRegister<VacationPolicyTiersFormValues>}
+            errors={errors as unknown as FieldErrors<VacationPolicyTiersFormValues>}
+            remove={remove}
+            addRow={addRow}
+          />
         )}
 
         <div>

--- a/code/webapp/src/components/employees/vacation-section.tsx
+++ b/code/webapp/src/components/employees/vacation-section.tsx
@@ -5,16 +5,23 @@ import { useAuthStore } from '@/stores/auth.store'
 import { useVacationSection } from './use-vacation-section'
 import { RegisterVacationRequestDialog } from './RegisterVacationRequestDialog'
 import { RequestStatusBadge } from './request-status-badge'
+import { VacationPolicyOverride } from './vacation-policy-override'
 import type { RegisterVacationRequestEmployee } from './use-register-vacation-request-dialog'
 import type { VacationEntitlement, VacationRequest } from '@/types/attendance-payroll'
+import type { Employee } from '@/types/employee'
+
+type VacationSectionEmployee = RegisterVacationRequestEmployee
+  & Pick<Employee, 'vacation_entitlement_rule_key' | 'vacation_entitlement_custom_table'>
 
 interface VacationSectionProps {
   readonly employeeId: string
-  readonly employee?: RegisterVacationRequestEmployee
+  readonly employee?: VacationSectionEmployee
 }
 
 const RULE_LABELS: Record<string, string> = {
   VacationsLFTMX: 'LFT México 2022',
+  CustomCompanyPolicy: 'Política de la empresa',
+  ContractualPolicy: 'Política contractual',
 }
 
 function ruleLabel(key: string): string {
@@ -106,14 +113,15 @@ export function VacationSection({ employeeId, employee }: VacationSectionProps) 
   const ctx = useVacationSection(employeeId, employee)
   const { can } = useAuthStore()
   const canSchedule = can('vacation-requests.schedule')
+  const canManagePolicy = can('employees.update')
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4" data-testid="vacation-section">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <h3 className="text-sm font-semibold text-foreground">Vacaciones</h3>
           <Badge variant="default" className="text-xs">
-            LFT México 2022
+            {ctx.summary?.active_rule_label ?? 'LFT México 2022'}
           </Badge>
         </div>
         {canSchedule && (
@@ -169,6 +177,16 @@ export function VacationSection({ employeeId, employee }: VacationSectionProps) 
             </p>
           )}
         </div>
+      )}
+
+      {canManagePolicy && employee && (
+        <VacationPolicyOverride
+          employee={{
+            id: employee.id,
+            vacation_entitlement_rule_key: employee.vacation_entitlement_rule_key,
+            vacation_entitlement_custom_table: employee.vacation_entitlement_custom_table,
+          }}
+        />
       )}
 
       {/* Vacation requests */}

--- a/code/webapp/src/components/settings/__tests__/vacation-policy-section.test.tsx
+++ b/code/webapp/src/components/settings/__tests__/vacation-policy-section.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import React from 'react'
+import type { VacationPolicySettings } from '@/types/attendance-payroll'
+
+const mockGet = vi.fn()
+const mockUpdate = vi.fn()
+const mockShowSuccess = vi.fn()
+const mockShowError = vi.fn()
+
+vi.mock('@/services/vacation-policy-api', () => ({
+  vacationPolicyApi: {
+    get: (...args: unknown[]) => mockGet(...args),
+    update: (...args: unknown[]) => mockUpdate(...args),
+  },
+}))
+
+vi.mock('@/components/ui/toast-context', () => ({
+  useToast: () => ({ showSuccess: mockShowSuccess, showError: mockShowError }),
+}))
+
+import { VacationPolicySection } from '../vacation-policy-section'
+
+function makeWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children)
+}
+
+function renderSection() {
+  return render(<VacationPolicySection />, { wrapper: makeWrapper() })
+}
+
+const lftSettings: VacationPolicySettings = {
+  active_rule_key: 'VacationsLFTMX',
+  active_rule_label: 'LFT México 2022',
+  tiers: [],
+}
+
+const customSettings: VacationPolicySettings = {
+  active_rule_key: 'CustomCompanyPolicy',
+  active_rule_label: 'Política de la empresa',
+  tiers: [
+    { id: '1', years_from: 1, days: 18, sort_order: 1 },
+    { id: '2', years_from: 5, days: 25, sort_order: 2 },
+  ],
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockGet.mockResolvedValue({ data: { data: lftSettings } })
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('VacationPolicySection', () => {
+  it('shows a loading message before settings resolve', () => {
+    mockGet.mockReturnValue(new Promise(() => {}))
+    renderSection()
+
+    expect(screen.getByText('Cargando configuración...')).toBeDefined()
+  })
+
+  it('does not show the tiers editor when LFT is the active rule', async () => {
+    renderSection()
+
+    await waitFor(() => expect(screen.getByLabelText('LFT México 2022')).toBeDefined())
+    expect(screen.queryByText('Agregar tramo')).toBeNull()
+  })
+
+  it('shows the tiers editor with existing rows when the custom policy is active', async () => {
+    mockGet.mockResolvedValue({ data: { data: customSettings } })
+    renderSection()
+
+    await waitFor(() => expect(screen.getAllByLabelText('Eliminar tramo').length).toBe(2))
+  })
+
+  it('reveals the tiers editor when switching to the custom policy', async () => {
+    renderSection()
+
+    await waitFor(() => expect(screen.getByLabelText('Política personalizada')).toBeDefined())
+    fireEvent.click(screen.getByLabelText('Política personalizada'))
+
+    await waitFor(() => expect(screen.getAllByLabelText('Eliminar tramo').length).toBeGreaterThan(0))
+  })
+
+  it('adds a new row when "Agregar tramo" is clicked', async () => {
+    mockGet.mockResolvedValue({ data: { data: customSettings } })
+    renderSection()
+
+    await waitFor(() => expect(screen.getAllByLabelText('Eliminar tramo').length).toBe(2))
+    fireEvent.click(screen.getByText('Agregar tramo'))
+
+    await waitFor(() => expect(screen.getAllByLabelText('Eliminar tramo').length).toBe(3))
+  })
+
+  it('submits the custom policy with its tiers', async () => {
+    mockGet.mockResolvedValue({ data: { data: customSettings } })
+    mockUpdate.mockResolvedValue({ data: { data: customSettings } })
+    renderSection()
+
+    await waitFor(() => expect(screen.getAllByLabelText('Eliminar tramo').length).toBe(2))
+
+    const dayInputs = document.querySelectorAll('input[name$=".days"]')
+    fireEvent.change(dayInputs[0]!, { target: { value: '20' } })
+
+    const submitButton = screen.getByText('Guardar cambios').closest('button')
+    await waitFor(() => expect(submitButton?.disabled).toBe(false))
+    fireEvent.click(submitButton!)
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledWith({
+      active_rule_key: 'CustomCompanyPolicy',
+      tiers: [
+        { years_from: 1, days: 20 },
+        { years_from: 5, days: 25 },
+      ],
+    }))
+  })
+
+  it('submits LFT without a tiers payload after switching back', async () => {
+    mockGet.mockResolvedValue({ data: { data: customSettings } })
+    mockUpdate.mockResolvedValue({ data: { data: lftSettings } })
+    renderSection()
+
+    await waitFor(() => expect(screen.getByLabelText('LFT México 2022')).toBeDefined())
+    fireEvent.click(screen.getByLabelText('LFT México 2022'))
+
+    const submitButton = screen.getByText('Guardar cambios').closest('button')
+    await waitFor(() => expect(submitButton?.disabled).toBe(false))
+    fireEvent.click(submitButton!)
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledWith({
+      active_rule_key: 'VacationsLFTMX',
+      tiers: undefined,
+    }))
+  })
+})

--- a/code/webapp/src/components/settings/use-vacation-policy-section.ts
+++ b/code/webapp/src/components/settings/use-vacation-policy-section.ts
@@ -1,0 +1,91 @@
+import { useEffect } from 'react'
+import { useForm, useFieldArray, type SubmitHandler } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { useVacationPolicy, useUpdateVacationPolicy } from '@/services/vacation-policy-hooks'
+
+const tierSchema = z.object({
+  years_from: z.number().int().min(1),
+  days: z.number().int().min(0),
+})
+
+export const vacationPolicySchema = z
+  .object({
+    active_rule_key: z.enum(['VacationsLFTMX', 'CustomCompanyPolicy']),
+    tiers: z.array(tierSchema),
+  })
+  .superRefine(({ active_rule_key, tiers }, ctx) => {
+    if (active_rule_key !== 'CustomCompanyPolicy') return
+
+    if (tiers.length === 0) {
+      ctx.addIssue({ code: 'custom', path: ['tiers'], message: 'Agrega al menos un tramo' })
+      return
+    }
+
+    const seen = new Set<number>()
+    tiers.forEach((tier, i) => {
+      if (seen.has(tier.years_from)) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['tiers', i, 'years_from'],
+          message: 'Debe ser único',
+        })
+      }
+      seen.add(tier.years_from)
+    })
+  })
+
+export type VacationPolicyFormValues = z.infer<typeof vacationPolicySchema>
+
+const DEFAULT_TIER = { years_from: 1, days: 12 }
+
+export function useVacationPolicySection() {
+  const { data: settings, isLoading } = useVacationPolicy()
+  const update = useUpdateVacationPolicy()
+
+  const form = useForm<VacationPolicyFormValues>({
+    resolver: zodResolver(vacationPolicySchema),
+    defaultValues: { active_rule_key: 'VacationsLFTMX', tiers: [DEFAULT_TIER] },
+  })
+
+  const { reset, watch } = form
+  const { fields, append, remove } = useFieldArray({ control: form.control, name: 'tiers' })
+
+  useEffect(() => {
+    if (settings) {
+      reset({
+        active_rule_key: settings.active_rule_key,
+        tiers: settings.tiers.length > 0
+          ? settings.tiers.map((t) => ({ years_from: t.years_from, days: t.days }))
+          : [DEFAULT_TIER],
+      })
+    }
+  }, [settings, reset])
+
+  const isCustom = watch('active_rule_key') === 'CustomCompanyPolicy'
+
+  const onSubmit: SubmitHandler<VacationPolicyFormValues> = (values) => {
+    update.mutate({
+      active_rule_key: values.active_rule_key,
+      tiers: values.active_rule_key === 'CustomCompanyPolicy' ? values.tiers : undefined,
+    })
+  }
+
+  const addRow = () => {
+    const lastIndex = fields.length - 1
+    const lastYearsFrom = form.getValues(`tiers.${lastIndex}.years_from`) ?? 0
+    append({ years_from: lastYearsFrom + 1, days: 0 })
+  }
+
+  return {
+    settings,
+    isLoading,
+    form,
+    fields,
+    remove,
+    addRow,
+    onSubmit,
+    isCustom,
+    isPending: update.isPending,
+  }
+}

--- a/code/webapp/src/components/settings/vacation-policy-section.tsx
+++ b/code/webapp/src/components/settings/vacation-policy-section.tsx
@@ -1,0 +1,108 @@
+import { Trash2, Plus } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { useVacationPolicySection } from './use-vacation-policy-section'
+
+export function VacationPolicySection() {
+  const { isLoading, form, fields, remove, addRow, onSubmit, isCustom, isPending } = useVacationPolicySection()
+
+  if (isLoading) {
+    return <p className="text-sm text-muted-foreground py-4">Cargando configuración...</p>
+  }
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isDirty },
+  } = form
+
+  return (
+    <>
+      <div className="mb-6">
+        <h3 className="text-base font-semibold mb-1">Reglas aplicables</h3>
+        <p className="text-sm text-muted-foreground">
+          La LFT México 2022 aplica como mínimo legal sin necesidad de configuración. Una política
+          personalizada permite otorgar más días de los que exige la ley.
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 max-w-xl">
+        <div className="space-y-2">
+          <label className="flex items-center gap-2 text-sm">
+            <input type="radio" value="VacationsLFTMX" {...register('active_rule_key')} />
+            LFT México 2022
+          </label>
+          <label className="flex items-center gap-2 text-sm">
+            <input type="radio" value="CustomCompanyPolicy" {...register('active_rule_key')} />
+            Política personalizada
+          </label>
+        </div>
+
+        {isCustom && (
+          <div className="space-y-3">
+            <div className="grid grid-cols-[1fr_1fr_40px] gap-3 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              <span>Desde año</span>
+              <span>Días</span>
+              <span />
+            </div>
+
+            {fields.map((field, index) => (
+              <div
+                key={field.id}
+                className="grid grid-cols-[1fr_1fr_40px] gap-3 items-start rounded-lg border bg-card px-4 py-3"
+              >
+                <div>
+                  <Input
+                    type="number"
+                    min={1}
+                    step={1}
+                    {...register(`tiers.${index}.years_from`, { valueAsNumber: true })}
+                  />
+                  {errors.tiers?.[index]?.years_from && (
+                    <p className="mt-1 text-xs text-red-600">{errors.tiers[index]?.years_from?.message}</p>
+                  )}
+                </div>
+
+                <div>
+                  <Input
+                    type="number"
+                    min={0}
+                    step={1}
+                    {...register(`tiers.${index}.days`, { valueAsNumber: true })}
+                  />
+                  {errors.tiers?.[index]?.days && (
+                    <p className="mt-1 text-xs text-red-600">{errors.tiers[index]?.days?.message}</p>
+                  )}
+                </div>
+
+                <div className="flex items-center justify-center h-9">
+                  <button
+                    type="button"
+                    onClick={() => remove(index)}
+                    disabled={fields.length === 1}
+                    aria-label="Eliminar tramo"
+                    title="Eliminar tramo"
+                    className="text-muted-foreground hover:text-destructive disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </div>
+              </div>
+            ))}
+
+            <Button type="button" variant="outline" size="sm" onClick={addRow}>
+              <Plus className="h-4 w-4 mr-1" />
+              Agregar tramo
+            </Button>
+          </div>
+        )}
+
+        <div className="pt-2">
+          <Button type="submit" disabled={!isDirty || isPending}>
+            {isPending ? 'Guardando...' : 'Guardar cambios'}
+          </Button>
+        </div>
+      </form>
+    </>
+  )
+}

--- a/code/webapp/src/components/settings/vacation-policy-section.tsx
+++ b/code/webapp/src/components/settings/vacation-policy-section.tsx
@@ -1,6 +1,9 @@
-import { Trash2, Plus } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
+import {
+  VacationPolicyTiersEditor,
+  type VacationPolicyTiersFormValues,
+} from '@/components/vacation-policy/vacation-policy-tiers-editor'
+import type { FieldArrayWithId, FieldErrors, UseFormRegister } from 'react-hook-form'
 import { useVacationPolicySection } from './use-vacation-policy-section'
 
 export function VacationPolicySection() {
@@ -29,72 +32,23 @@ export function VacationPolicySection() {
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 max-w-xl">
         <div className="space-y-2">
           <label className="flex items-center gap-2 text-sm">
-            <input type="radio" value="VacationsLFTMX" {...register('active_rule_key')} />
+            <input type="radio" value="VacationsLFTMX" {...register('active_rule_key')} />{' '}
             LFT México 2022
           </label>
           <label className="flex items-center gap-2 text-sm">
-            <input type="radio" value="CustomCompanyPolicy" {...register('active_rule_key')} />
+            <input type="radio" value="CustomCompanyPolicy" {...register('active_rule_key')} />{' '}
             Política personalizada
           </label>
         </div>
 
         {isCustom && (
-          <div className="space-y-3">
-            <div className="grid grid-cols-[1fr_1fr_40px] gap-3 px-4 text-xs font-medium text-muted-foreground uppercase tracking-wide">
-              <span>Desde año</span>
-              <span>Días</span>
-              <span />
-            </div>
-
-            {fields.map((field, index) => (
-              <div
-                key={field.id}
-                className="grid grid-cols-[1fr_1fr_40px] gap-3 items-start rounded-lg border bg-card px-4 py-3"
-              >
-                <div>
-                  <Input
-                    type="number"
-                    min={1}
-                    step={1}
-                    {...register(`tiers.${index}.years_from`, { valueAsNumber: true })}
-                  />
-                  {errors.tiers?.[index]?.years_from && (
-                    <p className="mt-1 text-xs text-red-600">{errors.tiers[index]?.years_from?.message}</p>
-                  )}
-                </div>
-
-                <div>
-                  <Input
-                    type="number"
-                    min={0}
-                    step={1}
-                    {...register(`tiers.${index}.days`, { valueAsNumber: true })}
-                  />
-                  {errors.tiers?.[index]?.days && (
-                    <p className="mt-1 text-xs text-red-600">{errors.tiers[index]?.days?.message}</p>
-                  )}
-                </div>
-
-                <div className="flex items-center justify-center h-9">
-                  <button
-                    type="button"
-                    onClick={() => remove(index)}
-                    disabled={fields.length === 1}
-                    aria-label="Eliminar tramo"
-                    title="Eliminar tramo"
-                    className="text-muted-foreground hover:text-destructive disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </button>
-                </div>
-              </div>
-            ))}
-
-            <Button type="button" variant="outline" size="sm" onClick={addRow}>
-              <Plus className="h-4 w-4 mr-1" />
-              Agregar tramo
-            </Button>
-          </div>
+          <VacationPolicyTiersEditor
+            fields={fields as unknown as FieldArrayWithId<VacationPolicyTiersFormValues, 'tiers', 'id'>[]}
+            register={register as unknown as UseFormRegister<VacationPolicyTiersFormValues>}
+            errors={errors as unknown as FieldErrors<VacationPolicyTiersFormValues>}
+            remove={remove}
+            addRow={addRow}
+          />
         )}
 
         <div className="pt-2">

--- a/code/webapp/src/components/vacation-policy/vacation-policy-tiers-editor.tsx
+++ b/code/webapp/src/components/vacation-policy/vacation-policy-tiers-editor.tsx
@@ -1,0 +1,82 @@
+import { Trash2, Plus } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import type { FieldArrayWithId, FieldErrors, UseFormRegister } from 'react-hook-form'
+
+export interface VacationPolicyTierValue {
+  years_from: number
+  days: number
+}
+
+export interface VacationPolicyTiersFormValues {
+  tiers: VacationPolicyTierValue[]
+}
+
+interface VacationPolicyTiersEditorProps {
+  readonly fields: FieldArrayWithId<VacationPolicyTiersFormValues, 'tiers', 'id'>[]
+  readonly register: UseFormRegister<VacationPolicyTiersFormValues>
+  readonly errors: FieldErrors<VacationPolicyTiersFormValues>
+  readonly remove: (index: number) => void
+  readonly addRow: () => void
+}
+
+export function VacationPolicyTiersEditor({ fields, register, errors, remove, addRow }: VacationPolicyTiersEditorProps) {
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-[1fr_1fr_40px] gap-3 px-2 text-xs font-medium text-muted-foreground uppercase tracking-wide">
+        <span>Desde año</span>
+        <span>Días</span>
+        <span />
+      </div>
+
+      {fields.map((field, index) => (
+        <div
+          key={field.id}
+          className="grid grid-cols-[1fr_1fr_40px] gap-3 items-start rounded-lg border bg-card px-3 py-2"
+        >
+          <div>
+            <Input
+              type="number"
+              min={1}
+              step={1}
+              {...register(`tiers.${index}.years_from`, { valueAsNumber: true })}
+            />
+            {errors.tiers?.[index]?.years_from && (
+              <p className="mt-1 text-xs text-red-600">{errors.tiers[index]?.years_from?.message}</p>
+            )}
+          </div>
+
+          <div>
+            <Input
+              type="number"
+              min={0}
+              step={1}
+              {...register(`tiers.${index}.days`, { valueAsNumber: true })}
+            />
+            {errors.tiers?.[index]?.days && (
+              <p className="mt-1 text-xs text-red-600">{errors.tiers[index]?.days?.message}</p>
+            )}
+          </div>
+
+          <div className="flex items-center justify-center h-9">
+            <button
+              type="button"
+              onClick={() => remove(index)}
+              disabled={fields.length === 1}
+              aria-label="Eliminar tramo"
+              title="Eliminar tramo"
+              className="text-muted-foreground hover:text-destructive disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            >
+              <Trash2 className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      ))}
+
+      <Button type="button" variant="outline" size="sm" onClick={addRow}>
+        <Plus className="h-4 w-4 mr-1" />
+        Agregar tramo
+      </Button>
+    </div>
+  )
+}

--- a/code/webapp/src/pages/__tests__/configuracion.test.tsx
+++ b/code/webapp/src/pages/__tests__/configuracion.test.tsx
@@ -25,6 +25,10 @@ vi.mock('@/components/settings/overtime-lft-tiers-section', () => ({
   OvertimeLftTiersSection: () => <div>Horas Extra Section</div>,
 }))
 
+vi.mock('@/components/settings/vacation-policy-section', () => ({
+  VacationPolicySection: () => <div>Vacaciones Section</div>,
+}))
+
 import { ConfiguracionPage } from '../configuracion'
 
 afterEach(() => {
@@ -33,13 +37,30 @@ afterEach(() => {
 })
 
 describe('ConfiguracionPage', () => {
-  it('shows both tabs when the user has both permissions', () => {
+  it('shows all tabs when the user has every permission', () => {
     mockCan.mockReturnValue(true)
     render(<ConfiguracionPage />)
 
     expect(screen.getByText('Puntualidad')).toBeDefined()
     expect(screen.getByText('Horas Extra')).toBeDefined()
+    expect(screen.getByText('Vacaciones')).toBeDefined()
     expect(screen.getByText('Puntualidad Section')).toBeDefined()
+  })
+
+  it('hides the Vacaciones tab when the user lacks vacation-policy.manage', () => {
+    mockCan.mockImplementation((permission: string) => permission === 'punctuality.manage')
+    render(<ConfiguracionPage />)
+
+    expect(screen.getByText('Puntualidad')).toBeDefined()
+    expect(screen.queryByText('Vacaciones')).toBeNull()
+  })
+
+  it('shows the Vacaciones tab and section when the user has vacation-policy.manage', () => {
+    mockCan.mockImplementation((permission: string) => permission === 'vacation-policy.manage')
+    render(<ConfiguracionPage />)
+
+    expect(screen.getByText('Vacaciones')).toBeDefined()
+    expect(screen.getByText('Vacaciones Section')).toBeDefined()
   })
 
   it('hides the Horas Extra tab when the user lacks overtime.manage', () => {

--- a/code/webapp/src/pages/configuracion.tsx
+++ b/code/webapp/src/pages/configuracion.tsx
@@ -6,6 +6,7 @@ import { PageHeader } from '@/components/ui/page-header'
 import { Tabs, TabPanel } from '@/components/ui/tabs'
 import { PunctualityConfigSection } from '@/components/settings/punctuality-config-section'
 import { OvertimeLftTiersSection } from '@/components/settings/overtime-lft-tiers-section'
+import { VacationPolicySection } from '@/components/settings/vacation-policy-section'
 import { useAuthStore } from '@/stores/auth.store'
 
 export const Route = createFileRoute('/configuracion')({
@@ -19,6 +20,7 @@ export function ConfiguracionPage() {
     const tabs = [
         can('punctuality.manage') && { id: 'puntualidad', label: 'Puntualidad' },
         can('overtime.manage') && { id: 'horas-extra', label: 'Horas Extra' },
+        can('vacation-policy.manage') && { id: 'vacaciones', label: 'Vacaciones' },
     ].filter((tab): tab is { id: string; label: string } => tab !== false)
 
     const [activeTab, setActiveTab] = useState(tabs[0]?.id ?? '')
@@ -39,6 +41,9 @@ export function ConfiguracionPage() {
                     </TabPanel>
                     <TabPanel id="horas-extra" activeTab={activeTab}>
                         <OvertimeLftTiersSection />
+                    </TabPanel>
+                    <TabPanel id="vacaciones" activeTab={activeTab}>
+                        <VacationPolicySection />
                     </TabPanel>
                 </div>
             </div>

--- a/code/webapp/src/services/__tests__/employee-vacation-policy-api.test.ts
+++ b/code/webapp/src/services/__tests__/employee-vacation-policy-api.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { employeeVacationPolicyApi } from '../employee-vacation-policy-api'
+
+vi.mock('@/lib/api-client', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+import { apiClient } from '@/lib/api-client'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('employeeVacationPolicyApi.updateOverride', () => {
+  it('calls PUT /employees/{employeeId}/vacation-policy-override with the payload', async () => {
+    const payload = { rule_key: 'ContractualPolicy' as const, tiers: [{ years_from: 1, days: 30 }] }
+    const mockResponse = { data: { status: 200, data: { rule_key: 'ContractualPolicy', tiers: [], active_rule_label: 'Política contractual' } } }
+    vi.mocked(apiClient.put).mockResolvedValue(mockResponse)
+
+    const result = await employeeVacationPolicyApi.updateOverride('emp-001', payload)
+
+    expect(apiClient.put).toHaveBeenCalledWith('/employees/emp-001/vacation-policy-override', payload)
+    expect(result).toEqual(mockResponse)
+  })
+
+  it('supports clearing the override with rule_key null', async () => {
+    const payload = { rule_key: null }
+    const mockResponse = { data: { status: 200, data: { rule_key: null, tiers: [], active_rule_label: 'LFT México 2022' } } }
+    vi.mocked(apiClient.put).mockResolvedValue(mockResponse)
+
+    await employeeVacationPolicyApi.updateOverride('emp-001', payload)
+
+    expect(apiClient.put).toHaveBeenCalledWith('/employees/emp-001/vacation-policy-override', payload)
+  })
+})

--- a/code/webapp/src/services/__tests__/employee-vacation-policy-hooks.test.tsx
+++ b/code/webapp/src/services/__tests__/employee-vacation-policy-hooks.test.tsx
@@ -26,8 +26,9 @@ function makeWrapper() {
   const qc = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   })
-  return ({ children }: { children: ReactNode }) =>
+  const wrapper = ({ children }: { children: ReactNode }) =>
     React.createElement(QueryClientProvider, { client: qc }, children)
+  return { wrapper, qc }
 }
 
 const fakeOverride: EmployeeVacationPolicyOverride = {
@@ -45,7 +46,8 @@ describe('useUpdateEmployeeVacationPolicy', () => {
 
   it('calls employeeVacationPolicyApi.updateOverride with employeeId and payload', async () => {
     mockUpdateOverride.mockResolvedValue({ data: { data: fakeOverride } })
-    const { result } = renderHook(() => useUpdateEmployeeVacationPolicy('emp-001'), { wrapper: makeWrapper() })
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useUpdateEmployeeVacationPolicy('emp-001'), { wrapper })
 
     act(() => { result.current.mutate(payload) })
 
@@ -55,7 +57,8 @@ describe('useUpdateEmployeeVacationPolicy', () => {
 
   it('shows success toast on success', async () => {
     mockUpdateOverride.mockResolvedValue({ data: { data: fakeOverride } })
-    const { result } = renderHook(() => useUpdateEmployeeVacationPolicy('emp-001'), { wrapper: makeWrapper() })
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useUpdateEmployeeVacationPolicy('emp-001'), { wrapper })
 
     act(() => { result.current.mutate(payload) })
 
@@ -63,9 +66,23 @@ describe('useUpdateEmployeeVacationPolicy', () => {
     expect(mockShowSuccess).toHaveBeenCalled()
   })
 
+  it('invalidates the vacation-entitlements and employee queries on success', async () => {
+    mockUpdateOverride.mockResolvedValue({ data: { data: fakeOverride } })
+    const { wrapper, qc } = makeWrapper()
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries')
+    const { result } = renderHook(() => useUpdateEmployeeVacationPolicy('emp-001'), { wrapper })
+
+    act(() => { result.current.mutate(payload) })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['vacation-entitlements', 'emp-001'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['employees', 'emp-001'] })
+  })
+
   it('shows error toast on failure', async () => {
     mockUpdateOverride.mockRejectedValue(new Error('Network error'))
-    const { result } = renderHook(() => useUpdateEmployeeVacationPolicy('emp-001'), { wrapper: makeWrapper() })
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useUpdateEmployeeVacationPolicy('emp-001'), { wrapper })
 
     act(() => { result.current.mutate(payload) })
 

--- a/code/webapp/src/services/__tests__/employee-vacation-policy-hooks.test.tsx
+++ b/code/webapp/src/services/__tests__/employee-vacation-policy-hooks.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import React from 'react'
+import type { EmployeeVacationPolicyOverride } from '@/types/attendance-payroll'
+
+const mockUpdateOverride = vi.fn()
+const mockShowSuccess = vi.fn()
+const mockShowError = vi.fn()
+
+vi.mock('@/services/employee-vacation-policy-api', () => ({
+  employeeVacationPolicyApi: {
+    updateOverride: (...args: unknown[]) => mockUpdateOverride(...args),
+  },
+}))
+
+vi.mock('@/components/ui/toast-context', () => ({
+  useToast: () => ({ showSuccess: mockShowSuccess, showError: mockShowError }),
+}))
+
+import { useUpdateEmployeeVacationPolicy } from '../employee-vacation-policy-hooks'
+
+function makeWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children)
+}
+
+const fakeOverride: EmployeeVacationPolicyOverride = {
+  rule_key: 'ContractualPolicy',
+  tiers: [{ years_from: 1, days: 30 }],
+  active_rule_label: 'Política contractual',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('useUpdateEmployeeVacationPolicy', () => {
+  const payload = { rule_key: 'ContractualPolicy' as const, tiers: [{ years_from: 1, days: 30 }] }
+
+  it('calls employeeVacationPolicyApi.updateOverride with employeeId and payload', async () => {
+    mockUpdateOverride.mockResolvedValue({ data: { data: fakeOverride } })
+    const { result } = renderHook(() => useUpdateEmployeeVacationPolicy('emp-001'), { wrapper: makeWrapper() })
+
+    act(() => { result.current.mutate(payload) })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockUpdateOverride).toHaveBeenCalledWith('emp-001', payload)
+  })
+
+  it('shows success toast on success', async () => {
+    mockUpdateOverride.mockResolvedValue({ data: { data: fakeOverride } })
+    const { result } = renderHook(() => useUpdateEmployeeVacationPolicy('emp-001'), { wrapper: makeWrapper() })
+
+    act(() => { result.current.mutate(payload) })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockShowSuccess).toHaveBeenCalled()
+  })
+
+  it('shows error toast on failure', async () => {
+    mockUpdateOverride.mockRejectedValue(new Error('Network error'))
+    const { result } = renderHook(() => useUpdateEmployeeVacationPolicy('emp-001'), { wrapper: makeWrapper() })
+
+    act(() => { result.current.mutate(payload) })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(mockShowError).toHaveBeenCalled()
+  })
+})

--- a/code/webapp/src/services/__tests__/vacation-policy-api.test.ts
+++ b/code/webapp/src/services/__tests__/vacation-policy-api.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { vacationPolicyApi } from '../vacation-policy-api'
+
+vi.mock('@/lib/api-client', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+import { apiClient } from '@/lib/api-client'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('vacationPolicyApi.get', () => {
+  it('calls GET /vacation-policy', async () => {
+    const mockResponse = { data: { status: 200, data: { active_rule_key: 'VacationsLFTMX', active_rule_label: 'LFT México 2022', tiers: [] } } }
+    vi.mocked(apiClient.get).mockResolvedValue(mockResponse)
+
+    const result = await vacationPolicyApi.get()
+
+    expect(apiClient.get).toHaveBeenCalledWith('/vacation-policy')
+    expect(result).toEqual(mockResponse)
+  })
+})
+
+describe('vacationPolicyApi.update', () => {
+  it('calls PUT /vacation-policy with the payload', async () => {
+    const payload = { active_rule_key: 'CustomCompanyPolicy' as const, tiers: [{ years_from: 1, days: 18 }] }
+    const mockResponse = { data: { status: 200, data: { active_rule_key: 'CustomCompanyPolicy', active_rule_label: 'Política de la empresa', tiers: [] } } }
+    vi.mocked(apiClient.put).mockResolvedValue(mockResponse)
+
+    const result = await vacationPolicyApi.update(payload)
+
+    expect(apiClient.put).toHaveBeenCalledWith('/vacation-policy', payload)
+    expect(result).toEqual(mockResponse)
+  })
+})

--- a/code/webapp/src/services/__tests__/vacation-policy-hooks.test.tsx
+++ b/code/webapp/src/services/__tests__/vacation-policy-hooks.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import React from 'react'
+import type { VacationPolicySettings } from '@/types/attendance-payroll'
+
+const mockGet = vi.fn()
+const mockUpdate = vi.fn()
+const mockShowSuccess = vi.fn()
+const mockShowError = vi.fn()
+
+vi.mock('@/services/vacation-policy-api', () => ({
+  vacationPolicyApi: {
+    get: (...args: unknown[]) => mockGet(...args),
+    update: (...args: unknown[]) => mockUpdate(...args),
+  },
+}))
+
+vi.mock('@/components/ui/toast-context', () => ({
+  useToast: () => ({ showSuccess: mockShowSuccess, showError: mockShowError }),
+}))
+
+import { useVacationPolicy, useUpdateVacationPolicy } from '../vacation-policy-hooks'
+
+function makeWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children)
+}
+
+const fakeSettings: VacationPolicySettings = {
+  active_rule_key: 'VacationsLFTMX',
+  active_rule_label: 'LFT México 2022',
+  tiers: [],
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('useVacationPolicy', () => {
+  it('returns data from get', async () => {
+    mockGet.mockResolvedValue({ data: { data: fakeSettings } })
+    const { result } = renderHook(() => useVacationPolicy(), { wrapper: makeWrapper() })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual(fakeSettings)
+  })
+
+  it('starts with data undefined before resolving', () => {
+    mockGet.mockReturnValue(new Promise(() => {}))
+    const { result } = renderHook(() => useVacationPolicy(), { wrapper: makeWrapper() })
+    expect(result.current.data).toBeUndefined()
+  })
+})
+
+describe('useUpdateVacationPolicy', () => {
+  const payload = { active_rule_key: 'CustomCompanyPolicy' as const, tiers: [{ years_from: 1, days: 18 }] }
+
+  it('calls vacationPolicyApi.update with the payload', async () => {
+    mockUpdate.mockResolvedValue({ data: { data: fakeSettings } })
+    const { result } = renderHook(() => useUpdateVacationPolicy(), { wrapper: makeWrapper() })
+
+    act(() => { result.current.mutate(payload) })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockUpdate).toHaveBeenCalledWith(payload)
+  })
+
+  it('shows success toast on success', async () => {
+    mockUpdate.mockResolvedValue({ data: { data: fakeSettings } })
+    const { result } = renderHook(() => useUpdateVacationPolicy(), { wrapper: makeWrapper() })
+
+    act(() => { result.current.mutate(payload) })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockShowSuccess).toHaveBeenCalledWith('Política de vacaciones actualizada.', 'Vacaciones')
+  })
+
+  it('shows error toast on failure', async () => {
+    mockUpdate.mockRejectedValue(new Error('Network error'))
+    const { result } = renderHook(() => useUpdateVacationPolicy(), { wrapper: makeWrapper() })
+
+    act(() => { result.current.mutate(payload) })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(mockShowError).toHaveBeenCalled()
+  })
+
+  it('starts with isPending false', () => {
+    const { result } = renderHook(() => useUpdateVacationPolicy(), { wrapper: makeWrapper() })
+    expect(result.current.isPending).toBe(false)
+  })
+})

--- a/code/webapp/src/services/employee-vacation-policy-api.ts
+++ b/code/webapp/src/services/employee-vacation-policy-api.ts
@@ -1,0 +1,10 @@
+import { apiClient } from '@/lib/api-client'
+import type { EmployeeVacationPolicyOverride, UpdateEmployeeVacationPolicyPayload } from '@/types/attendance-payroll'
+
+export const employeeVacationPolicyApi = {
+  updateOverride: (employeeId: string, payload: UpdateEmployeeVacationPolicyPayload) =>
+    apiClient.put<{ status: number; data: EmployeeVacationPolicyOverride }>(
+      `/employees/${employeeId}/vacation-policy-override`,
+      payload,
+    ),
+}

--- a/code/webapp/src/services/employee-vacation-policy-hooks.ts
+++ b/code/webapp/src/services/employee-vacation-policy-hooks.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { getApiErrorMessage } from '@/lib/api-error'
+import { useToast } from '@/components/ui/toast-context'
+import type { UpdateEmployeeVacationPolicyPayload } from '@/types/attendance-payroll'
+import { employeeVacationPolicyApi } from './employee-vacation-policy-api'
+
+export function useUpdateEmployeeVacationPolicy(employeeId: string) {
+  const queryClient = useQueryClient()
+  const { showSuccess, showError } = useToast()
+
+  return useMutation({
+    mutationFn: (payload: UpdateEmployeeVacationPolicyPayload) =>
+      employeeVacationPolicyApi.updateOverride(employeeId, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['vacation-entitlements', employeeId] })
+      showSuccess('Política de vacaciones del empleado actualizada.', 'Vacaciones')
+    },
+    onError: (error: unknown) => {
+      showError(getApiErrorMessage(error, 'Error al actualizar la política de vacaciones del empleado.'), 'Vacaciones')
+    },
+  })
+}

--- a/code/webapp/src/services/employee-vacation-policy-hooks.ts
+++ b/code/webapp/src/services/employee-vacation-policy-hooks.ts
@@ -13,6 +13,7 @@ export function useUpdateEmployeeVacationPolicy(employeeId: string) {
       employeeVacationPolicyApi.updateOverride(employeeId, payload),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['vacation-entitlements', employeeId] })
+      queryClient.invalidateQueries({ queryKey: ['employees', employeeId] })
       showSuccess('Política de vacaciones del empleado actualizada.', 'Vacaciones')
     },
     onError: (error: unknown) => {

--- a/code/webapp/src/services/vacation-policy-api.ts
+++ b/code/webapp/src/services/vacation-policy-api.ts
@@ -1,0 +1,10 @@
+import { apiClient } from '@/lib/api-client'
+import type { VacationPolicySettings, UpdateVacationPolicyPayload } from '@/types/attendance-payroll'
+
+export const vacationPolicyApi = {
+  get: () =>
+    apiClient.get<{ status: number; data: VacationPolicySettings }>('/vacation-policy'),
+
+  update: (payload: UpdateVacationPolicyPayload) =>
+    apiClient.put<{ status: number; data: VacationPolicySettings }>('/vacation-policy', payload),
+}

--- a/code/webapp/src/services/vacation-policy-hooks.ts
+++ b/code/webapp/src/services/vacation-policy-hooks.ts
@@ -1,0 +1,32 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { getApiErrorMessage } from '@/lib/api-error'
+import { useToast } from '@/components/ui/toast-context'
+import type { VacationPolicySettings, UpdateVacationPolicyPayload } from '@/types/attendance-payroll'
+import { vacationPolicyApi } from './vacation-policy-api'
+
+export function useVacationPolicy() {
+  return useQuery<VacationPolicySettings>({
+    queryKey: ['vacation-policy'],
+    queryFn: async () => {
+      const response = await vacationPolicyApi.get()
+      return response.data.data
+    },
+    staleTime: 5 * 60_000,
+  })
+}
+
+export function useUpdateVacationPolicy() {
+  const queryClient = useQueryClient()
+  const { showSuccess, showError } = useToast()
+
+  return useMutation({
+    mutationFn: (payload: UpdateVacationPolicyPayload) => vacationPolicyApi.update(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['vacation-policy'] })
+      showSuccess('Política de vacaciones actualizada.', 'Vacaciones')
+    },
+    onError: (error: unknown) => {
+      showError(getApiErrorMessage(error, 'Error al actualizar la política de vacaciones.'), 'Vacaciones')
+    },
+  })
+}

--- a/code/webapp/src/types/attendance-payroll.ts
+++ b/code/webapp/src/types/attendance-payroll.ts
@@ -197,6 +197,44 @@ export interface VacationEntitlement {
 export interface VacationSummary {
   seniority_years: number
   next_anniversary_date: string | null
+  active_rule_label: string
+}
+
+// ── Vacation Policy Settings (tenant-level) ─────────────────────────────────
+
+export type VacationPolicyRuleKey = 'VacationsLFTMX' | 'CustomCompanyPolicy'
+
+export interface VacationPolicyTier {
+  id: string
+  years_from: number
+  days: number
+  sort_order: number
+}
+
+export interface VacationPolicySettings {
+  active_rule_key: VacationPolicyRuleKey
+  active_rule_label: string
+  tiers: VacationPolicyTier[]
+}
+
+export interface UpdateVacationPolicyPayload {
+  active_rule_key: VacationPolicyRuleKey
+  tiers?: { years_from: number; days: number }[]
+}
+
+// ── Employee Vacation Policy Override ───────────────────────────────────────
+
+export type EmployeeVacationRuleKey = 'ContractualPolicy' | null
+
+export interface EmployeeVacationPolicyOverride {
+  rule_key: EmployeeVacationRuleKey
+  tiers: { years_from: number; days: number }[]
+  active_rule_label: string
+}
+
+export interface UpdateEmployeeVacationPolicyPayload {
+  rule_key: EmployeeVacationRuleKey
+  tiers?: { years_from: number; days: number }[]
 }
 
 // ── Overtime LFT Tiers ───────────────────────────────────────────────────────

--- a/code/webapp/src/types/employee.ts
+++ b/code/webapp/src/types/employee.ts
@@ -31,6 +31,9 @@ export interface Employee {
   is_active: boolean
   /** True for roles (e.g. admin, super-admin) that do not check in/out — excluded from the attendance list */
   attendance_exempt: boolean
+  /** null = inherits the tenant-wide vacation policy; 'ContractualPolicy' = this employee has a contractual override */
+  vacation_entitlement_rule_key: 'ContractualPolicy' | null
+  vacation_entitlement_custom_table: { years_from: number; days: number }[] | null
   has_active_period?: boolean | null
   has_user: boolean
   email?: string | null

--- a/doc/tasks/2026-07/214-configurable-vacation-policies.md
+++ b/doc/tasks/2026-07/214-configurable-vacation-policies.md
@@ -37,42 +37,43 @@ Since there is no tenant/company model in this codebase yet (single-instance app
 
 ## ✅ Backend Tasks
 
-- [ ] 🔧 `VacationEntitlementRule` interface — add `key(): string`
-- [ ] 🔧 `VacationsLFTMX::key()` → `'VacationsLFTMX'`
-- [ ] ✨ `app/Services/VacationRules/CustomVacationPolicy.php` — generic table-driven strategy
-- [ ] ✨ `app/Services/VacationEntitlementResolver.php` — employee override → tenant custom → LFT default
-- [ ] 🔨 `VacationEntitlementService` — inject resolver instead of fixed rule; resolve per employee in `pendingAnniversaries`, `generateMissing`, `summary` (adds `active_rule_label` to summary)
-- [ ] 🔨 `SeniorityService` — inject resolver instead of fixed rule; resolve per employee in `nextAnniversary`; remove unused `entitledDaysForSeniorityYear` (no employee context, no callers)
-- [ ] 📂 Migration `create_vacation_policy_settings_table` — singleton row (`active_rule_key` default `VacationsLFTMX`)
-- [ ] 📂 Migration `create_vacation_policy_tiers_table` — `years_from`, `days`, `sort_order` (mirrors `overtime_lft_tiers`)
-- [ ] 📂 Migration `add_vacation_entitlement_rule_to_employees_table` — `vacation_entitlement_rule_key` (nullable), `vacation_entitlement_custom_table` (nullable json)
-- [ ] 🔧 `VacationPolicySetting` model (+ `current()` singleton accessor), `VacationPolicyTier` model
-- [ ] 🌐 `GET/PUT /api/v1/vacation-policy` — `ListVacationPolicyController` / `UpdateVacationPolicyController` (full-replace tiers, atomic transaction)
-- [ ] 🌐 `PUT /api/v1/employees/{employee}/vacation-policy-override` — `UpdateEmployeeVacationPolicyController`
-- [ ] 🔑 New permission `vacation-policy.manage` in Production/Development/Testing seeders (group "Asistencia", granted to admin + super-admin)
-- [ ] 🧪 Unit tests: `CustomVacationPolicyTest`, `VacationEntitlementResolverTest`
-- [ ] 🧪 Feature tests: `VacationPolicySettingsApiTest`, `EmployeeVacationPolicyOverrideApiTest`
-- [ ] 🧪 Update `SeniorityServiceTest` for the new resolver-based constructor
+- [x] 🔧 `VacationEntitlementRule` interface — add `key(): string`
+- [x] 🔧 `VacationsLFTMX::key()` → `'VacationsLFTMX'`
+- [x] ✨ `app/Services/VacationRules/CustomVacationPolicy.php` — generic table-driven strategy
+- [x] ✨ `app/Services/VacationEntitlementResolver.php` — employee override → tenant custom → LFT default
+- [x] 🔨 `VacationEntitlementService` — inject resolver instead of fixed rule; resolve per employee in `pendingAnniversaries`, `generateMissing`, `summary` (adds `active_rule_label` to summary)
+- [x] 🔨 `SeniorityService` — inject resolver instead of fixed rule; resolve per employee in `nextAnniversary`; removed unused `entitledDaysForSeniorityYear` (no employee context, no callers)
+- [x] 📂 Migration `create_vacation_policy_settings_table` — singleton row (`active_rule_key` default `VacationsLFTMX`)
+- [x] 📂 Migration `create_vacation_policy_tiers_table` — `years_from`, `days`, `sort_order` (mirrors `overtime_lft_tiers`)
+- [x] 📂 Migration `add_vacation_entitlement_rule_to_employees_table` — `vacation_entitlement_rule_key` (nullable), `vacation_entitlement_custom_table` (nullable json)
+- [x] 🔧 `VacationPolicySetting` model (+ `current()` singleton accessor), `VacationPolicyTier` model
+- [x] 🌐 `GET/PUT /api/v1/vacation-policy` — `ListVacationPolicyController` / `UpdateVacationPolicyController` (full-replace tiers, atomic transaction)
+- [x] 🌐 `PUT /api/v1/employees/{employee}/vacation-policy-override` — `UpdateEmployeeVacationPolicyController`
+- [x] 🔑 New permission `vacation-policy.manage` in Production/Development/Testing seeders (group "Asistencia", granted to admin + super-admin)
+- [x] 🧪 Unit tests: `CustomVacationPolicyTest`, `VacationEntitlementResolverTest`
+- [x] 🧪 Feature tests: `VacationPolicySettingsApiTest`, `EmployeeVacationPolicyOverrideApiTest`
+- [x] 🧪 Update `SeniorityServiceTest` for the new resolver-based constructor
 
 ## ✅ Frontend Tasks
 
-- [ ] 📝 Types: `VacationPolicyTier`, `VacationPolicySettings`, `UpdateVacationPolicyPayload`, employee override payload/response
-- [ ] 🔧 `src/services/vacation-policy-api.ts` + `vacation-policy-hooks.ts` (mirrors `overtime-lft-tiers-*`)
-- [ ] 🔧 `use-vacation-policy-config-page.ts` + `vacation-policy-shared.tsx` — rule selector (LFT / personalizada) + conditional tiers editor
-- [ ] 📱 `vacation-policy-section.tsx` wired into `configuracion.tsx` as a new "Vacaciones" tab, gated by `vacation-policy.manage`
-- [ ] 🔧 Employee-level override service/hook + small section in employee detail (toggle "Política contractual" + tiers editor)
-- [ ] 📱 Replace hardcoded "LFT México 2022" badge in `vacation-section.tsx` with the backend-resolved `active_rule_label`
-- [ ] ✅ Vitest coverage for all new services/hooks/components
+- [x] 📝 Types: `VacationPolicyTier`, `VacationPolicySettings`, `UpdateVacationPolicyPayload`, employee override payload/response
+- [x] 🔧 `src/services/vacation-policy-api.ts` + `vacation-policy-hooks.ts` (mirrors `overtime-lft-tiers-*`)
+- [x] 🔧 `components/settings/use-vacation-policy-section.ts` + `vacation-policy-section.tsx` — rule selector (LFT / personalizada) + conditional tiers editor (kept alongside the component per the Custom Hook Convention, unlike overtime's `pages/attendance/` split)
+- [x] 📱 `vacation-policy-section.tsx` wired into `configuracion.tsx` as a new "Vacaciones" tab, gated by `vacation-policy.manage`
+- [x] 🔧 `employee-vacation-policy-api.ts`/`hooks.ts` + `VacationPolicyOverride` component in the employee's Vacaciones section (toggle "Política contractual" + tiers editor)
+- [x] 📱 Replace hardcoded "LFT México 2022" badge in `vacation-section.tsx` with the backend-resolved `active_rule_label`
+- [x] ✅ Vitest coverage for all new services/hooks/components
+- [x] ✅ E2E: `cypress/e2e/vacation-policy-settings.cy.ts` — verified passing against the sushigo-d E2E stack
 
 ---
 
 ## 🎯 Acceptance Criteria
 
-- [ ] Tenant admin can select an active vacation rule from a "Reglas aplicables" dropdown in company settings
-- [ ] A custom policy allows defining a day table (years_from → days) via UI
-- [ ] Per-employee override field exists and takes precedence over the tenant default
-- [ ] `VacationsLFTMX` remains the default and requires zero configuration
-- [ ] All existing entitlement calculations continue to work unchanged
+- [x] Tenant admin can select an active vacation rule from a "Reglas aplicables" dropdown in company settings
+- [x] A custom policy allows defining a day table (years_from → days) via UI
+- [x] Per-employee override field exists and takes precedence over the tenant default
+- [x] `VacationsLFTMX` remains the default and requires zero configuration
+- [x] All existing entitlement calculations continue to work unchanged
 
 ---
 
@@ -86,11 +87,26 @@ Since there is no tenant/company model in this codebase yet (single-instance app
 ## ⏱️ Time
 
 ### 📊 Estimates
-- **Optimistic:** `4h` · **Pessimistic:** `7h` · **Tracked:** _in progress_
+- **Optimistic:** `4h` · **Pessimistic:** `7h` · **Tracked:** `7h09m`
 
 ### 📅 Sessions
 ```json
 [
-  { "date": "2026-07-14", "start": "02:25", "end": "?" }
+  { "date": "2026-07-14", "start": "02:25", "end": "09:34" }
 ]
 ```
+
+---
+
+## 📊 Retrospective
+
+**Estimated:** 4h–7h · **Tracked:** 7h09m · **Overrun:** +9m (within pessimistic estimate)
+
+**Why it took the full pessimistic estimate:**
+
+- **No existing tenant/settings infrastructure:** the issue assumed a `tenant_settings`/`company_configs` table would exist to extend — it didn't. Had to design and build the singleton `vacation_policy_settings` table from scratch, closely mirroring the `overtime_lft_tiers` admin-editable-table pattern found during research.
+- **Two-level resolution, one generic strategy:** per the user's direction, both the tenant-level `CustomCompanyPolicy` and the employee-level `ContractualPolicy` had to reuse a single `CustomVacationPolicy` class — required adding a `key()` method to the `VacationEntitlementRule` interface and refactoring both `VacationEntitlementService` and `SeniorityService` off a fixed constructor-injected rule onto a per-employee `VacationEntitlementResolver`.
+- **Shared test-database collision (+10-15m):** `phpunit.xml` hardcodes `DB_DATABASE=mydb_test` for every workspace instead of the per-workspace `sushigo_ws_<letter>` used in dev mode — another workspace (sushigo-e) running its own test suite concurrently caused deadlocks and corrupted migration state. Worked around it by creating a workspace-local `sushigo_ws_d_test` database and exporting `DB_DATABASE` for test runs, without touching the shared `phpunit.xml`.
+- **E2E stack cold start:** no E2E Docker stack was running for this workspace; `make e2e WORKSPACE=sushigo-d` (build + start) plus two iterations to fix Cypress selector scoping (an unscoped `cy.contains('td', ...)` matched a hidden column in the background employee list table instead of the intended entitlement row) added time but caught a real selector bug before merge.
+
+**What went well:** the `overtime_lft_tiers` precedent (found during Phase 2 research) made the tenant-level tiers table, its full-replace PUT endpoint, and its frontend editor nearly a direct port — no design iteration needed there. All 1177 PHPUnit tests and 3326 Vitest tests passed on first full-suite run after the refactor; the resolver change required no production behavior fixes, only test fixture updates (new required `Employee` fields) and one `SeniorityServiceTest` constructor-signature update. The E2E spec confirmed the full stack — tenant policy change → per-employee entitlement calculation → UI display — works correctly end-to-end on the first fully-scoped run.

--- a/doc/tasks/2026-07/214-configurable-vacation-policies.md
+++ b/doc/tasks/2026-07/214-configurable-vacation-policies.md
@@ -1,0 +1,96 @@
+# 💳 Task #214: Allow Configurable Vacation Entitlement Policies Beyond LFT Minimum
+
+**GitHub Issue:** [#214](https://github.com/pakodiazdev/sushigo/issues/214)
+
+## 📖 Story
+
+**English:**
+As a Tenant Admin, I want to configure a vacation entitlement rule more generous than the LFT minimum — either company-wide or for a specific employee — so the system reflects our actual policy instead of only the legal floor.
+
+**Español:**
+Como Admin del tenant, quiero configurar una regla de derecho vacacional más generosa que el mínimo de la LFT — ya sea para toda la empresa o para un empleado específico — para que el sistema refleje nuestra política real y no solo el piso legal.
+
+---
+
+## 🧠 Context
+
+Task #081 implemented vacation day calculation using a Strategy pattern (`VacationEntitlementRule`), but locked the system to a single strategy (`VacationsLFTMX`) resolved via a fixed IoC binding. This debt extends the pattern with two additional levels, both reusing the same generic custom-table strategy:
+
+1. **Company-wide policy** — tenant admin selects "LFT México 2022" (default) or "Política personalizada" in `/configuracion`, and defines a custom years→days table when personalizada is selected.
+2. **Per-employee override** — an employee can have a `ContractualPolicy` override (same custom-table mechanism, employee-scoped) that takes precedence over the tenant default.
+
+Since there is no tenant/company model in this codebase yet (single-instance app; multi-tenancy is planned as one DB per tenant, not a shared `tenant_id` column), tenant-level settings are stored in a new singleton table, not scoped by tenant ID.
+
+---
+
+## 🏗️ Design Decisions
+
+- **Generic custom strategy:** one `CustomVacationPolicy` class (implements `VacationEntitlementRule`) is parameterized with a day table + label + key, and is reused for both `CustomCompanyPolicy` (tenant-level) and `ContractualPolicy` (employee-level) — no separate classes.
+- **Custom table shape:** free-form list of `{ years_from, days }` rows (not fixed LFT-style brackets). `calculate($years)` picks the row with the highest `years_from <= years`. Display `table()` derives ranges between consecutive `years_from` values.
+- **Tenant-level storage:** new singleton table `vacation_policy_settings` (`active_rule_key`) + `vacation_policy_tiers` (rows), mirroring the existing `overtime_lft_tiers` admin-editable-table pattern (full-replace PUT). No `tenant_id` column — future multi-tenancy is one DB per tenant.
+- **Employee-level storage:** two new nullable columns on `employees` — `vacation_entitlement_rule_key` (null = inherit tenant default) and `vacation_entitlement_custom_table` (JSON) — per the issue's suggested schema.
+- **Resolution order:** `VacationEntitlementResolver` — employee override (if set) → tenant custom policy (if active) → `VacationsLFTMX` (default, zero config).
+- **`VacationEntitlementRule` gains a `key(): string` method** (stable identifier for `rule_key`/labeling), replacing `class_basename($rule)` which can no longer distinguish "company" vs "contractual" instances of the same PHP class.
+- **`VacationEntitlementService` and `SeniorityService`** move from constructor-injecting a single `VacationEntitlementRule` to injecting `VacationEntitlementResolver` and resolving per employee.
+
+---
+
+## ✅ Backend Tasks
+
+- [ ] 🔧 `VacationEntitlementRule` interface — add `key(): string`
+- [ ] 🔧 `VacationsLFTMX::key()` → `'VacationsLFTMX'`
+- [ ] ✨ `app/Services/VacationRules/CustomVacationPolicy.php` — generic table-driven strategy
+- [ ] ✨ `app/Services/VacationEntitlementResolver.php` — employee override → tenant custom → LFT default
+- [ ] 🔨 `VacationEntitlementService` — inject resolver instead of fixed rule; resolve per employee in `pendingAnniversaries`, `generateMissing`, `summary` (adds `active_rule_label` to summary)
+- [ ] 🔨 `SeniorityService` — inject resolver instead of fixed rule; resolve per employee in `nextAnniversary`; remove unused `entitledDaysForSeniorityYear` (no employee context, no callers)
+- [ ] 📂 Migration `create_vacation_policy_settings_table` — singleton row (`active_rule_key` default `VacationsLFTMX`)
+- [ ] 📂 Migration `create_vacation_policy_tiers_table` — `years_from`, `days`, `sort_order` (mirrors `overtime_lft_tiers`)
+- [ ] 📂 Migration `add_vacation_entitlement_rule_to_employees_table` — `vacation_entitlement_rule_key` (nullable), `vacation_entitlement_custom_table` (nullable json)
+- [ ] 🔧 `VacationPolicySetting` model (+ `current()` singleton accessor), `VacationPolicyTier` model
+- [ ] 🌐 `GET/PUT /api/v1/vacation-policy` — `ListVacationPolicyController` / `UpdateVacationPolicyController` (full-replace tiers, atomic transaction)
+- [ ] 🌐 `PUT /api/v1/employees/{employee}/vacation-policy-override` — `UpdateEmployeeVacationPolicyController`
+- [ ] 🔑 New permission `vacation-policy.manage` in Production/Development/Testing seeders (group "Asistencia", granted to admin + super-admin)
+- [ ] 🧪 Unit tests: `CustomVacationPolicyTest`, `VacationEntitlementResolverTest`
+- [ ] 🧪 Feature tests: `VacationPolicySettingsApiTest`, `EmployeeVacationPolicyOverrideApiTest`
+- [ ] 🧪 Update `SeniorityServiceTest` for the new resolver-based constructor
+
+## ✅ Frontend Tasks
+
+- [ ] 📝 Types: `VacationPolicyTier`, `VacationPolicySettings`, `UpdateVacationPolicyPayload`, employee override payload/response
+- [ ] 🔧 `src/services/vacation-policy-api.ts` + `vacation-policy-hooks.ts` (mirrors `overtime-lft-tiers-*`)
+- [ ] 🔧 `use-vacation-policy-config-page.ts` + `vacation-policy-shared.tsx` — rule selector (LFT / personalizada) + conditional tiers editor
+- [ ] 📱 `vacation-policy-section.tsx` wired into `configuracion.tsx` as a new "Vacaciones" tab, gated by `vacation-policy.manage`
+- [ ] 🔧 Employee-level override service/hook + small section in employee detail (toggle "Política contractual" + tiers editor)
+- [ ] 📱 Replace hardcoded "LFT México 2022" badge in `vacation-section.tsx` with the backend-resolved `active_rule_label`
+- [ ] ✅ Vitest coverage for all new services/hooks/components
+
+---
+
+## 🎯 Acceptance Criteria
+
+- [ ] Tenant admin can select an active vacation rule from a "Reglas aplicables" dropdown in company settings
+- [ ] A custom policy allows defining a day table (years_from → days) via UI
+- [ ] Per-employee override field exists and takes precedence over the tenant default
+- [ ] `VacationsLFTMX` remains the default and requires zero configuration
+- [ ] All existing entitlement calculations continue to work unchanged
+
+---
+
+## 🔗 References
+
+- **Blocked by / follow-up to:** #081
+- Art. 76 LFT (2022 reform) — baseline rule implemented in `VacationsLFTMX`
+
+---
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `4h` · **Pessimistic:** `7h` · **Tracked:** _in progress_
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-07-14", "start": "02:25", "end": "?" }
+]
+```


### PR DESCRIPTION
## Summary
- Extends the #081 Strategy pattern with a resolver: **employee override → tenant custom policy → LFT default** (zero config)
- Adds a tenant-level "Reglas aplicables" selector in `/configuracion` → Vacaciones tab (LFT México 2022 or a custom years→days table), backed by new `vacation_policy_settings`/`vacation_policy_tiers` tables
- Adds a per-employee "Política contractual" override (toggle + tiers editor) in the employee's Vacaciones section, taking precedence over the tenant default
- Both custom-table cases reuse a single generic `CustomVacationPolicy` strategy class
- No tenant/company model exists in this codebase yet — settings are stored in a singleton table (future multi-tenancy is planned as one DB per tenant, not a shared `tenant_id` column)

## Test plan
- [x] PHPUnit: `php artisan test` — 1177 passed
- [x] PHPUnit (new): `--filter=CustomVacationPolicyTest`, `VacationEntitlementResolverTest`, `VacationPolicySettingsApiTest`, `EmployeeVacationPolicyOverrideApiTest`, `SeniorityServiceTest`
- [x] Vitest: `npx vitest run` — 3326 passed
- [x] Cypress E2E: `cypress/e2e/vacation-policy-settings.cy.ts` — verified passing against the sushigo-d E2E stack
- [x] Linters: Pint ✅ · ESLint ✅ · TypeScript ✅

## Manual Testing
1. Log in as `admin@sushigo.com` and go to **Configuración → Vacaciones**. "LFT México 2022" is selected by default, no tiers editor shown.
2. Select "Política personalizada", edit/add rows (años desde → días), click **Guardar cambios** — a success toast appears and the choice survives a page reload.
3. Open any employee's detail view → **Vacaciones** section. The badge now reads "Política de la empresa" (or "LFT México 2022" if unconfigured), and any newly auto-generated entitlement uses the custom day table.
4. In that same employee's Vacaciones section, check **Política contractual**, define a table, save — the badge switches to "Política contractual" and takes precedence over the tenant policy. Uncheck it to fall back to the tenant default.

## Closes
Closes #214

## Workspace
`sushigo-d` — `feature/214-configurable-vacation-policies`

🤖 Generated with [Claude Code](https://claude.com/claude-code)