### PR TITLE
🔨 [#282][e] - Extract CashAdjustments field-casting and UOM-conversion duplication 🧹

### DIFF
--- a/code/api/app/Http/Requests/CashAdjustments/BankAccounts/StoreBankAccountRequest.php
+++ b/code/api/app/Http/Requests/CashAdjustments/BankAccounts/StoreBankAccountRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\CashAdjustments\BankAccounts;
 
 use App\Http\Requests\Concerns\CastsRequestFields;
+use App\Models\BankAccount;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
@@ -25,7 +26,7 @@ class StoreBankAccountRequest extends FormRequest
 
     public function authorize(): bool
     {
-        return $this->user()->can('create', \App\Models\BankAccount::class);
+        return $this->user()->can('create', BankAccount::class);
     }
 
     public function rules(): array

--- a/code/api/app/Http/Requests/CashAdjustments/BankAccounts/StoreBankAccountRequest.php
+++ b/code/api/app/Http/Requests/CashAdjustments/BankAccounts/StoreBankAccountRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\CashAdjustments\BankAccounts;
 
+use App\Http\Requests\Concerns\CastsRequestFields;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
@@ -20,6 +21,8 @@ use Illuminate\Foundation\Http\FormRequest;
  */
 class StoreBankAccountRequest extends FormRequest
 {
+    use CastsRequestFields;
+
     public function authorize(): bool
     {
         return $this->user()->can('create', \App\Models\BankAccount::class);
@@ -50,10 +53,6 @@ class StoreBankAccountRequest extends FormRequest
 
     public function prepareForValidation(): void
     {
-        if ($this->has('is_active') && is_string($this->is_active)) {
-            $this->merge([
-                'is_active' => filter_var($this->is_active, FILTER_VALIDATE_BOOLEAN),
-            ]);
-        }
+        $this->castToBoolean('is_active');
     }
 }

--- a/code/api/app/Http/Requests/CashAdjustments/BankAccounts/UpdateBankAccountRequest.php
+++ b/code/api/app/Http/Requests/CashAdjustments/BankAccounts/UpdateBankAccountRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\CashAdjustments\BankAccounts;
 
+use App\Http\Requests\Concerns\CastsRequestFields;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
@@ -18,6 +19,8 @@ use Illuminate\Foundation\Http\FormRequest;
  */
 class UpdateBankAccountRequest extends FormRequest
 {
+    use CastsRequestFields;
+
     public function authorize(): bool
     {
         return $this->user()->can('update', $this->route('bankAccount'));
@@ -37,10 +40,6 @@ class UpdateBankAccountRequest extends FormRequest
 
     public function prepareForValidation(): void
     {
-        if ($this->has('is_active') && is_string($this->is_active)) {
-            $this->merge([
-                'is_active' => filter_var($this->is_active, FILTER_VALIDATE_BOOLEAN),
-            ]);
-        }
+        $this->castToBoolean('is_active');
     }
 }

--- a/code/api/app/Http/Requests/CashAdjustments/CashExpenses/StoreCashExpenseRequest.php
+++ b/code/api/app/Http/Requests/CashAdjustments/CashExpenses/StoreCashExpenseRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\CashAdjustments\CashExpenses;
 
+use App\Http\Requests\Concerns\CastsRequestFields;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Validator;
 
@@ -25,6 +26,8 @@ use Illuminate\Validation\Validator;
  */
 class StoreCashExpenseRequest extends FormRequest
 {
+    use CastsRequestFields;
+
     public function authorize(): bool
     {
         return $this->user()->can('create', \App\Models\CashExpense::class);
@@ -80,10 +83,6 @@ class StoreCashExpenseRequest extends FormRequest
 
     public function prepareForValidation(): void
     {
-        if ($this->has('amount') && is_string($this->amount)) {
-            $this->merge([
-                'amount' => (float) $this->amount,
-            ]);
-        }
+        $this->castToFloat('amount');
     }
 }

--- a/code/api/app/Http/Requests/CashAdjustments/CashExpenses/StoreCashExpenseRequest.php
+++ b/code/api/app/Http/Requests/CashAdjustments/CashExpenses/StoreCashExpenseRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\CashAdjustments\CashExpenses;
 
 use App\Http\Requests\Concerns\CastsRequestFields;
+use App\Models\CashExpense;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Validator;
 
@@ -30,7 +31,7 @@ class StoreCashExpenseRequest extends FormRequest
 
     public function authorize(): bool
     {
-        return $this->user()->can('create', \App\Models\CashExpense::class);
+        return $this->user()->can('create', CashExpense::class);
     }
 
     public function rules(): array

--- a/code/api/app/Http/Requests/CashAdjustments/CashExpenses/UpdateCashExpenseRequest.php
+++ b/code/api/app/Http/Requests/CashAdjustments/CashExpenses/UpdateCashExpenseRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\CashAdjustments\CashExpenses;
 
+use App\Http\Requests\Concerns\CastsRequestFields;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Validator;
 
@@ -23,6 +24,8 @@ use Illuminate\Validation\Validator;
  */
 class UpdateCashExpenseRequest extends FormRequest
 {
+    use CastsRequestFields;
+
     public function authorize(): bool
     {
         $expense = $this->route('cashExpense');
@@ -85,10 +88,6 @@ class UpdateCashExpenseRequest extends FormRequest
 
     public function prepareForValidation(): void
     {
-        if ($this->has('amount') && is_string($this->amount)) {
-            $this->merge([
-                'amount' => (float) $this->amount,
-            ]);
-        }
+        $this->castToFloat('amount');
     }
 }

--- a/code/api/app/Http/Requests/CashAdjustments/CashRegisters/StoreCashRegisterRequest.php
+++ b/code/api/app/Http/Requests/CashAdjustments/CashRegisters/StoreCashRegisterRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\CashAdjustments\CashRegisters;
 
+use App\Http\Requests\Concerns\CastsRequestFields;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
@@ -20,6 +21,8 @@ use Illuminate\Foundation\Http\FormRequest;
  */
 class StoreCashRegisterRequest extends FormRequest
 {
+    use CastsRequestFields;
+
     public function authorize(): bool
     {
         return $this->user()->can('create', \App\Models\CashRegister::class);
@@ -53,10 +56,6 @@ class StoreCashRegisterRequest extends FormRequest
 
     public function prepareForValidation(): void
     {
-        if ($this->has('is_active') && is_string($this->is_active)) {
-            $this->merge([
-                'is_active' => filter_var($this->is_active, FILTER_VALIDATE_BOOLEAN),
-            ]);
-        }
+        $this->castToBoolean('is_active');
     }
 }

--- a/code/api/app/Http/Requests/CashAdjustments/CashRegisters/StoreCashRegisterRequest.php
+++ b/code/api/app/Http/Requests/CashAdjustments/CashRegisters/StoreCashRegisterRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\CashAdjustments\CashRegisters;
 
 use App\Http\Requests\Concerns\CastsRequestFields;
+use App\Models\CashRegister;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
@@ -25,7 +26,7 @@ class StoreCashRegisterRequest extends FormRequest
 
     public function authorize(): bool
     {
-        return $this->user()->can('create', \App\Models\CashRegister::class);
+        return $this->user()->can('create', CashRegister::class);
     }
 
     public function rules(): array

--- a/code/api/app/Http/Requests/CashAdjustments/CashRegisters/UpdateCashRegisterRequest.php
+++ b/code/api/app/Http/Requests/CashAdjustments/CashRegisters/UpdateCashRegisterRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\CashAdjustments\CashRegisters;
 
+use App\Http\Requests\Concerns\CastsRequestFields;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
@@ -18,6 +19,8 @@ use Illuminate\Foundation\Http\FormRequest;
  */
 class UpdateCashRegisterRequest extends FormRequest
 {
+    use CastsRequestFields;
+
     public function authorize(): bool
     {
         return $this->user()->can('update', $this->route('cashRegister'));
@@ -47,10 +50,6 @@ class UpdateCashRegisterRequest extends FormRequest
 
     public function prepareForValidation(): void
     {
-        if ($this->has('is_active') && is_string($this->is_active)) {
-            $this->merge([
-                'is_active' => filter_var($this->is_active, FILTER_VALIDATE_BOOLEAN),
-            ]);
-        }
+        $this->castToBoolean('is_active');
     }
 }

--- a/code/api/app/Http/Requests/CashAdjustments/CashSessions/StoreCashSessionRequest.php
+++ b/code/api/app/Http/Requests/CashAdjustments/CashSessions/StoreCashSessionRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\CashAdjustments\CashSessions;
 
 use App\Http\Requests\Concerns\CastsRequestFields;
+use App\Models\CashSession;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
@@ -22,7 +23,7 @@ class StoreCashSessionRequest extends FormRequest
 
     public function authorize(): bool
     {
-        return $this->user()->can('create', \App\Models\CashSession::class);
+        return $this->user()->can('create', CashSession::class);
     }
 
     public function rules(): array

--- a/code/api/app/Http/Requests/CashAdjustments/CashSessions/StoreCashSessionRequest.php
+++ b/code/api/app/Http/Requests/CashAdjustments/CashSessions/StoreCashSessionRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\CashAdjustments\CashSessions;
 
+use App\Http\Requests\Concerns\CastsRequestFields;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
@@ -17,6 +18,8 @@ use Illuminate\Foundation\Http\FormRequest;
  */
 class StoreCashSessionRequest extends FormRequest
 {
+    use CastsRequestFields;
+
     public function authorize(): bool
     {
         return $this->user()->can('create', \App\Models\CashSession::class);
@@ -46,10 +49,6 @@ class StoreCashSessionRequest extends FormRequest
 
     public function prepareForValidation(): void
     {
-        if ($this->has('opening_balance') && is_string($this->opening_balance)) {
-            $this->merge([
-                'opening_balance' => (float) $this->opening_balance,
-            ]);
-        }
+        $this->castToFloat('opening_balance');
     }
 }

--- a/code/api/app/Http/Requests/CashAdjustments/CashSessions/UpdateCashSessionRequest.php
+++ b/code/api/app/Http/Requests/CashAdjustments/CashSessions/UpdateCashSessionRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\CashAdjustments\CashSessions;
 
+use App\Http\Requests\Concerns\CastsRequestFields;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
@@ -15,6 +16,8 @@ use Illuminate\Foundation\Http\FormRequest;
  */
 class UpdateCashSessionRequest extends FormRequest
 {
+    use CastsRequestFields;
+
     public function authorize(): bool
     {
         $session = $this->route('cashSession');
@@ -45,16 +48,7 @@ class UpdateCashSessionRequest extends FormRequest
 
     public function prepareForValidation(): void
     {
-        if ($this->has('opening_balance') && is_string($this->opening_balance)) {
-            $this->merge([
-                'opening_balance' => (float) $this->opening_balance,
-            ]);
-        }
-
-        if ($this->has('closing_balance') && is_string($this->closing_balance)) {
-            $this->merge([
-                'closing_balance' => (float) $this->closing_balance,
-            ]);
-        }
+        $this->castToFloat('opening_balance');
+        $this->castToFloat('closing_balance');
     }
 }

--- a/code/api/app/Http/Requests/CashAdjustments/CashTerminals/StoreCashTerminalRequest.php
+++ b/code/api/app/Http/Requests/CashAdjustments/CashTerminals/StoreCashTerminalRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\CashAdjustments\CashTerminals;
 
 use App\Http\Requests\Concerns\CastsRequestFields;
+use App\Models\CashTerminal;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
@@ -25,7 +26,7 @@ class StoreCashTerminalRequest extends FormRequest
 
     public function authorize(): bool
     {
-        return $this->user()->can('create', \App\Models\CashTerminal::class);
+        return $this->user()->can('create', CashTerminal::class);
     }
 
     public function rules(): array

--- a/code/api/app/Http/Requests/CashAdjustments/CashTerminals/StoreCashTerminalRequest.php
+++ b/code/api/app/Http/Requests/CashAdjustments/CashTerminals/StoreCashTerminalRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\CashAdjustments\CashTerminals;
 
+use App\Http\Requests\Concerns\CastsRequestFields;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
@@ -20,6 +21,8 @@ use Illuminate\Foundation\Http\FormRequest;
  */
 class StoreCashTerminalRequest extends FormRequest
 {
+    use CastsRequestFields;
+
     public function authorize(): bool
     {
         return $this->user()->can('create', \App\Models\CashTerminal::class);
@@ -51,10 +54,6 @@ class StoreCashTerminalRequest extends FormRequest
 
     public function prepareForValidation(): void
     {
-        if ($this->has('is_active') && is_string($this->is_active)) {
-            $this->merge([
-                'is_active' => filter_var($this->is_active, FILTER_VALIDATE_BOOLEAN),
-            ]);
-        }
+        $this->castToBoolean('is_active');
     }
 }

--- a/code/api/app/Http/Requests/CashAdjustments/CashTerminals/UpdateCashTerminalRequest.php
+++ b/code/api/app/Http/Requests/CashAdjustments/CashTerminals/UpdateCashTerminalRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\CashAdjustments\CashTerminals;
 
+use App\Http\Requests\Concerns\CastsRequestFields;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
@@ -18,6 +19,8 @@ use Illuminate\Foundation\Http\FormRequest;
  */
 class UpdateCashTerminalRequest extends FormRequest
 {
+    use CastsRequestFields;
+
     public function authorize(): bool
     {
         return $this->user()->can('update', $this->route('cashTerminal'));
@@ -45,10 +48,6 @@ class UpdateCashTerminalRequest extends FormRequest
 
     public function prepareForValidation(): void
     {
-        if ($this->has('is_active') && is_string($this->is_active)) {
-            $this->merge([
-                'is_active' => filter_var($this->is_active, FILTER_VALIDATE_BOOLEAN),
-            ]);
-        }
+        $this->castToBoolean('is_active');
     }
 }

--- a/code/api/app/Http/Requests/Concerns/CastsRequestFields.php
+++ b/code/api/app/Http/Requests/Concerns/CastsRequestFields.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests\Concerns;
+
+/**
+ * String-to-native-type casts repeated across CashAdjustments FormRequests,
+ * needed because numeric/boolean fields can arrive as strings (e.g. multipart
+ * form-data or query-string input).
+ */
+trait CastsRequestFields
+{
+    protected function castToFloat(string $field): void
+    {
+        if ($this->has($field) && is_string($this->$field)) {
+            $this->merge([$field => (float) $this->$field]);
+        }
+    }
+
+    protected function castToBoolean(string $field): void
+    {
+        if ($this->has($field) && is_string($this->$field)) {
+            $this->merge([$field => filter_var($this->$field, FILTER_VALIDATE_BOOLEAN)]);
+        }
+    }
+}

--- a/code/api/app/Services/Inventory/Concerns/ConvertsUomQuantities.php
+++ b/code/api/app/Services/Inventory/Concerns/ConvertsUomQuantities.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Services\Inventory\Concerns;
+
+use App\Exceptions\UomConversionNotFoundException;
+use App\Models\ItemVariant;
+use App\Models\UnitOfMeasure;
+use App\Models\UomConversion;
+
+/**
+ * UOM-to-base-UOM conversion logic shared by StockOutService and OpeningBalanceService.
+ */
+trait ConvertsUomQuantities
+{
+    /**
+     * Get conversion between two UOMs (searches in both directions)
+     */
+    protected function getConversion(int $fromUomId, int $toUomId): ?UomConversion
+    {
+        // Try direct conversion first
+        $conversion = UomConversion::where('from_uom_id', $fromUomId)
+            ->where('to_uom_id', $toUomId)
+            ->where('is_active', true)
+            ->first();
+
+        if ($conversion) {
+            return $conversion;
+        }
+
+        // Try inverse conversion
+        $inverseConversion = UomConversion::where('from_uom_id', $toUomId)
+            ->where('to_uom_id', $fromUomId)
+            ->where('is_active', true)
+            ->first();
+
+        if ($inverseConversion) {
+            // Create a virtual conversion with inverted factor
+            $virtual = new UomConversion;
+            $virtual->from_uom_id = $fromUomId;
+            $virtual->to_uom_id = $toUomId;
+            $virtual->factor = 1 / $inverseConversion->factor;
+            $virtual->tolerance_percent = $inverseConversion->tolerance_percent;
+            $virtual->is_active = true;
+
+            return $virtual;
+        }
+
+        return null;
+    }
+
+    /**
+     * Convert a UOM quantity to base UOM, returning [baseQuantity, conversionFactor].
+     *
+     * @throws UomConversionNotFoundException
+     */
+    private function convertToBaseQuantity(float $quantity, int $uomId, ItemVariant $variant, UnitOfMeasure $uom): array
+    {
+        if ($uomId === $variant->uom_id) {
+            return [$quantity, 1.0];
+        }
+
+        $conversion = $this->getConversion($uomId, $variant->uom_id);
+        if (! $conversion) {
+            throw new UomConversionNotFoundException(
+                "No conversion found from {$uom->code} to {$variant->unitOfMeasure->code}"
+            );
+        }
+
+        return [$quantity * $conversion->factor, $conversion->factor];
+    }
+}

--- a/code/api/app/Services/Inventory/OpeningBalanceService.php
+++ b/code/api/app/Services/Inventory/OpeningBalanceService.php
@@ -10,11 +10,13 @@ use App\Models\Stock;
 use App\Models\StockMovement;
 use App\Models\StockMovementLine;
 use App\Models\UnitOfMeasure;
-use App\Models\UomConversion;
+use App\Services\Inventory\Concerns\ConvertsUomQuantities;
 use Illuminate\Support\Facades\DB;
 
 class OpeningBalanceService
 {
+    use ConvertsUomQuantities;
+
     /**
      * Register opening balance for an item variant at a specific location
      *
@@ -104,42 +106,6 @@ class OpeningBalanceService
     }
 
     /**
-     * Get conversion between two UOMs (searches in both directions)
-     */
-    protected function getConversion(int $fromUomId, int $toUomId): ?UomConversion
-    {
-        // Try direct conversion first
-        $conversion = UomConversion::where('from_uom_id', $fromUomId)
-            ->where('to_uom_id', $toUomId)
-            ->where('is_active', true)
-            ->first();
-
-        if ($conversion) {
-            return $conversion;
-        }
-
-        // Try inverse conversion
-        $inverseConversion = UomConversion::where('from_uom_id', $toUomId)
-            ->where('to_uom_id', $fromUomId)
-            ->where('is_active', true)
-            ->first();
-
-        if ($inverseConversion) {
-            // Create a virtual conversion with inverted factor
-            $virtual = new UomConversion;
-            $virtual->from_uom_id = $fromUomId;
-            $virtual->to_uom_id = $toUomId;
-            $virtual->factor = 1 / $inverseConversion->factor;
-            $virtual->tolerance_percent = $inverseConversion->tolerance_percent;
-            $virtual->is_active = true;
-
-            return $virtual;
-        }
-
-        return null;
-    }
-
-    /**
      * Update variant costing with weighted average
      */
     protected function updateVariantCosting(ItemVariant $variant, float $newQty, float $newCost): void
@@ -161,27 +127,6 @@ class OpeningBalanceService
             'last_unit_cost' => $newCost,
             'avg_unit_cost' => $newAvg,
         ]);
-    }
-
-    /**
-     * Convert an entry-UOM quantity to base UOM, returning [baseQuantity, conversionFactor].
-     *
-     * @throws UomConversionNotFoundException
-     */
-    private function convertToBaseQuantity(float $quantity, int $entryUomId, ItemVariant $variant, UnitOfMeasure $entryUom): array
-    {
-        if ($entryUomId === $variant->uom_id) {
-            return [$quantity, 1.0];
-        }
-
-        $conversion = $this->getConversion($entryUomId, $variant->uom_id);
-        if (! $conversion) {
-            throw new UomConversionNotFoundException(
-                "No conversion found from {$entryUom->code} to {$variant->unitOfMeasure->code}"
-            );
-        }
-
-        return [$quantity * $conversion->factor, $conversion->factor];
     }
 
     /**

--- a/code/api/app/Services/Inventory/StockOutService.php
+++ b/code/api/app/Services/Inventory/StockOutService.php
@@ -13,11 +13,13 @@ use App\Models\Stock;
 use App\Models\StockMovement;
 use App\Models\StockMovementLine;
 use App\Models\UnitOfMeasure;
-use App\Models\UomConversion;
+use App\Services\Inventory\Concerns\ConvertsUomQuantities;
 use Illuminate\Support\Facades\DB;
 
 class StockOutService
 {
+    use ConvertsUomQuantities;
+
     /**
      * Register a stock outbound movement (SALE or CONSUMPTION)
      *
@@ -127,63 +129,6 @@ class StockOutService
 
             return $movement->fresh(['lines', 'fromLocation', 'itemVariant.item', 'itemVariant.unitOfMeasure']);
         });
-    }
-
-    /**
-     * Get conversion between two UOMs (searches in both directions)
-     */
-    protected function getConversion(int $fromUomId, int $toUomId): ?UomConversion
-    {
-        // Try direct conversion first
-        $conversion = UomConversion::where('from_uom_id', $fromUomId)
-            ->where('to_uom_id', $toUomId)
-            ->where('is_active', true)
-            ->first();
-
-        if ($conversion) {
-            return $conversion;
-        }
-
-        // Try inverse conversion
-        $inverseConversion = UomConversion::where('from_uom_id', $toUomId)
-            ->where('to_uom_id', $fromUomId)
-            ->where('is_active', true)
-            ->first();
-
-        if ($inverseConversion) {
-            // Create a virtual conversion with inverted factor
-            $virtual = new UomConversion;
-            $virtual->from_uom_id = $fromUomId;
-            $virtual->to_uom_id = $toUomId;
-            $virtual->factor = 1 / $inverseConversion->factor;
-            $virtual->tolerance_percent = $inverseConversion->tolerance_percent;
-            $virtual->is_active = true;
-
-            return $virtual;
-        }
-
-        return null;
-    }
-
-    /**
-     * Convert a transaction-UOM quantity to base UOM, returning [baseQuantity, conversionFactor].
-     *
-     * @throws UomConversionNotFoundException
-     */
-    private function convertToBaseQuantity(float $quantity, int $transactionUomId, ItemVariant $variant, UnitOfMeasure $transactionUom): array
-    {
-        if ($transactionUomId === $variant->uom_id) {
-            return [$quantity, 1.0];
-        }
-
-        $conversion = $this->getConversion($transactionUomId, $variant->uom_id);
-        if (! $conversion) {
-            throw new UomConversionNotFoundException(
-                "No conversion found from {$transactionUom->code} to {$variant->unitOfMeasure->code}"
-            );
-        }
-
-        return [$quantity * $conversion->factor, $conversion->factor];
     }
 
     /**

--- a/code/api/tests/Feature/CashAdjustments/CastsRequestFieldsTest.php
+++ b/code/api/tests/Feature/CashAdjustments/CastsRequestFieldsTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Tests\Feature\CashAdjustments;
+
+use App\Models\Branch;
+use App\Models\CashRegister;
+use App\Models\CashSession;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class CastsRequestFieldsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Branch $branch;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $permissions = [
+            'bank_accounts.create',
+            'cash_registers.create',
+            'cash_terminals.create',
+            'cash_sessions.create',
+            'cash_expenses.create',
+        ];
+
+        foreach ($permissions as $name) {
+            Permission::firstOrCreate(['name' => $name, 'guard_name' => 'api']);
+        }
+
+        $role = Role::firstOrCreate(['name' => 'cash-manager', 'guard_name' => 'api']);
+        $role->syncPermissions($permissions);
+
+        $user = User::factory()->create();
+        $user->assignRole('cash-manager');
+
+        Passport::actingAs($user);
+
+        $this->branch = Branch::factory()->create();
+    }
+
+    #[Test]
+    public function bank_account_create_casts_string_boolean(): void
+    {
+        $this->postJson('/api/v1/bank-accounts', [
+            'branch_id' => $this->branch->id,
+            'alias' => 'Cuenta Principal',
+            'bank_name' => 'BBVA',
+            'account_number_masked' => '****1234',
+            'is_active' => 'false',
+        ])
+            ->assertStatus(201)
+            ->assertJsonPath('data.is_active', false);
+
+        $this->assertDatabaseHas('bank_accounts', [
+            'alias' => 'Cuenta Principal',
+            'is_active' => false,
+        ]);
+    }
+
+    #[Test]
+    public function cash_register_create_casts_string_boolean(): void
+    {
+        $this->postJson('/api/v1/cash-registers', [
+            'branch_id' => $this->branch->id,
+            'code' => 'REG-100',
+            'name' => 'Caja Principal',
+            'type' => 'ON_PREMISE',
+            'is_active' => '0',
+        ])
+            ->assertStatus(201)
+            ->assertJsonPath('data.is_active', false);
+
+        $this->assertDatabaseHas('cash_registers', [
+            'code' => 'REG-100',
+            'is_active' => false,
+        ]);
+    }
+
+    #[Test]
+    public function cash_terminal_create_casts_string_boolean(): void
+    {
+        $this->postJson('/api/v1/cash-terminals', [
+            'branch_id' => $this->branch->id,
+            'name' => 'Terminal CLIP',
+            'provider' => 'CLIP',
+            'account_ref' => 'ACC-001',
+            'last_four' => '1234',
+            'is_active' => 'true',
+        ])
+            ->assertStatus(201)
+            ->assertJsonPath('data.is_active', true);
+
+        $this->assertDatabaseHas('cash_terminals', [
+            'name' => 'Terminal CLIP',
+            'is_active' => true,
+        ]);
+    }
+
+    #[Test]
+    public function cash_session_create_casts_string_opening_balance_to_float(): void
+    {
+        $register = CashRegister::factory()->create(['branch_id' => $this->branch->id]);
+
+        $this->postJson('/api/v1/cash-sessions', [
+            'cash_register_id' => $register->id,
+            'operating_date' => '2026-01-05',
+            'opening_balance' => '1500.50',
+        ])
+            ->assertStatus(201)
+            ->assertJsonPath('data.opening_balance', '1500.5000');
+
+        $this->assertDatabaseHas('cash_sessions', [
+            'cash_register_id' => $register->id,
+            'opening_balance' => 1500.50,
+        ]);
+    }
+
+    #[Test]
+    public function cash_expense_create_casts_string_amount_to_float(): void
+    {
+        $register = CashRegister::factory()->create(['branch_id' => $this->branch->id]);
+        $session = CashSession::factory()->create(['cash_register_id' => $register->id]);
+
+        $this->postJson('/api/v1/cash-expenses', [
+            'cash_session_id' => $session->id,
+            'tender_type' => 'CASH',
+            'amount' => '250.75',
+            'category' => 'SUPPLIES',
+            'vendor' => 'Office Depot',
+        ])
+            ->assertStatus(201)
+            ->assertJsonPath('data.amount', '250.7500');
+
+        $this->assertDatabaseHas('cash_expenses', [
+            'cash_session_id' => $session->id,
+            'amount' => 250.75,
+        ]);
+    }
+}

--- a/doc/tasks/backlog/infrastructure/282-fix-sonarcloud-duplication-api.md
+++ b/doc/tasks/backlog/infrastructure/282-fix-sonarcloud-duplication-api.md
@@ -1,0 +1,79 @@
+# 🔨 Task #282: Fix SonarCloud Code Duplication in sushigo-api (883 duplicated lines / 42 blocks)
+
+## 📖 Story
+
+**English:**
+As a developer, I need to resolve the code duplication flagged by SonarCloud for sushigo-api, so the codebase stays consistent, easier to maintain, and the project's duplication debt is paid down.
+
+**Español:**
+Como desarrollador, necesito resolver la duplicación de código que SonarCloud reporta para sushigo-api, para que el código se mantenga consistente, más fácil de mantener, y se pague la deuda de duplicación del proyecto.
+
+---
+
+## 🔍 SonarCloud Findings — grouped by cluster
+
+Baseline (via `GET /api/measures/component` and `GET /api/measures/component_tree`, SonarCloud public API): **duplicated_lines_density = 2.0%**, **duplicated_lines = 883**, **duplicated_blocks = 42**, **duplicated_files = 31**.
+
+**Scope note:** given the size, this issue is split into one PR per cluster below rather than fixed in a single pass, mirroring #268.
+
+---
+
+## ✅ Technical Tasks
+
+- [x] 🔨 **CashAdjustments FormRequest field casting (10 files):** `prepareForValidation()` in `Store/UpdateBankAccountRequest`, `Store/UpdateCashRegisterRequest`, `Store/UpdateCashTerminalRequest`, `Store/UpdateCashSessionRequest`, `Store/UpdateCashExpenseRequest` all repeated the same "if string, cast to float/bool and merge" boilerplate for a differently-named field each time (`is_active`, `opening_balance`, `closing_balance`, `amount`). Extracted into `App\Http\Requests\Concerns\CastsRequestFields` (`castToFloat()`/`castToBoolean()`), used via `use CastsRequestFields;` in all 10 classes. *(Session: 2026-07-22)*
+- [x] 🔨 **StockOutService / OpeningBalanceService UOM conversion (2 files):** both services had a byte-identical `getConversion()` (38 lines, searches direct + inverse UOM conversion) and near-identical `convertToBaseQuantity()` (differing only in parameter names — `transactionUomId`/`transactionUom` vs `entryUomId`/`entryUom`). Extracted both into `App\Services\Inventory\Concerns\ConvertsUomQuantities`, used via `use ConvertsUomQuantities;` in both services. *(Session: 2026-07-22)*
+- [ ] 🔨 **PayrollSeedService internal duplication:** two ~20-line blocks (lines ~201, ~330) with the same shape — needs inspection to confirm what's repeated and extract to a private method.
+- [ ] 🔨 **PassportClientSeeder Development vs Production (2 files):** nearly-identical ~55-56 line files (86%/85.9% self-duplication density) — likely differ only in a couple of client secrets/redirect URIs. Candidate: shared base method parameterized by environment, or a single seeder reading env-specific config.
+- [ ] 🔨 **EmployeeSeeder internal duplication:** two 29-line blocks within the same file (lines ~103, ~168) — likely two near-identical employee/schedule definitions that can be parameterized into a loop or shared private method.
+- [ ] 🔨 **CoreTestSeeder internal duplication:** two 33-line blocks within the same file (lines ~438, ~449) — same pattern, needs inspection.
+- [ ] 🔍 **InventoryLocation/UnitsOfMeasure Request `rules()` shape overlap:** SonarCloud flags `CreateInventoryLocationRequest`, `UpdateInventoryLocationRequest`, and `UpdateUnitOfMeasureRequest` as mutually duplicate (~20-line blocks), but inspection shows these are different domains with different field names — the "duplication" is just the coincidental array-literal shape (`'field' => ['nullable', 'string', 'max:N']` repeated structure), not real copy-paste logic. Forcing a shared abstraction here would reduce clarity for a marginal metric win. Recommend: leave as-is, document as an accepted/won't-fix false positive.
+- [ ] 🔨 **Controller response-shaping duplication (8 files):** `InventoryLocation` Show/Create controllers, `Items` Show/Create/Update/List controllers, `Stock` ByVariant/ByLocation controllers, and `Devtools` ShiftClock/SetClock controllers each hand-build a similar response array or repeat the same clock-state-update-and-respond block. Candidate: extract to API Resource classes (e.g. `InventoryLocationResource`) for the data-shaping controllers, and a small trait for the Devtools clock controllers. Needs care to preserve exact JSON shape (Swagger schemas, existing consumers).
+- [ ] 🔧 **Migrations duplication (2 pairs):** `create_cash_expenses_table` / `create_cash_adjustments_table`, and `create_vacation_request_dates_table` / `create_leave_dates_table` share ~20-line column-definition blocks. These are already-applied migrations — recommend excluding `database/migrations/**` via `sonar.cpd.exclusions` in `sonar-project.properties` rather than editing historical migration files, since migrations are point-in-time schema snapshots and refactoring them retroactively risks breaking chronological schema application for no behavioral benefit.
+- [ ] 🧪 Run full test suite (`php artisan test`) and `./vendor/bin/pint` after each batch — no behavior change is expected, only structure
+- [ ] 🔍 Re-check https://sonarcloud.io/component_measures?id=pakodiazdev_sushigo-api&metric=duplicated_lines_density shows an improved density at the end
+
+---
+
+## 🎯 Acceptance Criteria
+
+- [ ] Duplicated lines density meaningfully reduced from the 2.0%/883-line baseline (exact target depends on which clusters are fixed vs. accepted as false positives/excluded)
+- [ ] No behavior change — full PHPUnit suite passes after each batch
+- [ ] `./vendor/bin/pint` passes with no formatting diffs
+
+---
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `4h` (mechanical extractions, assuming clean matches)
+- **Pessimistic:** `10h` (seeder/migration clusters may need judgment calls on env-specific values; controller cluster needs care around Swagger/response-shape parity)
+- **Tracked:** `0.4h` (in progress — 2 of 9 clusters complete)
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-07-22", "start": "15:07", "end": "15:31" }
+]
+```
+
+---
+
+## 📊 Sub-task Retrospectives
+
+### ✅ CashAdjustments FormRequest field casting + StockOutService/OpeningBalanceService UOM conversion
+- **Actual:** 24m
+
+**Justification:** Both clusters were found via the SonarCloud public API (`/api/measures/component_tree` sorted by `duplicated_lines`, then `/api/duplications/show` per file to see exact matched line ranges) rather than guessing from the file list — this pinpointed exactly which methods/blocks were byte-identical vs. merely similar. Both fixes were mechanical: `CastsRequestFields` trait (2 one-line helper methods) collapsed 10 near-identical `prepareForValidation()` bodies into one-line calls; `ConvertsUomQuantities` trait moved 2 byte-identical/near-identical methods (`getConversion()`, `convertToBaseQuantity()`) out of `StockOutService`/`OpeningBalanceService` with zero behavior change (verified against `StockOutTest`/`OpeningBalanceTest`, including UOM-conversion-specific cases). No dedicated Feature/HTTP tests exist yet for the CashAdjustments endpoints (only Service-level unit tests), so that cluster's fix couldn't be regression-tested via HTTP, only via `php -l` + full suite + manual code review confirming the extraction preserved every conditional/cast exactly.
+
+---
+
+## 🔗 References
+
+- GitHub issue: [#282](https://github.com/pakodiazdev/sushigo/issues/282)
+- SonarCloud duplications: https://sonarcloud.io/component_measures?id=pakodiazdev_sushigo-api&metric=duplicated_lines_density
+
+---
+
+## 📌 Multi-PR tracking note
+
+This issue is deliberately split across 9 clusters/PRs (see Technical Tasks above). This task file stays in `doc/tasks/backlog/infrastructure/` and the GitHub issue stays open across all of them — it only moves to the monthly folder and gets closed once every cluster above is checked off (fixed or explicitly accepted/excluded with justification).


### PR DESCRIPTION
## Summary
Refs #282 (cluster 1 of 9 — SonarCloud code duplication)

- Added `App\Http\Requests\Concerns\CastsRequestFields` (`castToFloat()`/`castToBoolean()`) and applied it to all 10 CashAdjustments FormRequests (`BankAccounts`, `CashRegisters`, `CashTerminals`, `CashSessions`, `CashExpenses` — Store + Update). Each `prepareForValidation()` had independently repeated the same "if string, cast and merge" boilerplate for a differently-named field (`is_active`, `opening_balance`, `closing_balance`, `amount`).
- Added `App\Services\Inventory\Concerns\ConvertsUomQuantities` (`getConversion()`/`convertToBaseQuantity()`), shared by `StockOutService` and `OpeningBalanceService` — both had a byte-identical 38-line `getConversion()` and a near-identical `convertToBaseQuantity()` (differing only in local variable names).
- No behavior change — verified by full test suite and manual review confirming every conditional/cast was preserved exactly.

## Test plan
- [x] `php artisan test` — full suite (1279 tests, 3813 assertions) passes
- [x] `./vendor/bin/pint` — no formatting diffs
- [x] Targeted runs: `CashAdjustmentServiceTest`, `CashExpenseServiceTest`, `CashSessionServiceTest`, `CashReconciliationServiceTest`, all CashAdjustments Policy tests, `StockOutTest`, `OpeningBalanceTest` (including UOM-conversion-specific and "no conversion found" cases)

## Manual Testing

No user-facing behavior changed (pure internal refactor — same validation rules, same casts, same conversion logic). To verify:
1. `POST /api/v1/cash-registers` (or any CashAdjustments create/update endpoint) with `is_active` sent as the string `"true"`/`"false"` — still coerces correctly
2. `POST /api/v1/cash-sessions` with `opening_balance` sent as a numeric string — still coerces to float correctly
3. `POST /api/v1/inventory/stock-out` and `POST /api/v1/inventory/opening-balance` with a transaction UOM that has only an inverse conversion row (e.g. L→ML exists but ML→L doesn't) — both still resolve via the inverted-factor fallback

## Workspace
`sushigo-e` — `refactor/282-cashadjustments-uom-duplication`