### PR TITLE
🔨 [#272][c] - Migrate in-scope raw buttons to the Button component 🔘

### DIFF
--- a/code/webapp/src/components/ui/__tests__/button.test.tsx
+++ b/code/webapp/src/components/ui/__tests__/button.test.tsx
@@ -88,6 +88,13 @@ describe('Button', () => {
             expect(button.className).toContain('text-white')
         })
 
+        it('renders indigo variant', () => {
+            const { container } = render(<Button variant="indigo">Calcular</Button>)
+            const button = container.firstChild as HTMLElement
+            expect(button.className).toContain('bg-indigo-600')
+            expect(button.className).toContain('text-white')
+        })
+
         it('renders ghost-danger variant with dark-mode-safe red contrast', () => {
             const { container } = render(<Button variant="ghost-danger">Cancelar</Button>)
             const button = container.firstChild as HTMLElement
@@ -178,6 +185,12 @@ describe('Button', () => {
             const { container } = render(<Button type="submit">Submit</Button>)
             const button = container.firstChild as HTMLButtonElement
             expect(button.type).toBe('submit')
+        })
+
+        it('defaults type to "button" when not passed', () => {
+            const { container } = render(<Button>No Type</Button>)
+            const button = container.firstChild as HTMLButtonElement
+            expect(button.type).toBe('button')
         })
     })
 })

--- a/code/webapp/src/components/ui/button.tsx
+++ b/code/webapp/src/components/ui/button.tsx
@@ -14,6 +14,7 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
         | "info"
         | "warning"
         | "success"
+        | "indigo"
         | "ghost"
         | "ghost-danger"
         | "link"
@@ -21,7 +22,7 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-    ({ className, variant = "default", size = "default", ...props }, ref) => {
+    ({ className, variant = "default", size = "default", type = "button", ...props }, ref) => {
         const variants = {
             default: "bg-primary text-primary-foreground hover:bg-primary/90",
             destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
@@ -38,6 +39,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
             info: "bg-blue-600 text-white hover:bg-blue-700",
             warning: "bg-amber-600 text-white hover:bg-amber-700",
             success: "bg-green-600 text-white hover:bg-green-700",
+            indigo: "bg-indigo-600 text-white hover:bg-indigo-700",
             ghost: "hover:bg-accent hover:text-accent-foreground",
             "ghost-danger":
                 "text-red-400 hover:bg-red-50 hover:text-red-600 dark:text-red-400 dark:hover:bg-red-950/30 dark:hover:text-red-300",
@@ -60,6 +62,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
                     className
                 )}
                 ref={ref}
+                type={type}
                 {...props}
             />
         )

--- a/code/webapp/src/pages/attendance/payroll/$periodId.tsx
+++ b/code/webapp/src/pages/attendance/payroll/$periodId.tsx
@@ -97,23 +97,15 @@ export function ClosedPeriodDetailPage() {
             <span className="text-sm text-gray-500">{payPeriod.total_employees} empleados</span>
 
             {isAdmin && payPeriod.status === 'CLOSED' && (
-              <button
-                type="button"
-                onClick={openReopenConfirm}
-                className="ml-auto rounded bg-amber-600 px-4 py-2 text-sm font-medium text-white hover:bg-amber-700"
-              >
+              <Button variant="warning" className="ml-auto" onClick={openReopenConfirm}>
                 Reabrir periodo
-              </button>
+              </Button>
             )}
 
             {isAdmin && payPeriod.status === 'REOPENED' && (
-              <button
-                type="button"
-                onClick={openRecloseConfirm}
-                className="ml-auto rounded bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700"
-              >
+              <Button variant="success" className="ml-auto" onClick={openRecloseConfirm}>
                 Volver a cerrar
-              </button>
+              </Button>
             )}
           </div>
 

--- a/code/webapp/src/pages/attendance/payroll/close.tsx
+++ b/code/webapp/src/pages/attendance/payroll/close.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { requirePermission } from '@/lib/route-guards'
 import { PageContainer } from '@/components/ui/page-container'
 import { PageHeader } from '@/components/ui/page-header'
+import { Button } from '@/components/ui/button'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { NoBranchState } from '@/components/attendance'
 import { useClosePreviewPage } from './use-close-preview'
@@ -73,14 +74,9 @@ export function PayrollClosePage() {
             onChange={e => setPendingRange({ ...pendingRange, periodEnd: e.target.value })}
           />
         </div>
-        <button
-          type="button"
-          onClick={calculate}
-          disabled={isLoading}
-          className="rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
-        >
+        <Button variant="indigo" onClick={calculate} disabled={isLoading}>
           {isLoading ? 'Calculando...' : 'Calcular preview'}
-        </button>
+        </Button>
       </div>
 
       {errorMessage && (
@@ -98,13 +94,9 @@ export function PayrollClosePage() {
           ))}
 
           <div className="flex justify-end pt-4">
-            <button
-              type="button"
-              onClick={openConfirm}
-              className="rounded bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700"
-            >
+            <Button variant="success" onClick={openConfirm}>
               Confirmar cierre
-            </button>
+            </Button>
           </div>
         </div>
       )}

