### PR TITLE
✨ [#249][b] - Add "apply to the rest" checkbox to bulk overtime decision dialog ✅

### DIFF
--- a/code/api/app/Actions/Attendances/RecordBulkOvertimeDecisionAction.php
+++ b/code/api/app/Actions/Attendances/RecordBulkOvertimeDecisionAction.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Actions\Attendances;
+
+use App\Models\Attendance;
+use App\Models\User;
+use Illuminate\Support\Collection;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * Apply the same overtime decision to a batch of attendances.
+ *
+ * Delegates each attendance to RecordOvertimeDecisionAction, which keeps its own
+ * DB transaction and the per-employee lockForUpdate() for LFT_PROPORTIONAL. A
+ * failure on one attendance (e.g. already decided) is captured per-item instead
+ * of aborting the rest of the batch.
+ *
+ * @see #249
+ */
+class RecordBulkOvertimeDecisionAction
+{
+    public function __construct(private readonly RecordOvertimeDecisionAction $recordDecision) {}
+
+    /**
+     * @param  Collection<int, Attendance>  $attendances  Already-resolved attendances, in request order
+     * @param  array{authorize: bool, valuation_method?: string, agreed_rate?: float, agreed_factor?: float, reason?: string}  $data  Validated decision data (without attendance_ids)
+     * @return array<int, array{attendance_id: string, success: bool, attendance?: Attendance, error?: string}>
+     */
+    public function __invoke(Collection $attendances, array $data, User $decidedBy): array
+    {
+        return $attendances
+            ->map(function (Attendance $attendance) use ($data, $decidedBy) {
+                try {
+                    $updated = ($this->recordDecision)($attendance, $data, $decidedBy);
+
+                    return [
+                        'attendance_id' => $attendance->public_id,
+                        'success' => true,
+                        'attendance' => $updated,
+                    ];
+                } catch (ValidationException $exception) {
+                    return [
+                        'attendance_id' => $attendance->public_id,
+                        'success' => false,
+                        'error' => collect($exception->errors())->flatten()->first() ?? $exception->getMessage(),
+                    ];
+                }
+            })
+            ->values()
+            ->all();
+    }
+}

--- a/code/api/app/Actions/Attendances/RecordBulkOvertimeDecisionAction.php
+++ b/code/api/app/Actions/Attendances/RecordBulkOvertimeDecisionAction.php
@@ -24,7 +24,7 @@ class RecordBulkOvertimeDecisionAction
     /**
      * @param  Collection<int, Attendance>  $attendances  Already-resolved attendances, in request order
      * @param  array{authorize: bool, valuation_method?: string, agreed_rate?: float, agreed_factor?: float, reason?: string}  $data  Validated decision data (without attendance_ids)
-     * @return array<int, array{attendance_id: string, success: bool, attendance?: Attendance, error?: string}>
+     * @return array<int, array{attendance_id: string, success: bool, attendance: ?Attendance, error: ?string}>
      */
     public function __invoke(Collection $attendances, array $data, User $decidedBy): array
     {
@@ -37,11 +37,13 @@ class RecordBulkOvertimeDecisionAction
                         'attendance_id' => $attendance->public_id,
                         'success' => true,
                         'attendance' => $updated,
+                        'error' => null,
                     ];
                 } catch (ValidationException $exception) {
                     return [
                         'attendance_id' => $attendance->public_id,
                         'success' => false,
+                        'attendance' => null,
                         'error' => collect($exception->errors())->flatten()->first() ?? $exception->getMessage(),
                     ];
                 }

