### PR TITLE
🐛 [#266][c] - Add explicit button type attribute 🔘

### DIFF
--- a/code/webapp/src/components/dev/DevDebugger.tsx
+++ b/code/webapp/src/components/dev/DevDebugger.tsx
@@ -98,6 +98,7 @@ export function DevDebugger() {
                 </a>
                 {sectionItems.map((item) => (
                     <button
+                        type="button"
                         key={item.key}
                         onClick={() => jumpToSection(item.key)}
                         className={`p-1 ${hoverBgClass} rounded shrink-0`}
@@ -130,6 +131,7 @@ export function DevDebugger() {
                     data-testid="dev-debugger"
                 >
                     <button
+                        type="button"
                         onClick={toggleMinimized}
                         className="flex items-center gap-2"
                         title="Expandir debugger"
@@ -140,6 +142,7 @@ export function DevDebugger() {
                     <div className="flex items-center gap-1 min-w-0">
                         <div className="flex items-center gap-1 overflow-x-auto">{renderQuickLinks('hover:bg-gray-800')}</div>
                         <button
+                            type="button"
                             onClick={toggleMinimized}
                             className="p-1 hover:bg-gray-800 rounded shrink-0"
                             title="Expandir debugger"
@@ -205,6 +208,7 @@ export function DevDebugger() {
                         <div className="flex items-center gap-1 overflow-x-auto">{renderQuickLinks('hover:bg-blue-700')}</div>
                     )}
                     <button
+                        type="button"
                         onClick={refreshQueries}
                         className="p-1 hover:bg-blue-700 rounded shrink-0"
                         title="Refresh all queries"
@@ -212,6 +216,7 @@ export function DevDebugger() {
                         <RefreshCw className="h-4 w-4" />
                     </button>
                     <button
+                        type="button"
                         onClick={toggleMinimized}
                         className="p-1 hover:bg-blue-700 rounded shrink-0"
                         title="Minimize debugger"

--- a/code/webapp/src/components/devtools/ClockDebugPanel.tsx
+++ b/code/webapp/src/components/devtools/ClockDebugPanel.tsx
@@ -77,7 +77,7 @@ export function ClockDebugPanel() {
             {error && (
                 <div className="p-2 rounded bg-red-900/40 border border-red-700/50 text-red-300 flex justify-between items-center gap-2">
                     <span className="truncate">{error}</span>
-                    <button onClick={clearError} className="shrink-0 text-red-400 hover:text-red-200">✕</button>
+                    <button type="button" onClick={clearError} className="shrink-0 text-red-400 hover:text-red-200">✕</button>
                 </div>
             )}
 
@@ -128,6 +128,7 @@ export function ClockDebugPanel() {
                         { label: '+1a', onClick: () => shiftCalendar('year', 1) },
                     ].map(({ label, onClick, icon }) => (
                         <button
+                            type="button"
                             key={label}
                             onClick={onClick}
                             disabled={isLoading}
@@ -154,6 +155,7 @@ export function ClockDebugPanel() {
                         className="flex-1 min-w-0 bg-gray-700 border border-gray-600 text-white text-xs rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:opacity-40"
                     />
                     <button
+                        type="button"
                         onClick={handleSetTime}
                         disabled={isLoading || !customDatetime}
                         className="flex items-center gap-1 px-2 py-1 rounded bg-blue-600 hover:bg-blue-500 text-white disabled:opacity-40 transition-colors shrink-0"
@@ -167,6 +169,7 @@ export function ClockDebugPanel() {
             {/* Reset + Refresh */}
             <div className="flex gap-1.5 pt-1 border-t border-gray-700">
                 <button
+                    type="button"
                     onClick={() => resetClockToSystem()}
                     disabled={isLoading || clockState?.mode === 'system'}
                     className="flex-1 flex items-center justify-center gap-1 px-2 py-1 rounded bg-gray-700 hover:bg-gray-600 border border-gray-600 text-gray-200 disabled:opacity-40 transition-colors"
@@ -175,6 +178,7 @@ export function ClockDebugPanel() {
                     Reset
                 </button>
                 <button
+                    type="button"
                     onClick={() => fetchClock()}
                     disabled={isLoading}
                     className="flex-1 flex items-center justify-center gap-1 px-2 py-1 rounded bg-gray-700 hover:bg-gray-600 border border-gray-600 text-gray-200 disabled:opacity-40 transition-colors"

--- a/code/webapp/src/components/employees/schedule-dialog.tsx
+++ b/code/webapp/src/components/employees/schedule-dialog.tsx
@@ -167,6 +167,7 @@ export function ScheduleDialog({ ctx, employee }: ScheduleDialogProps) {
           <div className="flex items-center gap-2">
             {isFormView && (
               <button
+                type="button"
                 onClick={ctx.showSchedule}
                 className="rounded-sm text-muted-foreground hover:text-foreground mr-1"
                 aria-label="Volver"
@@ -177,7 +178,7 @@ export function ScheduleDialog({ ctx, employee }: ScheduleDialogProps) {
             <CalendarDays className="h-4 w-4 text-muted-foreground" />
             <h3 className="text-base font-semibold">{getDialogTitle(view)}</h3>
           </div>
-          <button onClick={close} className="rounded-sm text-muted-foreground hover:text-foreground">
+          <button type="button" onClick={close} aria-label="Cerrar" title="Cerrar" className="rounded-sm text-muted-foreground hover:text-foreground">
             <X className="h-4 w-4" />
           </button>
         </div>

--- a/code/webapp/src/pages/attendance/payroll/close.tsx
+++ b/code/webapp/src/pages/attendance/payroll/close.tsx
@@ -74,6 +74,7 @@ export function PayrollClosePage() {
           />
         </div>
         <button
+          type="button"
           onClick={calculate}
           disabled={isLoading}
           className="rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"

--- a/doc/tasks/2026-07/266-button-type-attribute.md
+++ b/doc/tasks/2026-07/266-button-type-attribute.md
@@ -1,0 +1,66 @@
+# 266 - Fix SonarCloud new-code issues in sushigo-webapp: missing button type attribute
+
+**Type:** 🐛 Bug fix / Quality gate
+**Priority:** Medium
+**Detected by:** SonarCloud New Code analysis (rule `typescript:S9011`)
+
+---
+
+## 📋 Description
+
+SonarCloud's [New Code summary for sushigo-webapp](https://sonarcloud.io/summary/new_code?id=pakodiazdev_sushigo-webapp) reports 13 new Code Smells (rule `typescript:S9011`), all with the message *"Add an explicit "type" attribute to this button."* No new bugs, vulnerabilities, or security hotspots are reported; new coverage (90.8%) and duplication (0%) are already passing.
+
+Without an explicit `type="button"`, these buttons default to `type="submit"`, which can trigger unintended form submissions when they're nested inside a `<form>`.
+
+---
+
+## 🔍 Affected files/lines
+
+- `src/components/employees/schedule-dialog.tsx` — lines 169, 180
+- `src/components/dev/DevDebugger.tsx` — lines 100, 132, 142, 207, 214
+- `src/components/devtools/ClockDebugPanel.tsx` — lines 80, 130, 156, 169, 177
+- `src/pages/attendance/payroll/close.tsx` — line 76
+
+---
+
+## 🎯 Acceptance Criteria
+
+- [x] All 13 flagged buttons have an explicit `type="button"` (or `type="submit"` if genuinely intended to submit a form)
+- [ ] SonarCloud New Code shows 0 new issues for sushigo-webapp (pending CI analysis on PR)
+- [x] `npm run lint` and `npm run typecheck` pass
+
+---
+
+## 🔗 References
+
+- GitHub issue: [#266](https://github.com/pakodiazdev/sushigo/issues/266)
+
+---
+
+## ⏱️ Estimates
+
+- **Optimistic:** `0.5h` · **Pessimistic:** `1h`
+
+---
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `0.5h` · **Pessimistic:** `1h` · **Tracked:** `13m`
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-07-21", "start": "14:19", "end": "14:22" },
+  { "date": "2026-07-21", "start": "14:22", "end": "14:32" }
+]
+```
+
+## 📊 Retrospective
+- **Actual total:** 13m (3m + 10m)
+- **vs optimistic:** −17m
+- **vs pessimistic:** −47m
+
+**Justification:**
+
+The fix was fully mechanical — adding `type="button"` to 13 already-identified buttons with no behavior change — so the first session finished well under the optimistic estimate with no surprises. The second session addressed two open review threads on PR #269 (Copilot): an icon-only close button missing an accessible name, and this task file's Tracked time/retrospective not matching the session convention. Both were small, well-scoped fixes, so the task still landed well under the pessimistic estimate overall.


### PR DESCRIPTION
## Summary
- Add `type="button"` to 13 buttons flagged by SonarCloud (rule `typescript:S9011`) across `schedule-dialog.tsx`, `DevDebugger.tsx`, `ClockDebugPanel.tsx`, and `close.tsx`
- All flagged buttons are click-handler actions (toggles, navigation, dev-tool controls) — none are meant to submit a form, so `type="button"` is the correct fix in every case
- No behavior change; purely a quality-gate fix

## Test plan
- [x] Vitest: `npx vitest run src/components/employees` (841 tests passed)
- [x] Vitest: `npx vitest run src/components/devtools/__tests__/ClockDebugPanel.test.tsx src/components/dev/__tests__/DevDebugger.test.tsx src/pages/attendance/payroll/__tests__/use-close-preview.test.ts` (44 tests passed)
- [x] Linters: ESLint ✅ (0 errors) · TypeScript ✅ (0 errors)
- [ ] SonarCloud New Code: pending CI analysis on this PR

## Manual Testing
This is a non-visual, non-functional attribute fix — no behavior changes to verify manually. Confirm via:
1. Open any page containing the affected components (e.g. Employee schedule dialog at `/employees/{id}` → Configuration → Schedule tab, or the Dev Debugger panel visible in local/dev builds) and confirm buttons still behave identically (open/close dialog, toggle debugger, shift clock time, etc.)
2. Confirm no button unexpectedly submits a form when clicked

## Closes
Closes #266

## Workspace
`sushigo-c` — `fix/266-button-type-attribute`

🤖 Generated with [Claude Code](https://claude.com/claude-code)