### PR TITLE
🔨 [#282][c] - Extract shared response-shaping into controller Concerns traits 🧩

### DIFF
--- a/code/api/app/Http/Controllers/Api/V1/Devtools/Concerns/AppliesSimulatedClock.php
+++ b/code/api/app/Http/Controllers/Api/V1/Devtools/Concerns/AppliesSimulatedClock.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Devtools\Concerns;
+
+use App\Enums\ClockMode;
+use App\Models\ApplicationClockState;
+use App\Support\Clock\ApplicationClock;
+use App\Support\Clock\DatabaseApplicationClock;
+use Carbon\CarbonImmutable;
+
+trait AppliesSimulatedClock
+{
+    /**
+     * Persist the given target datetime as the new simulated clock state
+     * and return the resulting clock snapshot.
+     *
+     * @return array<string, mixed>
+     */
+    protected function applySimulatedClock(ApplicationClock $clock, CarbonImmutable $targetDatetime): array
+    {
+        $state = ApplicationClockState::current();
+        $state->update([
+            'mode' => ClockMode::SIMULATED,
+            'base_datetime_utc' => $targetDatetime,
+            'started_real_datetime_utc' => CarbonImmutable::now('UTC'),
+            'updated_by' => auth()->id(),
+        ]);
+
+        // Clear cache so next read reflects new state
+        if ($clock instanceof DatabaseApplicationClock) {
+            $clock->clearCache();
+        }
+
+        return [
+            'mode' => $clock->mode()->value,
+            'application_now_utc' => $clock->nowUtc()->toIso8601String(),
+            'business_timezone' => $clock->businessTimezone(),
+            'business_date' => $clock->todayInBusinessTz(),
+            'business_now' => $clock->nowInBusinessTz()->toIso8601String(),
+        ];
+    }
+}

--- a/code/api/app/Http/Controllers/Api/V1/Devtools/SetClockController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Devtools/SetClockController.php
@@ -2,12 +2,10 @@
 
 namespace App\Http\Controllers\Api\V1\Devtools;
 
-use App\Enums\ClockMode;
+use App\Http\Controllers\Api\V1\Devtools\Concerns\AppliesSimulatedClock;
 use App\Http\Controllers\Controller;
-use App\Models\ApplicationClockState;
 use App\Support\Clock\ApplicationClock;
 use App\Support\Clock\ClockSimulationGuard;
-use App\Support\Clock\DatabaseApplicationClock;
 use Carbon\CarbonImmutable;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -19,6 +17,8 @@ use Illuminate\Http\Request;
  */
 class SetClockController extends Controller
 {
+    use AppliesSimulatedClock;
+
     public function __invoke(Request $request, ApplicationClock $clock): JsonResponse
     {
         ClockSimulationGuard::validate();
@@ -32,25 +32,6 @@ class SetClockController extends Controller
         $businessTz = $clock->businessTimezone();
         $targetDatetime = CarbonImmutable::parse($validated['datetime'], $businessTz)->utc();
 
-        $state = ApplicationClockState::current();
-        $state->update([
-            'mode' => ClockMode::SIMULATED,
-            'base_datetime_utc' => $targetDatetime,
-            'started_real_datetime_utc' => CarbonImmutable::now('UTC'),
-            'updated_by' => auth()->id(),
-        ]);
-
-        // Clear cache so next read reflects new state
-        if ($clock instanceof DatabaseApplicationClock) {
-            $clock->clearCache();
-        }
-
-        return response()->json([
-            'mode' => $clock->mode()->value,
-            'application_now_utc' => $clock->nowUtc()->toIso8601String(),
-            'business_timezone' => $clock->businessTimezone(),
-            'business_date' => $clock->todayInBusinessTz(),
-            'business_now' => $clock->nowInBusinessTz()->toIso8601String(),
-        ]);
+        return response()->json($this->applySimulatedClock($clock, $targetDatetime));
     }
 }

--- a/code/api/app/Http/Controllers/Api/V1/Devtools/ShiftClockController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Devtools/ShiftClockController.php
@@ -2,13 +2,10 @@
 
 namespace App\Http\Controllers\Api\V1\Devtools;
 
-use App\Enums\ClockMode;
+use App\Http\Controllers\Api\V1\Devtools\Concerns\AppliesSimulatedClock;
 use App\Http\Controllers\Controller;
-use App\Models\ApplicationClockState;
 use App\Support\Clock\ApplicationClock;
 use App\Support\Clock\ClockSimulationGuard;
-use App\Support\Clock\DatabaseApplicationClock;
-use Carbon\CarbonImmutable;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -20,6 +17,8 @@ use Illuminate\Http\Request;
  */
 class ShiftClockController extends Controller
 {
+    use AppliesSimulatedClock;
+
     public function __invoke(Request $request, ApplicationClock $clock): JsonResponse
     {
         ClockSimulationGuard::validate();
@@ -36,25 +35,8 @@ class ShiftClockController extends Controller
         // Calculate new target time
         $targetDatetime = $currentAppTime->addMinutes($minutes);
 
-        $state = ApplicationClockState::current();
-        $state->update([
-            'mode' => ClockMode::SIMULATED,
-            'base_datetime_utc' => $targetDatetime,
-            'started_real_datetime_utc' => CarbonImmutable::now('UTC'),
-            'updated_by' => auth()->id(),
-        ]);
-
-        // Clear cache so next read reflects new state
-        if ($clock instanceof DatabaseApplicationClock) {
-            $clock->clearCache();
-        }
-
         return response()->json([
-            'mode' => $clock->mode()->value,
-            'application_now_utc' => $clock->nowUtc()->toIso8601String(),
-            'business_timezone' => $clock->businessTimezone(),
-            'business_date' => $clock->todayInBusinessTz(),
-            'business_now' => $clock->nowInBusinessTz()->toIso8601String(),
+            ...$this->applySimulatedClock($clock, $targetDatetime),
             'shifted_minutes' => $minutes,
         ]);
     }

--- a/code/api/app/Http/Controllers/Api/V1/InventoryLocation/Concerns/FormatsInventoryLocation.php
+++ b/code/api/app/Http/Controllers/Api/V1/InventoryLocation/Concerns/FormatsInventoryLocation.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\InventoryLocation\Concerns;
+
+use App\Models\InventoryLocation;
+
+trait FormatsInventoryLocation
+{
+    /**
+     * @return array<string, mixed>
+     */
+    protected function baseLocationData(InventoryLocation $location): array
+    {
+        return [
+            'id' => $location->id,
+            'operating_unit_id' => $location->operating_unit_id,
+            'name' => $location->name,
+            'type' => $location->type,
+            'priority' => $location->priority,
+            'is_primary' => $location->is_primary,
+            'is_active' => $location->is_active,
+            'notes' => $location->notes,
+            'operating_unit' => [
+                'id' => $location->operatingUnit->id,
+                'name' => $location->operatingUnit->name,
+                'type' => $location->operatingUnit->type,
+                'branch' => [
+                    'id' => $location->operatingUnit->branch->id,
+                    'code' => $location->operatingUnit->branch->code,
+                    'name' => $location->operatingUnit->branch->name,
+                ],
+            ],
+        ];
+    }
+}

--- a/code/api/app/Http/Controllers/Api/V1/InventoryLocation/CreateInventoryLocationController.php
+++ b/code/api/app/Http/Controllers/Api/V1/InventoryLocation/CreateInventoryLocationController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\V1\InventoryLocation;
 
+use App\Http\Controllers\Api\V1\InventoryLocation\Concerns\FormatsInventoryLocation;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\InventoryLocation\CreateInventoryLocationRequest;
 use App\Http\Responses\Common\ResponseEntity;
@@ -22,6 +23,8 @@ use App\Models\InventoryLocation;
  */
 class CreateInventoryLocationController extends Controller
 {
+    use FormatsInventoryLocation;
+
     public function __invoke(CreateInventoryLocationRequest $request)
     {
         $location = InventoryLocation::create([
@@ -38,24 +41,7 @@ class CreateInventoryLocationController extends Controller
 
         return new ResponseEntity(
             data: [
-                'id' => $location->id,
-                'operating_unit_id' => $location->operating_unit_id,
-                'name' => $location->name,
-                'type' => $location->type,
-                'priority' => $location->priority,
-                'is_primary' => $location->is_primary,
-                'is_active' => $location->is_active,
-                'notes' => $location->notes,
-                'operating_unit' => [
-                    'id' => $location->operatingUnit->id,
-                    'name' => $location->operatingUnit->name,
-                    'type' => $location->operatingUnit->type,
-                    'branch' => [
-                        'id' => $location->operatingUnit->branch->id,
-                        'code' => $location->operatingUnit->branch->code,
-                        'name' => $location->operatingUnit->branch->name,
-                    ],
-                ],
+                ...$this->baseLocationData($location),
                 'created_at' => $location->created_at,
             ],
             status: 201

--- a/code/api/app/Http/Controllers/Api/V1/InventoryLocation/ShowInventoryLocationController.php
+++ b/code/api/app/Http/Controllers/Api/V1/InventoryLocation/ShowInventoryLocationController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\V1\InventoryLocation;
 
+use App\Http\Controllers\Api\V1\InventoryLocation\Concerns\FormatsInventoryLocation;
 use App\Http\Controllers\Controller;
 use App\Http\Responses\Common\ResponseEntity;
 use App\Models\InventoryLocation;
@@ -20,6 +21,8 @@ use App\Models\InventoryLocation;
  */
 class ShowInventoryLocationController extends Controller
 {
+    use FormatsInventoryLocation;
+
     public function __invoke(int $id)
     {
         $location = InventoryLocation::with([
@@ -39,24 +42,7 @@ class ShowInventoryLocationController extends Controller
 
         return new ResponseEntity(
             data: [
-                'id' => $location->id,
-                'operating_unit_id' => $location->operating_unit_id,
-                'name' => $location->name,
-                'type' => $location->type,
-                'priority' => $location->priority,
-                'is_primary' => $location->is_primary,
-                'is_active' => $location->is_active,
-                'notes' => $location->notes,
-                'operating_unit' => [
-                    'id' => $location->operatingUnit->id,
-                    'name' => $location->operatingUnit->name,
-                    'type' => $location->operatingUnit->type,
-                    'branch' => [
-                        'id' => $location->operatingUnit->branch->id,
-                        'code' => $location->operatingUnit->branch->code,
-                        'name' => $location->operatingUnit->branch->name,
-                    ],
-                ],
+                ...$this->baseLocationData($location),
                 'stock_summary' => [
                     'variant_count' => (int) $stockTotals->variant_count,
                     'total_on_hand' => (float) $stockTotals->total_on_hand,

--- a/code/api/app/Http/Controllers/Api/V1/Items/Concerns/FiltersItemListing.php
+++ b/code/api/app/Http/Controllers/Api/V1/Items/Concerns/FiltersItemListing.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Items\Concerns;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Request;
+
+trait FiltersItemListing
+{
+    protected function applyIsActiveFilter(Builder $query, Request $request): void
+    {
+        if ($request->filled('is_active')) {
+            $query->where('is_active', $request->boolean('is_active'));
+        }
+    }
+
+    /**
+     * @param  array<int, string>  $fields
+     */
+    protected function applySearchFilter(Builder $query, Request $request, array $fields): void
+    {
+        if (! $request->filled('search')) {
+            return;
+        }
+
+        $search = $request->search;
+
+        $query->where(function (Builder $q) use ($search, $fields) {
+            foreach ($fields as $index => $field) {
+                $method = $index === 0 ? 'where' : 'orWhere';
+                $q->{$method}($field, 'ILIKE', "%{$search}%");
+            }
+        });
+    }
+
+    protected function resolvePerPage(Request $request): int
+    {
+        return (int) $request->input('per_page', 15);
+    }
+}

--- a/code/api/app/Http/Controllers/Api/V1/Items/Concerns/FormatsItemVariant.php
+++ b/code/api/app/Http/Controllers/Api/V1/Items/Concerns/FormatsItemVariant.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Items\Concerns;
+
+use App\Models\ItemVariant;
+
+trait FormatsItemVariant
+{
+    /**
+     * @return array<string, mixed>
+     */
+    protected function baseVariantData(ItemVariant $variant): array
+    {
+        return [
+            'id' => $variant->id,
+            'item_id' => $variant->item_id,
+            'uom_id' => $variant->uom_id,
+            'code' => $variant->code,
+            'name' => $variant->name,
+            'description' => $variant->description,
+            'track_lot' => $variant->track_lot,
+            'track_serial' => $variant->track_serial,
+            'last_unit_cost' => (float) $variant->last_unit_cost,
+            'avg_unit_cost' => (float) $variant->avg_unit_cost,
+            'sale_price' => $variant->sale_price ? (float) $variant->sale_price : null,
+            'min_stock' => (float) $variant->min_stock,
+            'max_stock' => (float) $variant->max_stock,
+            'is_active' => $variant->is_active,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function variantRelations(ItemVariant $variant): array
+    {
+        return [
+            'uom' => [
+                'id' => $variant->unitOfMeasure->id,
+                'code' => $variant->unitOfMeasure->code,
+                'name' => $variant->unitOfMeasure->name,
+                'symbol' => $variant->unitOfMeasure->symbol,
+            ],
+            'item' => [
+                'id' => $variant->item->id,
+                'sku' => $variant->item->sku,
+                'name' => $variant->item->name,
+                'type' => $variant->item->type,
+            ],
+        ];
+    }
+}

--- a/code/api/app/Http/Controllers/Api/V1/Items/CreateItemVariantController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Items/CreateItemVariantController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\V1\Items;
 
+use App\Http\Controllers\Api\V1\Items\Concerns\FormatsItemVariant;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Items\CreateItemVariantRequest;
 use App\Http\Responses\Common\ResponseEntity;
@@ -34,6 +35,8 @@ use App\Models\ItemVariant;
  */
 class CreateItemVariantController extends Controller
 {
+    use FormatsItemVariant;
+
     public function __invoke(CreateItemVariantRequest $request)
     {
         $variant = ItemVariant::create([
@@ -57,32 +60,8 @@ class CreateItemVariantController extends Controller
 
         return new ResponseEntity(
             data: [
-                'id' => $variant->id,
-                'item_id' => $variant->item_id,
-                'uom_id' => $variant->uom_id,
-                'code' => $variant->code,
-                'name' => $variant->name,
-                'description' => $variant->description,
-                'track_lot' => $variant->track_lot,
-                'track_serial' => $variant->track_serial,
-                'last_unit_cost' => (float) $variant->last_unit_cost,
-                'avg_unit_cost' => (float) $variant->avg_unit_cost,
-                'sale_price' => $variant->sale_price ? (float) $variant->sale_price : null,
-                'min_stock' => (float) $variant->min_stock,
-                'max_stock' => (float) $variant->max_stock,
-                'is_active' => $variant->is_active,
-                'uom' => [
-                    'id' => $variant->unitOfMeasure->id,
-                    'code' => $variant->unitOfMeasure->code,
-                    'name' => $variant->unitOfMeasure->name,
-                    'symbol' => $variant->unitOfMeasure->symbol,
-                ],
-                'item' => [
-                    'id' => $variant->item->id,
-                    'sku' => $variant->item->sku,
-                    'name' => $variant->item->name,
-                    'type' => $variant->item->type,
-                ],
+                ...$this->baseVariantData($variant),
+                ...$this->variantRelations($variant),
                 'created_at' => $variant->created_at,
                 'updated_at' => $variant->updated_at,
             ],

--- a/code/api/app/Http/Controllers/Api/V1/Items/ListItemVariantsController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Items/ListItemVariantsController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\V1\Items;
 
+use App\Http\Controllers\Api\V1\Items\Concerns\FiltersItemListing;
 use App\Http\Controllers\Controller;
 use App\Http\Responses\Common\ResponsePaginated;
 use App\Models\ItemVariant;
@@ -34,6 +35,8 @@ use Illuminate\Http\Request;
  */
 class ListItemVariantsController extends Controller
 {
+    use FiltersItemListing;
+
     public function __invoke(Request $request)
     {
         $query = ItemVariant::with(['item', 'unitOfMeasure']);
@@ -42,20 +45,10 @@ class ListItemVariantsController extends Controller
             $query->where('item_id', $request->item_id);
         }
 
-        if ($request->filled('is_active')) {
-            $query->where('is_active', $request->boolean('is_active'));
-        }
+        $this->applyIsActiveFilter($query, $request);
+        $this->applySearchFilter($query, $request, ['code', 'name']);
 
-        if ($request->filled('search')) {
-            $search = $request->search;
-            $query->where(function ($q) use ($search) {
-                $q->where('code', 'ILIKE', "%{$search}%")
-                    ->orWhere('name', 'ILIKE', "%{$search}%");
-            });
-        }
-
-        $perPage = $request->input('per_page', 15);
-        $variants = $query->orderBy('code')->paginate($perPage);
+        $variants = $query->orderBy('code')->paginate($this->resolvePerPage($request));
 
         return new ResponsePaginated(paginator: $variants);
     }

--- a/code/api/app/Http/Controllers/Api/V1/Items/ListItemsController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Items/ListItemsController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\V1\Items;
 
+use App\Http\Controllers\Api\V1\Items\Concerns\FiltersItemListing;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Items\ListItemsRequest;
 use App\Http\Responses\Common\ResponsePaginated;
@@ -37,6 +38,8 @@ use App\Models\Item;
  */
 class ListItemsController extends Controller
 {
+    use FiltersItemListing;
+
     public function __invoke(ListItemsRequest $request)
     {
         $query = Item::query();
@@ -53,20 +56,10 @@ class ListItemsController extends Controller
             $query->where('is_perishable', $request->boolean('is_perishable'));
         }
 
-        if ($request->filled('is_active')) {
-            $query->where('is_active', $request->boolean('is_active'));
-        }
+        $this->applyIsActiveFilter($query, $request);
+        $this->applySearchFilter($query, $request, ['sku', 'name']);
 
-        if ($request->filled('search')) {
-            $search = $request->search;
-            $query->where(function ($q) use ($search) {
-                $q->where('sku', 'ILIKE', "%{$search}%")
-                    ->orWhere('name', 'ILIKE', "%{$search}%");
-            });
-        }
-
-        $perPage = $request->input('per_page', 15);
-        $items = $query->orderBy('sku')->paginate($perPage);
+        $items = $query->orderBy('sku')->paginate($this->resolvePerPage($request));
 
         return new ResponsePaginated(paginator: $items);
     }

--- a/code/api/app/Http/Controllers/Api/V1/Items/ShowItemVariantController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Items/ShowItemVariantController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\V1\Items;
 
+use App\Http\Controllers\Api\V1\Items\Concerns\FormatsItemVariant;
 use App\Http\Controllers\Controller;
 use App\Http\Responses\Common\ResponseEntity;
 use App\Models\ItemVariant;
@@ -32,6 +33,8 @@ use App\Models\ItemVariant;
  */
 class ShowItemVariantController extends Controller
 {
+    use FormatsItemVariant;
+
     public function __invoke(int $id)
     {
         $variant = ItemVariant::with(['item', 'unitOfMeasure', 'stock.inventoryLocation', 'mediaAttachments.mediaGallery'])
@@ -42,35 +45,11 @@ class ShowItemVariantController extends Controller
 
         return new ResponseEntity(
             data: [
-                'id' => $variant->id,
-                'item_id' => $variant->item_id,
-                'uom_id' => $variant->uom_id,
-                'code' => $variant->code,
-                'name' => $variant->name,
-                'description' => $variant->description,
-                'track_lot' => $variant->track_lot,
-                'track_serial' => $variant->track_serial,
-                'last_unit_cost' => (float) $variant->last_unit_cost,
-                'avg_unit_cost' => (float) $variant->avg_unit_cost,
-                'sale_price' => $variant->sale_price ? (float) $variant->sale_price : null,
-                'min_stock' => (float) $variant->min_stock,
-                'max_stock' => (float) $variant->max_stock,
-                'is_active' => $variant->is_active,
+                ...$this->baseVariantData($variant),
                 'total_on_hand' => (float) $totalOnHand,
                 'total_reserved' => (float) $totalReserved,
                 'total_available' => (float) ($totalOnHand - $totalReserved),
-                'uom' => [
-                    'id' => $variant->unitOfMeasure->id,
-                    'code' => $variant->unitOfMeasure->code,
-                    'name' => $variant->unitOfMeasure->name,
-                    'symbol' => $variant->unitOfMeasure->symbol,
-                ],
-                'item' => [
-                    'id' => $variant->item->id,
-                    'sku' => $variant->item->sku,
-                    'name' => $variant->item->name,
-                    'type' => $variant->item->type,
-                ],
+                ...$this->variantRelations($variant),
                 'created_at' => $variant->created_at,
                 'updated_at' => $variant->updated_at,
             ]

--- a/code/api/app/Http/Controllers/Api/V1/Items/UpdateItemVariantController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Items/UpdateItemVariantController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\V1\Items;
 
+use App\Http\Controllers\Api\V1\Items\Concerns\FormatsItemVariant;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Items\UpdateItemVariantRequest;
 use App\Http\Responses\Common\ResponseEntity;
@@ -37,6 +38,8 @@ use App\Models\ItemVariant;
  */
 class UpdateItemVariantController extends Controller
 {
+    use FormatsItemVariant;
+
     public function __invoke(UpdateItemVariantRequest $request, int $id)
     {
         $variant = ItemVariant::findOrFail($id);
@@ -45,20 +48,7 @@ class UpdateItemVariantController extends Controller
 
         return new ResponseEntity(
             data: [
-                'id' => $variant->id,
-                'item_id' => $variant->item_id,
-                'uom_id' => $variant->uom_id,
-                'code' => $variant->code,
-                'name' => $variant->name,
-                'description' => $variant->description,
-                'track_lot' => $variant->track_lot,
-                'track_serial' => $variant->track_serial,
-                'last_unit_cost' => (float) $variant->last_unit_cost,
-                'avg_unit_cost' => (float) $variant->avg_unit_cost,
-                'sale_price' => $variant->sale_price ? (float) $variant->sale_price : null,
-                'min_stock' => (float) $variant->min_stock,
-                'max_stock' => (float) $variant->max_stock,
-                'is_active' => $variant->is_active,
+                ...$this->baseVariantData($variant),
                 'created_at' => $variant->created_at,
                 'updated_at' => $variant->updated_at,
             ]

--- a/code/api/app/Http/Controllers/Api/V1/Stock/Concerns/SummarizesStock.php
+++ b/code/api/app/Http/Controllers/Api/V1/Stock/Concerns/SummarizesStock.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Stock\Concerns;
+
+use App\Models\Stock;
+use Illuminate\Support\Collection;
+
+trait SummarizesStock
+{
+    /**
+     * @return array<string, mixed>
+     */
+    protected function stockMoneyFields(Stock $stock): array
+    {
+        return [
+            'on_hand' => (float) $stock->on_hand,
+            'reserved' => (float) $stock->reserved,
+            'available' => (float) $stock->available,
+            'weighted_avg_cost' => (float) $stock->weighted_avg_cost,
+            'total_value' => (float) ($stock->on_hand * $stock->weighted_avg_cost),
+        ];
+    }
+
+    /**
+     * @param  Collection<int, Stock>  $stockRecords
+     * @return array<string, mixed>
+     */
+    protected function stockTotals(Collection $stockRecords): array
+    {
+        return [
+            'total_on_hand' => (float) $stockRecords->sum('on_hand'),
+            'total_reserved' => (float) $stockRecords->sum('reserved'),
+            'total_available' => (float) $stockRecords->sum('available'),
+        ];
+    }
+}

--- a/code/api/app/Http/Controllers/Api/V1/Stock/StockByLocationController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Stock/StockByLocationController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\V1\Stock;
 
+use App\Http\Controllers\Api\V1\Stock\Concerns\SummarizesStock;
 use App\Http\Controllers\Controller;
 use App\Http\Responses\Common\ResponseEntity;
 use App\Models\InventoryLocation;
@@ -21,6 +22,8 @@ use App\Models\Stock;
  */
 class StockByLocationController extends Controller
 {
+    use SummarizesStock;
+
     public function __invoke(int $id)
     {
         $location = InventoryLocation::findOrFail($id);
@@ -38,19 +41,13 @@ class StockByLocationController extends Controller
                 'item_variant_name' => $stock->itemVariant->name,
                 'item_name' => $stock->itemVariant->item->name,
                 'item_sku' => $stock->itemVariant->item->sku,
-                'on_hand' => (float) $stock->on_hand,
-                'reserved' => (float) $stock->reserved,
-                'available' => (float) $stock->available,
-                'weighted_avg_cost' => (float) $stock->weighted_avg_cost,
-                'total_value' => (float) ($stock->on_hand * $stock->weighted_avg_cost),
+                ...$this->stockMoneyFields($stock),
             ];
         });
 
         $summary = [
             'total_variants' => $stockRecords->count(),
-            'total_on_hand' => (float) $stockRecords->sum('on_hand'),
-            'total_reserved' => (float) $stockRecords->sum('reserved'),
-            'total_available' => (float) $stockRecords->sum('available'),
+            ...$this->stockTotals($stockRecords),
             'total_inventory_value' => (float) $stockRecords->map(fn ($s) => $s->on_hand * $s->weighted_avg_cost)->sum(),
         ];
 

--- a/code/api/app/Http/Controllers/Api/V1/Stock/StockByVariantController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Stock/StockByVariantController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\V1\Stock;
 
+use App\Http\Controllers\Api\V1\Stock\Concerns\SummarizesStock;
 use App\Http\Controllers\Controller;
 use App\Http\Responses\Common\ResponseEntity;
 use App\Models\ItemVariant;
@@ -21,6 +22,8 @@ use App\Models\Stock;
  */
 class StockByVariantController extends Controller
 {
+    use SummarizesStock;
+
     public function __invoke(int $id)
     {
         $variant = ItemVariant::with(['item'])->findOrFail($id);
@@ -37,19 +40,13 @@ class StockByVariantController extends Controller
                 'location_name' => $stock->inventoryLocation->name,
                 'location_type' => $stock->inventoryLocation->type,
                 'operating_unit' => $stock->inventoryLocation->operatingUnit->name,
-                'on_hand' => (float) $stock->on_hand,
-                'reserved' => (float) $stock->reserved,
-                'available' => (float) $stock->available,
-                'weighted_avg_cost' => (float) $stock->weighted_avg_cost,
-                'total_value' => (float) ($stock->on_hand * $stock->weighted_avg_cost),
+                ...$this->stockMoneyFields($stock),
             ];
         });
 
         $summary = [
             'total_locations' => $stockRecords->count(),
-            'total_on_hand' => (float) $stockRecords->sum('on_hand'),
-            'total_reserved' => (float) $stockRecords->sum('reserved'),
-            'total_available' => (float) $stockRecords->sum('available'),
+            ...$this->stockTotals($stockRecords),
             'avg_weighted_cost' => (float) $stockRecords->avg('weighted_avg_cost'),
             'total_inventory_value' => (float) $stockRecords->map(fn ($s) => $s->on_hand * $s->weighted_avg_cost)->sum(),
         ];

--- a/doc/tasks/backlog/infrastructure/282-fix-sonarcloud-duplication-api.md
+++ b/doc/tasks/backlog/infrastructure/282-fix-sonarcloud-duplication-api.md
@@ -27,7 +27,7 @@ Baseline (via `GET /api/measures/component` and `GET /api/measures/component_tre
 - [ ] 🔨 **EmployeeSeeder internal duplication:** two 29-line blocks within the same file (lines ~103, ~168) — likely two near-identical employee/schedule definitions that can be parameterized into a loop or shared private method.
 - [ ] 🔨 **CoreTestSeeder internal duplication:** two 33-line blocks within the same file (lines ~438, ~449) — same pattern, needs inspection.
 - [ ] 🔍 **InventoryLocation/UnitsOfMeasure Request `rules()` shape overlap:** SonarCloud flags `CreateInventoryLocationRequest`, `UpdateInventoryLocationRequest`, and `UpdateUnitOfMeasureRequest` as mutually duplicate (~20-line blocks), but inspection shows these are different domains with different field names — the "duplication" is just the coincidental array-literal shape (`'field' => ['nullable', 'string', 'max:N']` repeated structure), not real copy-paste logic. Forcing a shared abstraction here would reduce clarity for a marginal metric win. Recommend: leave as-is, document as an accepted/won't-fix false positive.
-- [ ] 🔨 **Controller response-shaping duplication (8 files):** `InventoryLocation` Show/Create controllers, `Items` Show/Create/Update/List controllers, `Stock` ByVariant/ByLocation controllers, and `Devtools` ShiftClock/SetClock controllers each hand-build a similar response array or repeat the same clock-state-update-and-respond block. Candidate: extract to API Resource classes (e.g. `InventoryLocationResource`) for the data-shaping controllers, and a small trait for the Devtools clock controllers. Needs care to preserve exact JSON shape (Swagger schemas, existing consumers).
+- [x] 🔨 **Controller response-shaping duplication (8 files):** `InventoryLocation` Show/Create controllers, `Items` Show/Create/Update/List controllers, `Stock` ByVariant/ByLocation controllers, and `Devtools` ShiftClock/SetClock controllers each hand-built a similar response array or repeated the same clock-state-update-and-respond block. Fixed via 5 domain-scoped `Concerns` traits (not JsonResource — kept the existing `ResponseEntity`/array-based envelope to avoid touching the response-wrapping mechanism): `FormatsInventoryLocation`, `AppliesSimulatedClock`, `FormatsItemVariant`, `FiltersItemListing` (the actual Sonar-flagged overlap for the List pair was query-filter duplication, not response shaping), `SummarizesStock`. *(Session: 2026-07-22/23)*
 - [ ] 🔧 **Migrations duplication (2 pairs):** `create_cash_expenses_table` / `create_cash_adjustments_table`, and `create_vacation_request_dates_table` / `create_leave_dates_table` share ~20-line column-definition blocks. These are already-applied migrations — recommend excluding `database/migrations/**` via `sonar.cpd.exclusions` in `sonar-project.properties` rather than editing historical migration files, since migrations are point-in-time schema snapshots and refactoring them retroactively risks breaking chronological schema application for no behavioral benefit.
 - [ ] 🧪 Run full test suite (`php artisan test`) and `./vendor/bin/pint` after each batch — no behavior change is expected, only structure
 - [ ] 🔍 Re-check https://sonarcloud.io/component_measures?id=pakodiazdev_sushigo-api&metric=duplicated_lines_density shows an improved density at the end
@@ -47,12 +47,14 @@ Baseline (via `GET /api/measures/component` and `GET /api/measures/component_tre
 ### 📊 Estimates
 - **Optimistic:** `4h` (mechanical extractions, assuming clean matches)
 - **Pessimistic:** `10h` (seeder/migration clusters may need judgment calls on env-specific values; controller cluster needs care around Swagger/response-shape parity)
-- **Tracked:** `0.4h` (in progress — 2 of 9 clusters complete)
+- **Tracked:** `1.88h` (in progress — 3 of 9 clusters complete)
 
 ### 📅 Sessions
 ```json
 [
-  { "date": "2026-07-22", "start": "15:07", "end": "15:31" }
+  { "date": "2026-07-22", "start": "15:07", "end": "15:31" },
+  { "date": "2026-07-22", "start": "23:10", "end": "24:00" },
+  { "date": "2026-07-23", "start": "00:00", "end": "00:39" }
 ]
 ```
 
@@ -64,6 +66,11 @@ Baseline (via `GET /api/measures/component` and `GET /api/measures/component_tre
 - **Actual:** 24m
 
 **Justification:** Both clusters were found via the SonarCloud public API (`/api/measures/component_tree` sorted by `duplicated_lines`, then `/api/duplications/show` per file to see exact matched line ranges) rather than guessing from the file list — this pinpointed exactly which methods/blocks were byte-identical vs. merely similar. Both fixes were mechanical: `CastsRequestFields` trait (2 one-line helper methods) collapsed 10 near-identical `prepareForValidation()` bodies into one-line calls; `ConvertsUomQuantities` trait moved 2 byte-identical/near-identical methods (`getConversion()`, `convertToBaseQuantity()`) out of `StockOutService`/`OpeningBalanceService` with zero behavior change (verified against `StockOutTest`/`OpeningBalanceTest`, including UOM-conversion-specific cases). No dedicated Feature/HTTP tests exist yet for the CashAdjustments endpoints (only Service-level unit tests), so that cluster's fix couldn't be regression-tested via HTTP, only via `php -l` + full suite + manual code review confirming the extraction preserved every conditional/cast exactly.
+
+### ✅ Controller response-shaping duplication
+- **Actual:** ~1.05h
+
+**Justification:** Used `/api/duplications/show` per flagged file (not just `/api/measures/component_tree`) to get the exact matched line ranges for all 5 sub-pairs before writing any code — this revealed that the `ListItems`/`ListItemVariants` pair's "duplication" was actually query-filter logic (`is_active` boolean filter, ILIKE search, `per_page` default), not response shaping as the issue's title suggested; the fix was scoped to what Sonar actually flagged rather than the issue's approximate description. Chose plain PHP traits over Laravel API Resources (`JsonResource`) for the data-shaping clusters (InventoryLocation, ItemVariant, Stock) specifically to avoid touching the response-wrapping mechanism (`ResponseEntity`) — the extraction is a pure copy-paste of the existing array-building code into a shared method, so the JSON shape risk is structurally eliminated rather than needing manual verification. Verified zero behavior change three ways: `php artisan route:list --path=api --json` diffed before/after (163 routes, byte-identical), the 62 Feature tests directly covering the 11 touched controllers (`InventoryLocationCrudTest`, `StockQueryTest`, `ClockEndpointsTest`, `ItemCrudTest`, `ItemVariantCrudTest`), and the full suite (1294 tests / 3852 assertions, all green).
 
 ---
 


### PR DESCRIPTION
## Summary

One of the 9 duplication clusters tracked in #282 (SonarCloud code duplication, 883 lines baseline). This PR fixes **Controller response-shaping duplication** — 11 controllers across 4 domains hand-built near-identical response arrays or repeated the same clock-state-update-and-respond block.

- Extracted 5 domain-scoped `Concerns` traits, each colocated with the controllers it serves:
  - `InventoryLocation\Concerns\FormatsInventoryLocation` — shared location + operating-unit + branch fields (Create/Show)
  - `Devtools\Concerns\AppliesSimulatedClock` — clock-state update + cache clear + response snapshot (SetClock/ShiftClock)
  - `Items\Concerns\FormatsItemVariant` — shared variant fields + uom/item relation shaping (Create/Update/Show)
  - `Items\Concerns\FiltersItemListing` — `is_active` filter, parameterized ILIKE search, `per_page` resolution (ListItems/ListItemVariants). Note: SonarCloud's flagged overlap here was actually query-filter logic, not response shaping as the issue title suggested — scoped the fix to what was actually duplicated.
  - `Stock\Concerns\SummarizesStock` — per-line money fields + running totals (StockByLocation/StockByVariant)
- Kept the existing `ResponseEntity` array-based envelope everywhere (did not switch to `JsonResource`) — the extraction is a pure copy-paste of existing array-building code into a shared method, so JSON shape is structurally identical rather than needing manual re-verification.

## Test plan
- [x] `php -l` on all 16 touched/new files — no syntax errors
- [x] `./vendor/bin/pint --dirty` — clean, no formatting diffs
- [x] `php artisan route:list --path=api --json` diffed before/after — 163 routes, byte-identical
- [x] Targeted Feature tests for the 11 touched controllers: `InventoryLocationCrudTest`, `StockQueryTest`, `ClockEndpointsTest`, `ItemCrudTest`, `ItemVariantCrudTest` — 62/62 passed
- [x] Full PHPUnit suite: 1294 tests / 3852 assertions, all green

## Closes
Refs #282 (this PR closes only the "Controller response-shaping duplication" cluster item — issue stays open for the remaining 6 clusters)

## Workspace
`sushigo-c` — `refactor/282-controller-response-shaping`

🤖 Generated with [Claude Code](https://claude.com/claude-code)