### PR TITLE
🔧 [#153][a] - Remove --ignore-platform-req=php now that deps support PHP 8.5 🐘

### DIFF
--- a/.github/workflows/api-lint.yml
+++ b/.github/workflows/api-lint.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install Composer dependencies
         if: steps.changes.outputs.api == 'true'
-        run: composer install --prefer-dist --no-interaction --no-progress --no-scripts --ignore-platform-req=php
+        run: composer install --prefer-dist --no-interaction --no-progress --no-scripts
 
       - name: Run PHP Pint (check mode)
         if: steps.changes.outputs.api == 'true'

--- a/.github/workflows/api-swagger.yml
+++ b/.github/workflows/api-swagger.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install Composer dependencies
         if: steps.changes.outputs.api == 'true'
-        run: composer install --prefer-dist --no-interaction --no-progress --no-scripts --ignore-platform-req=php
+        run: composer install --prefer-dist --no-interaction --no-progress --no-scripts
 
       - name: Copy .env and generate app key
         if: steps.changes.outputs.api == 'true'

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install Composer dependencies
         if: steps.changes.outputs.api == 'true'
-        run: composer install --prefer-dist --no-interaction --no-progress --no-scripts --ignore-platform-req=php
+        run: composer install --prefer-dist --no-interaction --no-progress --no-scripts
 
       - name: Copy .env and generate app key
         if: steps.changes.outputs.api == 'true'

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -67,7 +67,7 @@ CMD ["/usr/local/bin/init.sh"]
 FROM base AS composer_deps
 WORKDIR /var/www/html/api
 COPY ./code/api/composer.json ./code/api/composer.lock ./
-RUN composer install --no-dev --prefer-dist --no-interaction --optimize-autoloader --no-scripts --ignore-platform-req=php
+RUN composer install --no-dev --prefer-dist --no-interaction --optimize-autoloader --no-scripts
 
 # Stage para instalar dependencias de NPM
 FROM node:20 AS npm_deps


### PR DESCRIPTION
## Summary
Closes #153

- Removed `--ignore-platform-req=php` from `docker/app/Dockerfile` (`composer_deps` stage), `.github/workflows/api-tests.yml`, and `.github/workflows/api-lint.yml`
- Companion PR in `sushigo-dev-lab` (#55) removes the same flag from `scripts/setup.sh` and `scripts/create-workspace.sh`

## How it was verified safe
Cloned this repo fresh and ran, with local PHP 8.5.6:
```bash
composer install --prefer-dist --no-interaction --no-progress --no-scripts
```
Resolved cleanly, no platform errors. The currently locked versions already declare PHP 8.5 support:
- `league/oauth2-server` 9.3.0 → `php: ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0`
- `lcobucci/clock` 3.6.0 → `php: ~8.4.0 || ~8.5.0`

## Manual Testing
1. `docker build -f docker/app/Dockerfile .` — the `composer_deps` stage installs without the flag and without resolver errors
2. Push this branch and confirm the `api-tests` and `api-lint` GitHub Actions workflows both pass their "Install Composer dependencies" step

## Test plan
- [x] `composer install --prefer-dist --no-interaction --no-progress --no-scripts` (no flag) resolves cleanly on this repo's current `composer.lock`
- [ ] CI (`api-tests.yml`, `api-lint.yml`) passes on this PR

## Workspace
`sushigo-a` — `chore/153-remove-php-platform-req-flag`