--- a/doc/conventions/frontend/button-styles.md
+++ b/doc/conventions/frontend/button-styles.md
@@ -25,6 +25,7 @@ Both are symptoms of the same gap: contrast belongs in the component, not in eac
 | `info` | Solid blue "Guardar"/"Nueva X" action (legacy blue palette, not the brand `default` token) | Use instead of hardcoding `bg-blue-600` |
 | `warning` | Solid amber confirm/attention action (e.g. "Dar de Baja", "Registrar ausencia") | Use instead of hardcoding `bg-amber-600` |
 | `success` | Solid green positive/confirm action (e.g. "Abrir Sesión de Caja", "Habilitar", "Reingreso") | Use instead of hardcoding `bg-green-600`/`bg-emerald-600` |
+| `indigo` | Solid indigo action, distinct from `info`'s blue (e.g. "Calcular preview") | Use instead of hardcoding `bg-indigo-600` |
 | `ghost` | Lowest-emphasis action (e.g. "Cancelar" next to a stronger action) | No border, no fixed background |
 | `ghost-danger` | Lowest-emphasis destructive/cancel action (e.g. an inline "Cancelar" link on a request card) | Dark-mode-safe red text baked in |
 | `link` | Inline text-styled action | |
@@ -55,3 +56,17 @@ If a button needs a `className` override for `border-*`, `text-*`, `bg-*`, or an
 `OvertimeDecisionDialog.tsx` ("No pagar" → `outline-danger`, "Regresar" → `outline`) is the reference for migrating existing ad-hoc overrides to the centralized variants. `EmployeeAttendanceCard.tsx` ("Marcar falta" → `outline-danger`, "Decidir horas extra" → `outline-warning`) is a second migration of the same pattern.
 
 As of issue #247, every `<Button>` usage in the webapp has been migrated off hardcoded palette `className` overrides, across `attendance/`, `cash/`, `employees/`, `inventory/`, `solicitudes/`, `dashboard/`, and `ui/confirm-dialog.tsx`. `ConfirmDialog`'s internal `variantStyles` map now resolves to a `Button` `variant` name (`confirmVariant`) instead of a raw className, so its own danger/warning/info confirm buttons go through the same system. See issue #247.
