### PR TITLE
🎨 [#248][c] - Centralize form Label component 🏷️

### DIFF
--- a/code/webapp/src/components/attendance/OvertimeDecisionDialog.tsx
+++ b/code/webapp/src/components/attendance/OvertimeDecisionDialog.tsx
@@ -2,6 +2,7 @@ import { useEffect, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 import { CheckCircle, XCircle, ArrowLeft, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
 import { useOvertimeDecisionDialog } from './use-overtime-decision-dialog'
 import type { OvertimeValuationMethod, OvertimeValuationPreview } from '@/types/attendance'
 
@@ -179,7 +180,7 @@ export function OvertimeDecisionDialog({
             </div>
 
             <div className="space-y-1">
-              <label htmlFor="valuation_method" className="text-sm font-medium">Método</label>
+              <Label htmlFor="valuation_method">Método</Label>
               <select
                 id="valuation_method"
                 {...register('valuation_method')}
@@ -194,7 +195,7 @@ export function OvertimeDecisionDialog({
 
             {selectedMethod === 'AGREED_RATE' && (
               <div className="space-y-1">
-                <label htmlFor="agreed_rate" className="text-sm font-medium">Tarifa por hora</label>
+                <Label htmlFor="agreed_rate">Tarifa por hora</Label>
                 <input
                   id="agreed_rate"
                   type="number"
@@ -211,7 +212,7 @@ export function OvertimeDecisionDialog({
 
             {selectedMethod === 'SALARY_FACTOR' && (
               <div className="space-y-1">
-                <label htmlFor="agreed_factor" className="text-sm font-medium">Factor (ej. 1.5 = 1.5x su salario)</label>
+                <Label htmlFor="agreed_factor">Factor (ej. 1.5 = 1.5x su salario)</Label>
                 <input
                   id="agreed_factor"
                   type="number"

--- a/code/webapp/src/components/ui/__tests__/label.test.tsx
+++ b/code/webapp/src/components/ui/__tests__/label.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { Label } from '../label'
+
+describe('Label', () => {
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('renders with default contrast-safe styles', () => {
+        render(<Label>Método</Label>)
+        const label = screen.getByText('Método')
+        expect(label.className).toContain('text-sm')
+        expect(label.className).toContain('font-medium')
+        expect(label.className).toContain('text-foreground')
+    })
+
+    it('renders as a label element', () => {
+        render(<Label>Tarifa por hora</Label>)
+        const label = screen.getByText('Tarifa por hora')
+        expect(label.tagName).toBe('LABEL')
+    })
+
+    it('associates with a form control via htmlFor', () => {
+        render(<Label htmlFor="agreed_rate">Tarifa por hora</Label>)
+        const label = screen.getByText('Tarifa por hora')
+        expect(label.getAttribute('for')).toBe('agreed_rate')
+    })
+
+    it('applies custom className without dropping base styles', () => {
+        render(<Label className="custom-label">Factor</Label>)
+        const label = screen.getByText('Factor')
+        expect(label.className).toContain('custom-label')
+        expect(label.className).toContain('text-foreground')
+    })
+
+    it('passes ref to the label element', () => {
+        const ref = { current: null as HTMLLabelElement | null }
+        render(<Label ref={ref}>Método</Label>)
+        expect(ref.current).not.toBeNull()
+        expect(ref.current?.tagName).toBe('LABEL')
+    })
+
+    it('passes through additional native attributes', () => {
+        render(<Label data-testid="method-label">Método</Label>)
+        expect(screen.getByTestId('method-label')).not.toBeNull()
+    })
+
+    it('applies peer-disabled styling hook for disabled sibling controls', () => {
+        render(<Label>Método</Label>)
+        const label = screen.getByText('Método')
+        expect(label.className).toContain('peer-disabled:cursor-not-allowed')
+        expect(label.className).toContain('peer-disabled:opacity-70')
+    })
+})

--- a/code/webapp/src/components/ui/label.tsx
+++ b/code/webapp/src/components/ui/label.tsx
@@ -6,7 +6,7 @@ export type LabelProps = React.LabelHTMLAttributes<HTMLLabelElement>
 const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
     ({ className, ...props }, ref) => {
         return (
-            <label
+            <label // NOSONAR — generic primitive; every call site passes htmlFor or wraps a control as children, but that isn't visible from this definition
                 className={cn(
                     "text-sm font-medium text-foreground leading-none",
                     "peer-disabled:cursor-not-allowed peer-disabled:opacity-70",

--- a/code/webapp/src/components/ui/label.tsx
+++ b/code/webapp/src/components/ui/label.tsx
@@ -1,0 +1,23 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export type LabelProps = React.LabelHTMLAttributes<HTMLLabelElement>
+
+const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
+    ({ className, ...props }, ref) => {
+        return (
+            <label
+                className={cn(
+                    "text-sm font-medium text-foreground leading-none",
+                    "peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+                    className
+                )}
+                ref={ref}
+                {...props}
+            />
+        )
+    }
+)
+Label.displayName = "Label"
+
+export { Label }

--- a/doc/conventions/frontend/label-styles.md
+++ b/doc/conventions/frontend/label-styles.md
@@ -1,0 +1,65 @@
+# Label Style Convention
+
+> **Rule:** Use `Label` (`src/components/ui/label.tsx`) for every form field label. Never hand-write `<label className="text-sm font-medium">` (or similar) with no explicit text color — it silently inherits whatever `color` the nearest ancestor sets, which is not always the app's `--foreground` token.
+
+## Why
+
+The native `<dialog>` element ships a UA stylesheet that sets `color: CanvasText` directly on it (not `inherit`) — a system color that follows the OS/browser color scheme, not this app's manual `.dark` class toggle. Any descendant text node that doesn't set its own explicit `color`/Tailwind text color silently inherits that system value instead of `--foreground`, so it can render dark-on-dark regardless of the app's theme.
+
+This bit `OvertimeDecisionDialog.tsx`: its "Método", "Tarifa por hora" and "Factor..." `<label>` elements had no explicit color class (`className="text-sm font-medium"` only) and were unreadable in dark mode. Centralizing the styling in one component — instead of every form hand-writing the same classes — means a fix like `text-foreground` only needs to be baked in once, and can never be silently omitted at a new call site.
+
+Same root cause and same class of problem as [#247](https://github.com/pakodiazdev/sushigo/issues/247) (button styles duplicated ad-hoc instead of centralized).
+
+## Usage
+
+`Label` wraps a native `<label>` with contrast-safe defaults and forwards a ref, same pattern as `Input`/`Button`:
+
+```tsx
+import { Label } from '@/components/ui/label'
+
+<Label htmlFor="agreed_rate">Tarifa por hora</Label>
+```
+
+It accepts every native `React.LabelHTMLAttributes<HTMLLabelElement>` prop (`htmlFor`, `id`, `data-*`, etc.) plus an optional `className` that is merged (not replaced) with the base styles via `cn()`. There is no `variant` prop — a label has no meaningful semantic variants the way a button does; contrast is baked in unconditionally.
+
+## Rule
+
+If a label needs a `className` with `text-*` color classes to stay readable, that is a signal it should be using `Label` instead of a raw `<label>` element.
+
+```tsx
+// ❌ Wrong — no explicit color, silently inherits from the nearest ancestor
+<label htmlFor="valuation_method" className="text-sm font-medium">Método</label>
+
+// ✅ Correct — contrast-safe by default, no matter what it's nested inside
+<Label htmlFor="valuation_method">Método</Label>
+```
+
+## Reference migration
+
+`OvertimeDecisionDialog.tsx` ("Método", "Tarifa por hora", "Factor...") is the reference migration for issue #248.
+
+The following files still use the same unstyled `<label>` pattern and are candidates for a follow-up migration (not in scope for #248):
+
+- `src/components/employees/rehire-form.tsx`
+- `src/components/employees/deactivate-form.tsx`
+- `src/components/employees/bonus-config-section.tsx`
+- `src/components/employees/register-wage-form.tsx`
+- `src/components/attendance/AttendanceTimeDialog.tsx`
+- `src/components/attendance/ExtraDayNegotiationDialog.tsx`
+- `src/components/employees/create-schedule-form.tsx`
+- `src/components/employees/override-scope-dialog.tsx`
+- `src/components/employees/vacation-policy-override.tsx`
+- `src/components/settings/vacation-policy-section.tsx`
+- `src/components/solicitudes/pending-requests/leave-review-content.tsx`
+- `src/components/solicitudes/pending-requests/review-request-dialog.tsx`
+- `src/components/solicitudes/pending-requests/vacation-review-content.tsx`
+- `src/components/ui/filter-select.tsx`
+- `src/components/ui/form-fields.tsx` (`FormField` and `Checkbox` both inline their own label markup)
+- `src/pages/attendance/audit.tsx`
+- `src/pages/attendance/config/holidays.tsx`
+- `src/pages/attendance/payroll/$periodId.tsx`
+- `src/pages/attendance/payroll/close.tsx` and `src/pages/attendance/payroll/index.tsx` (use hardcoded `text-gray-700` instead of `text-foreground` — worth flagging separately, doesn't follow theme tokens at all)
+- `src/pages/attendance/punctuality-config-shared.tsx`
+- `src/pages/forgot-password.tsx`, `src/pages/login.tsx`, `src/pages/reset-password.tsx`
+
+See issue #248.

--- a/doc/tasks/2026-07/248-centralize-label-component.md
+++ b/doc/tasks/2026-07/248-centralize-label-component.md
@@ -54,7 +54,14 @@ This is the same class of problem as [#247](https://github.com/pakodiazdev/sushi
 
 ---
 
-## ⏱️ Sessions
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `2h` · **Pessimistic:** `4h` · **Tracked:** _in progress_
+
+### 📅 Sessions
 ```json
-[]
+[
+  { "date": "2026-07-18", "start": "17:39", "end": "?" }
+]
 ```

--- a/doc/tasks/2026-07/248-centralize-label-component.md
+++ b/doc/tasks/2026-07/248-centralize-label-component.md
@@ -57,11 +57,11 @@ This is the same class of problem as [#247](https://github.com/pakodiazdev/sushi
 ## ⏱️ Time
 
 ### 📊 Estimates
-- **Optimistic:** `2h` · **Pessimistic:** `4h` · **Tracked:** _in progress_
+- **Optimistic:** `2h` · **Pessimistic:** `4h` · **Tracked:** `~0.15h`
 
 ### 📅 Sessions
 ```json
 [
-  { "date": "2026-07-18", "start": "17:39", "end": "?" }
+  { "date": "2026-07-18", "start": "17:39", "end": "17:46" }
 ]
 ```


### PR DESCRIPTION
## Summary
- Adds a centralized `Label` component (`src/components/ui/label.tsx`) with contrast-safe `text-foreground` styling baked in, following the same `forwardRef` + `cn()` pattern as `Input`/`Button`
- Migrates `OvertimeDecisionDialog.tsx`'s three raw `<label className="text-sm font-medium">` elements ("Método", "Tarifa por hora", "Factor...") to the new component, as the reference migration
- Documents the convention in `doc/conventions/frontend/label-styles.md`, mirroring the `button-styles.md` structure from #247, including a list of ~25 other files with the same unstyled-label pattern as follow-up migration candidates (out of scope for this PR)

## Test plan
- [x] Vitest: `npx vitest run src/components/ui/__tests__/label.test.tsx` — 7 tests covering default styles, `htmlFor`, `className` merge, ref forwarding, native attribute passthrough, and `peer-disabled` styling hook
- [x] Vitest: `npx vitest run src/components/attendance/__tests__/use-overtime-decision-dialog.test.ts` — 9 pre-existing tests still pass, unaffected by the markup change
- [x] Linters: ESLint ✅ · TypeScript ✅
- [ ] Cypress E2E: no new spec needed — `cypress/e2e/attendance-close-day-overtime.cy.ts` and `cypress/e2e/attendance-overtime-decision.cy.ts` already exercise this dialog's happy path, and the DOM structure/text is unchanged by this refactor

## Manual Testing
1. Start the dev-lab workspace (`./init-agent-workspace.sh`)
2. Navigate to the attendance day-close flow and trigger the overtime decision dialog for an employee with pending overtime minutes
3. Switch the browser/OS to dark mode (or toggle the app's dark mode if available)
4. Confirm the "Método", "Tarifa por hora" (when "Tarifa fija pactada" is selected), and "Factor..." (when "Factor sobre salario" is selected) labels are clearly readable against the dialog background — before this fix, they were unreadable in dark mode inside the native `<dialog>` element

## Closes
Closes #248

## Workspace
`sushigo-c` — `refactor/248-centralize-label-component`

🤖 Generated with [Claude Code](https://claude.com/claude-code)