### PR TITLE
🔨 [#259][c] - Migrate remaining color-less labels 🔁

### DIFF
--- a/code/webapp/src/components/employees/bonus-config-section.tsx
+++ b/code/webapp/src/components/employees/bonus-config-section.tsx
@@ -1,6 +1,7 @@
 import { Loader2, Award, Plus, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
+import { Label } from '@/components/ui/label'
 import { useBonusConfigSection } from './use-bonus-config-section'
 
 interface BonusConfigSectionProps {
@@ -81,7 +82,7 @@ export function BonusConfigSection({ employeeId }: BonusConfigSectionProps) {
       {showForm && (
         <form onSubmit={handleSubmit(onSubmit)} className="rounded-md border border-border p-4 space-y-3">
           <div className="space-y-1">
-            <label htmlFor="bonus_group_id" className="text-sm font-medium">Grupo de bono</label>
+            <Label htmlFor="bonus_group_id">Grupo de bono</Label>
             <select
               id="bonus_group_id"
               {...register('bonus_group_id')}
@@ -101,7 +102,7 @@ export function BonusConfigSection({ employeeId }: BonusConfigSectionProps) {
           </div>
 
           <div className="space-y-1">
-            <label htmlFor="effective_from" className="text-sm font-medium">Fecha de vigencia</label>
+            <Label htmlFor="effective_from">Fecha de vigencia</Label>
             <input
               id="effective_from"
               type="date"

--- a/code/webapp/src/components/employees/deactivate-form.tsx
+++ b/code/webapp/src/components/employees/deactivate-form.tsx
@@ -35,8 +35,9 @@ export function DeactivateForm({ isLoading, onSubmit, onCancel }: DeactivateForm
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
         {/* Fecha de baja */}
         <div className="space-y-1">
-          <Label className="block">Fecha de baja</Label>
+          <Label htmlFor="deactivate-end-date" className="block">Fecha de baja</Label>
           <input
+            id="deactivate-end-date"
             type="date"
             max={today}
             {...register('end_date')}
@@ -49,8 +50,9 @@ export function DeactivateForm({ isLoading, onSubmit, onCancel }: DeactivateForm
 
         {/* Motivo */}
         <div className="space-y-1">
-          <Label className="block">Motivo (opcional)</Label>
+          <Label htmlFor="deactivate-termination-reason" className="block">Motivo (opcional)</Label>
           <textarea
+            id="deactivate-termination-reason"
             {...register('termination_reason')}
             placeholder="Renuncia voluntaria, despido, etc."
             className="w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm"

--- a/code/webapp/src/components/employees/deactivate-form.tsx
+++ b/code/webapp/src/components/employees/deactivate-form.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
 import { Loader2 } from 'lucide-react'
 import { useDeactivateForm } from './use-deactivate-form'
 import type { DeactivateFormValues } from './use-deactivate-form'
@@ -34,7 +35,7 @@ export function DeactivateForm({ isLoading, onSubmit, onCancel }: DeactivateForm
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
         {/* Fecha de baja */}
         <div className="space-y-1">
-          <label className="block text-sm font-medium">Fecha de baja</label>
+          <Label className="block">Fecha de baja</Label>
           <input
             type="date"
             max={today}
@@ -48,7 +49,7 @@ export function DeactivateForm({ isLoading, onSubmit, onCancel }: DeactivateForm
 
         {/* Motivo */}
         <div className="space-y-1">
-          <label className="block text-sm font-medium">Motivo (opcional)</label>
+          <Label className="block">Motivo (opcional)</Label>
           <textarea
             {...register('termination_reason')}
             placeholder="Renuncia voluntaria, despido, etc."

--- a/code/webapp/src/components/employees/override-scope-dialog.tsx
+++ b/code/webapp/src/components/employees/override-scope-dialog.tsx
@@ -2,6 +2,7 @@ import { createPortal } from 'react-dom'
 import { X, Zap, AlertTriangle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import type { ScheduleDayOverride } from '@/types/schedule'
 import type { OverrideScope } from './use-create-day-override'
 import { useOverrideScopeDialog } from './use-override-scope-dialog'
@@ -97,16 +98,16 @@ export function OverrideScopeDialog({ dayLabel, dayOfWeek, existingOverrides, is
               </fieldset>
 
               <div className="space-y-2">
-                <label htmlFor="scope-effective-from" className="block text-xs font-medium">
+                <Label htmlFor="scope-effective-from" className="block text-xs">
                   {dateLabel}<span className="ml-0.5 text-red-500">*</span>
-                </label>
+                </Label>
                 <Input id="scope-effective-from" type="date" min={today} {...register('effectiveFrom')} />
                 {errors.effectiveFrom && <p className="text-[10px] text-red-600">{errors.effectiveFrom.message}</p>}
               </div>
 
               {scope === 'range' && (
                 <div className="space-y-2">
-                  <label htmlFor="scope-effective-to" className="block text-xs font-medium">Hasta<span className="ml-0.5 text-red-500">*</span></label>
+                  <Label htmlFor="scope-effective-to" className="block text-xs">Hasta<span className="ml-0.5 text-red-500">*</span></Label>
                   <Input id="scope-effective-to" type="date" min={effectiveFrom || today} {...register('effectiveTo')} />
                   {errors.effectiveTo && <p className="text-[10px] text-red-600">{errors.effectiveTo.message}</p>}
                 </div>

--- a/code/webapp/src/components/employees/register-wage-form.tsx
+++ b/code/webapp/src/components/employees/register-wage-form.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
+import { Label } from '@/components/ui/label'
 import { Loader2, Info, AlertCircle } from 'lucide-react'
 import { useCreateWage } from '@/services/employee-hooks'
 import { InfoTooltip } from '@/components/ui/info-tooltip'
@@ -64,10 +65,10 @@ export function RegisterWageForm({ employeeId, onSuccess, onCancel }: RegisterWa
                     <div className="grid grid-cols-3 gap-3">
                         {/* Input Bruto Semanal */}
                         <div className="space-y-1">
-                            <label className="block text-sm font-medium flex items-center gap-1">
+                            <Label className="block flex items-center gap-1">
                                 Bruto semanal
                                 <InfoTooltip text="Salario antes de deducciones (IMSS e ISR). Incluye el día de descanso semanal." />
-                            </label>
+                            </Label>
                             <input
                                 type="number"
                                 step="0.001"
@@ -85,10 +86,10 @@ export function RegisterWageForm({ employeeId, onSuccess, onCancel }: RegisterWa
 
                         {/* Input Salario Diario */}
                         <div className="space-y-1">
-                            <label className="block text-sm font-medium flex items-center gap-1">
+                            <Label className="block flex items-center gap-1">
                                 Salario diario
                                 <InfoTooltip text="Salario bruto dividido entre 7 días. Base para cálculos de IMSS, prestaciones e incidencias." />
-                            </label>
+                            </Label>
                             <input
                                 type="number"
                                 step="0.001"
@@ -106,10 +107,10 @@ export function RegisterWageForm({ employeeId, onSuccess, onCancel }: RegisterWa
 
                         {/* Input Neto Semanal */}
                         <div className="space-y-1">
-                            <label className="block text-sm font-medium flex items-center gap-1">
+                            <Label className="block flex items-center gap-1">
                                 Neto semanal
                                 <InfoTooltip text="Lo que el trabajador recibirá en mano después de descuentos de IMSS e ISR." />
-                            </label>
+                            </Label>
                             <input
                                 type="number"
                                 step="0.001"
@@ -137,10 +138,10 @@ export function RegisterWageForm({ employeeId, onSuccess, onCancel }: RegisterWa
 
                     {/* Jornada semanal (horas) */}
                     <div className="space-y-1">
-                        <label className="block text-sm font-medium flex items-center gap-1">
+                        <Label className="block flex items-center gap-1">
                             Jornada semanal (horas)
                             <InfoTooltip text="Horas que el colaborador tiene programadas por semana. Se usan para calcular la tarifa por hora y prorratear incidencias como faltas o retardos." />
-                        </label>
+                        </Label>
                         <input
                             type="number"
                             min="1"
@@ -165,10 +166,10 @@ export function RegisterWageForm({ employeeId, onSuccess, onCancel }: RegisterWa
 
                     {/* Tarifa por hora (referencia) */}
                     <div className="space-y-1">
-                        <label className="block text-sm font-medium flex items-center gap-1">
+                        <Label className="block flex items-center gap-1">
                             Tarifa por hora (referencia)
                             <InfoTooltip text="No es el salario formal. Solo se usa internamente para calcular descuentos o pagos proporcionales por incidencias de asistencia." />
-                        </label>
+                        </Label>
                         <input
                             type="number"
                             step="0.001"
@@ -199,7 +200,7 @@ export function RegisterWageForm({ employeeId, onSuccess, onCancel }: RegisterWa
 
                     {/* Fecha de inicio */}
                     <div className="space-y-1">
-                        <label className="block text-sm font-medium">Fecha de inicio</label>
+                        <Label className="block">Fecha de inicio</Label>
                         <input
                             type="date"
                             value={formData.effective_from}
@@ -217,7 +218,7 @@ export function RegisterWageForm({ employeeId, onSuccess, onCancel }: RegisterWa
 
                     {/* Observaciones */}
                     <div className="space-y-1">
-                        <label className="block text-sm font-medium">Observaciones (opcional)</label>
+                        <Label className="block">Observaciones (opcional)</Label>
                         <textarea
                             value={formData.notes || ''}
                             onChange={(e) => handleNotesChange(e.target.value)}

--- a/code/webapp/src/components/employees/rehire-form.tsx
+++ b/code/webapp/src/components/employees/rehire-form.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
 import { Loader2 } from 'lucide-react'
 import { useRehireForm } from './use-rehire-form'
 import type { RehireFormValues } from './use-rehire-form'
@@ -36,7 +37,7 @@ export function RehireForm({ isLoading, onSubmit, onCancel }: RehireFormProps) {
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
         {/* Fecha de reingreso */}
         <div className="space-y-1">
-          <label className="block text-sm font-medium">Fecha de reingreso</label>
+          <Label className="block">Fecha de reingreso</Label>
           <input
             type="date"
             max={today}

--- a/code/webapp/src/components/employees/rehire-form.tsx
+++ b/code/webapp/src/components/employees/rehire-form.tsx
@@ -37,8 +37,9 @@ export function RehireForm({ isLoading, onSubmit, onCancel }: RehireFormProps) {
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
         {/* Fecha de reingreso */}
         <div className="space-y-1">
-          <Label className="block">Fecha de reingreso</Label>
+          <Label htmlFor="rehire-start-date" className="block">Fecha de reingreso</Label>
           <input
+            id="rehire-start-date"
             type="date"
             max={today}
             {...register('start_date')}

--- a/code/webapp/src/components/employees/vacation-policy-override.tsx
+++ b/code/webapp/src/components/employees/vacation-policy-override.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
 import {
   VacationPolicyTiersEditor,
   type VacationPolicyTiersFormValues,
@@ -22,10 +23,10 @@ export function VacationPolicyOverride({ employee }: VacationPolicyOverrideProps
 
   return (
     <div className="space-y-3 rounded-lg border border-border p-4">
-      <label className="flex items-center gap-2 text-sm font-medium">
+      <Label className="flex items-center gap-2">
         <input type="checkbox" {...register('enabled')} />{' '}
         Política contractual
-      </label>
+      </Label>
       <p className="text-xs text-muted-foreground">
         Activa para otorgar a este empleado un derecho vacacional distinto al de la política de la
         empresa, tomando precedencia sobre ella.

--- a/code/webapp/src/pages/attendance/config/holidays.tsx
+++ b/code/webapp/src/pages/attendance/config/holidays.tsx
@@ -9,6 +9,7 @@ import { Input } from '@/components/ui/input'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { SlidePanel } from '@/components/ui/slide-panel'
 import { DataGrid, type Column } from '@/components/ui/data-grid'
+import { Label } from '@/components/ui/label'
 import {
   useHolidayManagement,
   type HolidayEditValues,
@@ -337,9 +338,9 @@ function AddHolidayForm({
       )}
 
       <div className="flex items-center gap-3">
-        <label htmlFor="add-is-annual" className="text-sm font-medium cursor-pointer">
+        <Label htmlFor="add-is-annual" className="cursor-pointer">
           ¿Se repite cada año?
-        </label>
+        </Label>
         <input
           id="add-is-annual"
           type="checkbox"

--- a/code/webapp/src/pages/forgot-password.tsx
+++ b/code/webapp/src/pages/forgot-password.tsx
@@ -4,6 +4,7 @@ import { apiClient } from '@/lib/api-client'
 import { getApiErrorMessage } from '@/lib/api-error'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import { Logo } from '@/components/ui/logo'
 import { Loader2, CheckCircle, ArrowLeft } from 'lucide-react'
@@ -103,9 +104,9 @@ function ForgotPasswordPage() {
                         )}
 
                         <div className="space-y-2">
-                            <label htmlFor="identifier" className="text-sm font-medium">
+                            <Label htmlFor="identifier">
                                 Correo electrónico o teléfono
-                            </label>
+                            </Label>
                             <Input
                                 id="identifier"
                                 type="text"

--- a/code/webapp/src/pages/login.tsx
+++ b/code/webapp/src/pages/login.tsx
@@ -3,6 +3,7 @@ import { useState, FormEvent } from 'react';
 import { useAuthStore } from '@/stores/auth.store';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Logo } from '@/components/ui/logo';
 import { Loader2 } from 'lucide-react';
@@ -51,9 +52,9 @@ export function LoginPage() {
                         )}
 
                         <div className="space-y-2">
-                            <label htmlFor="identifier" className="text-sm font-medium">
+                            <Label htmlFor="identifier">
                                 Correo electrónico o teléfono
-                            </label>
+                            </Label>
                             <Input
                                 id="identifier"
                                 type="text"
@@ -68,9 +69,9 @@ export function LoginPage() {
                         </div>
 
                         <div className="space-y-2">
-                            <label htmlFor="password" className="text-sm font-medium">
+                            <Label htmlFor="password">
                                 Contraseña
-                            </label>
+                            </Label>
                             <Input
                                 id="password"
                                 type="password"

--- a/code/webapp/src/pages/reset-password.tsx
+++ b/code/webapp/src/pages/reset-password.tsx
@@ -5,6 +5,7 @@ import { getApiFieldError } from '@/lib/api-error'
 import { useAuthStore } from '@/stores/auth.store'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import { Logo } from '@/components/ui/logo'
 import { Loader2, CheckCircle, AlertCircle } from 'lucide-react'
@@ -203,9 +204,9 @@ function ResetPasswordPage() {
                         </div>
 
                         <div className="space-y-2">
-                            <label htmlFor="password" className="text-sm font-medium">
+                            <Label htmlFor="password">
                                 Nueva contraseña
-                            </label>
+                            </Label>
                             <Input
                                 id="password"
                                 type="password"
@@ -220,9 +221,9 @@ function ResetPasswordPage() {
                         </div>
 
                         <div className="space-y-2">
-                            <label htmlFor="password_confirmation" className="text-sm font-medium">
+                            <Label htmlFor="password_confirmation">
                                 Confirmar contraseña
-                            </label>
+                            </Label>
                             <Input
                                 id="password_confirmation"
                                 type="password"

--- a/doc/conventions/frontend/label-styles.md
+++ b/doc/conventions/frontend/label-styles.md
@@ -38,17 +38,23 @@ If a label needs a `className` with `text-*` color classes to stay readable, tha
 
 `OvertimeDecisionDialog.tsx` ("Método", "Tarifa por hora", "Factor...") is the reference migration for issue #248.
 
-The following files still use the same unstyled `<label>` pattern and are candidates for a follow-up migration (not in scope for #248):
+Issue #259 migrated every remaining `<label>` usage that had **no explicit text color at all** (the same contrast-loss risk as #248):
 
 - `src/components/employees/rehire-form.tsx`
 - `src/components/employees/deactivate-form.tsx`
 - `src/components/employees/bonus-config-section.tsx`
 - `src/components/employees/register-wage-form.tsx`
+- `src/components/employees/vacation-policy-override.tsx`
+- `src/pages/login.tsx`, `src/pages/forgot-password.tsx`, `src/pages/reset-password.tsx`
+- `src/components/employees/override-scope-dialog.tsx` (partial — only the two color-less labels; see below)
+- `src/pages/attendance/config/holidays.tsx` (partial — only the "¿Se repite cada año?" label; see below)
+
+The following files still use `<label>` directly and are candidates for a follow-up migration (not in scope for #248 or #259 — these already set an explicit `text-foreground`/`text-muted-foreground` color, or are structural labels wrapping a checkbox/radio "pill" option that `Label`'s plain-text styling doesn't fit as-is):
+
 - `src/components/attendance/AttendanceTimeDialog.tsx`
 - `src/components/attendance/ExtraDayNegotiationDialog.tsx`
 - `src/components/employees/create-schedule-form.tsx`
-- `src/components/employees/override-scope-dialog.tsx`
-- `src/components/employees/vacation-policy-override.tsx`
+- `src/components/employees/override-scope-dialog.tsx` (remaining option-pill label and the already-colored "Motivo" label)
 - `src/components/settings/vacation-policy-section.tsx`
 - `src/components/solicitudes/pending-requests/leave-review-content.tsx`
 - `src/components/solicitudes/pending-requests/review-request-dialog.tsx`
@@ -56,10 +62,9 @@ The following files still use the same unstyled `<label>` pattern and are candid
 - `src/components/ui/filter-select.tsx`
 - `src/components/ui/form-fields.tsx` (`FormField` and `Checkbox` both inline their own label markup)
 - `src/pages/attendance/audit.tsx`
-- `src/pages/attendance/config/holidays.tsx`
+- `src/pages/attendance/config/holidays.tsx` (remaining `text-xs font-medium text-muted-foreground uppercase tracking-wide` labels)
 - `src/pages/attendance/payroll/$periodId.tsx`
 - `src/pages/attendance/payroll/close.tsx` and `src/pages/attendance/payroll/index.tsx` (use hardcoded `text-gray-700` instead of `text-foreground` — worth flagging separately, doesn't follow theme tokens at all)
 - `src/pages/attendance/punctuality-config-shared.tsx`
-- `src/pages/forgot-password.tsx`, `src/pages/login.tsx`, `src/pages/reset-password.tsx`
 
-See issue #248.
+See issues #248 and #259.

--- a/doc/tasks/2026-07/248-centralize-label-component.md
+++ b/doc/tasks/2026-07/248-centralize-label-component.md
@@ -57,11 +57,23 @@ This is the same class of problem as [#247](https://github.com/pakodiazdev/sushi
 ## ⏱️ Time
 
 ### 📊 Estimates
-- **Optimistic:** `2h` · **Pessimistic:** `4h` · **Tracked:** `~0.15h`
+- **Optimistic:** `2h` · **Pessimistic:** `4h` · **Tracked:** `1h 4m`
 
 ### 📅 Sessions
 ```json
 [
-  { "date": "2026-07-18", "start": "17:39", "end": "17:46" }
+  { "date": "2026-07-18", "start": "17:39", "end": "17:46" },
+  { "date": "2026-07-19", "start": "14:10", "end": "15:07" }
 ]
 ```
+
+---
+
+## 📊 Retrospective
+- **Actual total:** 1h 4m (7 min + 57 min)
+- **vs optimistic:** −56m
+- **vs pessimistic:** −2h 56m
+
+**Justification:**
+
+The first session (7 min) built the `Label` component, migrated `OvertimeDecisionDialog.tsx`, and wrote the convention doc — fast because it followed the exact pattern already established by `Input`/`Button` in `src/components/ui/`, with no design decisions to make. The second session (57 min, next day) was not new feature work: it covered responding to a Copilot PR review comment (tried the suggested `interface` refactor, reverted it after confirming it breaks `@typescript-eslint/no-empty-object-type`, and replied with justification), then a `/sonar-review` cycle to fix a `typescript:S6853` false positive on the same file (investigate the rule, apply a `NOSONAR` comment, commit, push, and wait for CI + SonarCloud re-scan to confirm). Most of that second session was CI/SonarCloud wait time rather than coding time.

--- a/doc/tasks/2026-07/259-migrate-remaining-labels.md
+++ b/doc/tasks/2026-07/259-migrate-remaining-labels.md
@@ -1,0 +1,87 @@
+# 🔨 Task #259: Migrate Remaining Color-less Form Labels to Label Component
+
+**GitHub Issue:** [#259](https://github.com/pakodiazdev/sushigo/issues/259)
+
+## 📖 Story
+
+**English:**
+As a frontend developer, I need the remaining form `<label>` elements that have no explicit text color migrated to the centralized `Label` component (introduced in #248), so they don't silently lose contrast the next time one of them ends up inside a native `<dialog>` or any other ancestor that sets its own `color`.
+
+**Español:**
+Como desarrollador frontend, necesito que los `<label>` restantes sin color de texto explícito se migren al componente centralizado `Label` (introducido en #248), para que no pierdan contraste en silencio la próxima vez que alguno termine dentro de un `<dialog>` nativo o cualquier otro ancestro que fije su propio `color`.
+
+---
+
+## 🧠 Context
+
+Issue #248 created the centralized `Label` component and migrated `OvertimeDecisionDialog.tsx` as the reference example, deliberately scoping out the rest of the codebase. A full repo scan (`grep -rn "<label" src`) found 89 `<label>` usages total. Of those, 17 across 10 files have no explicit text color at all — the exact same bug class fixed in #248, currently only "working" because none of them happen to sit inside a native `<dialog>` yet.
+
+This issue covers only that highest-risk subset. Two other groups were found and are explicitly out of scope here:
+- Labels that already set `text-foreground`/`text-muted-foreground` (lower urgency, consistency-only)
+- Labels with hardcoded `text-gray-700` in `payroll/index.tsx` and `payroll/close.tsx` (a different bug — doesn't use the theme token at all — worth its own issue)
+- Structural labels wrapping checkbox/radio "pill" option cards (`flex items-center gap-*` layouts) — `Label`'s plain-text styling doesn't fit these as-is
+
+**Depends on #248** — this branch is stacked on `refactor/248-centralize-label-component` since `Label` doesn't exist on `main` yet.
+
+---
+
+## ✅ Technical Tasks
+
+- [ ] 🔁 Migrate the following color-less `<label>` usages to `<Label>`:
+  - `src/components/employees/rehire-form.tsx:39`
+  - `src/components/employees/deactivate-form.tsx:37,51`
+  - `src/components/employees/bonus-config-section.tsx:84,104`
+  - `src/components/employees/register-wage-form.tsx:67,88,109,140,168,202,220`
+  - `src/components/employees/override-scope-dialog.tsx:100,109`
+  - `src/components/employees/vacation-policy-override.tsx:25`
+  - `src/pages/login.tsx:54,71`
+  - `src/pages/forgot-password.tsx:106`
+  - `src/pages/reset-password.tsx:206,223`
+  - `src/pages/attendance/config/holidays.tsx:340`
+- [ ] 📝 Update `doc/conventions/frontend/label-styles.md` to move these files from the "follow-up candidates" list into the migrated set
+
+---
+
+## 🎯 Acceptance Criteria
+
+- [ ] All 17 listed `<label>` usages render via the centralized `Label` component instead of hand-written `className="text-sm font-medium"` (or equivalent color-less variants)
+- [ ] No visual regression — labels keep their existing layout classes (`block`, `flex items-center gap-1`, etc.) via `className` passthrough
+- [ ] Existing Vitest/Cypress suites for the touched forms still pass
+
+---
+
+## 🔗 References
+
+- Follow-up to #248 (centralized `Label` component + reference migration)
+
+---
+
+## ⏱️ Estimates
+
+- **Optimistic:** `2h` · **Pessimistic:** `4h`
+
+---
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `2h` · **Pessimistic:** `4h` · **Tracked:** `36m`
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-07-19", "start": "13:36", "end": "14:09" },
+  { "date": "2026-07-19", "start": "15:07", "end": "15:10" }
+]
+```
+
+---
+
+## 📊 Retrospective
+- **Actual total:** 36m (33 min + 3 min)
+- **vs optimistic:** −1h 24m
+- **vs pessimistic:** −3h 24m
+
+**Justification:**
+
+The 17 call sites and their exact file:line locations had already been identified by the repo-wide scan done before this issue was created, so this was a mechanical migration with no discovery work — just applying the already-proven `Label` component pattern from #248 to each site and verifying no regressions (typecheck, lint, existing Vitest suites). The short second session (3 min) was branch maintenance after #248 merged: rebasing onto the updated `main`, retargeting the PR base, and deleting the now-stale intermediate branch — not part of the original technical scope but necessary to leave the PR mergeable.

--- a/doc/tasks/2026-07/259-migrate-remaining-labels.md
+++ b/doc/tasks/2026-07/259-migrate-remaining-labels.md
@@ -14,7 +14,7 @@ Como desarrollador frontend, necesito que los `<label>` restantes sin color de t
 
 ## 🧠 Context
 
-Issue #248 created the centralized `Label` component and migrated `OvertimeDecisionDialog.tsx` as the reference example, deliberately scoping out the rest of the codebase. A full repo scan (`grep -rn "<label" src`) found 89 `<label>` usages total. Of those, 17 across 10 files have no explicit text color at all — the exact same bug class fixed in #248, currently only "working" because none of them happen to sit inside a native `<dialog>` yet.
+Issue #248 created the centralized `Label` component and migrated `OvertimeDecisionDialog.tsx` as the reference example, deliberately scoping out the rest of the codebase. A full repo scan (`grep -rn "<label" src`) found 89 `<label>` usages total. Of those, 21 across 10 files have no explicit text color at all — the exact same bug class fixed in #248, currently only "working" because none of them happen to sit inside a native `<dialog>` yet.
 
 This issue covers only that highest-risk subset. Two other groups were found and are explicitly out of scope here:
 - Labels that already set `text-foreground`/`text-muted-foreground` (lower urgency, consistency-only)
@@ -44,7 +44,7 @@ This issue covers only that highest-risk subset. Two other groups were found and
 
 ## 🎯 Acceptance Criteria
 
-- [ ] All 17 listed `<label>` usages render via the centralized `Label` component instead of hand-written `className="text-sm font-medium"` (or equivalent color-less variants)
+- [ ] All 21 listed `<label>` usages render via the centralized `Label` component instead of hand-written `className="text-sm font-medium"` (or equivalent color-less variants)
 - [ ] No visual regression — labels keep their existing layout classes (`block`, `flex items-center gap-1`, etc.) via `className` passthrough
 - [ ] Existing Vitest/Cypress suites for the touched forms still pass
 


### PR DESCRIPTION
## Summary
- Migrates the 17 `<label>` usages across 10 files that had **no explicit text color at all** (the same dark-mode contrast risk fixed in #248) to the centralized `Label` component
- Updates `doc/conventions/frontend/label-styles.md` to move these files from "follow-up candidates" into the migrated set, and clarifies which labels remain out of scope (already-colored labels, structural checkbox/radio "pill" labels, and the hardcoded `text-gray-700` labels in payroll pages — tracked separately)

**⚠️ Stacked on #256 (issue #248)** — this branch is based on `refactor/248-centralize-label-component` because the `Label` component doesn't exist on `main` yet. Please merge #256 first; this PR's base will automatically retarget to `main` once that happens, and the diff will shrink to just this PR's own commits.

## Test plan
- [x] Vitest: `npx vitest run src/components/employees/__tests__/{bonus-config-section,rehire-form,vacation-policy-override,override-scope-dialog,deactivate-form}.test.tsx src/pages/__tests__/login.test.tsx src/components/ui/__tests__/label.test.tsx` — 102 tests passing, no regressions
- [x] Linters: ESLint ✅ · TypeScript ✅
- [ ] Cypress E2E: no new spec needed — this is a pure markup/styling substitution with no behavior change; existing specs for these flows are unaffected

## Manual Testing
1. Start the dev-lab workspace (`./init-agent-workspace.sh`)
2. Switch the browser/OS to dark mode
3. Visit `/login`, `/forgot-password`, and `/reset-password` — confirm "Correo electrónico o teléfono", "Contraseña", "Nueva contraseña", "Confirmar contraseña" labels are readable
4. In the employee detail view, open "Reingreso", "Dar de Baja", and "Registrar nuevo salario" panels — confirm all field labels are readable
5. In an employee's schedule, open the day-override dialog and confirm "Fecha"/"Hasta" labels are readable
6. In `attendance/config/holidays`, confirm "¿Se repite cada año?" is readable

## Closes
Closes #259

## Workspace
`sushigo-c` — `refactor/259-migrate-remaining-labels`

🤖 Generated with [Claude Code](https://claude.com/claude-code)