+
+## `type` defaults to `"button"`
+
+`Button` defaults its `type` prop to `"button"` when not explicitly passed (issue #272). Real form-submit buttons must still pass `type="submit"` explicitly — the default only prevents the SonarCloud `typescript:S9011` finding (missing `type` attribute) from recurring for consumers who forget to set it, the same way centralized variants prevent ad-hoc dark-mode overrides.
+
+## Raw `<button>` patterns intentionally excluded from `Button` migration (issue #272)
+
+A full audit of raw `<button>` usage in `src/` (issue #272) found that most instances are not "a labeled action button someone forgot to style" but a structurally different kind of control. Forcing these through `Button` would fight its fixed sizing/layout rather than fix a styling gap, so they are explicitly excluded rather than silently left alone:
+
+- **Dialog backdrop click-catchers** — an invisible `absolute inset-0` `<button>` used purely for keyboard/AT-accessible click-outside-to-close (e.g. `dialog-frame.tsx`, `ExtraDayNegotiationDialog.tsx`, `permission-manager-dialog.tsx`). `Button`'s base classes (`rounded-md`, fixed height, `ring-offset`) don't apply to a transparent full-screen overlay.
+- **Small inline icon-only utility controls** — close (`✕`), chevron nav, and row-level edit/save/cancel/approve icons (e.g. dialog close buttons, `week-calendar.tsx` nav arrows, `schedule-config-rows.tsx` row actions). These already use theme tokens (`text-muted-foreground hover:text-foreground`) and are dark-mode safe; `Button`'s `icon` size is a fixed `h-10 w-10`, much larger than these compact inline controls.
+- **Tab-like / step-like / disclosure controls** — `schedule-dialog.tsx` tabs, `SolicitudesLayout.tsx` tabs, `product-wizard.tsx` wizard steps, `Sidebar.tsx` submenu toggle, `week-calendar.tsx` year/month pickers. These implement custom active/inactive selection logic that doesn't map onto `Button`'s variant system.
+- **Clickable card/list-row containers** — `BranchSelectionDialog.tsx`, `BranchSwitcher.tsx`, `override-list-dialog.tsx`, `schedule-history-item.tsx`, `stock-dashboard.tsx` location cards. Multi-line nested content that `Button`'s centered-flex layout would break.
+- **Dev-only tooling with its own hardcoded dark palette** — `components/dev/DevDebugger.tsx`, `components/dev/page-actions/payroll-close-actions.tsx`, `components/devtools/ClockBadge.tsx`, `components/devtools/ClockDebugPanel.tsx`. These intentionally use a fixed dark palette (`bg-gray-900`, `bg-blue-600`, etc.) independent of the app's `--primary`/`--foreground` theme tokens `Button` is built on — not a candidate for centralization.

--- a/doc/tasks/2026-07/272-migrate-raw-buttons-to-button-component.md
+++ b/doc/tasks/2026-07/272-migrate-raw-buttons-to-button-component.md
@@ -1,0 +1,71 @@
+# 272 - Migrate remaining raw &lt;button&gt; usages to the centralized Button component
+
+## 📖 Story
+
+**English:** As a frontend developer, I want every button in the webapp to use the centralized `Button` component (`src/components/ui/button.tsx`, established in #247) instead of a raw `<button className="...">`, so that styling, dark-mode contrast, and the `type` attribute are resolved once in the component instead of being hand-written (and sometimes forgotten, like #266) at every call site.
+
+**Español:** Como desarrollador frontend, quiero que todos los botones del webapp usen el componente centralizado `Button` (`src/components/ui/button.tsx`, establecido en #247) en vez de un `<button className="...">` crudo, para que el estilo, el contraste en modo oscuro y el atributo `type` se resuelvan una sola vez en el componente en lugar de escribirse a mano (y a veces olvidarse, como en #266) en cada sitio de uso.
+
+---
+
+## 🧠 Context
+
+#266 fixed 13 SonarCloud `typescript:S9011` findings (missing `type="button"`) by adding the attribute directly to raw `<button>` elements in `schedule-dialog.tsx`, `DevDebugger.tsx`, `ClockDebugPanel.tsx`, and `close.tsx`. That was the correct minimal fix for the SonarCloud gate, but it repeated the same root problem #247 already solved for styling: consumers hand-writing button markup instead of going through the centralized component.
+
+A first grep (`grep -rln "<button" src --include="*.tsx"`) found raw `<button>` usages in ~50 files. Not all of them are in scope — this needs to be triaged during the audit:
+
+- **In scope (likely):** feature components/pages using ad-hoc `<button className="...">` for actions that a styled `Button` variant already covers (dialogs, forms, cards, list rows) — the same class of file #247 already migrated for styling; these should also stop needing hand-written `type="button"`.
+- **Needs a decision during the audit:** `components/dev/DevDebugger.tsx`, `components/devtools/ClockDebugPanel.tsx`, `components/devtools/ClockBadge.tsx` — dev-only tooling using a fixed hardcoded dark palette (`bg-gray-900`, `bg-blue-600`, etc.), not the app's `--primary`/`--foreground` theme tokens `Button` is built on. Migrating them may not be a good fit; if not, they should be explicitly excluded with a reason, not silently skipped.
+- **Out of scope:** the design-system primitives themselves (`components/ui/button.tsx`, `tabs.tsx`, `dropdown-menu.tsx`, `toggle-switch.tsx`, `calendar-picker.tsx`, `data-grid.tsx`, `multi-date-calendar.tsx`, `search-input.tsx`, `slide-panel.tsx`, `toast.tsx`) — these implement the design system rather than consume it. Test files (`__tests__/`) are also out of scope.
+
+As a companion fix, consider making `Button` default `type="button"` when no `type` prop is passed (explicit `type="submit"` still works for real form-submit buttons). That would prevent this exact SonarCloud rule from recurring for every future `Button` consumer, the same way the centralized variants already prevent ad-hoc dark-mode overrides.
+
+---
+
+## ✅ Technical Tasks
+
+- [ ] 🔍 Full audit of raw `<button>` usages across `src/` (excluding `components/ui/*` primitives and `__tests__/`), classifying each as: migrate to `Button`, exclude with reason (e.g. dev-tooling with its own palette), or already-fine (e.g. a `Button`-wrapped native element)
+- [ ] 🔧 Consider defaulting `Button`'s `type` prop to `"button"` when not explicitly passed, so new consumers get the SonarCloud-safe behavior for free
+- [ ] 🔁 Migrate the in-scope files found in the audit to `Button` with the appropriate `variant` (see `doc/conventions/frontend/button-styles.md`)
+- [ ] 📝 Update `doc/conventions/frontend/button-styles.md` if the audit surfaces a new pattern (e.g. explicit guidance for dev-tooling exclusions)
+- [ ] 🧪 Update/add tests for any migrated component whose rendered markup changes in a way tests assert on
+
+---
+
+## 🎯 Acceptance Criteria
+
+- [ ] Every in-scope raw `<button>` in `src/` (per the audit's classification) is migrated to the centralized `Button` component
+- [ ] Excluded files are explicitly listed with a reason in this issue or the convention doc, not just silently left alone
+- [ ] `npm run lint` and `npm run typecheck` pass
+- [ ] SonarCloud New Code shows 0 new issues for sushigo-webapp
+
+---
+
+## 🔗 References
+
+- GitHub issue: [#272](https://github.com/pakodiazdev/sushigo/issues/272)
+- Triggered by review feedback on #266 (PR #269) — the 13 buttons fixed there are raw `<button>` elements that should eventually go through `Button` instead
+- Same centralization pattern as [#247](../2026-07/247-centralize-button-components.md) (Button variants) and [#248](../2026-07/248-centralize-label-component.md) (Label component)
+
+---
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `3h` · **Pessimistic:** `6h` · **Tracked:** `22m`
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-07-21", "start": "16:45", "end": "17:07" }
+]
+```
+
+## 📊 Retrospective
+- **Actual total:** 22m (22 min)
+- **vs optimistic:** −2h 38m
+- **vs pessimistic:** −5h 38m
+
+**Justification:**
+
+The audit was the bulk of the estimated scope, and it resolved much smaller than expected: of the ~50 files with raw `<button>` usages, only 4 buttons across 2 files actually matched `Button`'s semantics (solid, labeled action buttons). The remaining ~90 occurrences turned out to be structurally different components — dialog backdrop click-catchers, inline icon-only utility controls, tab/step/disclosure controls, clickable card/list-row containers, and dev-only tooling with its own hardcoded palette — which were correctly excluded with documented reasons rather than migrated. That meant no risky refactor across dozens of files, keeping the session well under both estimates.


### PR DESCRIPTION
## Summary
Closes #272

- Added an `indigo` `Button` variant and defaulted `Button`'s `type` prop to `"button"` when not passed (companion fix from the issue, prevents `typescript:S9011` from recurring)
- Migrated the 4 clear raw-`<button>` matches found in the audit to `Button`: `Reabrir periodo`/`Volver a cerrar` (`$periodId.tsx`) and `Calcular preview`/`Confirmar cierre` (`close.tsx`)
- Audited all other raw `<button>` usages in `src/` (48 files) and found the vast majority are structurally different from `Button` — not a styling gap, but a different component class (backdrop click-catchers, inline icon-only utility controls, tab/step/disclosure controls, clickable card/list-row containers, and dev-only tooling with its own hardcoded dark palette). These are explicitly excluded with reasons documented in `doc/conventions/frontend/button-styles.md` rather than silently left alone.

## Audit results (issue #272 acceptance criteria)

**Migrated:**
- `src/pages/attendance/payroll/$periodId.tsx` — "Reabrir periodo" → `variant="warning"`, "Volver a cerrar" → `variant="success"`
- `src/pages/attendance/payroll/close.tsx` — "Calcular preview" → new `variant="indigo"`, "Confirmar cierre" → `variant="success"`

**Excluded (see `doc/conventions/frontend/button-styles.md` → "Raw `<button>` patterns intentionally excluded from `Button` migration"):**
- Dialog backdrop click-catchers (a11y click-outside overlays)
- Inline icon-only utility controls (close ✕, chevron nav, row edit/save/cancel icons) — already dark-mode safe, `Button`'s fixed `icon` size doesn't fit inline contexts
- Tab-like / step-like / disclosure controls (`schedule-dialog.tsx`, `SolicitudesLayout.tsx`, `product-wizard.tsx`, `Sidebar.tsx`, `week-calendar.tsx`)
- Clickable card/list-row containers (`BranchSelectionDialog.tsx`, `BranchSwitcher.tsx`, `override-list-dialog.tsx`, `schedule-history-item.tsx`, `stock-dashboard.tsx`)
- Dev-only tooling with its own hardcoded dark palette (`DevDebugger.tsx`, `payroll-close-actions.tsx`, `ClockBadge.tsx`, `ClockDebugPanel.tsx`)

## Test plan
- [x] Vitest: `npx vitest run` — 239 files / 3405 tests passed, 0 regressions
- [x] Vitest: new `Button` tests for `indigo` variant and default `type="button"` behavior
- [x] Linters: ESLint ✅ · TypeScript ✅
- [ ] Cypress E2E: not re-run in this session (requires a separate E2E Docker stack not currently up) — existing specs `payroll-close-preview.cy.ts`, `payroll-close-confirm.cy.ts`, and `reopen-reclose-period.cy.ts` already cover these buttons' happy paths via text-based selectors and were not modified, since click behavior/text is unchanged

## Manual Testing

**Payroll close preview** (`/attendance/payroll/close`):
1. Select a period start/end date
2. Click "Calcular preview" — should render as an indigo button, same click behavior as before
3. Click "Confirmar cierre" — should render as a green button, opens the confirm dialog as before

**Payroll period detail — reopen/reclose** (`/attendance/payroll/$periodId`, as admin):
1. On a `CLOSED` period, "Reabrir periodo" renders as an amber button and opens the reopen confirm dialog
2. On a `REOPENED` period, "Volver a cerrar" renders as a green button and opens the reclose confirm dialog

**Button default type:**
1. Any `Button` usage without an explicit `type` now renders `type="button"` in the DOM — verify via devtools inspector on any migrated button that it no longer submits an enclosing form

## Workspace
`sushigo-c` — `refactor/272-migrate-buttons-to-component`

🤖 Generated with [Claude Code](https://claude.com/claude-code)