--- a/code/api/app/Actions/Attendances/RecordBulkOvertimeDecisionAction.php
+++ b/code/api/app/Actions/Attendances/RecordBulkOvertimeDecisionAction.php
@@ -24,17 +24,20 @@ class RecordBulkOvertimeDecisionAction
     /**
      * @param  Collection<int, Attendance>  $attendances  Already-resolved attendances, in request order
      * @param  array{authorize: bool, valuation_method?: string, agreed_rate?: float, agreed_factor?: float, reason?: string}  $data  Validated decision data (without attendance_ids)
-     * @return array<int, array{attendance_id: string, success: bool, attendance: ?Attendance, error: ?string}>
+     * @return array<int, array{attendance_id: string, employee_name: string, success: bool, attendance: ?Attendance, error: ?string}>
      */
     public function __invoke(Collection $attendances, array $data, User $decidedBy): array
     {
         return $attendances
             ->map(function (Attendance $attendance) use ($data, $decidedBy) {
+                $employeeName = "{$attendance->employee->first_name} {$attendance->employee->last_name}";
+
                 try {
                     $updated = ($this->recordDecision)($attendance, $data, $decidedBy);
 
                     return [
                         'attendance_id' => $attendance->public_id,
+                        'employee_name' => $employeeName,
                         'success' => true,
                         'attendance' => $updated,
                         'error' => null,
@@ -42,6 +45,7 @@ class RecordBulkOvertimeDecisionAction
                 } catch (ValidationException $exception) {
                     return [
                         'attendance_id' => $attendance->public_id,
+                        'employee_name' => $employeeName,
                         'success' => false,
                         'attendance' => null,
                         'error' => collect($exception->errors())->flatten()->first() ?? $exception->getMessage(),

--- a/code/api/app/Http/Controllers/Api/V1/Attendances/BulkOvertimeDecisionController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Attendances/BulkOvertimeDecisionController.php
@@ -44,6 +44,7 @@ use App\Http\Responses\Common\ResponseEntity;
  *                         type="object",
  *
  *                         @OA\Property(property="attendance_id", type="string", example="01JN4Z8RFPQRSTUV0WXYZ12345"),
+ *                         @OA\Property(property="employee_name", type="string", example="Ana López"),
  *                         @OA\Property(property="success", type="boolean", example=true),
  *                         @OA\Property(property="attendance", ref="#/components/schemas/AttendanceResponse", nullable=true),
  *                         @OA\Property(property="error", type="string", nullable=true, example="Ya se registró una decisión sobre las horas extra de este empleado.")

--- a/code/api/app/Http/Controllers/Api/V1/Attendances/BulkOvertimeDecisionController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Attendances/BulkOvertimeDecisionController.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Attendances;
+
+use App\Actions\Attendances\RecordBulkOvertimeDecisionAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Attendances\BulkOvertimeDecisionRequest;
+use App\Http\Resources\Attendance\AttendanceResource;
+use App\Http\Responses\Common\ResponseEntity;
+
+/**
+ * POST /api/v1/attendances/overtime-decisions/bulk
+ *
+ * Authorize or reject overtime payment for several attendances at once, applying
+ * the same decision to every one of them in a single request.
+ *
+ * @OA\Post(
+ *     path="/api/v1/attendances/overtime-decisions/bulk",
+ *     summary="Authorize or reject overtime payment for a batch of attendances",
+ *     tags={"Attendances"},
+ *     security={{"passport":{}}},
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/BulkOvertimeDecisionRequest")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Per-attendance results — a failed item does not block the rest of the batch",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="status", type="integer", example=200),
+ *             @OA\Property(
+ *                 property="data",
+ *                 type="object",
+ *                 @OA\Property(
+ *                     property="results",
+ *                     type="array",
+ *
+ *                     @OA\Items(
+ *                         type="object",
+ *
+ *                         @OA\Property(property="attendance_id", type="string", example="01JN4Z8RFPQRSTUV0WXYZ12345"),
+ *                         @OA\Property(property="success", type="boolean", example=true),
+ *                         @OA\Property(property="attendance", ref="#/components/schemas/AttendanceResponse", nullable=true),
+ *                         @OA\Property(property="error", type="string", nullable=true, example="Ya se registró una decisión sobre las horas extra de este empleado.")
+ *                     )
+ *                 )
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(response=422, description="Validation error"),
+ *     @OA\Response(response=403, description="Not authorized to edit one or more of the given attendances"),
+ *     @OA\Response(response=401, description="Unauthenticated")
+ * )
+ */
+class BulkOvertimeDecisionController extends Controller
+{
+    public function __construct(private readonly RecordBulkOvertimeDecisionAction $action) {}
+
+    public function __invoke(BulkOvertimeDecisionRequest $request): ResponseEntity
+    {
+        $attendances = $request->resolveAttendances();
+
+        $results = ($this->action)($attendances, $request->decisionData(), $request->user());
+
+        $results = array_map(function (array $result) {
+            if ($result['success']) {
+                $result['attendance'] = new AttendanceResource($result['attendance']);
+            } else {
+                $result['attendance'] = null;
+            }
+
+            return $result;
+        }, $results);
+
+        return new ResponseEntity(data: ['results' => $results], status: 200);
+    }
+}

--- a/code/api/app/Http/Controllers/Api/V1/Attendances/BulkOvertimeDecisionController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Attendances/BulkOvertimeDecisionController.php
@@ -69,10 +69,8 @@ class BulkOvertimeDecisionController extends Controller
         $results = ($this->action)($attendances, $request->decisionData(), $request->user());
 
         $results = array_map(function (array $result) {
-            if ($result['success']) {
+            if ($result['attendance'] !== null) {
                 $result['attendance'] = new AttendanceResource($result['attendance']);
-            } else {
-                $result['attendance'] = null;
             }
 
             return $result;

--- a/code/api/app/Http/Requests/Attendances/BulkOvertimeDecisionRequest.php
+++ b/code/api/app/Http/Requests/Attendances/BulkOvertimeDecisionRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests\Attendances;
 
 use App\Enums\OvertimeValuationMethod;
 use App\Models\Attendance;
+use App\Support\Clock\ApplicationClock;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Gate;
@@ -63,12 +64,17 @@ use Illuminate\Validation\Rule;
  *         property="reason",
  *         type="string",
  *         example="Autorización retroactiva aprobada por gerencia",
- *         description="Optional reason recorded on every attendance's audit entry."
+ *         description="Required when an Admin decides overtime for any past-day attendance in the batch. Recorded on every attendance's audit entry."
  *     )
  * )
  */
 class BulkOvertimeDecisionRequest extends FormRequest
 {
+    public function __construct(private readonly ApplicationClock $clock)
+    {
+        parent::__construct();
+    }
+
     private ?Collection $resolvedAttendances = null;
 
     public function authorize(): bool
@@ -100,7 +106,7 @@ class BulkOvertimeDecisionRequest extends FormRequest
             'valuation_method' => ['nullable', 'required_if:authorize,true', Rule::enum(OvertimeValuationMethod::class)],
             'agreed_rate' => ['nullable', 'required_if:valuation_method,AGREED_RATE', 'numeric', 'gt:0'],
             'agreed_factor' => ['nullable', 'required_if:valuation_method,SALARY_FACTOR', 'numeric', 'gt:0'],
-            'reason' => ['nullable', 'string', 'max:500'],
+            'reason' => $this->reasonRules(),
         ];
     }
 
@@ -119,7 +125,34 @@ class BulkOvertimeDecisionRequest extends FormRequest
             'valuation_method.required_if' => 'El método de valoración es requerido al autorizar el pago.',
             'agreed_rate.required_if' => 'La tarifa pactada es requerida cuando el método es Tarifa Pactada.',
             'agreed_factor.required_if' => 'El factor es requerido cuando el método es Factor sobre Salario.',
+            'reason.required' => 'Se requiere un motivo para editar registros de días anteriores.',
         ];
+    }
+
+    /**
+     * Mirrors AttendanceFormRequest::reasonRules() for a batch: an admin deciding
+     * overtime for ANY past-day attendance in the batch must supply a reason,
+     * same as the single-decision endpoint. Managers never reach this — past-day
+     * attendances are already blocked earlier by AttendancePolicy::edit in authorize().
+     *
+     * @return array<int, string>
+     */
+    private function reasonRules(): array
+    {
+        $user = $this->user();
+        $isAdmin = $user?->hasRole('admin') || $user?->hasRole('super-admin');
+
+        if (! $isAdmin) {
+            return ['nullable', 'string', 'max:500'];
+        }
+
+        $today = $this->clock->todayInBusinessTz();
+        $hasPastDayAttendance = $this->resolveAttendances()
+            ->contains(fn (Attendance $attendance) => $attendance->date->toDateString() < $today);
+
+        return $hasPastDayAttendance
+            ? ['required', 'string', 'min:5', 'max:500']
+            : ['nullable', 'string', 'max:500'];
     }
 
     /**
@@ -130,11 +163,15 @@ class BulkOvertimeDecisionRequest extends FormRequest
     public function resolveAttendances(): Collection
     {
         if ($this->resolvedAttendances === null) {
-            $byId = Attendance::whereIn('public_id', $this->input('attendance_ids', []))
+            $ids = $this->input('attendance_ids');
+            $ids = is_array($ids) ? $ids : [];
+
+            $byId = Attendance::with('employee')
+                ->whereIn('public_id', $ids)
                 ->get()
                 ->keyBy('public_id');
 
-            $this->resolvedAttendances = collect($this->input('attendance_ids', []))
+            $this->resolvedAttendances = collect($ids)
                 ->map(fn (string $id) => $byId->get($id))
                 ->filter()
                 ->values();

--- a/code/api/app/Http/Requests/Attendances/BulkOvertimeDecisionRequest.php
+++ b/code/api/app/Http/Requests/Attendances/BulkOvertimeDecisionRequest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace App\Http\Requests\Attendances;
+
+use App\Enums\OvertimeValuationMethod;
+use App\Models\Attendance;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validate the bulk overtime authorization/rejection payload.
+ *
+ * Applies the same decision (authorize/reject, method, rate or factor) to every
+ * attendance in `attendance_ids`. Authorization is all-or-nothing: the whole
+ * batch is denied (403) if the user cannot edit any one of the given attendances,
+ * consistent with the single-decision endpoint's `AttendancePolicy::edit`.
+ *
+ * @OA\Schema(
+ *     schema="BulkOvertimeDecisionRequest",
+ *     required={"attendance_ids", "authorize"},
+ *
+ *     @OA\Property(
+ *         property="attendance_ids",
+ *         type="array",
+ *         description="Attendance public_ids (ULIDs) to apply the decision to",
+ *
+ *         @OA\Items(type="string", example="01JN4Z8RFPQRSTUV0WXYZ12345")
+ *     ),
+ *
+ *     @OA\Property(
+ *         property="authorize",
+ *         type="boolean",
+ *         example=true,
+ *         description="true to authorize overtime payment, false to reject it, for every attendance in the batch."
+ *     ),
+ *     @OA\Property(
+ *         property="valuation_method",
+ *         type="string",
+ *         enum={"LFT_PROPORTIONAL", "AGREED_RATE", "SALARY_FACTOR"},
+ *         nullable=true,
+ *         example="AGREED_RATE",
+ *         description="Required when authorize=true. LFT_PROPORTIONAL resolves its factor independently per employee."
+ *     ),
+ *     @OA\Property(
+ *         property="agreed_rate",
+ *         type="number",
+ *         format="float",
+ *         nullable=true,
+ *         example=90.00,
+ *         description="Required when valuation_method=AGREED_RATE (flat hourly rate). Ignored otherwise."
+ *     ),
+ *     @OA\Property(
+ *         property="agreed_factor",
+ *         type="number",
+ *         format="float",
+ *         nullable=true,
+ *         example=1.5,
+ *         description="Required when valuation_method=SALARY_FACTOR (multiplier of each employee's own minute rate). Ignored otherwise."
+ *     ),
+ *     @OA\Property(
+ *         property="reason",
+ *         type="string",
+ *         example="Autorización retroactiva aprobada por gerencia",
+ *         description="Optional reason recorded on every attendance's audit entry."
+ *     )
+ * )
+ */
+class BulkOvertimeDecisionRequest extends FormRequest
+{
+    private ?Collection $resolvedAttendances = null;
+
+    public function authorize(): bool
+    {
+        $attendances = $this->resolveAttendances();
+
+        if ($attendances->count() !== count($this->input('attendance_ids', []))) {
+            return true; // some IDs don't exist — let validation report it as 422
+        }
+
+        return $attendances->every(fn (Attendance $attendance) => Gate::allows('edit', $attendance));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'attendance_ids' => ['required', 'array', 'min:1'],
+            'attendance_ids.*' => ['required', 'string', 'distinct', 'exists:attendances,public_id'],
+            'authorize' => ['required', 'boolean'],
+            'valuation_method' => ['nullable', 'required_if:authorize,true', Rule::enum(OvertimeValuationMethod::class)],
+            'agreed_rate' => ['nullable', 'required_if:valuation_method,AGREED_RATE', 'numeric', 'gt:0'],
+            'agreed_factor' => ['nullable', 'required_if:valuation_method,SALARY_FACTOR', 'numeric', 'gt:0'],
+            'reason' => ['nullable', 'string', 'max:500'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'attendance_ids.required' => 'Debes seleccionar al menos un empleado.',
+            'attendance_ids.min' => 'Debes seleccionar al menos un empleado.',
+            'attendance_ids.*.distinct' => 'No se puede repetir el mismo empleado en el lote.',
+            'attendance_ids.*.exists' => 'Uno de los registros de asistencia no existe.',
+            'authorize.required' => 'La decisión sobre horas extra es requerida.',
+            'authorize.boolean' => 'La decisión debe ser verdadero o falso.',
+            'valuation_method.required_if' => 'El método de valoración es requerido al autorizar el pago.',
+            'agreed_rate.required_if' => 'La tarifa pactada es requerida cuando el método es Tarifa Pactada.',
+            'agreed_factor.required_if' => 'El factor es requerido cuando el método es Factor sobre Salario.',
+        ];
+    }
+
+    /**
+     * Resolved attendances in the same order as `attendance_ids`, keyed by public_id.
+     *
+     * @return Collection<int, Attendance>
+     */
+    public function resolveAttendances(): Collection
+    {
+        if ($this->resolvedAttendances === null) {
+            $byId = Attendance::whereIn('public_id', $this->input('attendance_ids', []))
+                ->get()
+                ->keyBy('public_id');
+
+            $this->resolvedAttendances = collect($this->input('attendance_ids', []))
+                ->map(fn (string $id) => $byId->get($id))
+                ->filter()
+                ->values();
+        }
+
+        return $this->resolvedAttendances;
+    }
+
+    /**
+     * @return array{authorize: bool, valuation_method?: string, agreed_rate?: float, agreed_factor?: float, reason?: string}
+     */
+    public function decisionData(): array
+    {
+        return collect($this->validated())
+            ->except('attendance_ids')
+            ->all();
+    }
+}

--- a/code/api/app/Http/Requests/Attendances/BulkOvertimeDecisionRequest.php
+++ b/code/api/app/Http/Requests/Attendances/BulkOvertimeDecisionRequest.php
@@ -2,13 +2,12 @@
 
 namespace App\Http\Requests\Attendances;
 
-use App\Enums\OvertimeValuationMethod;
+use App\Http\Requests\Concerns\ValidatesOvertimeDecisionFields;
 use App\Models\Attendance;
 use App\Support\Clock\ApplicationClock;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Gate;
-use Illuminate\Validation\Rule;
 
 /**
  * Validate the bulk overtime authorization/rejection payload.
@@ -70,6 +69,8 @@ use Illuminate\Validation\Rule;
  */
 class BulkOvertimeDecisionRequest extends FormRequest
 {
+    use ValidatesOvertimeDecisionFields;
+
     public function __construct(private readonly ApplicationClock $clock)
     {
         parent::__construct();
@@ -102,10 +103,7 @@ class BulkOvertimeDecisionRequest extends FormRequest
         return [
             'attendance_ids' => ['required', 'array', 'min:1'],
             'attendance_ids.*' => ['required', 'string', 'distinct', 'exists:attendances,public_id'],
-            'authorize' => ['required', 'boolean'],
-            'valuation_method' => ['nullable', 'required_if:authorize,true', Rule::enum(OvertimeValuationMethod::class)],
-            'agreed_rate' => ['nullable', 'required_if:valuation_method,AGREED_RATE', 'numeric', 'gt:0'],
-            'agreed_factor' => ['nullable', 'required_if:valuation_method,SALARY_FACTOR', 'numeric', 'gt:0'],
+            ...$this->overtimeDecisionRules(),
             'reason' => $this->reasonRules(),
         ];
     }
@@ -120,11 +118,7 @@ class BulkOvertimeDecisionRequest extends FormRequest
             'attendance_ids.min' => 'Debes seleccionar al menos un empleado.',
             'attendance_ids.*.distinct' => 'No se puede repetir el mismo empleado en el lote.',
             'attendance_ids.*.exists' => 'Uno de los registros de asistencia no existe.',
-            'authorize.required' => 'La decisión sobre horas extra es requerida.',
-            'authorize.boolean' => 'La decisión debe ser verdadero o falso.',
-            'valuation_method.required_if' => 'El método de valoración es requerido al autorizar el pago.',
-            'agreed_rate.required_if' => 'La tarifa pactada es requerida cuando el método es Tarifa Pactada.',
-            'agreed_factor.required_if' => 'El factor es requerido cuando el método es Factor sobre Salario.',
+            ...$this->overtimeDecisionMessages(),
             'reason.required' => 'Se requiere un motivo para editar registros de días anteriores.',
         ];
     }

--- a/code/api/app/Http/Requests/Attendances/BulkOvertimeDecisionRequest.php
+++ b/code/api/app/Http/Requests/Attendances/BulkOvertimeDecisionRequest.php
@@ -73,9 +73,15 @@ class BulkOvertimeDecisionRequest extends FormRequest
 
     public function authorize(): bool
     {
+        $ids = $this->input('attendance_ids');
+
+        if (! is_array($ids)) {
+            return true; // wrong type — let the 'array' validation rule report it as 422
+        }
+
         $attendances = $this->resolveAttendances();
 
-        if ($attendances->count() !== count($this->input('attendance_ids', []))) {
+        if ($attendances->count() !== count($ids)) {
             return true; // some IDs don't exist — let validation report it as 422
         }
 

--- a/code/api/app/Http/Requests/Attendances/OvertimeDecisionRequest.php
+++ b/code/api/app/Http/Requests/Attendances/OvertimeDecisionRequest.php
@@ -2,8 +2,7 @@
 
 namespace App\Http\Requests\Attendances;
 
-use App\Enums\OvertimeValuationMethod;
-use Illuminate\Validation\Rule;
+use App\Http\Requests\Concerns\ValidatesOvertimeDecisionFields;
 
 /**
  * Validate the overtime authorization/rejection payload.
@@ -52,13 +51,12 @@ use Illuminate\Validation\Rule;
  */
 class OvertimeDecisionRequest extends AttendanceFormRequest
 {
+    use ValidatesOvertimeDecisionFields;
+
     public function rules(): array
     {
         return [
-            'authorize' => ['required', 'boolean'],
-            'valuation_method' => ['nullable', 'required_if:authorize,true', Rule::enum(OvertimeValuationMethod::class)],
-            'agreed_rate' => ['nullable', 'required_if:valuation_method,AGREED_RATE', 'numeric', 'gt:0'],
-            'agreed_factor' => ['nullable', 'required_if:valuation_method,SALARY_FACTOR', 'numeric', 'gt:0'],
+            ...$this->overtimeDecisionRules(),
             'reason' => $this->reasonRules(),
         ];
     }
@@ -66,11 +64,7 @@ class OvertimeDecisionRequest extends AttendanceFormRequest
     public function messages(): array
     {
         return [
-            'authorize.required' => 'La decisión sobre horas extra es requerida.',
-            'authorize.boolean' => 'La decisión debe ser verdadero o falso.',
-            'valuation_method.required_if' => 'El método de valoración es requerido al autorizar el pago.',
-            'agreed_rate.required_if' => 'La tarifa pactada es requerida cuando el método es Tarifa Pactada.',
-            'agreed_factor.required_if' => 'El factor es requerido cuando el método es Factor sobre Salario.',
+            ...$this->overtimeDecisionMessages(),
             'reason.required' => 'Se requiere un motivo para editar registros de días anteriores.',
         ];
     }

--- a/code/api/app/Http/Requests/Concerns/ValidatesOvertimeDecisionFields.php
+++ b/code/api/app/Http/Requests/Concerns/ValidatesOvertimeDecisionFields.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Requests\Concerns;
+
+use App\Enums\OvertimeValuationMethod;
+use Illuminate\Validation\Rule;
+
+/**
+ * Shared "authorize / valuation_method / agreed_rate / agreed_factor" validation,
+ * used by both OvertimeDecisionRequest (single) and BulkOvertimeDecisionRequest.
+ */
+trait ValidatesOvertimeDecisionFields
+{
+    /**
+     * @return array<string, mixed>
+     */
+    protected function overtimeDecisionRules(): array
+    {
+        return [
+            'authorize' => ['required', 'boolean'],
+            'valuation_method' => ['nullable', 'required_if:authorize,true', Rule::enum(OvertimeValuationMethod::class)],
+            'agreed_rate' => ['nullable', 'required_if:valuation_method,AGREED_RATE', 'numeric', 'gt:0'],
+            'agreed_factor' => ['nullable', 'required_if:valuation_method,SALARY_FACTOR', 'numeric', 'gt:0'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function overtimeDecisionMessages(): array
+    {
+        return [
+            'authorize.required' => 'La decisión sobre horas extra es requerida.',
+            'authorize.boolean' => 'La decisión debe ser verdadero o falso.',
+            'valuation_method.required_if' => 'El método de valoración es requerido al autorizar el pago.',
+            'agreed_rate.required_if' => 'La tarifa pactada es requerida cuando el método es Tarifa Pactada.',
+            'agreed_factor.required_if' => 'El factor es requerido cuando el método es Factor sobre Salario.',
+        ];
+    }
+}

--- a/code/api/routes/api.php
+++ b/code/api/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Contracts\PasswordResetTokenRecorder;
+use App\Http\Controllers\Api\V1\Attendances\BulkOvertimeDecisionController;
 use App\Http\Controllers\Api\V1\Attendances\CloseDayController;
 use App\Http\Controllers\Api\V1\Attendances\MarkDayStatusController;
 use App\Http\Controllers\Api\V1\Attendances\OvertimeDecisionController;
@@ -386,6 +387,7 @@ Route::prefix('v1')->group(function () {
         Route::post('check-in', RegisterCheckInController::class)->name('check-in');
         Route::post('day-status', MarkDayStatusController::class)->name('day-status');
         Route::post('close-day', CloseDayController::class)->name('close-day');
+        Route::post('overtime-decisions/bulk', BulkOvertimeDecisionController::class)->name('overtime-decisions.bulk');
         // Per-attendance actions (identified by public_id)
         Route::patch('{id}/lunch-start', RegisterLunchStartController::class)->name('lunch-start');
         Route::patch('{id}/lunch-return', RegisterLunchReturnController::class)->name('lunch-return');

--- a/code/api/tests/Feature/AttendancePayroll/BulkOvertimeDecisionApiTest.php
+++ b/code/api/tests/Feature/AttendancePayroll/BulkOvertimeDecisionApiTest.php
@@ -88,9 +88,11 @@ class BulkOvertimeDecisionApiTest extends TestCase
             ->assertJsonPath('data.results.0.attendance_id', $a1->public_id)
             ->assertJsonPath('data.results.0.success', true)
             ->assertJsonPath('data.results.0.attendance.overtime_authorized', true)
+            ->assertJsonPath('data.results.0.error', null)
             ->assertJsonPath('data.results.1.attendance_id', $a2->public_id)
             ->assertJsonPath('data.results.1.success', true)
-            ->assertJsonPath('data.results.1.attendance.overtime_authorized', true);
+            ->assertJsonPath('data.results.1.attendance.overtime_authorized', true)
+            ->assertJsonPath('data.results.1.error', null);
 
         $a1->refresh();
         $a2->refresh();
@@ -145,6 +147,7 @@ class BulkOvertimeDecisionApiTest extends TestCase
         $response->assertStatus(200)
             ->assertJsonPath('data.results.0.attendance_id', $decided->public_id)
             ->assertJsonPath('data.results.0.success', false)
+            ->assertJsonPath('data.results.0.attendance', null)
             ->assertJsonPath('data.results.1.attendance_id', $pending->public_id)
             ->assertJsonPath('data.results.1.success', true);
 
@@ -221,6 +224,16 @@ class BulkOvertimeDecisionApiTest extends TestCase
     {
         $this->postJson('/api/v1/attendances/overtime-decisions/bulk', [
             'attendance_ids' => [],
+            'authorize' => false,
+        ])->assertStatus(422)
+            ->assertJsonValidationErrors(['attendance_ids']);
+    }
+
+    #[Test]
+    public function returns_422_instead_of_500_when_attendance_ids_is_not_an_array(): void
+    {
+        $this->postJson('/api/v1/attendances/overtime-decisions/bulk', [
+            'attendance_ids' => 'not-an-array',
             'authorize' => false,
         ])->assertStatus(422)
             ->assertJsonValidationErrors(['attendance_ids']);

--- a/code/api/tests/Feature/AttendancePayroll/BulkOvertimeDecisionApiTest.php
+++ b/code/api/tests/Feature/AttendancePayroll/BulkOvertimeDecisionApiTest.php
@@ -1,0 +1,307 @@
+<?php
+
+namespace Tests\Feature\AttendancePayroll;
+
+use App\Models\Attendance;
+use App\Models\Employee;
+use App\Models\OvertimeLftTier;
+use App\Models\User;
+use App\Models\WageHistory;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+/**
+ * Feature tests for POST /api/v1/attendances/overtime-decisions/bulk
+ *
+ * Covers:
+ *   - Full batch success (authorize + reject)
+ *   - Partial success when one attendance was already decided
+ *   - LFT_PROPORTIONAL across multiple employees in the same batch
+ *   - Validation errors
+ *   - Unauthorized / unauthenticated access
+ */
+class BulkOvertimeDecisionApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $adminUser;
+
+    protected User $managerUser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Carbon::setTestNow(Carbon::parse('2026-02-23 23:59:00'));
+
+        app()[PermissionRegistrar::class]->forgetCachedPermissions();
+
+        Permission::create(['name' => 'attendances.create', 'guard_name' => 'api']);
+        $adminRole = Role::create(['name' => 'admin', 'guard_name' => 'api']);
+        $adminRole->givePermissionTo('attendances.create');
+        $managerRole = Role::create(['name' => 'manager', 'guard_name' => 'api']);
+        $managerRole->givePermissionTo('attendances.create');
+
+        Role::firstOrCreate(['name' => 'employee', 'guard_name' => 'api']);
+        Role::firstOrCreate(['name' => 'employee-manager', 'guard_name' => 'api']);
+        foreach (Employee::POSITION_ROLES as $roleName) {
+            Role::firstOrCreate(['name' => $roleName, 'guard_name' => 'api']);
+        }
+
+        $this->adminUser = User::factory()->create();
+        $this->adminUser->assignRole('admin');
+
+        $this->managerUser = User::factory()->create();
+        $this->managerUser->assignRole('manager');
+
+        Passport::actingAs($this->adminUser);
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow(null);
+        parent::tearDown();
+    }
+
+    // #region Happy path
+
+    #[Test]
+    public function authorizes_every_attendance_in_the_batch(): void
+    {
+        $a1 = Attendance::factory()->withOvertime(30)->create(['date' => '2026-02-23']);
+        $a2 = Attendance::factory()->withOvertime(45)->create(['date' => '2026-02-23']);
+
+        $response = $this->postJson('/api/v1/attendances/overtime-decisions/bulk', [
+            'attendance_ids' => [$a1->public_id, $a2->public_id],
+            'authorize' => true,
+            'valuation_method' => 'AGREED_RATE',
+            'agreed_rate' => 90,
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.results.0.attendance_id', $a1->public_id)
+            ->assertJsonPath('data.results.0.success', true)
+            ->assertJsonPath('data.results.0.attendance.overtime_authorized', true)
+            ->assertJsonPath('data.results.1.attendance_id', $a2->public_id)
+            ->assertJsonPath('data.results.1.success', true)
+            ->assertJsonPath('data.results.1.attendance.overtime_authorized', true);
+
+        $a1->refresh();
+        $a2->refresh();
+        $this->assertTrue($a1->overtime_authorized);
+        $this->assertTrue($a2->overtime_authorized);
+        $this->assertEquals($this->adminUser->id, $a1->overtime_authorized_by);
+    }
+
+    #[Test]
+    public function rejects_every_attendance_in_the_batch(): void
+    {
+        $a1 = Attendance::factory()->withOvertime(30)->create(['date' => '2026-02-23']);
+        $a2 = Attendance::factory()->withOvertime(45)->create(['date' => '2026-02-23']);
+
+        $response = $this->postJson('/api/v1/attendances/overtime-decisions/bulk', [
+            'attendance_ids' => [$a1->public_id, $a2->public_id],
+            'authorize' => false,
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.results.0.success', true)
+            ->assertJsonPath('data.results.1.success', true);
+
+        $a1->refresh();
+        $a2->refresh();
+        $this->assertFalse($a1->overtime_authorized);
+        $this->assertFalse($a2->overtime_authorized);
+    }
+
+    // #endregion
+
+    // #region Partial success
+
+    #[Test]
+    public function partial_success_when_one_attendance_was_already_decided(): void
+    {
+        $decided = Attendance::factory()->withOvertime(40)->create([
+            'date' => '2026-02-23',
+            'overtime_authorized' => true,
+            'overtime_authorized_by' => $this->adminUser->id,
+            'overtime_authorized_at' => Carbon::now()->utc(),
+        ]);
+        $pending = Attendance::factory()->withOvertime(30)->create(['date' => '2026-02-23']);
+
+        $response = $this->postJson('/api/v1/attendances/overtime-decisions/bulk', [
+            'attendance_ids' => [$decided->public_id, $pending->public_id],
+            'authorize' => true,
+            'valuation_method' => 'AGREED_RATE',
+            'agreed_rate' => 90,
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.results.0.attendance_id', $decided->public_id)
+            ->assertJsonPath('data.results.0.success', false)
+            ->assertJsonPath('data.results.1.attendance_id', $pending->public_id)
+            ->assertJsonPath('data.results.1.success', true);
+
+        $this->assertNotNull($response->json('data.results.0.error'));
+
+        $pending->refresh();
+        $this->assertTrue($pending->overtime_authorized);
+    }
+
+    // #endregion
+
+    // #region LFT proportional across multiple employees
+
+    #[Test]
+    public function lft_proportional_resolves_independently_per_employee_in_the_same_batch(): void
+    {
+        OvertimeLftTier::insert([
+            ['public_id' => '01BLKA', 'factor' => '2.00', 'up_to_hours' => '9.00', 'sort_order' => 1, 'created_at' => now(), 'updated_at' => now()],
+            ['public_id' => '01BLKB', 'factor' => '3.00', 'up_to_hours' => null, 'sort_order' => 2, 'created_at' => now(), 'updated_at' => now()],
+        ]);
+
+        $employeeA = Employee::factory()->create();
+        WageHistory::factory()->create([
+            'employee_id' => $employeeA->id,
+            'hourly_rate' => '120.00',
+            'effective_from' => '2026-01-01',
+            'effective_to' => null,
+        ]);
+        $attendanceA = Attendance::factory()->withOvertime(120)->create([
+            'employee_id' => $employeeA->id,
+            'date' => '2026-02-23',
+        ]);
+
+        $employeeB = Employee::factory()->create();
+        WageHistory::factory()->create([
+            'employee_id' => $employeeB->id,
+            'hourly_rate' => '120.00',
+            'effective_from' => '2026-01-01',
+            'effective_to' => null,
+        ]);
+        $attendanceB = Attendance::factory()->withOvertime(60)->create([
+            'employee_id' => $employeeB->id,
+            'date' => '2026-02-23',
+        ]);
+
+        $response = $this->postJson('/api/v1/attendances/overtime-decisions/bulk', [
+            'attendance_ids' => [$attendanceA->public_id, $attendanceB->public_id],
+            'authorize' => true,
+            'valuation_method' => 'LFT_PROPORTIONAL',
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.results.0.success', true)
+            ->assertJsonPath('data.results.0.attendance.overtime_rate_applied', 2)
+            ->assertJsonPath('data.results.1.success', true)
+            ->assertJsonPath('data.results.1.attendance.overtime_rate_applied', 2);
+    }
+
+    // #endregion
+
+    // #region Validation errors — 422
+
+    #[Test]
+    public function returns_422_when_attendance_ids_is_missing(): void
+    {
+        $this->postJson('/api/v1/attendances/overtime-decisions/bulk', [
+            'authorize' => false,
+        ])->assertStatus(422)
+            ->assertJsonValidationErrors(['attendance_ids']);
+    }
+
+    #[Test]
+    public function returns_422_when_attendance_ids_is_empty(): void
+    {
+        $this->postJson('/api/v1/attendances/overtime-decisions/bulk', [
+            'attendance_ids' => [],
+            'authorize' => false,
+        ])->assertStatus(422)
+            ->assertJsonValidationErrors(['attendance_ids']);
+    }
+
+    #[Test]
+    public function returns_422_when_an_attendance_id_does_not_exist(): void
+    {
+        $attendance = Attendance::factory()->withOvertime(30)->create();
+
+        $this->postJson('/api/v1/attendances/overtime-decisions/bulk', [
+            'attendance_ids' => [$attendance->public_id, 'nonexistent-id'],
+            'authorize' => false,
+        ])->assertStatus(422)
+            ->assertJsonValidationErrors(['attendance_ids.1']);
+    }
+
+    #[Test]
+    public function returns_422_when_attendance_ids_are_not_distinct(): void
+    {
+        $attendance = Attendance::factory()->withOvertime(30)->create();
+
+        $this->postJson('/api/v1/attendances/overtime-decisions/bulk', [
+            'attendance_ids' => [$attendance->public_id, $attendance->public_id],
+            'authorize' => false,
+        ])->assertStatus(422)
+            ->assertJsonValidationErrors(['attendance_ids.1']);
+    }
+
+    #[Test]
+    public function returns_422_when_authorize_field_is_missing(): void
+    {
+        $attendance = Attendance::factory()->withOvertime(30)->create();
+
+        $this->postJson('/api/v1/attendances/overtime-decisions/bulk', [
+            'attendance_ids' => [$attendance->public_id],
+        ])->assertStatus(422)
+            ->assertJsonValidationErrors(['authorize']);
+    }
+
+    #[Test]
+    public function returns_422_when_valuation_method_missing_while_authorizing(): void
+    {
+        $attendance = Attendance::factory()->withOvertime(30)->create();
+
+        $this->postJson('/api/v1/attendances/overtime-decisions/bulk', [
+            'attendance_ids' => [$attendance->public_id],
+            'authorize' => true,
+        ])->assertStatus(422)
+            ->assertJsonValidationErrors(['valuation_method']);
+    }
+
+    // #endregion
+
+    // #region 401 / 403
+
+    #[Test]
+    public function returns_401_when_unauthenticated(): void
+    {
+        auth()->forgetGuards();
+
+        $attendance = Attendance::factory()->withOvertime(30)->create();
+
+        $this->postJson('/api/v1/attendances/overtime-decisions/bulk', [
+            'attendance_ids' => [$attendance->public_id],
+            'authorize' => false,
+        ])->assertStatus(401);
+    }
+
+    #[Test]
+    public function returns_403_when_a_manager_tries_to_decide_a_past_day_attendance(): void
+    {
+        Passport::actingAs($this->managerUser);
+
+        $attendance = Attendance::factory()->withOvertime(30)->create(['date' => '2026-02-20']);
+
+        $this->postJson('/api/v1/attendances/overtime-decisions/bulk', [
+            'attendance_ids' => [$attendance->public_id],
+            'authorize' => false,
+        ])->assertStatus(403);
+    }
+
+    // #endregion
+}

--- a/code/api/tests/Feature/AttendancePayroll/BulkOvertimeDecisionApiTest.php
+++ b/code/api/tests/Feature/AttendancePayroll/BulkOvertimeDecisionApiTest.php
@@ -122,6 +122,24 @@ class BulkOvertimeDecisionApiTest extends TestCase
         $this->assertFalse($a2->overtime_authorized);
     }
 
+    #[Test]
+    public function each_result_includes_the_employee_name_for_success_and_failure(): void
+    {
+        $employee = Employee::factory()->create(['first_name' => 'Ana', 'last_name' => 'López']);
+        $attendance = Attendance::factory()->withOvertime(30)->create([
+            'employee_id' => $employee->id,
+            'date' => '2026-02-23',
+        ]);
+
+        $response = $this->postJson('/api/v1/attendances/overtime-decisions/bulk', [
+            'attendance_ids' => [$attendance->public_id],
+            'authorize' => false,
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.results.0.employee_name', 'Ana López');
+    }
+
     // #endregion
 
     // #region Partial success
@@ -284,6 +302,60 @@ class BulkOvertimeDecisionApiTest extends TestCase
             'authorize' => true,
         ])->assertStatus(422)
             ->assertJsonValidationErrors(['valuation_method']);
+    }
+
+    // #endregion
+
+    // #region Past-day reason requirement (mirrors the single-decision endpoint)
+
+    #[Test]
+    public function returns_422_when_admin_decides_a_past_day_attendance_without_a_reason(): void
+    {
+        $attendance = Attendance::factory()->withOvertime(30)->create(['date' => '2026-02-20']);
+
+        $this->postJson('/api/v1/attendances/overtime-decisions/bulk', [
+            'attendance_ids' => [$attendance->public_id],
+            'authorize' => false,
+        ])->assertStatus(422)
+            ->assertJsonValidationErrors(['reason']);
+    }
+
+    #[Test]
+    public function returns_422_when_batch_mixes_today_and_past_day_attendances_without_a_reason(): void
+    {
+        $today = Attendance::factory()->withOvertime(30)->create(['date' => '2026-02-23']);
+        $pastDay = Attendance::factory()->withOvertime(30)->create(['date' => '2026-02-20']);
+
+        $this->postJson('/api/v1/attendances/overtime-decisions/bulk', [
+            'attendance_ids' => [$today->public_id, $pastDay->public_id],
+            'authorize' => false,
+        ])->assertStatus(422)
+            ->assertJsonValidationErrors(['reason']);
+    }
+
+    #[Test]
+    public function admin_can_decide_a_past_day_attendance_when_a_reason_is_supplied(): void
+    {
+        $attendance = Attendance::factory()->withOvertime(30)->create(['date' => '2026-02-20']);
+
+        $this->postJson('/api/v1/attendances/overtime-decisions/bulk', [
+            'attendance_ids' => [$attendance->public_id],
+            'authorize' => false,
+            'reason' => 'Autorización retroactiva aprobada por gerencia',
+        ])->assertStatus(200)
+            ->assertJsonPath('data.results.0.success', true);
+    }
+
+    #[Test]
+    public function admin_does_not_need_a_reason_when_every_attendance_is_from_today(): void
+    {
+        $attendance = Attendance::factory()->withOvertime(30)->create(['date' => '2026-02-23']);
+
+        $this->postJson('/api/v1/attendances/overtime-decisions/bulk', [
+            'attendance_ids' => [$attendance->public_id],
+            'authorize' => false,
+        ])->assertStatus(200)
+            ->assertJsonPath('data.results.0.success', true);
     }
 
     // #endregion

--- a/code/webapp/cypress/e2e/attendance-close-day-overtime.cy.ts
+++ b/code/webapp/cypress/e2e/attendance-close-day-overtime.cy.ts
@@ -165,7 +165,7 @@ describe("Close day with overtime — decision queue after bulk close", () => {
     // First employee's dialog — with 2 entries in the queue, the checkbox offers
     // to apply the same decision to the other 1 employee left.
     cy.contains("Decisión de horas extra", { timeout: 10_000 }).should("be.visible");
-    cy.contains("Aplicar para el resto (1 empleados)").should("be.visible");
+    cy.contains("Aplicar para el resto (1 empleado)").should("be.visible");
 
     cy.get("[data-testid='checkbox-apply-to-rest']").check({ force: true });
     cy.get("[data-testid='btn-reject-overtime']").click();

--- a/code/webapp/cypress/e2e/attendance-close-day-overtime.cy.ts
+++ b/code/webapp/cypress/e2e/attendance-close-day-overtime.cy.ts
@@ -143,4 +143,47 @@ describe("Close day with overtime — decision queue after bulk close", () => {
       cy.contains("Salida", { timeout: 10_000 }).should("be.visible");
     });
   });
+
+  // ════════════════════════════════════════════════════════════════════════
+  // #249 — "Aplicar para el resto" checkbox
+  // ════════════════════════════════════════════════════════════════════════
+
+  it("applies the same decision to the rest of the queue in a single bulk request", () => {
+    cy.intercept("POST", "**/attendances/close-day").as("closeDay");
+    cy.intercept("POST", "**/attendances/overtime-decisions/bulk").as("bulkOvertimeDecision");
+    cy.intercept("PATCH", "**/attendances/**/overtime-decision").as("overtimeDecision");
+    cy.intercept("GET", "**/attendances/today*").as("refetchAttendance");
+
+    cy.contains("button", "Cerrar día").scrollIntoView().click();
+    cy.contains("Confirmar cierre del día", { timeout: 5_000 }).should("be.visible");
+    cy.get('input[type="time"]').clear({ force: true }).type("22:35", { force: true });
+    cy.contains("button", "Confirmar cierre").click();
+
+    cy.wait("@closeDay", { timeout: 10_000 }).its("response.statusCode").should("eq", 200);
+    cy.wait("@refetchAttendance", { timeout: 10_000 });
+
+    // First employee's dialog — with 2 entries in the queue, the checkbox offers
+    // to apply the same decision to the other 1 employee left.
+    cy.contains("Decisión de horas extra", { timeout: 10_000 }).should("be.visible");
+    cy.contains("Aplicar para el resto (1 empleados)").should("be.visible");
+
+    cy.get("[data-testid='checkbox-apply-to-rest']").check({ force: true });
+    cy.get("[data-testid='btn-reject-overtime']").click();
+
+    cy.wait("@bulkOvertimeDecision", { timeout: 10_000 })
+      .its("response.statusCode")
+      .should("eq", 200);
+
+    // No per-item PATCH calls, and no further dialogs — the whole queue was
+    // resolved by the single batch request.
+    cy.get("@overtimeDecision.all").should("have.length", 0);
+    cy.contains("Decisión de horas extra").should("not.exist");
+
+    getCard("Sánchez", "Roberto").within(() => {
+      cy.contains("Salida", { timeout: 10_000 }).should("be.visible");
+    });
+    getCard("Torres", "Laura").within(() => {
+      cy.contains("Salida", { timeout: 10_000 }).should("be.visible");
+    });
+  });
 });

--- a/code/webapp/src/components/attendance/OvertimeDecisionDialog.tsx
+++ b/code/webapp/src/components/attendance/OvertimeDecisionDialog.tsx
@@ -78,6 +78,7 @@ export function OvertimeDecisionDialog({
   const { register, handleSubmit, watch, formState: { errors } } = form
   const selectedMethod = watch('valuation_method')
   const showApplyToRest = (remainingCount ?? 0) > 1
+  const restCount = (remainingCount ?? 1) - 1
 
   const applyToRestCheckbox = showApplyToRest ? (
     <label className="flex items-start gap-2 text-sm text-muted-foreground">
@@ -89,7 +90,7 @@ export function OvertimeDecisionDialog({
         disabled={isLoading}
         className="mt-0.5"
       />
-      <span>Aplicar para el resto ({(remainingCount ?? 1) - 1} empleados)</span>
+      <span>Aplicar para el resto ({restCount} {restCount === 1 ? 'empleado' : 'empleados'})</span>
     </label>
   ) : null
 

--- a/code/webapp/src/components/attendance/OvertimeDecisionDialog.tsx
+++ b/code/webapp/src/components/attendance/OvertimeDecisionDialog.tsx
@@ -12,8 +12,10 @@ export interface OvertimeDecisionDialogProps {
   employeeName: string
   overtimeMinutes: number
   isLoading: boolean
-  onAuthorize: (method: OvertimeValuationMethod, agreedRate?: number, agreedFactor?: number) => void
-  onReject: () => void
+  /** Total entries left in the bulk queue (current included). Only pass this from the bulk (day-close) flow — the checkbox never shows for a single decision. */
+  remainingCount?: number
+  onAuthorize: (method: OvertimeValuationMethod, agreedRate: number | undefined, agreedFactor: number | undefined, applyToRest: boolean) => void
+  onReject: (applyToRest: boolean) => void
   onClose: () => void
 }
 
@@ -66,14 +68,30 @@ export function OvertimeDecisionDialog({
   employeeName,
   overtimeMinutes,
   isLoading,
+  remainingCount,
   onAuthorize,
   onReject,
   onClose,
 }: Readonly<OvertimeDecisionDialogProps>) {
-  const { step, form, handlePagar, handleBack, onSubmitMethod, preview, isPreviewLoading, previewError } =
+  const { step, form, handlePagar, handleBack, onSubmitMethod, applyToRest, setApplyToRest, preview, isPreviewLoading, previewError } =
     useOvertimeDecisionDialog({ isOpen, attendanceId, onAuthorize })
   const { register, handleSubmit, watch, formState: { errors } } = form
   const selectedMethod = watch('valuation_method')
+  const showApplyToRest = (remainingCount ?? 0) > 1
+
+  const applyToRestCheckbox = showApplyToRest ? (
+    <label className="flex items-start gap-2 text-sm text-muted-foreground">
+      <input
+        type="checkbox"
+        data-testid="checkbox-apply-to-rest"
+        checked={applyToRest}
+        onChange={(e) => setApplyToRest(e.target.checked)}
+        disabled={isLoading}
+        className="mt-0.5"
+      />
+      <span>Aplicar para el resto ({(remainingCount ?? 1) - 1} empleados)</span>
+    </label>
+  ) : null
 
   // Escape key handler
   useEffect(() => {
@@ -134,6 +152,8 @@ export function OvertimeDecisionDialog({
               </p>
             </div>
 
+            {applyToRestCheckbox}
+
             <div className="flex flex-col gap-2">
               <Button
                 className="w-full"
@@ -148,7 +168,7 @@ export function OvertimeDecisionDialog({
               <Button
                 variant="outline-danger"
                 className="w-full"
-                onClick={onReject}
+                onClick={() => onReject(applyToRest)}
                 disabled={isLoading}
                 data-testid="btn-reject-overtime"
               >
@@ -238,6 +258,8 @@ export function OvertimeDecisionDialog({
             >
               {renderOvertimePreview(isPreviewLoading, previewError, preview)}
             </div>
+
+            {applyToRestCheckbox}
 
             <div className="flex flex-col gap-2">
               <Button type="submit" className="w-full" disabled={isLoading} data-testid="btn-confirm-valuation">

--- a/code/webapp/src/components/attendance/__tests__/OvertimeDecisionDialog.test.tsx
+++ b/code/webapp/src/components/attendance/__tests__/OvertimeDecisionDialog.test.tsx
@@ -76,7 +76,7 @@ describe('OvertimeDecisionDialog — actions', () => {
     )
     fireEvent.click(getByTestId('btn-authorize-overtime'))
     fireEvent.click(getByTestId('btn-confirm-valuation'))
-    await waitFor(() => expect(onAuthorize).toHaveBeenCalledWith('LFT_PROPORTIONAL', undefined, undefined))
+    await waitFor(() => expect(onAuthorize).toHaveBeenCalledWith('LFT_PROPORTIONAL', undefined, undefined, false))
   })
 
   it('requires agreed_rate when AGREED_RATE method is selected', async () => {
@@ -100,7 +100,7 @@ describe('OvertimeDecisionDialog — actions', () => {
     fireEvent.change(getByLabelText('Método'), { target: { value: 'AGREED_RATE' } })
     fireEvent.change(getByLabelText('Tarifa por hora'), { target: { value: '90' } })
     fireEvent.click(getByTestId('btn-confirm-valuation'))
-    await waitFor(() => expect(onAuthorize).toHaveBeenCalledWith('AGREED_RATE', 90, undefined))
+    await waitFor(() => expect(onAuthorize).toHaveBeenCalledWith('AGREED_RATE', 90, undefined, false))
   })
 
   it('requires agreed_factor when SALARY_FACTOR method is selected', async () => {
@@ -124,7 +124,7 @@ describe('OvertimeDecisionDialog — actions', () => {
     fireEvent.change(getByLabelText('Método'), { target: { value: 'SALARY_FACTOR' } })
     fireEvent.change(getByLabelText(/Factor/), { target: { value: '1.5' } })
     fireEvent.click(getByTestId('btn-confirm-valuation'))
-    await waitFor(() => expect(onAuthorize).toHaveBeenCalledWith('SALARY_FACTOR', undefined, 1.5))
+    await waitFor(() => expect(onAuthorize).toHaveBeenCalledWith('SALARY_FACTOR', undefined, 1.5, false))
   })
 
   it('returns to the confirm step when Regresar is clicked', () => {
@@ -276,6 +276,61 @@ describe('OvertimeDecisionDialog — cost preview', () => {
     fireEvent.click(getByTestId('btn-authorize-overtime'))
     expect(getByText('No hay un tramo LFT configurado para las horas acumuladas de este empleado.')).toBeDefined()
     expect(queryByText(/Completa los datos/)).toBeNull()
+  })
+})
+
+describe('OvertimeDecisionDialog — apply to rest (bulk flow)', () => {
+  it('does not render the checkbox when remainingCount is not provided', () => {
+    const { queryByTestId } = render(<OvertimeDecisionDialog {...defaultProps} />)
+    expect(queryByTestId('checkbox-apply-to-rest')).toBeNull()
+  })
+
+  it('does not render the checkbox when remainingCount is 1 (individual flow)', () => {
+    const { queryByTestId } = render(<OvertimeDecisionDialog {...defaultProps} remainingCount={1} />)
+    expect(queryByTestId('checkbox-apply-to-rest')).toBeNull()
+  })
+
+  it('renders the checkbox on the confirm step when remainingCount is greater than 1', () => {
+    const { getByTestId, getByText } = render(<OvertimeDecisionDialog {...defaultProps} remainingCount={4} />)
+    expect(getByTestId('checkbox-apply-to-rest')).toBeDefined()
+    expect(getByText(/Aplicar para el resto/)).toBeDefined()
+    expect(getByText(/3 empleados/)).toBeDefined()
+  })
+
+  it('renders the checkbox on the method step when remainingCount is greater than 1', () => {
+    const { getByTestId } = render(<OvertimeDecisionDialog {...defaultProps} remainingCount={3} />)
+    fireEvent.click(getByTestId('btn-authorize-overtime'))
+    expect(getByTestId('checkbox-apply-to-rest')).toBeDefined()
+  })
+
+  it('calls onReject with applyToRest=true when the checkbox is checked', () => {
+    const onReject = vi.fn()
+    const { getByTestId } = render(
+      <OvertimeDecisionDialog {...defaultProps} remainingCount={3} onReject={onReject} />
+    )
+    fireEvent.click(getByTestId('checkbox-apply-to-rest'))
+    fireEvent.click(getByTestId('btn-reject-overtime'))
+    expect(onReject).toHaveBeenCalledWith(true)
+  })
+
+  it('calls onReject with applyToRest=false when the checkbox is left unchecked', () => {
+    const onReject = vi.fn()
+    const { getByTestId } = render(
+      <OvertimeDecisionDialog {...defaultProps} remainingCount={3} onReject={onReject} />
+    )
+    fireEvent.click(getByTestId('btn-reject-overtime'))
+    expect(onReject).toHaveBeenCalledWith(false)
+  })
+
+  it('calls onAuthorize with applyToRest=true when the checkbox is checked on the method step', async () => {
+    const onAuthorize = vi.fn()
+    const { getByTestId } = render(
+      <OvertimeDecisionDialog {...defaultProps} remainingCount={3} onAuthorize={onAuthorize} />
+    )
+    fireEvent.click(getByTestId('btn-authorize-overtime'))
+    fireEvent.click(getByTestId('checkbox-apply-to-rest'))
+    fireEvent.click(getByTestId('btn-confirm-valuation'))
+    await waitFor(() => expect(onAuthorize).toHaveBeenCalledWith('LFT_PROPORTIONAL', undefined, undefined, true))
   })
 })
 

--- a/code/webapp/src/components/attendance/__tests__/OvertimeDecisionDialog.test.tsx
+++ b/code/webapp/src/components/attendance/__tests__/OvertimeDecisionDialog.test.tsx
@@ -297,6 +297,11 @@ describe('OvertimeDecisionDialog — apply to rest (bulk flow)', () => {
     expect(getByText(/3 empleados/)).toBeDefined()
   })
 
+  it('uses singular "empleado" when only one other entry remains in the queue', () => {
+    const { getByText } = render(<OvertimeDecisionDialog {...defaultProps} remainingCount={2} />)
+    expect(getByText('Aplicar para el resto (1 empleado)')).toBeDefined()
+  })
+
   it('renders the checkbox on the method step when remainingCount is greater than 1', () => {
     const { getByTestId } = render(<OvertimeDecisionDialog {...defaultProps} remainingCount={3} />)
     fireEvent.click(getByTestId('btn-authorize-overtime'))

--- a/code/webapp/src/components/attendance/__tests__/use-overtime-decision-dialog.test.ts
+++ b/code/webapp/src/components/attendance/__tests__/use-overtime-decision-dialog.test.ts
@@ -68,7 +68,7 @@ describe('useOvertimeDecisionDialog', () => {
       await result.current.onSubmitMethod({ valuation_method: 'LFT_PROPORTIONAL', agreed_rate: '', agreed_factor: '' })
     })
 
-    expect(onAuthorize).toHaveBeenCalledWith('LFT_PROPORTIONAL', undefined, undefined)
+    expect(onAuthorize).toHaveBeenCalledWith('LFT_PROPORTIONAL', undefined, undefined, false)
   })
 
   it('onSubmitMethod calls onAuthorize with AGREED_RATE and the numeric rate', async () => {
@@ -81,7 +81,7 @@ describe('useOvertimeDecisionDialog', () => {
       await result.current.onSubmitMethod({ valuation_method: 'AGREED_RATE', agreed_rate: '90', agreed_factor: '' })
     })
 
-    expect(onAuthorize).toHaveBeenCalledWith('AGREED_RATE', 90, undefined)
+    expect(onAuthorize).toHaveBeenCalledWith('AGREED_RATE', 90, undefined, false)
   })
 
   it('onSubmitMethod calls onAuthorize with SALARY_FACTOR and the numeric factor', async () => {
@@ -94,7 +94,7 @@ describe('useOvertimeDecisionDialog', () => {
       await result.current.onSubmitMethod({ valuation_method: 'SALARY_FACTOR', agreed_rate: '', agreed_factor: '1.5' })
     })
 
-    expect(onAuthorize).toHaveBeenCalledWith('SALARY_FACTOR', undefined, 1.5)
+    expect(onAuthorize).toHaveBeenCalledWith('SALARY_FACTOR', undefined, 1.5, false)
   })
 
   it('form defaults to LFT_PROPORTIONAL', async () => {
@@ -102,5 +102,48 @@ describe('useOvertimeDecisionDialog', () => {
       useOvertimeDecisionDialog({ isOpen: true, attendanceId: 'att-1', onAuthorize: vi.fn() }),
     )
     await waitFor(() => expect(result.current.form.getValues('valuation_method')).toBe('LFT_PROPORTIONAL'))
+  })
+
+  // ── applyToRest (bulk "apply to the rest" checkbox) ──────────────────────
+
+  it('applyToRest defaults to false', () => {
+    const { result } = renderHook(() =>
+      useOvertimeDecisionDialog({ isOpen: true, attendanceId: 'att-1', onAuthorize: vi.fn() }),
+    )
+    expect(result.current.applyToRest).toBe(false)
+  })
+
+  it('setApplyToRest toggles the checkbox state', () => {
+    const { result } = renderHook(() =>
+      useOvertimeDecisionDialog({ isOpen: true, attendanceId: 'att-1', onAuthorize: vi.fn() }),
+    )
+    act(() => { result.current.setApplyToRest(true) })
+    expect(result.current.applyToRest).toBe(true)
+  })
+
+  it('resets applyToRest to false when attendanceId changes (bulk queue advancing)', () => {
+    const { result, rerender } = renderHook(
+      ({ attendanceId }) => useOvertimeDecisionDialog({ isOpen: true, attendanceId, onAuthorize: vi.fn() }),
+      { initialProps: { attendanceId: 'att-1' } },
+    )
+    act(() => { result.current.setApplyToRest(true) })
+    expect(result.current.applyToRest).toBe(true)
+
+    rerender({ attendanceId: 'att-2' })
+    expect(result.current.applyToRest).toBe(false)
+  })
+
+  it('onSubmitMethod reports applyToRest alongside the decision', async () => {
+    const onAuthorize = vi.fn()
+    const { result } = renderHook(() =>
+      useOvertimeDecisionDialog({ isOpen: true, attendanceId: 'att-1', onAuthorize }),
+    )
+
+    act(() => { result.current.setApplyToRest(true) })
+    await act(async () => {
+      await result.current.onSubmitMethod({ valuation_method: 'LFT_PROPORTIONAL', agreed_rate: '', agreed_factor: '' })
+    })
+
+    expect(onAuthorize).toHaveBeenCalledWith('LFT_PROPORTIONAL', undefined, undefined, true)
   })
 })

--- a/code/webapp/src/components/attendance/use-overtime-decision-dialog.ts
+++ b/code/webapp/src/components/attendance/use-overtime-decision-dialog.ts
@@ -32,7 +32,7 @@ interface PreviewParams {
 interface UseOvertimeDecisionDialogArgs {
   isOpen: boolean
   attendanceId: string | null
-  onAuthorize: (method: OvertimeValuationMethod, agreedRate?: number, agreedFactor?: number) => void
+  onAuthorize: (method: OvertimeValuationMethod, agreedRate: number | undefined, agreedFactor: number | undefined, applyToRest: boolean) => void
 }
 
 const PREVIEW_DEBOUNCE_MS = 400
@@ -43,6 +43,7 @@ const PREVIEW_DEBOUNCE_MS = 400
  */
 export function useOvertimeDecisionDialog({ isOpen, attendanceId, onAuthorize }: UseOvertimeDecisionDialogArgs) {
   const [step, setStep] = useState<'confirm' | 'method'>('confirm')
+  const [applyToRest, setApplyToRest] = useState(false)
 
   const form = useForm<OvertimeMethodFormValues>({
     resolver: zodResolver(methodSchema),
@@ -54,6 +55,7 @@ export function useOvertimeDecisionDialog({ isOpen, attendanceId, onAuthorize }:
   useEffect(() => {
     if (isOpen) {
       setStep('confirm')
+      setApplyToRest(false)
       form.reset({ valuation_method: 'LFT_PROPORTIONAL', agreed_rate: '', agreed_factor: '' })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -67,6 +69,7 @@ export function useOvertimeDecisionDialog({ isOpen, attendanceId, onAuthorize }:
       values.valuation_method,
       values.valuation_method === 'AGREED_RATE' ? Number(values.agreed_rate) : undefined,
       values.valuation_method === 'SALARY_FACTOR' ? Number(values.agreed_factor) : undefined,
+      applyToRest,
     )
   }
 
@@ -111,6 +114,8 @@ export function useOvertimeDecisionDialog({ isOpen, attendanceId, onAuthorize }:
     handlePagar,
     handleBack,
     onSubmitMethod,
+    applyToRest,
+    setApplyToRest,
     preview: previewQuery.data,
     isPreviewLoading: previewQuery.isFetching,
     previewError,

--- a/code/webapp/src/pages/attendance/-use-today-attendance-page.ts
+++ b/code/webapp/src/pages/attendance/-use-today-attendance-page.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect } from 'react'
 import { useAuthStore } from '@/stores/auth.store'
-import { useDailyAttendance, useCheckIn, useLunchStart, useLunchReturn, useCheckOut, useOvertimeDecision, useMarkDayStatus } from '@/services/attendance-hooks'
+import { useDailyAttendance, useCheckIn, useLunchStart, useLunchReturn, useCheckOut, useOvertimeDecision, useBulkOvertimeDecision, useMarkDayStatus } from '@/services/attendance-hooks'
 import { useExtraDayExpress } from '@/components/attendance/use-extra-day-express'
 import { getAttendancePhase } from '@/types/attendance'
 import { todayDateCdmx } from '@/lib/datetime'
@@ -122,8 +122,9 @@ export interface UseTodayAttendancePageResult {
   confirmOvertimeDecision: (authorize: boolean, valuationMethod?: OvertimeValuationMethod, agreedRate?: number, agreedFactor?: number) => void
   // Bulk overtime queue (from bulk day close)
   currentBulkOvertime: OvertimePendingEntry | null
+  bulkOvertimeQueueLength: number
   enqueueBulkOvertime: (entries: OvertimePendingEntry[]) => void
-  confirmBulkOvertimeDecision: (authorize: boolean, valuationMethod?: OvertimeValuationMethod, agreedRate?: number, agreedFactor?: number) => void
+  confirmBulkOvertimeDecision: (authorize: boolean, valuationMethod?: OvertimeValuationMethod, agreedRate?: number, agreedFactor?: number, applyToRest?: boolean) => void
   closeBulkOvertimeDecision: () => void
   // Mark day status action
   isMarkingDayStatus: boolean
@@ -154,6 +155,7 @@ export function useTodayAttendancePage(): UseTodayAttendancePageResult {
   const lunchReturnMutation = useLunchReturn()
   const checkOutMutation = useCheckOut()
   const overtimeDecisionMutation = useOvertimeDecision()
+  const bulkOvertimeDecisionMutation = useBulkOvertimeDecision()
   const markDayStatusMutation = useMarkDayStatus()
   const extraDayMutation = useExtraDayExpress()
 
@@ -297,8 +299,21 @@ export function useTodayAttendancePage(): UseTodayAttendancePageResult {
     valuationMethod?: OvertimeValuationMethod,
     agreedRate?: number,
     agreedFactor?: number,
+    applyToRest?: boolean,
   ) => {
     if (!currentBulkOvertime) return
+
+    if (applyToRest) {
+      bulkOvertimeDecisionMutation.mutate(
+        {
+          attendance_ids: bulkOvertimeQueue.map(entry => entry.attendance_id),
+          ...buildOvertimeDecisionPayload(authorize, valuationMethod, agreedRate, agreedFactor),
+        },
+        { onSuccess: () => setBulkOvertimeQueue([]) },
+      )
+      return
+    }
+
     overtimeDecisionMutation.mutate(
       {
         attendance_id: currentBulkOvertime.attendance_id,
@@ -306,7 +321,7 @@ export function useTodayAttendancePage(): UseTodayAttendancePageResult {
       },
       { onSuccess: () => setBulkOvertimeQueue(q => q.slice(1)) },
     )
-  }, [currentBulkOvertime, overtimeDecisionMutation])
+  }, [currentBulkOvertime, bulkOvertimeQueue, overtimeDecisionMutation, bulkOvertimeDecisionMutation])
 
   const closeBulkOvertimeDecision = useCallback(() => {
     setBulkOvertimeQueue([])
@@ -401,12 +416,13 @@ export function useTodayAttendancePage(): UseTodayAttendancePageResult {
     // Overtime decision (individual)
     pendingOvertimeDecision,
     pendingOvertimeMinutes,
-    isRecordingOvertimeDecision: overtimeDecisionMutation.isPending,
+    isRecordingOvertimeDecision: overtimeDecisionMutation.isPending || bulkOvertimeDecisionMutation.isPending,
     openOvertimeDecision,
     closeOvertimeDecision,
     confirmOvertimeDecision,
     // Bulk overtime queue
     currentBulkOvertime,
+    bulkOvertimeQueueLength: bulkOvertimeQueue.length,
     enqueueBulkOvertime,
     confirmBulkOvertimeDecision,
     closeBulkOvertimeDecision,

--- a/code/webapp/src/pages/attendance/__tests__/use-today-attendance-page.test.ts
+++ b/code/webapp/src/pages/attendance/__tests__/use-today-attendance-page.test.ts
@@ -35,6 +35,7 @@ vi.mock('@/services/attendance-api', () => ({
     lunchReturn: vi.fn(),
     checkOut: vi.fn(),
     overtimeDecision: vi.fn().mockResolvedValue({ data: { status: 200, data: {} } }),
+    bulkOvertimeDecision: vi.fn().mockResolvedValue({ data: { status: 200, data: { results: [] } } }),
     closeDay: vi.fn(),
     markDayStatus: vi.fn(),
   },
@@ -891,6 +892,66 @@ describe('useTodayAttendancePage', () => {
       await waitFor(() => {
         expect(result.current.currentBulkOvertime).toBeNull()
       })
+    })
+
+    // ── applyToRest=true ("Aplicar para el resto" checkbox) ──────────────────
+
+    it('confirmBulkOvertimeDecision(applyToRest=true) calls the bulk endpoint with every queued attendance_id', async () => {
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      act(() => {
+        result.current.enqueueBulkOvertime([
+          { attendance_id: 'att-001', employee_name: 'Carlos Mendoza', overtime_minutes: 35 },
+          { attendance_id: 'att-002', employee_name: 'María García', overtime_minutes: 20 },
+          { attendance_id: 'att-003', employee_name: 'Ana López', overtime_minutes: 15 },
+        ])
+      })
+
+      await act(async () => {
+        result.current.confirmBulkOvertimeDecision(true, 'AGREED_RATE', 90, undefined, true)
+      })
+
+      await waitFor(() => {
+        expect(attendanceApi.bulkOvertimeDecision).toHaveBeenCalledWith({
+          attendance_ids: ['att-001', 'att-002', 'att-003'],
+          authorize: true,
+          valuation_method: 'AGREED_RATE',
+          agreed_rate: 90,
+        })
+      })
+      expect(attendanceApi.overtimeDecision).not.toHaveBeenCalled()
+    })
+
+    it('confirmBulkOvertimeDecision(applyToRest=true) clears the whole queue on success', async () => {
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      act(() => {
+        result.current.enqueueBulkOvertime([
+          { attendance_id: 'att-001', employee_name: 'Carlos Mendoza', overtime_minutes: 35 },
+          { attendance_id: 'att-002', employee_name: 'María García', overtime_minutes: 20 },
+        ])
+      })
+
+      await act(async () => {
+        result.current.confirmBulkOvertimeDecision(false, undefined, undefined, undefined, true)
+      })
+
+      await waitFor(() => {
+        expect(result.current.currentBulkOvertime).toBeNull()
+      })
+    })
+
+    it('confirmBulkOvertimeDecision(applyToRest=true) does nothing when queue is empty', async () => {
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      act(() => {
+        result.current.confirmBulkOvertimeDecision(true, undefined, undefined, undefined, true)
+      })
+
+      expect(attendanceApi.bulkOvertimeDecision).not.toHaveBeenCalled()
     })
   })
 

--- a/code/webapp/src/pages/attendance/index.tsx
+++ b/code/webapp/src/pages/attendance/index.tsx
@@ -56,17 +56,28 @@ interface OvertimeDialogState {
   onClose: () => void
 }
 
+interface ResolveOvertimeDialogArgs {
+  individual: PendingAttendanceData | null
+  bulk: OvertimePendingEntry | null
+  individualMinutes: number
+  bulkQueueLength: number
+  confirmIndividual: (auth: boolean, method?: OvertimeValuationMethod, agreedRate?: number, agreedFactor?: number) => void
+  closeIndividual: () => void
+  confirmBulk: (auth: boolean, method?: OvertimeValuationMethod, agreedRate?: number, agreedFactor?: number, applyToRest?: boolean) => void
+  closeBulk: () => void
+}
+
 /** Resolve overtime dialog props — individual flow takes priority over bulk queue. */
-function resolveOvertimeDialog(
-  individual: PendingAttendanceData | null,
-  bulk: OvertimePendingEntry | null,
-  individualMinutes: number,
-  bulkQueueLength: number,
-  confirmIndividual: (auth: boolean, method?: OvertimeValuationMethod, agreedRate?: number, agreedFactor?: number) => void,
-  closeIndividual: () => void,
-  confirmBulk: (auth: boolean, method?: OvertimeValuationMethod, agreedRate?: number, agreedFactor?: number, applyToRest?: boolean) => void,
-  closeBulk: () => void,
-): OvertimeDialogState {
+function resolveOvertimeDialog({
+  individual,
+  bulk,
+  individualMinutes,
+  bulkQueueLength,
+  confirmIndividual,
+  closeIndividual,
+  confirmBulk,
+  closeBulk,
+}: ResolveOvertimeDialogArgs): OvertimeDialogState {
   if (individual) {
     return {
       isOpen: true,
@@ -170,16 +181,16 @@ export function AttendancePage() {
     }
   }, [overtimePending, enqueueBulkOvertime, clearOvertimePending])
 
-  const overtimeDialog = resolveOvertimeDialog(
-    pendingOvertimeDecision,
-    currentBulkOvertime,
-    pendingOvertimeMinutes,
-    bulkOvertimeQueueLength,
-    confirmOvertimeDecision,
-    closeOvertimeDecision,
-    confirmBulkOvertimeDecision,
-    closeBulkOvertimeDecision,
-  )
+  const overtimeDialog = resolveOvertimeDialog({
+    individual: pendingOvertimeDecision,
+    bulk: currentBulkOvertime,
+    individualMinutes: pendingOvertimeMinutes,
+    bulkQueueLength: bulkOvertimeQueueLength,
+    confirmIndividual: confirmOvertimeDecision,
+    closeIndividual: closeOvertimeDecision,
+    confirmBulk: confirmBulkOvertimeDecision,
+    closeBulk: closeBulkOvertimeDecision,
+  })
 
   if (!hasBranch) {
     return (

--- a/code/webapp/src/pages/attendance/index.tsx
+++ b/code/webapp/src/pages/attendance/index.tsx
@@ -50,8 +50,9 @@ interface OvertimeDialogState {
   attendanceId: string | null
   employeeName: string
   overtimeMinutes: number
-  onAuthorize: (method: OvertimeValuationMethod, agreedRate?: number, agreedFactor?: number) => void
-  onReject: () => void
+  remainingCount?: number
+  onAuthorize: (method: OvertimeValuationMethod, agreedRate: number | undefined, agreedFactor: number | undefined, applyToRest: boolean) => void
+  onReject: (applyToRest: boolean) => void
   onClose: () => void
 }
 
@@ -60,9 +61,10 @@ function resolveOvertimeDialog(
   individual: PendingAttendanceData | null,
   bulk: OvertimePendingEntry | null,
   individualMinutes: number,
+  bulkQueueLength: number,
   confirmIndividual: (auth: boolean, method?: OvertimeValuationMethod, agreedRate?: number, agreedFactor?: number) => void,
   closeIndividual: () => void,
-  confirmBulk: (auth: boolean, method?: OvertimeValuationMethod, agreedRate?: number, agreedFactor?: number) => void,
+  confirmBulk: (auth: boolean, method?: OvertimeValuationMethod, agreedRate?: number, agreedFactor?: number, applyToRest?: boolean) => void,
   closeBulk: () => void,
 ): OvertimeDialogState {
   if (individual) {
@@ -81,8 +83,9 @@ function resolveOvertimeDialog(
     attendanceId: bulk?.attendance_id ?? null,
     employeeName: bulk?.employee_name ?? '',
     overtimeMinutes: bulk?.overtime_minutes ?? 0,
-    onAuthorize: (method, agreedRate, agreedFactor) => confirmBulk(true, method, agreedRate, agreedFactor),
-    onReject: () => confirmBulk(false),
+    remainingCount: bulkQueueLength,
+    onAuthorize: (method, agreedRate, agreedFactor, applyToRest) => confirmBulk(true, method, agreedRate, agreedFactor, applyToRest),
+    onReject: (applyToRest) => confirmBulk(false, undefined, undefined, undefined, applyToRest),
     onClose: closeBulk,
   }
 }
@@ -136,6 +139,7 @@ export function AttendancePage() {
     confirmOvertimeDecision,
     // Bulk overtime queue
     currentBulkOvertime,
+    bulkOvertimeQueueLength,
     enqueueBulkOvertime,
     confirmBulkOvertimeDecision,
     closeBulkOvertimeDecision,
@@ -170,6 +174,7 @@ export function AttendancePage() {
     pendingOvertimeDecision,
     currentBulkOvertime,
     pendingOvertimeMinutes,
+    bulkOvertimeQueueLength,
     confirmOvertimeDecision,
     closeOvertimeDecision,
     confirmBulkOvertimeDecision,

--- a/code/webapp/src/services/__tests__/attendance-hooks-overtime.test.ts
+++ b/code/webapp/src/services/__tests__/attendance-hooks-overtime.test.ts
@@ -220,8 +220,8 @@ const mockBulkResponse = {
     status: 200,
     data: {
       results: [
-        { attendance_id: 'att-1', success: true, attendance: { id: 'att-1' }, error: null },
-        { attendance_id: 'att-2', success: true, attendance: { id: 'att-2' }, error: null },
+        { attendance_id: 'att-1', employee_name: 'Carlos Mendoza', success: true, attendance: { id: 'att-1' }, error: null },
+        { attendance_id: 'att-2', employee_name: 'María García', success: true, attendance: { id: 'att-2' }, error: null },
       ],
     },
   },
@@ -291,8 +291,8 @@ describe('useBulkOvertimeDecision', () => {
         status: 200,
         data: {
           results: [
-            { attendance_id: 'att-1', success: true, attendance: { id: 'att-1' }, error: null },
-            { attendance_id: 'att-2', success: false, attendance: null, error: 'Ya se registró una decisión.' },
+            { attendance_id: 'att-1', employee_name: 'Carlos Mendoza', success: true, attendance: { id: 'att-1' }, error: null },
+            { attendance_id: 'att-2', employee_name: 'María García', success: false, attendance: null, error: 'Ya se registró una decisión.' },
           ],
         },
       },
@@ -305,7 +305,7 @@ describe('useBulkOvertimeDecision', () => {
     })
 
     expect(mockShowError).toHaveBeenCalledWith(
-      expect.stringContaining('Ya se registró una decisión.'),
+      expect.stringContaining('María García: Ya se registró una decisión.'),
       'Algunos registros no se pudieron actualizar'
     )
   })

--- a/code/webapp/src/services/__tests__/attendance-hooks-overtime.test.ts
+++ b/code/webapp/src/services/__tests__/attendance-hooks-overtime.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest'
 import { renderHook, act, waitFor } from '@testing-library/react'
 import React from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { useOvertimeDecision, useOvertimeValuationPreview } from '@/services/attendance-hooks'
+import { useOvertimeDecision, useOvertimeValuationPreview, useBulkOvertimeDecision } from '@/services/attendance-hooks'
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
 
@@ -23,6 +23,7 @@ vi.mock('@/services/attendance-api', () => ({
     checkOut: vi.fn(),
     closeDay: vi.fn(),
     overtimeDecision: vi.fn(),
+    bulkOvertimeDecision: vi.fn(),
     previewOvertimeValuation: vi.fn(),
   },
 }))
@@ -209,6 +210,120 @@ describe('useOvertimeDecision', () => {
     expect(invalidateSpy).toHaveBeenCalledWith(
       expect.objectContaining({ queryKey: ['attendances', 'daily'] })
     )
+  })
+})
+
+// ── useBulkOvertimeDecision ───────────────────────────────────────────────────
+
+const mockBulkResponse = {
+  data: {
+    status: 200,
+    data: {
+      results: [
+        { attendance_id: 'att-1', success: true, attendance: { id: 'att-1' }, error: null },
+        { attendance_id: 'att-2', success: true, attendance: { id: 'att-2' }, error: null },
+      ],
+    },
+  },
+}
+
+describe('useBulkOvertimeDecision', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('calls attendanceApi.bulkOvertimeDecision with attendance_ids and decision fields', async () => {
+    vi.mocked(attendanceApi.bulkOvertimeDecision).mockResolvedValueOnce(mockBulkResponse as never)
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useBulkOvertimeDecision(), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        attendance_ids: ['att-1', 'att-2'],
+        authorize: true,
+        valuation_method: 'AGREED_RATE',
+        agreed_rate: 90,
+      })
+    })
+
+    expect(attendanceApi.bulkOvertimeDecision).toHaveBeenCalledWith({
+      attendance_ids: ['att-1', 'att-2'],
+      authorize: true,
+      valuation_method: 'AGREED_RATE',
+      agreed_rate: 90,
+    })
+  })
+
+  it('invalidates today attendance queries on success', async () => {
+    vi.mocked(attendanceApi.bulkOvertimeDecision).mockResolvedValueOnce(mockBulkResponse as never)
+    const { wrapper, queryClient } = makeWrapper()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+    const { result } = renderHook(() => useBulkOvertimeDecision(), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({ attendance_ids: ['att-1'], authorize: false })
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['attendances', 'daily'] })
+    )
+  })
+
+  it('shows a success toast when every result succeeds', async () => {
+    vi.mocked(attendanceApi.bulkOvertimeDecision).mockResolvedValueOnce(mockBulkResponse as never)
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useBulkOvertimeDecision(), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({ attendance_ids: ['att-1', 'att-2'], authorize: false })
+    })
+
+    expect(mockShowSuccess).toHaveBeenCalledWith(
+      expect.stringContaining('2'),
+      'Decisión aplicada'
+    )
+    expect(mockShowError).not.toHaveBeenCalled()
+  })
+
+  it('shows an error toast listing failed employees when some results fail', async () => {
+    vi.mocked(attendanceApi.bulkOvertimeDecision).mockResolvedValueOnce({
+      data: {
+        status: 200,
+        data: {
+          results: [
+            { attendance_id: 'att-1', success: true, attendance: { id: 'att-1' }, error: null },
+            { attendance_id: 'att-2', success: false, attendance: null, error: 'Ya se registró una decisión.' },
+          ],
+        },
+      },
+    } as never)
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useBulkOvertimeDecision(), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({ attendance_ids: ['att-1', 'att-2'], authorize: false })
+    })
+
+    expect(mockShowError).toHaveBeenCalledWith(
+      expect.stringContaining('Ya se registró una decisión.'),
+      'Algunos registros no se pudieron actualizar'
+    )
+  })
+
+  it('shows an error toast on request failure', async () => {
+    vi.mocked(attendanceApi.bulkOvertimeDecision).mockRejectedValueOnce(new Error('Server error'))
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useBulkOvertimeDecision(), { wrapper })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({ attendance_ids: ['att-1'], authorize: false })
+      } catch {
+        // expected
+      }
+    })
+
+    expect(mockShowError).toHaveBeenCalledWith(expect.any(String), 'Error al registrar')
   })
 })
 

--- a/code/webapp/src/services/attendance-api.ts
+++ b/code/webapp/src/services/attendance-api.ts
@@ -1,5 +1,5 @@
 import { apiClient } from '@/lib/api-client'
-import type { TodayAttendanceResponse, AttendanceRecord, CloseDayRequest, CloseDayResponse, OvertimeDecisionPayload, OvertimeValuationMethod, OvertimeValuationPreview } from '@/types/attendance'
+import type { TodayAttendanceResponse, AttendanceRecord, CloseDayRequest, CloseDayResponse, OvertimeDecisionPayload, OvertimeValuationMethod, OvertimeValuationPreview, BulkOvertimeDecisionPayload, BulkOvertimeDecisionResponse } from '@/types/attendance'
 
 export const attendanceApi = {
   /**
@@ -58,6 +58,18 @@ export const attendanceApi = {
   overtimeDecision: (attendanceId: string, data: OvertimeDecisionPayload) =>
     apiClient.patch<{ status: number; data: AttendanceRecord }>(
       `/attendances/${attendanceId}/overtime-decision`,
+      data,
+    ),
+
+  /**
+   * POST /attendances/overtime-decisions/bulk
+   * Body: { attendance_ids: string[], authorize, valuation_method?, agreed_rate?, agreed_factor?, reason? }
+   * Applies the same decision to every attendance in attendance_ids in a single
+   * request. Returns a per-attendance result — a failed item does not block the rest.
+   */
+  bulkOvertimeDecision: (data: BulkOvertimeDecisionPayload) =>
+    apiClient.post<{ status: number; data: BulkOvertimeDecisionResponse }>(
+      '/attendances/overtime-decisions/bulk',
       data,
     ),
 

--- a/code/webapp/src/services/attendance-hooks.ts
+++ b/code/webapp/src/services/attendance-hooks.ts
@@ -171,7 +171,7 @@ export function useBulkOvertimeDecision() {
       }
 
       showError(
-        failed.map(r => r.error).filter(Boolean).join(' '),
+        failed.map(r => `${r.attendance_id}: ${r.error ?? 'Error desconocido'}`).join(' '),
         'Algunos registros no se pudieron actualizar'
       )
     },

--- a/code/webapp/src/services/attendance-hooks.ts
+++ b/code/webapp/src/services/attendance-hooks.ts
@@ -2,7 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { attendanceApi } from './attendance-api'
 import { useToast } from '@/components/ui/toast-context'
 import { getApiErrorMessage } from '@/lib/api-error'
-import type { TodayAttendanceRow, CloseDayRequest, OvertimeDecisionPayload, OvertimeValuationMethod, OvertimeValuationPreview } from '@/types/attendance'
+import type { TodayAttendanceRow, CloseDayRequest, OvertimeDecisionPayload, OvertimeValuationMethod, OvertimeValuationPreview, BulkOvertimeDecisionPayload } from '@/types/attendance'
 
 /**
  * Fetch attendance for all active employees of a branch for a given date.
@@ -141,6 +141,43 @@ export function useOvertimeDecision() {
     onError: (error: unknown) => {
       showError(
         getApiErrorMessage(error, 'No se pudo registrar la decisión.'),
+        'Error al registrar'
+      )
+    },
+  })
+}
+
+/**
+ * Mutation: apply the same overtime decision to a batch of attendances in a
+ * single request. Used by the bulk day-close flow's "Aplicar para el resto"
+ * checkbox. A failed item is reported per-attendance and does not block the
+ * rest — the toast surfaces those failures instead of silently dropping them.
+ */
+export function useBulkOvertimeDecision() {
+  const queryClient = useQueryClient()
+  const { showSuccess, showError } = useToast()
+
+  return useMutation({
+    mutationFn: (data: BulkOvertimeDecisionPayload) => attendanceApi.bulkOvertimeDecision(data),
+    onSuccess: (response) => {
+      queryClient.invalidateQueries({ queryKey: ['attendances', 'daily'] })
+
+      const results = response.data.data.results
+      const failed = results.filter(r => !r.success)
+
+      if (failed.length === 0) {
+        showSuccess(`Decisión aplicada a ${results.length} empleados.`, 'Decisión aplicada')
+        return
+      }
+
+      showError(
+        failed.map(r => r.error).filter(Boolean).join(' '),
+        'Algunos registros no se pudieron actualizar'
+      )
+    },
+    onError: (error: unknown) => {
+      showError(
+        getApiErrorMessage(error, 'No se pudo registrar la decisión en lote.'),
         'Error al registrar'
       )
     },

--- a/code/webapp/src/services/attendance-hooks.ts
+++ b/code/webapp/src/services/attendance-hooks.ts
@@ -171,7 +171,7 @@ export function useBulkOvertimeDecision() {
       }
 
       showError(
-        failed.map(r => `${r.attendance_id}: ${r.error ?? 'Error desconocido'}`).join(' '),
+        failed.map(r => `${r.employee_name}: ${r.error ?? 'Error desconocido'}`).join(' '),
         'Algunos registros no se pudieron actualizar'
       )
     },

--- a/code/webapp/src/types/attendance.ts
+++ b/code/webapp/src/types/attendance.ts
@@ -12,6 +12,23 @@ export type OvertimeDecisionPayload =
   | { authorize: true; reason?: string; valuation_method: 'AGREED_RATE'; agreed_rate: number }
   | { authorize: true; reason?: string; valuation_method: 'SALARY_FACTOR'; agreed_factor: number }
 
+/**
+ * POST /attendances/overtime-decisions/bulk body.
+ * Applies the same OvertimeDecisionPayload to every attendance in `attendance_ids`.
+ */
+export type BulkOvertimeDecisionPayload = { attendance_ids: string[] } & OvertimeDecisionPayload
+
+export interface BulkOvertimeDecisionResult {
+  attendance_id: string
+  success: boolean
+  attendance: AttendanceRecord | null
+  error: string | null
+}
+
+export interface BulkOvertimeDecisionResponse {
+  results: BulkOvertimeDecisionResult[]
+}
+
 export interface OvertimeValuationPreview {
   valuation_method: OvertimeValuationMethod
   rate_applied: number

--- a/code/webapp/src/types/attendance.ts
+++ b/code/webapp/src/types/attendance.ts
@@ -20,6 +20,7 @@ export type BulkOvertimeDecisionPayload = { attendance_ids: string[] } & Overtim
 
 export interface BulkOvertimeDecisionResult {
   attendance_id: string
+  employee_name: string
   success: boolean
   attendance: AttendanceRecord | null
   error: string | null

--- a/doc/tasks/2026-07/249-overtime-apply-to-rest.md
+++ b/doc/tasks/2026-07/249-overtime-apply-to-rest.md
@@ -60,11 +60,11 @@ When many employees end up with the same decision (e.g. everyone gets paid at th
 ## ⏱️ Time
 
 ### 📊 Estimates
-- **Optimistic:** `5h` · **Pessimistic:** `9h` · **Tracked:** _in progress_
+- **Optimistic:** `5h` · **Pessimistic:** `9h` · **Tracked:** `~1h`
 
 ### 📅 Sessions
 ```json
 [
-  { "date": "2026-07-18", "start": "17:34", "end": "?" }
+  { "date": "2026-07-18", "start": "17:34", "end": "18:29" }
 ]
 ```

--- a/doc/tasks/2026-07/249-overtime-apply-to-rest.md
+++ b/doc/tasks/2026-07/249-overtime-apply-to-rest.md
@@ -57,13 +57,14 @@ When many employees end up with the same decision (e.g. everyone gets paid at th
 
 ---
 
-## ⏱️ Estimates
+## ⏱️ Time
 
-- **Optimistic:** `5h` · **Pessimistic:** `9h`
+### 📊 Estimates
+- **Optimistic:** `5h` · **Pessimistic:** `9h` · **Tracked:** _in progress_
 
----
-
-## ⏱️ Sessions
+### 📅 Sessions
 ```json
-[]
+[
+  { "date": "2026-07-18", "start": "17:34", "end": "?" }
+]
 ```


### PR DESCRIPTION
## Summary
- Adds `POST /api/v1/attendances/overtime-decisions/bulk` (`BulkOvertimeDecisionController` + `BulkOvertimeDecisionRequest` + `RecordBulkOvertimeDecisionAction`), which applies one decision to a batch of attendances in a single request, reusing `RecordOvertimeDecisionAction` per item (own transaction + the `LFT_PROPORTIONAL` per-employee lock preserved) and reporting per-attendance success/failure so one already-decided item doesn't block the rest of the batch
- Adds an "Aplicar para el resto (N empleados)" checkbox to `OvertimeDecisionDialog`, shown only in the bulk day-close flow when more than one entry remains in the queue — the single/individual decision flow is unaffected
- When checked, `useTodayAttendancePage` calls the new bulk endpoint once with every attendance in the queue instead of looping the single-decision mutation per employee, and surfaces any partial failures via toast

## Test plan
- [x] PHPUnit: `php artisan test --filter=BulkOvertimeDecisionApiTest` (12 passed) + full suite
- [x] Vitest: `attendance-hooks-overtime.test.ts`, `OvertimeDecisionDialog.test.tsx`, `use-overtime-decision-dialog.test.ts`, `use-today-attendance-page.test.ts` + full suite
- [x] Cypress E2E: `attendance-close-day-overtime.cy.ts` (2/2, includes the new apply-to-rest happy path) — run against the dev-lab E2E stack
- [x] Linters: Pint ✅ · ESLint ✅ · TypeScript ✅

## Manual Testing
1. Log in as `admin@sushigo.com`, go to Asistencia
2. Ensure at least 2 employees end up with pending overtime after closing the day (e.g. clock in 2+ employees, let their shift run past `expected_end`)
3. Click "Cerrar día" and confirm the close — the overtime decision dialog appears for the first pending employee
4. Confirm the "Aplicar para el resto (N empleados)" checkbox is visible (only when 2+ entries remain) and is **not** visible when resolving a single individual overtime decision (via the employee card's own overtime action)
5. Check the box, choose "Pagar" → a valuation method (or "No pagar"), confirm — verify a single network call to `POST /attendances/overtime-decisions/bulk` is made (Network tab) and all remaining employees' cards update to the same decision, with no further dialogs
6. Repeat without checking the box — confirm the previous one-dialog-per-employee behavior is unchanged

## Closes
Closes #249

## Workspace
`sushigo-b` — `feature/249-overtime-apply-to-rest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)