### PR TITLE
📚 [#254][a] - Recover stranded retrospective and backlog docs 📝

### DIFF
--- a/doc/tasks/2026-07/075-period-export-csv.md
+++ b/doc/tasks/2026-07/075-period-export-csv.md
@@ -46,20 +46,31 @@ Como Admin, quiero exportar un periodo de nómina cerrado a un archivo CSV, para
 ## ⏱️ Time
 
 ### 📊 Estimates
-- **Optimistic:** `1h` · **Pessimistic:** `2h` · **Tracked:** `~5h04m`
+- **Optimistic:** `1h` · **Pessimistic:** `2h` · **Tracked:** `~10h19m`
 
 ### 📅 Sessions
 ```json
 [
-  { "date": "2026-07-14", "start": "02:18", "end": "07:22" }
+  { "date": "2026-07-14", "start": "02:18", "end": "07:22" },
+  { "date": "2026-07-14", "start": "20:45", "end": "23:45" },
+  { "date": "2026-07-15", "start": "15:55", "end": "18:10" }
 ]
 ```
 
 ## 📊 Retrospective
-- **Actual total:** 5h 04m (304 min)
-- **vs optimistic:** +4h 04m
-- **vs pessimistic:** +3h 04m
+- **Actual total:** 10h 19m (304 min + 180 min + 135 min)
+- **vs optimistic:** +9h 19m
+- **vs pessimistic:** +8h 19m
 
 **Justification:**
 
-The implementation itself (backend endpoint, frontend service/hook/button, tests) was quick and matched the estimate. The overrun came almost entirely from environment collisions outside the task's scope: the dev-lab's shared `mydb_test` PostgreSQL database is used by every workspace, and other workspaces (`sushigo-b`, `sushigo-e`) ran their own PHPUnit suites concurrently multiple times during this session, causing repeated deadlocks and, once, a corrupted intermediate schema that needed a manual `migrate:fresh` to recover before tests could run at all. Standing up the isolated E2E Docker stack for the mandatory Cypress spec (first-time container build) also added time. None of this reflects unplanned work on the feature itself — see the `feedback-shared-test-db-collision` memory for the underlying infra issue.
+Session 1 (5h04m) was the original implementation — see prior note: the overrun there came almost entirely from shared `mydb_test` collisions with other workspaces and standing up the E2E Docker stack for the first time, not from the feature itself. See `feedback-shared-test-db-collision` memory.
+
+Sessions 2 and 3 (+5h15m combined) were **not** rework on the original scope — they were review follow-up and scope additions layered on afterward:
+- Fixed two Devin-reported code review bugs (inline FQCN import, a premature `canExport` flag before period data loads).
+- Added a new, unplanned deliverable: `PayPeriodHistorySeeder` (Development) and `PayrollPeriodHistorySeeder` (Testing) backfilling ~1 year / ~2 months of realistic weekly pay-period history, reusing the real close-period computation — plus its own Cypress E2E spec (`payroll-period-history.cy.ts`). This alone required a research sub-agent pass over the seeder conventions and payroll domain, and included recovering from an environment mistake (accidentally truncating the workspace's local dev DB via `test:reset` reading the wrong `.env`, fixed with `migrate:fresh --seed`).
+- A second Devin review pass flagged that `REOPENED` periods were exportable — a genuine product-decision gap, resolved by restricting export to `CLOSED` only on both backend and frontend, with new/updated tests.
+- A full `/sonar-review` cycle: the added seeder code introduced a 30-line duplication with `ConfirmCloseController` and a too-many-parameters smell, both fixed by extracting a shared `ClosePayPeriodForEmployeeAction`; a minor webapp code smell was also fixed. Required two CI round-trips to confirm the gate went green.
+- Finished with a `rebase-main` and a full history squash (11 commits → 1) at explicit request.
+
+None of this reflects estimation error on the original 1–2h scope — the estimate was for "add a CSV export endpoint + button," and roughly 90% of the tracked time across sessions 2–3 was additional scope (history backfill feature, review remediation, quality-gate compliance) requested or discovered after the original feature was already done.

--- a/doc/tasks/backlog/248-centralize-label-component.md
+++ b/doc/tasks/backlog/248-centralize-label-component.md
@@ -1,0 +1,60 @@
+# 🎨 Task #248: Centralize Form Label Component
+
+**GitHub Issue:** [#248](https://github.com/pakodiazdev/sushigo/issues/248)
+
+## 📖 Story
+
+**English:**
+As a frontend developer, I need a centralized `Label` component (styles + behavior baked in) so that form field labels never silently lose contrast in dark mode again, instead of every form hand-writing `<label className="text-sm font-medium">` with no explicit text color.
+
+**Español:**
+Como desarrollador frontend, necesito un componente `Label` centralizado (con sus estilos y comportamiento ya resueltos) para que las etiquetas de campos de formulario nunca vuelvan a perder contraste en modo oscuro en silencio, en vez de que cada formulario escriba a mano `<label className="text-sm font-medium">` sin color de texto explícito.
+
+---
+
+## 🧠 Context
+
+The native `<dialog>` element ships a UA stylesheet that sets `color: CanvasText` directly on it (not `inherit`) — a system color that follows the OS/browser color scheme, not this app's manual `.dark` class toggle. Any descendant text node that doesn't set its own explicit `color`/Tailwind text color silently inherits that system value instead of the app's `--foreground` token, so it can render dark-on-dark regardless of the app's theme.
+
+This just bit `src/components/attendance/OvertimeDecisionDialog.tsx`: the "Método", "Tarifa por hora" and "Factor..." `<label>` elements had no explicit color class (`className="text-sm font-medium"` only) and were unreadable in dark mode. Fixed on the spot by adding `text-foreground` on the `<dialog>` panel itself (root-cause fix, cascades to every unstyled descendant). Same root cause as the "Regresar" button contrast issue also fixed on this branch (#229) — that fix happened to work because the button already set `text-foreground` explicitly, unlike these labels.
+
+A quick grep shows this same unstyled-label pattern (`text-sm font-medium` with no color) repeated across the webapp (`rehire-form.tsx`, `deactivate-form.tsx`, `bonus-config-section.tsx`, `register-wage-form.tsx`, etc.) — all currently working only because they don't happen to sit inside a native `<dialog>`, but latent to the same bug the moment they do.
+
+This is the same class of problem as [#247](https://github.com/pakodiazdev/sushigo/issues/247) (button styles duplicated ad-hoc instead of centralized) — labels need the same treatment.
+
+---
+
+## ✅ Technical Tasks
+
+- [ ] 🔍 Audit existing `<label className="...">` usages across the webapp for missing explicit text color
+- [ ] 🔧 Create a centralized `Label` component (e.g. `src/components/ui/label.tsx`) with the standard `text-sm font-medium text-foreground` styling and `htmlFor`/`disabled` behavior baked in
+- [ ] 🔁 Migrate `OvertimeDecisionDialog.tsx` labels ("Método", "Tarifa por hora", "Factor...") to the new component as the reference migration
+- [ ] 📝 Document the `Label` usage in `doc/conventions/frontend/` alongside the button style guide from #247
+
+---
+
+## 🎯 Acceptance Criteria
+
+- [ ] Centralized `Label` component exists with contrast-safe styling that doesn't depend on inheriting from a parent that might not propagate `--foreground` (e.g. native `<dialog>`)
+- [ ] `OvertimeDecisionDialog.tsx` uses it instead of raw `<label>` + hand-written classes
+- [ ] Style guide documented so future forms reuse the component instead of rewriting classes
+
+---
+
+## 🔗 References
+
+- Discovered while fixing the "Método" label dark-mode contrast in #229 (`OvertimeDecisionDialog.tsx`, day-close overtime flow)
+- Same centralization problem as [#247](https://github.com/pakodiazdev/sushigo/issues/247) (button styles)
+
+---
+
+## ⏱️ Estimates
+
+- **Optimistic:** `2h` · **Pessimistic:** `4h`
+
+---
+
+## ⏱️ Sessions
+```json
+[]
+```

--- a/doc/tasks/backlog/249-overtime-apply-to-rest.md
+++ b/doc/tasks/backlog/249-overtime-apply-to-rest.md
@@ -1,0 +1,69 @@
+# ✨ Task #249: "Apply to the Rest" Checkbox for Bulk Overtime Decisions
+
+**GitHub Issue:** [#249](https://github.com/pakodiazdev/sushigo/issues/249)
+
+## 📖 Story
+
+**English:**
+As an Admin closing the day for a branch, when several employees show the same overtime decision (`overtime_pending`), I want to check "Aplicar para el resto" on the decision/valuation dialog so that the decision I just configured (authorize/reject, method, rate or factor) is copied and applied to every other pending employee in the queue at once — in a single request — instead of having to confirm the same dialog one employee at a time.
+
+**Español:**
+Como Admin cerrando el día de una sucursal, cuando varios empleados muestran la misma decisión de hora extra pendiente (`overtime_pending`), quiero marcar "Aplicar para el resto" en el diálogo de decisión/valoración para que la decisión que acabo de configurar (autorizar/rechazar, método, tarifa o factor) se copie y aplique de una vez al resto de empleados pendientes en la cola — en una sola petición — en vez de tener que confirmar el mismo diálogo uno por uno.
+
+---
+
+## 🧠 Context
+
+#229 introduced the bulk overtime flow: `useTodayAttendancePage` (`code/webapp/src/pages/attendance/-use-today-attendance-page.ts`) queues every `overtime_pending` entry from the close-day panel into `bulkOvertimeQueue` (a FIFO array), and `AttendancePage` (`code/webapp/src/pages/attendance/index.tsx`) shows `OvertimeDecisionDialog` once per entry via `resolveOvertimeDialog` / `currentBulkOvertime`, popping the queue one at a time through `confirmBulkOvertimeDecision`. Each confirmation fires its own `overtimeDecisionMutation` call against `PATCH /api/v1/attendances/{id}/overtime-decision` (`OvertimeDecisionController` → `RecordOvertimeDecisionAction`) — there is no batch endpoint today.
+
+When many employees end up with the same decision (e.g. everyone gets paid at the LFT-proportional rate), the admin still has to click through every dialog individually, and looping the single-decision endpoint client-side would mean N round trips. This issue adds a checkbox to skip that: capture the decision once and apply it to the rest of the queue **in one backend request**.
+
+`RecordOvertimeDecisionAction` already locks the employee row (`lockForUpdate()`) when the method is `LFT_PROPORTIONAL`, since that method reads the employee's accumulated overtime hours for the week — the batch action must preserve that per-employee guard while processing multiple (usually different) employees in the same request.
+
+---
+
+## ✅ Backend Tasks
+
+- [ ] 🔧 Add a bulk endpoint, e.g. `POST /api/v1/attendances/overtime-decisions/bulk`, via a new `BulkOvertimeDecisionController` + `BulkOvertimeDecisionRequest` — accepts `attendance_ids: string[]` (ULIDs) plus the same decision fields as `OvertimeDecisionRequest` (`authorize`, `valuation_method`, `agreed_rate`, `agreed_factor`, `reason`)
+- [ ] 🔧 Add `RecordBulkOvertimeDecisionAction` that applies `RecordOvertimeDecisionAction` per attendance, keeping each attendance's own DB transaction and the existing per-employee `lockForUpdate()` for `LFT_PROPORTIONAL`, so one failed/already-decided item doesn't abort the rest of the batch
+- [ ] 📤 Response reports a per-attendance result (success + updated attendance, or the validation error) rather than all-or-nothing, so the frontend can show which employees (if any) failed
+- [ ] 🧪 Feature tests: full batch success, a batch where one attendance was already decided by another manager (partial success, rest still applied), unauthorized access, and `LFT_PROPORTIONAL` across multiple employees in the same batch
+- [ ] 📝 Swagger schema for the new endpoint request/response
+
+## ✅ Frontend Tasks
+
+- [ ] 🔲 Add an "Aplicar para el resto (N empleados)" checkbox to `OvertimeDecisionDialog.tsx`, shown only when opened from the bulk flow and the queue has more than one remaining entry (not shown for the single/individual `pendingOvertimeDecision` flow)
+- [ ] 🔧 Extend `onAuthorize`/`onReject` (or add an `applyToRest: boolean` param) so the dialog reports the checkbox state alongside the decision
+- [ ] 🔁 In `-use-today-attendance-page.ts`, when `applyToRest` is true, call the new bulk endpoint once with every remaining `attendance_id` in `bulkOvertimeQueue` and the chosen `authorize`/`valuation_method`/`agreed_rate`/`agreed_factor`, instead of looping the single-decision mutation; clear the queue once the response comes back
+- [ ] 🎨 Surface any partial failures reported by the bulk response (e.g. toast listing employees that couldn't be updated) instead of silently dropping them
+- [ ] 🧪 Cover both paths: "Pagar" + valuation method + apply-to-rest, and "No pagar" + apply-to-rest
+
+---
+
+## 🎯 Acceptance Criteria
+
+- [ ] The "Aplicar para el resto" checkbox only appears in the bulk (day-close) flow, and only when there's more than one pending entry left
+- [ ] Checking it and confirming sends a single batch request that applies the exact same decision to every remaining employee in the queue, without showing further dialogs
+- [ ] Leaving it unchecked preserves current behavior — one dialog and one request per employee
+- [ ] Works from both the initial "¿Se pagan?" step (No pagar) and the "Método de valoración" step (Pagar)
+- [ ] A partial failure in the batch (e.g. an attendance already decided concurrently) is reported to the admin and doesn't block the rest of the batch from being applied
+
+---
+
+## 🔗 References
+
+- Builds on #229 (bulk overtime queue in the day-close flow) and #228 (valuation method dialog + preview)
+- Existing single-decision endpoint: `PATCH /api/v1/attendances/{id}/overtime-decision` (`OvertimeDecisionController`, `RecordOvertimeDecisionAction`)
+
+---
+
+## ⏱️ Estimates
+
+- **Optimistic:** `5h` · **Pessimistic:** `9h`
+
+---
+
+## ⏱️ Sessions
+```json
+[]
+```


### PR DESCRIPTION
## Summary
Closes #254

- Recovered the expanded #075 retrospective (follow-up sessions: review remediation, sonar-review cleanup, history squash) that was sitting uncommitted in `sushigo-a` after its feature branch was already merged
- Recovered the drafted backlog task docs for #248 and #249 that were untracked in `sushigo-c`

Documentation only — no functional code changes.

## Test plan
- [ ] N/A — doc-only change, no code paths affected

## Manual Testing
- `doc/tasks/2026-07/075-period-export-csv.md` retrospective now includes sessions 2-3
- `doc/tasks/backlog/248-centralize-label-component.md` and `249-overtime-apply-to-rest.md` exist and match what was drafted in `sushigo-c`

## Workspace
`sushigo-a` — `docs/254-recover-stranded-docs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)