### PR TITLE
🎨 [#247][c] - Centralize button style components to stop duplicating dark-mode overrides 🔧

### DIFF
--- a/code/webapp/src/components/attendance/EmployeeAttendanceCard.tsx
+++ b/code/webapp/src/components/attendance/EmployeeAttendanceCard.tsx
@@ -294,8 +294,8 @@ export function EmployeeAttendanceCard({
                 {!isScheduledRestDay && (
                     <Button
                         size="sm"
-                        variant="outline"
-                        className="w-full border-red-300 text-red-700 hover:bg-red-50 dark:border-red-700 dark:text-red-400 dark:hover:bg-red-950/30"
+                        variant="outline-danger"
+                        className="w-full"
                         data-testid="btn-mark-falta"
                         onClick={() => setConfirmFaltaOpen(true)}
                     >
@@ -479,8 +479,8 @@ export function EmployeeAttendanceCard({
                     return (
                         <Button
                             size="sm"
-                            variant="outline"
-                            className="w-full border-yellow-300 text-yellow-700 hover:bg-yellow-50 dark:border-yellow-700 dark:text-yellow-400 dark:hover:bg-yellow-950/30"
+                            variant="outline-warning"
+                            className="w-full"
                             onClick={() => onOvertimeDecision(row.employee, att.id)}
                             data-testid="btn-overtime-decision"
                         >

--- a/code/webapp/src/components/attendance/OvertimeDecisionDialog.tsx
+++ b/code/webapp/src/components/attendance/OvertimeDecisionDialog.tsx
@@ -145,8 +145,8 @@ export function OvertimeDecisionDialog({
               </Button>
 
               <Button
-                variant="outline"
-                className="w-full border-red-300 text-red-700 hover:bg-red-50 dark:border-red-700 dark:text-red-400 dark:hover:bg-red-950/30"
+                variant="outline-danger"
+                className="w-full"
                 onClick={onReject}
                 disabled={isLoading}
                 data-testid="btn-reject-overtime"

--- a/code/webapp/src/components/attendance/RegisterLeaveDialog.tsx
+++ b/code/webapp/src/components/attendance/RegisterLeaveDialog.tsx
@@ -236,16 +236,16 @@ export function RegisterLeaveDialog({
           <div className="flex justify-end gap-3 pt-1">
             <Button
               type="button"
+              variant="neutral"
               onClick={onClose}
               disabled={isPending}
-              className="bg-gray-200 text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
             >
               Cancelar
             </Button>
             <Button
               type="submit"
+              variant="warning"
               disabled={isPending}
-              className="bg-amber-600 text-white hover:bg-amber-700"
             >
               {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               Registrar ausencia

--- a/code/webapp/src/components/cash/__tests__/bank-account-form.test.tsx
+++ b/code/webapp/src/components/cash/__tests__/bank-account-form.test.tsx
@@ -118,6 +118,17 @@ describe('BankAccountForm', () => {
         })
     })
 
+    describe('estado checkbox', () => {
+        it('toggles the active checkbox', () => {
+            const { container } = render(<BankAccountForm {...defaultProps} />)
+            const checkbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement
+
+            expect(checkbox.checked).toBe(true)
+            fireEvent.click(checkbox)
+            expect(checkbox.checked).toBe(false)
+        })
+    })
+
     describe('form interactions', () => {
         it('calls onClose when cancel button is clicked', () => {
             const onClose = vi.fn()

--- a/code/webapp/src/components/cash/bank-account-form.tsx
+++ b/code/webapp/src/components/cash/bank-account-form.tsx
@@ -2,10 +2,9 @@ import { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
-import { Loader2 } from 'lucide-react'
-import { Button } from '@/components/ui/button'
-import { FormField, Select, Checkbox } from '@/components/ui/form-fields'
+import { FormField, Select } from '@/components/ui/form-fields'
 import { SlidePanel } from '@/components/ui/slide-panel'
+import { CashFormFooter } from '@/components/cash/cash-form-footer'
 import { useCreateBankAccount, useUpdateBankAccount } from '@/services/cash-hooks'
 import type { BankAccount } from '@/types/cash'
 
@@ -213,32 +212,13 @@ export function BankAccountForm({
                     />
                 </FormField>
 
-                <FormField label="Estado">
-                    <Checkbox
-                        checked={isActive}
-                        onChange={(e) => setValue('is_active', e.target.checked)}
-                        label="Activa"
-                    />
-                </FormField>
-
-                <div className="flex justify-end gap-3 pt-4 border-t">
-                    <Button
-                        type="button"
-                        onClick={onClose}
-                        disabled={isLoading}
-                        className="bg-gray-200 text-gray-800 hover:bg-gray-300"
-                    >
-                        Cancelar
-                    </Button>
-                    <Button
-                        type="submit"
-                        disabled={isLoading}
-                        className="bg-blue-600 text-white hover:bg-blue-700"
-                    >
-                        {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                        {isEditing ? 'Actualizar' : 'Crear'}
-                    </Button>
-                </div>
+                <CashFormFooter
+                    isActive={isActive}
+                    onActiveChange={(checked) => setValue('is_active', checked)}
+                    onCancel={onClose}
+                    isLoading={isLoading}
+                    isEditing={isEditing}
+                />
             </form>
         </SlidePanel>
     )

--- a/code/webapp/src/components/cash/cash-form-footer.tsx
+++ b/code/webapp/src/components/cash/cash-form-footer.tsx
@@ -1,0 +1,45 @@
+import { Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { FormField, Checkbox } from '@/components/ui/form-fields'
+
+export interface CashFormFooterProps {
+    isActive: boolean
+    onActiveChange: (checked: boolean) => void
+    onCancel: () => void
+    isLoading: boolean
+    isEditing: boolean
+}
+
+/** Must be rendered inside a `<form>` — the submit button relies on the ancestor form's onSubmit. */
+export function CashFormFooter({ isActive, onActiveChange, onCancel, isLoading, isEditing }: Readonly<CashFormFooterProps>) {
+    return (
+        <>
+            <FormField label="Estado">
+                <Checkbox
+                    checked={isActive}
+                    onChange={(e) => onActiveChange(e.target.checked)}
+                    label="Activa"
+                />
+            </FormField>
+
+            <div className="flex justify-end gap-3 pt-4 border-t">
+                <Button
+                    type="button"
+                    variant="neutral"
+                    onClick={onCancel}
+                    disabled={isLoading}
+                >
+                    Cancelar
+                </Button>
+                <Button
+                    type="submit"
+                    variant="info"
+                    disabled={isLoading}
+                >
+                    {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                    {isEditing ? 'Actualizar' : 'Crear'}
+                </Button>
+            </div>
+        </>
+    )
+}

--- a/code/webapp/src/components/cash/cash-register-form.tsx
+++ b/code/webapp/src/components/cash/cash-register-form.tsx
@@ -211,16 +211,16 @@ export function CashRegisterForm({
                     <div className="flex justify-end gap-3">
                         <Button
                             type="button"
+                            variant="neutral"
                             onClick={onClose}
                             disabled={isLoading}
-                            className="bg-gray-200 text-gray-800 hover:bg-gray-300"
                         >
                             Cancelar
                         </Button>
                         <Button
                             type="submit"
+                            variant="info"
                             disabled={isLoading}
-                            className="bg-blue-600 text-white hover:bg-blue-700"
                         >
                             {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                             {isEditing ? 'Actualizar' : 'Crear'}

--- a/code/webapp/src/components/cash/cash-register-list.tsx
+++ b/code/webapp/src/components/cash/cash-register-list.tsx
@@ -98,7 +98,7 @@ export function CashRegisterList({ onEdit, onCreate }: CashRegisterListProps) {
             <div className="flex justify-end">
                 <Button
                     onClick={onCreate}
-                    className="bg-blue-600 text-white hover:bg-blue-700"
+                    variant="info"
                 >
                     <Plus className="mr-2 h-4 w-4" />
                     Nueva Caja

--- a/code/webapp/src/components/cash/cash-terminal-form.tsx
+++ b/code/webapp/src/components/cash/cash-terminal-form.tsx
@@ -2,10 +2,9 @@ import { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
-import { Loader2 } from 'lucide-react'
-import { Button } from '@/components/ui/button'
-import { FormField, Select, Checkbox } from '@/components/ui/form-fields'
+import { FormField, Select } from '@/components/ui/form-fields'
 import { SlidePanel } from '@/components/ui/slide-panel'
+import { CashFormFooter } from '@/components/cash/cash-form-footer'
 import { useCreateCashTerminal, useUpdateCashTerminal } from '@/services/cash-hooks'
 import type { CashTerminal } from '@/types/cash'
 
@@ -198,32 +197,13 @@ export function CashTerminalForm({
                     />
                 </FormField>
 
-                <FormField label="Estado">
-                    <Checkbox
-                        checked={isActive}
-                        onChange={(e) => setValue('is_active', e.target.checked)}
-                        label="Activa"
-                    />
-                </FormField>
-
-                <div className="flex justify-end gap-3 pt-4 border-t">
-                    <Button
-                        type="button"
-                        onClick={onClose}
-                        disabled={isLoading}
-                        className="bg-gray-200 text-gray-800 hover:bg-gray-300"
-                    >
-                        Cancelar
-                    </Button>
-                    <Button
-                        type="submit"
-                        disabled={isLoading}
-                        className="bg-blue-600 text-white hover:bg-blue-700"
-                    >
-                        {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                        {isEditing ? 'Actualizar' : 'Crear'}
-                    </Button>
-                </div>
+                <CashFormFooter
+                    isActive={isActive}
+                    onActiveChange={(checked) => setValue('is_active', checked)}
+                    onCancel={onClose}
+                    isLoading={isLoading}
+                    isEditing={isEditing}
+                />
             </form>
         </SlidePanel>
     )

--- a/code/webapp/src/components/dashboard/Dashboard.tsx
+++ b/code/webapp/src/components/dashboard/Dashboard.tsx
@@ -183,8 +183,8 @@ function SessionCard({ session, onRegisterAdjustment }: { session: CashSession; 
                     </Button>
                     <Button
                         size="sm"
+                        variant="info"
                         onClick={() => onRegisterAdjustment(session.id)}
-                        className="bg-blue-600 hover:bg-blue-700 text-white"
                     >
                         <Plus className="mr-2 h-4 w-4" />
                         Registrar Ajuste
@@ -297,15 +297,15 @@ export default function Dashboard() {
                 </CardHeader>
                 <CardContent className="flex flex-wrap gap-3">
                     <Button
+                        variant="success"
                         onClick={handleOpenSession}
-                        className="bg-green-600 hover:bg-green-700 text-white"
                     >
                         <Plus className="mr-2 h-4 w-4" />
                         Abrir Sesión de Caja
                     </Button>
                     <Button
+                        variant="info"
                         onClick={() => handleCreateAdjustment()}
-                        className="bg-blue-600 hover:bg-blue-700 text-white"
                         disabled={!sessionsData?.data || sessionsData.data.length === 0}
                     >
                         <DollarSign className="mr-2 h-4 w-4" />
@@ -365,7 +365,7 @@ export default function Dashboard() {
                             <Button
                                 onClick={handleOpenSession}
                                 size="sm"
-                                className="bg-green-600 hover:bg-green-700 text-white"
+                                variant="success"
                             >
                                 <Plus className="mr-2 h-4 w-4" />
                                 Abrir Sesión

--- a/code/webapp/src/components/employees/ManualOvertimeMovementDialog.tsx
+++ b/code/webapp/src/components/employees/ManualOvertimeMovementDialog.tsx
@@ -134,16 +134,16 @@ export function ManualOvertimeMovementDialog({
           <div className="flex justify-end gap-3 pt-1">
             <Button
               type="button"
+              variant="neutral"
               onClick={close}
               disabled={isPending}
-              className="bg-gray-200 text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
             >
               Cancelar
             </Button>
             <Button
               type="submit"
+              variant="warning"
               disabled={isPending}
-              className="bg-amber-600 text-white hover:bg-amber-700"
             >
               {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               Registrar movimiento

--- a/code/webapp/src/components/employees/RegisterVacationRequestDialog.tsx
+++ b/code/webapp/src/components/employees/RegisterVacationRequestDialog.tsx
@@ -145,16 +145,16 @@ export function RegisterVacationRequestDialog({
           <div className="flex justify-end gap-3 pt-1">
             <Button
               type="button"
+              variant="neutral"
               onClick={close}
               disabled={isPending}
-              className="bg-gray-200 text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
             >
               Cancelar
             </Button>
             <Button
               type="submit"
+              variant="warning"
               disabled={isPending}
-              className="bg-amber-600 text-white hover:bg-amber-700"
             >
               {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               {willAutoApprove ? 'Registrar vacaciones' : 'Programar vacaciones'}

--- a/code/webapp/src/components/employees/__tests__/employee-detail-view.test.tsx
+++ b/code/webapp/src/components/employees/__tests__/employee-detail-view.test.tsx
@@ -176,4 +176,11 @@ describe('EmployeeDetailView', () => {
     expect(screen.queryByText('Permisos directos del usuario')).toBeNull()
     expect(screen.queryByText('Gestionar →')).toBeNull()
   })
+
+  it('renders the Habilitar toggle button when the employee is inactive', () => {
+    render(<EmployeeDetailView {...baseProps} employee={{ ...employee, is_active: false } as Employee} />)
+
+    expect(screen.getByText('Habilitar')).toBeTruthy()
+    expect(screen.queryByText('Deshabilitar')).toBeNull()
+  })
 })

--- a/code/webapp/src/components/employees/bonus-config-section.tsx
+++ b/code/webapp/src/components/employees/bonus-config-section.tsx
@@ -115,7 +115,7 @@ export function BonusConfigSection({ employeeId }: BonusConfigSectionProps) {
           </div>
 
           <div className="flex gap-2">
-            <Button type="submit" size="sm" disabled={isPending} className="bg-blue-600 text-white hover:bg-blue-700">
+            <Button type="submit" size="sm" variant="info" disabled={isPending}>
               {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               Asignar
             </Button>

--- a/code/webapp/src/components/employees/deactivate-form.tsx
+++ b/code/webapp/src/components/employees/deactivate-form.tsx
@@ -64,18 +64,20 @@ export function DeactivateForm({ isLoading, onSubmit, onCancel }: DeactivateForm
         <div className="flex justify-end gap-2">
           <Button
             type="button"
+            variant="neutral"
             size="sm"
             onClick={onCancel}
             disabled={isLoading}
-            className="bg-gray-200 text-gray-800 hover:bg-gray-300 text-xs"
+            className="text-xs"
           >
             Cancelar
           </Button>
           <Button
             type="submit"
+            variant="warning"
             size="sm"
             disabled={isLoading}
-            className="bg-amber-600 text-white hover:bg-amber-700 text-xs"
+            className="text-xs"
           >
             {isLoading && <Loader2 className="mr-1 h-3 w-3 animate-spin" />}
             Confirmar Baja

--- a/code/webapp/src/components/employees/employee-detail-view.tsx
+++ b/code/webapp/src/components/employees/employee-detail-view.tsx
@@ -178,9 +178,9 @@ export function EmployeeDetailView({
       <div className="flex flex-wrap gap-3">
         <Button
           type="button"
+          variant="info"
           onClick={onEdit}
           disabled={isLoading}
-          className="bg-blue-600 text-white hover:bg-blue-700"
         >
           <Edit className="mr-2 h-4 w-4" />
           Editar
@@ -190,13 +190,9 @@ export function EmployeeDetailView({
         {hasActivePeriod && !showDeactivateForm && !showRehireForm && (
           <Button
             type="button"
+            variant={employee.is_active ? 'neutral-dark' : 'success'}
             onClick={openToggleConfirm}
             disabled={isLoading}
-            className={
-              employee.is_active
-                ? 'bg-gray-600 text-white hover:bg-gray-700'
-                : 'bg-emerald-600 text-white hover:bg-emerald-700'
-            }
           >
             {isTogglingActive ? (
               <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -213,9 +209,9 @@ export function EmployeeDetailView({
         {hasActivePeriod && !showDeactivateForm && !showRehireForm && (
           <Button
             type="button"
+            variant="warning"
             onClick={openDeactivateForm}
             disabled={isLoading}
-            className="bg-amber-600 text-white hover:bg-amber-700"
           >
             <UserMinus className="mr-2 h-4 w-4" />
             Dar de Baja
@@ -226,9 +222,9 @@ export function EmployeeDetailView({
         {!hasActivePeriod && !showRehireForm && !showDeactivateForm && (
           <Button
             type="button"
+            variant="success"
             onClick={openRehireForm}
             disabled={isLoading}
-            className="bg-green-600 text-white hover:bg-green-700"
           >
             <UserPlus className="mr-2 h-4 w-4" />
             Reingreso

--- a/code/webapp/src/components/employees/employee-edit-create-form.tsx
+++ b/code/webapp/src/components/employees/employee-edit-create-form.tsx
@@ -396,16 +396,16 @@ export function EmployeeEditCreateForm({
       <div className="flex justify-end gap-3 pt-4 border-t">
         <Button
           type="button"
+          variant="neutral"
           onClick={onCancel}
           disabled={isLoading}
-          className="bg-gray-200 text-gray-800 hover:bg-gray-300"
         >
           Cancelar
         </Button>
         <Button
           type="submit"
+          variant="info"
           disabled={isLoading}
-          className="bg-blue-600 text-white hover:bg-blue-700"
         >
           {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
           {mode === 'edit' ? 'Actualizar' : 'Crear'}

--- a/code/webapp/src/components/employees/employee-filters.tsx
+++ b/code/webapp/src/components/employees/employee-filters.tsx
@@ -62,7 +62,7 @@ export function EmployeeFilters({
       <div className="flex-1" />
       <Button
         onClick={onNew}
-        className="bg-blue-600 text-white hover:bg-blue-700"
+        variant="info"
       >
         <Plus className="mr-2 h-4 w-4" />
         Nuevo Empleado

--- a/code/webapp/src/components/employees/extra-day-form.tsx
+++ b/code/webapp/src/components/employees/extra-day-form.tsx
@@ -211,8 +211,8 @@ export function ExtraDayForm({ isOpen, onClose, employee }: ExtraDayFormProps) {
           </Button>
           <Button
             type="submit"
+            variant="success"
             disabled={isPending || isLoadingWages || hasNoWage}
-            className="bg-emerald-600 text-white hover:bg-emerald-700"
           >
             {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
             Registrar acuerdo

--- a/code/webapp/src/components/employees/permission-manager-dialog.tsx
+++ b/code/webapp/src/components/employees/permission-manager-dialog.tsx
@@ -187,17 +187,17 @@ export function PermissionManagerDialog({
         <div className="flex justify-end gap-3 border-t border-border px-6 py-4">
           <Button
             type="button"
+            variant="neutral"
             onClick={onClose}
             disabled={isSaving}
-            className="bg-gray-200 text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
           >
             Cancelar
           </Button>
           <Button
             type="button"
+            variant="info"
             onClick={onSave}
             disabled={isSaving || !hasChanges}
-            className="bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
           >
             {isSaving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
             Guardar cambios

--- a/code/webapp/src/components/employees/register-wage-form.tsx
+++ b/code/webapp/src/components/employees/register-wage-form.tsx
@@ -238,18 +238,20 @@ export function RegisterWageForm({ employeeId, onSuccess, onCancel }: RegisterWa
                     <div className="flex justify-end gap-2">
                         <Button
                             type="button"
+                            variant="neutral"
                             size="sm"
                             onClick={onCancel}
                             disabled={createWage.isPending}
-                            className="bg-gray-200 text-gray-800 hover:bg-gray-300 text-xs"
+                            className="text-xs"
                         >
                             Cancelar
                         </Button>
                         <Button
                             type="submit"
+                            variant="info"
                             size="sm"
                             disabled={createWage.isPending}
-                            className="bg-blue-600 text-white hover:bg-blue-700 text-xs"
+                            className="text-xs"
                         >
                             {createWage.isPending && <Loader2 className="mr-1 h-3 w-3 animate-spin" />}
                             Guardar Salario

--- a/code/webapp/src/components/employees/rehire-form.tsx
+++ b/code/webapp/src/components/employees/rehire-form.tsx
@@ -63,18 +63,20 @@ export function RehireForm({ isLoading, onSubmit, onCancel }: RehireFormProps) {
         <div className="flex justify-end gap-2">
           <Button
             type="button"
+            variant="neutral"
             size="sm"
             onClick={onCancel}
             disabled={isLoading}
-            className="bg-gray-200 text-gray-800 hover:bg-gray-300 text-xs"
+            className="text-xs"
           >
             Cancelar
           </Button>
           <Button
             type="submit"
+            variant="success"
             size="sm"
             disabled={isLoading || !effectiveBranch}
-            className="bg-green-600 text-white hover:bg-green-700 text-xs"
+            className="text-xs"
           >
             {isLoading && <Loader2 className="mr-1 h-3 w-3 animate-spin" />}
             Confirmar Reingreso

--- a/code/webapp/src/components/inventory/item-details.tsx
+++ b/code/webapp/src/components/inventory/item-details.tsx
@@ -217,8 +217,7 @@ export function ItemDetails({
       <SlidePanel.Footer>
         <div className="flex justify-between">
           <Button
-            variant="outline"
-            className="text-red-600 hover:text-red-700"
+            variant="outline-danger"
             onClick={onDelete}
           >
             <Trash2 className="mr-2 h-4 w-4" />

--- a/code/webapp/src/components/inventory/location-details.tsx
+++ b/code/webapp/src/components/inventory/location-details.tsx
@@ -185,8 +185,7 @@ export function LocationDetails({
       <SlidePanel.Footer>
         <div className="flex justify-between">
           <Button
-            variant="outline"
-            className="text-red-600 hover:text-red-700"
+            variant="outline-danger"
             onClick={onDelete}
           >
             <Trash2 className="mr-2 h-4 w-4" />

--- a/code/webapp/src/components/solicitudes/my-requests/request-status-card.tsx
+++ b/code/webapp/src/components/solicitudes/my-requests/request-status-card.tsx
@@ -176,9 +176,9 @@ export function RequestStatusCard({ request, onCancel, isCancelling }: RequestSt
 
           {cancellable && (
             <Button
-              variant="ghost"
+              variant="ghost-danger"
               size="sm"
-              className="text-red-400 hover:bg-red-50 hover:text-red-600 shrink-0"
+              className="shrink-0"
               onClick={() => setConfirmOpen(true)}
               disabled={isCancelling}
             >

--- a/code/webapp/src/components/ui/__tests__/button.test.tsx
+++ b/code/webapp/src/components/ui/__tests__/button.test.tsx
@@ -23,11 +23,76 @@ describe('Button', () => {
             expect(button.className).toContain('bg-destructive')
         })
 
-        it('renders outline variant', () => {
+        it('renders outline variant with dark-mode-safe border contrast', () => {
             const { container } = render(<Button variant="outline">Outline</Button>)
             const button = container.firstChild as HTMLElement
             expect(button.className).toContain('border')
             expect(button.className).toContain('bg-background')
+            expect(button.className).toContain('border-muted-foreground/40')
+            expect(button.className).toContain('dark:border-muted-foreground/50')
+            expect(button.className).toContain('dark:hover:bg-muted/60')
+        })
+
+        it('renders outline-danger variant with dark-mode-safe red contrast', () => {
+            const { container } = render(<Button variant="outline-danger">Danger</Button>)
+            const button = container.firstChild as HTMLElement
+            expect(button.className).toContain('border-red-300')
+            expect(button.className).toContain('text-red-700')
+            expect(button.className).toContain('dark:border-red-700')
+            expect(button.className).toContain('dark:text-red-400')
+        })
+
+        it('renders outline-warning variant with dark-mode-safe yellow contrast', () => {
+            const { container } = render(<Button variant="outline-warning">Warning</Button>)
+            const button = container.firstChild as HTMLElement
+            expect(button.className).toContain('border-yellow-300')
+            expect(button.className).toContain('text-yellow-700')
+            expect(button.className).toContain('dark:border-yellow-700')
+            expect(button.className).toContain('dark:text-yellow-400')
+        })
+
+        it('renders neutral variant with dark-mode-safe gray contrast', () => {
+            const { container } = render(<Button variant="neutral">Cancelar</Button>)
+            const button = container.firstChild as HTMLElement
+            expect(button.className).toContain('bg-gray-200')
+            expect(button.className).toContain('text-gray-800')
+            expect(button.className).toContain('dark:bg-gray-700')
+            expect(button.className).toContain('dark:text-gray-200')
+        })
+
+        it('renders neutral-dark variant', () => {
+            const { container } = render(<Button variant="neutral-dark">Deshabilitar</Button>)
+            const button = container.firstChild as HTMLElement
+            expect(button.className).toContain('bg-gray-600')
+            expect(button.className).toContain('text-white')
+        })
+
+        it('renders info variant', () => {
+            const { container } = render(<Button variant="info">Guardar</Button>)
+            const button = container.firstChild as HTMLElement
+            expect(button.className).toContain('bg-blue-600')
+            expect(button.className).toContain('text-white')
+        })
+
+        it('renders warning variant', () => {
+            const { container } = render(<Button variant="warning">Confirmar</Button>)
+            const button = container.firstChild as HTMLElement
+            expect(button.className).toContain('bg-amber-600')
+            expect(button.className).toContain('text-white')
+        })
+
+        it('renders success variant', () => {
+            const { container } = render(<Button variant="success">Aceptar</Button>)
+            const button = container.firstChild as HTMLElement
+            expect(button.className).toContain('bg-green-600')
+            expect(button.className).toContain('text-white')
+        })
+
+        it('renders ghost-danger variant with dark-mode-safe red contrast', () => {
+            const { container } = render(<Button variant="ghost-danger">Cancelar</Button>)
+            const button = container.firstChild as HTMLElement
+            expect(button.className).toContain('text-red-400')
+            expect(button.className).toContain('dark:hover:bg-red-950/30')
         })
 
         it('renders secondary variant', () => {

--- a/code/webapp/src/components/ui/button.tsx
+++ b/code/webapp/src/components/ui/button.tsx
@@ -2,7 +2,21 @@ import * as React from "react"
 import { cn } from "@/lib/utils"
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-    variant?: "default" | "destructive" | "outline" | "secondary" | "ghost" | "link"
+    variant?:
+        | "default"
+        | "destructive"
+        | "outline"
+        | "outline-danger"
+        | "outline-warning"
+        | "secondary"
+        | "neutral"
+        | "neutral-dark"
+        | "info"
+        | "warning"
+        | "success"
+        | "ghost"
+        | "ghost-danger"
+        | "link"
     size?: "default" | "sm" | "lg" | "icon"
 }
 
@@ -11,9 +25,22 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         const variants = {
             default: "bg-primary text-primary-foreground hover:bg-primary/90",
             destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
-            outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+            outline:
+                "border border-muted-foreground/40 bg-background text-foreground hover:bg-accent hover:text-accent-foreground dark:border-muted-foreground/50 dark:hover:bg-muted/60",
+            "outline-danger":
+                "border border-red-300 bg-background text-red-700 hover:bg-red-50 hover:text-red-700 dark:border-red-700 dark:text-red-400 dark:hover:bg-red-950/30 dark:hover:text-red-300",
+            "outline-warning":
+                "border border-yellow-300 bg-background text-yellow-700 hover:bg-yellow-50 hover:text-yellow-700 dark:border-yellow-700 dark:text-yellow-400 dark:hover:bg-yellow-950/30 dark:hover:text-yellow-300",
             secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+            neutral:
+                "bg-gray-200 text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600",
+            "neutral-dark": "bg-gray-600 text-white hover:bg-gray-700",
+            info: "bg-blue-600 text-white hover:bg-blue-700",
+            warning: "bg-amber-600 text-white hover:bg-amber-700",
+            success: "bg-green-600 text-white hover:bg-green-700",
             ghost: "hover:bg-accent hover:text-accent-foreground",
+            "ghost-danger":
+                "text-red-400 hover:bg-red-50 hover:text-red-600 dark:text-red-400 dark:hover:bg-red-950/30 dark:hover:text-red-300",
             link: "text-primary underline-offset-4 hover:underline",
         }
 

--- a/code/webapp/src/components/ui/confirm-dialog.tsx
+++ b/code/webapp/src/components/ui/confirm-dialog.tsx
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { Button } from '@/components/ui/button'
+import { Button, type ButtonProps } from '@/components/ui/button'
 import { Loader2, AlertTriangle, Info } from 'lucide-react'
 import { SlidePanelOverlayContext } from '@/components/ui/slide-panel-context'
 
@@ -25,24 +25,24 @@ export interface ConfirmDialogProps {
   container?: 'viewport'
 }
 
-const variantStyles = {
+const variantStyles: Record<NonNullable<ConfirmDialogProps['variant']>, { icon: typeof AlertTriangle; iconBg: string; iconColor: string; confirmVariant: ButtonProps['variant'] }> = {
   danger: {
     icon: AlertTriangle,
     iconBg: 'bg-red-100 dark:bg-red-900/40',
     iconColor: 'text-red-600 dark:text-red-400',
-    confirmBtn: 'bg-red-600 text-white hover:bg-red-700',
+    confirmVariant: 'destructive',
   },
   warning: {
     icon: AlertTriangle,
     iconBg: 'bg-amber-100 dark:bg-amber-900/40',
     iconColor: 'text-amber-600 dark:text-amber-400',
-    confirmBtn: 'bg-amber-600 text-white hover:bg-amber-700',
+    confirmVariant: 'warning',
   },
   info: {
     icon: Info,
     iconBg: 'bg-blue-100 dark:bg-blue-900/40',
     iconColor: 'text-blue-600 dark:text-blue-400',
-    confirmBtn: 'bg-blue-600 text-white hover:bg-blue-700',
+    confirmVariant: 'info',
   },
 }
 
@@ -181,17 +181,17 @@ export function ConfirmDialog({
         <div className="flex justify-end gap-3 border-t border-border px-6 py-4">
           <Button
             type="button"
+            variant="neutral"
             onClick={onClose}
             disabled={isLoading}
-            className="bg-gray-200 text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
           >
             {cancelLabel}
           </Button>
           <Button
             type="button"
+            variant={styles.confirmVariant}
             onClick={onConfirm}
             disabled={isLoading || confirmDisabled}
-            className={styles.confirmBtn}
           >
             {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
             {confirmLabel}

--- a/doc/conventions/frontend/button-styles.md
+++ b/doc/conventions/frontend/button-styles.md
@@ -1,0 +1,57 @@
+# Button Style Convention
+
+> **Rule:** Use the `variant` prop on `Button` (`src/components/ui/button.tsx`) for every semantic style a button needs. Never bolt on ad-hoc contrast/palette `className` overrides (`border-*`, `text-*`, `bg-*`, and especially their `dark:` variants) to get contrast on a specific dialog or card. Layout-only classes (`w-full`, spacing, sizing) are fine on any variant.
+
+## Why
+
+`Button`'s `outline` variant is used across the webapp inside `bg-card` panels (dialogs, cards). Its border/background were not designed with dark-mode contrast in mind, which pushed consumers to hand-write one-off `dark:border-*` / `dark:text-*` overrides per component. Two examples both lived in `OvertimeDecisionDialog.tsx` before this convention existed:
+- A "No pagar" (destructive) button needed its own inline red palette.
+- A "Regresar" (neutral) button blended into the dialog's `bg-card` panel in dark mode, needing its own inline border-contrast fix.
+
+Both are symptoms of the same gap: contrast belongs in the component, not in each consumer.
+
+## Available variants
+
+| Variant | Use for | Notes |
+|---|---|---|
+| `default` | Primary / main call to action | Solid `bg-primary` (brand color), safe in both themes by default |
+| `secondary` | Secondary action using the brand secondary token | Solid `bg-secondary` |
+| `outline` | Neutral action inside a card/dialog panel (e.g. "Regresar", "Cancelar" when not using `ghost`) | Dark-mode-safe border baked in — do not add your own `dark:border-*` |
+| `outline-danger` | Destructive/negative action styled as outline (not a solid button) — e.g. "No pagar", "Marcar falta", "Delete" in inventory panels | Dark-mode-safe red palette baked in |
+| `outline-warning` | Pending/attention action styled as outline — e.g. "Decidir horas extra" | Dark-mode-safe yellow palette baked in |
+| `destructive` | Destructive action as a solid button, using the brand destructive token | Use when the action should read as more severe than `outline-danger`; also the default `confirmVariant` for `ConfirmDialog`'s `danger` variant |
+| `neutral` | Solid gray "Cancelar" button in a modal footer (legacy blue/gray palette, not the brand `secondary` token) | Dark-mode-safe gray baked in — use instead of hardcoding `bg-gray-200`/`dark:bg-gray-700` |
+| `neutral-dark` | Solid darker-gray action (e.g. "Deshabilitar" toggle) | One-off darker neutral tone, distinct from `neutral` |
+| `info` | Solid blue "Guardar"/"Nueva X" action (legacy blue palette, not the brand `default` token) | Use instead of hardcoding `bg-blue-600` |
+| `warning` | Solid amber confirm/attention action (e.g. "Dar de Baja", "Registrar ausencia") | Use instead of hardcoding `bg-amber-600` |
+| `success` | Solid green positive/confirm action (e.g. "Abrir Sesión de Caja", "Habilitar", "Reingreso") | Use instead of hardcoding `bg-green-600`/`bg-emerald-600` |
+| `ghost` | Lowest-emphasis action (e.g. "Cancelar" next to a stronger action) | No border, no fixed background |
+| `ghost-danger` | Lowest-emphasis destructive/cancel action (e.g. an inline "Cancelar" link on a request card) | Dark-mode-safe red text baked in |
+| `link` | Inline text-styled action | |
+
+`info`/`neutral`/`warning`/`success` intentionally preserve a legacy blue/gray/amber/green palette that predates the brand tokens (`--primary` is red/pink, `--secondary` is navy) — they exist so pre-existing "Guardar"/"Cancelar" button colors don't visibly change while still being centralized. Prefer `default`/`secondary`/`destructive` for new brand-aligned UI; reach for `info`/`neutral`/`warning`/`success` only when matching this existing pattern.
+
+## Rule
+
+If a button needs a `className` override for `border-*`, `text-*`, `bg-*`, or any `dark:` variant of those, that is a signal the base `variant` is missing a semantic role — add or fix the variant in `button.tsx` instead of overriding it at the call site.
+
+```tsx
+// ❌ Wrong — ad-hoc override, breaks again the next time someone touches dark mode
+<Button
+  variant="outline"
+  className="w-full border-red-300 text-red-700 hover:bg-red-50 dark:border-red-700 dark:text-red-400 dark:hover:bg-red-950/30"
+>
+  No pagar
+</Button>
+
+// ✅ Correct — semantic variant carries its own dark-mode contrast
+<Button variant="outline-danger" className="w-full">
+  No pagar
+</Button>
+```
+
+## Reference migration
+
+`OvertimeDecisionDialog.tsx` ("No pagar" → `outline-danger`, "Regresar" → `outline`) is the reference for migrating existing ad-hoc overrides to the centralized variants. `EmployeeAttendanceCard.tsx` ("Marcar falta" → `outline-danger`, "Decidir horas extra" → `outline-warning`) is a second migration of the same pattern.
+
+As of issue #247, every `<Button>` usage in the webapp has been migrated off hardcoded palette `className` overrides, across `attendance/`, `cash/`, `employees/`, `inventory/`, `solicitudes/`, `dashboard/`, and `ui/confirm-dialog.tsx`. `ConfirmDialog`'s internal `variantStyles` map now resolves to a `Button` `variant` name (`confirmVariant`) instead of a raw className, so its own danger/warning/info confirm buttons go through the same system. See issue #247.

--- a/doc/tasks/2026-07/247-centralize-button-components.md
+++ b/doc/tasks/2026-07/247-centralize-button-components.md
@@ -1,0 +1,81 @@
+# 🎨 Task #247: Centralize Button Style Components
+
+**GitHub Issue:** [#247](https://github.com/pakodiazdev/sushigo/issues/247)
+
+## 📖 Story
+
+**English:**
+As a frontend developer, I need centralized styled button components (e.g. `ButtonPrimary`, `ButtonSecondary`, `ButtonDanger`) with light/dark contrast already baked in, so that I don't have to hand-write ad-hoc Tailwind overrides (including `dark:` variants) in every dialog that needs a visually distinct button.
+
+**Español:**
+Como desarrollador frontend, necesito componentes de botón con estilos centralizados (ej. `ButtonPrimary`, `ButtonSecondary`, `ButtonDanger`) con el contraste claro/oscuro ya resuelto, para no tener que reescribir overrides de Tailwind ad-hoc (incluyendo variantes `dark:`) en cada diálogo que necesite un botón visualmente distinto.
+
+---
+
+## 🧠 Context
+
+`src/components/ui/button.tsx` only defines generic variants (`default`, `outline`, `secondary`, `ghost`, `destructive`, `link`) via plain Tailwind class strings, with no dark-mode-aware contrast guarantees. This pushes consumers to bolt on inline `dark:` overrides per component instead of getting correct contrast for free.
+
+Two concrete examples in the same file, `src/components/attendance/OvertimeDecisionDialog.tsx`:
+- The "No pagar" button already needed inline overrides: `border-red-300 text-red-700 hover:bg-red-50 dark:border-red-700 dark:text-red-400 dark:hover:bg-red-950/30`.
+- The "Regresar" button (`variant="outline"`) blended into the dialog's `bg-card` panel in dark mode because `border-input`/`bg-background` are too close in lightness to `--card` in the dark palette. Fixed on the #229 branch with another one-off override (`border-muted-foreground/40 text-foreground hover:bg-accent hover:text-accent-foreground dark:border-muted-foreground/50 dark:hover:bg-muted/60`) — the same class of problem, duplicated again.
+
+Both are symptoms of the same gap: button contrast/semantics are not centralized, so every new dialog re-derives (and sometimes re-breaks) them.
+
+---
+
+## ✅ Technical Tasks
+
+- [x] 🔍 Audit existing ad-hoc `dark:` overrides on `Button` usages across the webapp (`grep -rn 'variant="outline"\|variant="ghost"' src | grep dark:`) — extended to a full-app scan of every `<Button>` for hardcoded palette classes, not just `dark:` ones
+- [x] 🎨 Design contrast-checked light/dark styles per semantic role (primary, secondary, destructive, ghost) in `src/components/ui/button.tsx`
+- [x] 🔧 Expose them as dedicated `variant` values with the styles baked in (`outline-danger`, `outline-warning`, `neutral`, `neutral-dark`, `info`, `warning`, `success`, `ghost-danger`) instead of separate `ButtonPrimary`/`ButtonSecondary` components
+- [x] 🔁 Migrate `OvertimeDecisionDialog.tsx` ("No pagar" and "Regresar" buttons) to the new components as the reference migration
+- [x] 📝 Document the button style guide in `doc/conventions/frontend/`
+
+---
+
+## 🎯 Acceptance Criteria
+
+- [x] Centralized button components cover at least primary/secondary/destructive semantics with dark-mode contrast built in — no consumer needs to add its own `dark:border-*` / `dark:text-*` just to be visible
+- [x] `OvertimeDecisionDialog.tsx` uses the new components instead of inline overrides
+- [x] Style guide documented so future dialogs reuse the components instead of rewriting classes
+
+---
+
+## 🔗 References
+
+- Discovered while fixing the "Regresar" button dark-mode contrast in #229 (`OvertimeDecisionDialog.tsx`, day-close overtime flow)
+
+---
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `3h` · **Pessimistic:** `6h` · **Tracked:** `~6h39m`
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-07-15", "start": "10:21", "end": "11:02" },
+  { "date": "2026-07-15", "start": "11:02", "end": "13:24" },
+  { "date": "2026-07-15", "start": "13:24", "end": "13:48" },
+  { "date": "2026-07-15", "start": "13:48", "end": "15:51" },
+  { "date": "2026-07-15", "start": "15:51", "end": "17:00" }
+]
+```
+
+---
+
+## 📊 Retrospective
+- **Actual total:** 6h 39m (41m + 2h22m + 24m + 2h3m + 1h9m)
+- **vs optimistic:** +3h 39m
+- **vs pessimistic:** +39m (over)
+
+**Justification:**
+The original scope (per the issue's acceptance criteria) was a reference migration limited to the two `OvertimeDecisionDialog.tsx` buttons plus a style guide — that alone landed within the optimistic estimate (session 1, 41m). Four unplanned expansions drove the rest of the time:
+1. A follow-up self-audit ("busca más botones") found the same anti-pattern repeated on `EmployeeAttendanceCard.tsx` (session 2) and, on a second, more thorough pass, across the *entire* webapp — 37 `<Button>` usages in 15 additional files using a hardcoded legacy blue/gray/amber/green palette instead of any variant at all (session 3). Migrating all of them (correctly, preserving exact existing colors per user direction) required designing 6 new variants and refactoring `ConfirmDialog`'s internal styling map.
+2. Two PR review cycles (Copilot) needed doc wording fixes.
+3. The expanded diff tripped SonarCloud's quality gate (coverage dropped to 75% via an untested ternary branch; duplication rose to 4.7% from two forms sharing a now-identical Cancel/Guardar block) — fixing it required extracting a new shared `CashFormFooter` component and adding two targeted tests (session 4).
+4. A final external review pass (pasted Sonar/AI feedback) caught one more missed button (`SessionCard`, a sub-component inside `Dashboard.tsx`, missed by the earlier automated audit) plus an undeclared visual change (`ConfirmDialog`'s danger button silently moved from a hardcoded red to the theme's `destructive` token, affecting 10+ call sites) that needed to be fixed and disclosed in the PR description (session 5).
+
+None of this was scope creep for its own sake — it was requested explicitly at each step (find more buttons → migrate them → pass the quality gate → address final review feedback) — but the task's true scope (full app-wide button centralization, verified to zero remaining instances) was always going to exceed a "reference migration" estimate. The 39m overrun on the pessimistic estimate reflects that gap between the original story's scope and what was actually delivered, not inefficiency within any single session.


### PR DESCRIPTION
## Summary
- Fixed the `outline` variant in `src/components/ui/button.tsx` to be dark-mode-contrast-safe against `bg-card` panels
- Added `outline-danger`/`outline-warning` (outline-style) and `neutral`/`neutral-dark`/`info`/`warning`/`success`/`ghost-danger` (solid-style) variants — the solid variants intentionally preserve the app's existing legacy blue/gray/amber/green palette (which predates the brand `--primary`/`--secondary` tokens) so no button visibly changed color, just centralized
- Migrated every `<Button>` usage in the webapp off hardcoded palette `className` overrides — 24 files across `attendance/`, `cash/`, `employees/`, `inventory/`, `solicitudes/`, `dashboard/`, and `ui/confirm-dialog.tsx` (including `SessionCard`, a sub-component inside `Dashboard.tsx`, missed in the first pass and fixed after review)
- Refactored `ConfirmDialog`'s internal `variantStyles` map to resolve a `Button` `variant` name instead of a raw className string
- Extracted a shared `CashFormFooter` component to eliminate a duplicated Estado/Cancelar/Guardar block between `bank-account-form.tsx` and `cash-terminal-form.tsx` (raised by the SonarCloud duplication check on the new code introduced here)
- Documented the full variant set, including the legacy-palette rationale, in `doc/conventions/frontend/button-styles.md`
- Verified with a script scanning every `<Button>` JSX tag in `src/` for hardcoded `border-*`/`text-*`/`bg-*`/`hover:*` color classes — 0 remaining after this PR (was 37 before)

**Four intentional visual refinements** (flagged since they're not purely mechanical):
- `item-details.tsx`/`location-details.tsx` "Delete" buttons: previously `variant="outline"` with only a red *text* override (neutral gray border); now `outline-danger`, which also gives them a red border — same semantic role, slightly more consistent styling
- `extra-day-form.tsx`'s "Registrar acuerdo" button used `emerald-600` uniquely; folded into the shared `success` (`green-600`) variant used everywhere else for this role — a barely perceptible hue shift
- `employee-detail-view.tsx`'s "Habilitar" toggle (shown when an employee is inactive) also used `emerald-600`; same fold into `success` (`green-600`) for the same reason — one shared "positive/confirm" green across the app instead of two near-identical greens
- `ConfirmDialog`'s `danger` variant confirm button moved from a hardcoded `bg-red-600` to `variant="destructive"` (the theme's `--destructive` token, a brighter/more saturated red in both light and dark mode). This affects every `ConfirmDialog variant="danger"` instance app-wide (10+ call sites, e.g. `EmployeeAttendanceCard.tsx`, `request-status-card.tsx`, `extra-day-section.tsx`, the holidays page) — same semantic role (destructive confirm), slightly different red, and now consistent with every other solid destructive button in the app instead of its own one-off hardcoded red

**Note on the base `outline` variant:** its border color changed everywhere (`border-input` → `border-muted-foreground/40`, with a matching dark-mode fix) — this is the core, intended fix of this PR, so every existing `variant="outline"` button (used extensively, e.g. `EmployeeAttendanceCard.tsx`) picks up a subtly different border in light mode too, not just dark mode.

## Test plan
- [x] Vitest: `npx vitest run` (full suite) — 3309/3309 passing, 3 pre-existing skips unrelated to this change
- [x] Vitest: `npx vitest run src/components/ui/__tests__/button.test.tsx` — 23/23, covering every variant including the 6 new ones
- [x] Linters: ESLint ✅ (0 errors) · TypeScript ✅
- [x] SonarCloud quality gate: ✅ PASSED — 0 new bugs/vulnerabilities/code smells/hotspots, 92.9% coverage on new code, 0.0% duplication

## Closes
Closes #247

## Manual Testing
1. Run `npm run dev` and open the webapp
2. Attendance → today's view → close a day with pending overtime; toggle dark mode and confirm the overtime decision dialog's "No pagar"/"Regresar" buttons are legible against the card panel
3. On an employee attendance card, confirm "Marcar falta" (red) and "Decidir horas extra" (yellow) are legible in dark mode
4. Open any employee's detail view (Empleados → seleccionar uno) — confirm "Editar" (blue), "Deshabilitar"/"Habilitar" (gray/green), "Dar de Baja" (amber) render correctly — note "Habilitar" is now `green-600` instead of the prior `emerald-600` (intentional, see above)
5. Open Caja → Nueva Caja / Nueva Cuenta Bancaria forms — confirm "Cancelar" (gray) / "Guardar" (blue) look unchanged, and the "Activa" checkbox still toggles correctly (now rendered via the shared `CashFormFooter`)
6. Dashboard → Caja → confirm the "Registrar Ajuste" button on each open session card is blue and works
7. Trigger any `ConfirmDialog` in `danger` mode (e.g. delete an inventory item) — confirm the confirm button is red (now the theme's destructive red, slightly different from before)

## Workspace
`sushigo-c` — `refactor/247-centralize-button-components`

🤖 Generated with [Claude Code](https://claude.com/claude-code)