### PR TITLE
🐛 [#291][c] - Fix broken model binding and missing authorization in CashAdjustments 🔒

### DIFF
--- a/code/api/app/Http/Controllers/CashAdjustments/BankAccounts/DeleteBankAccountController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/BankAccounts/DeleteBankAccountController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\CashAdjustments\BankAccounts;
 use App\Http\Controllers\Controller;
 use App\Models\BankAccount;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Delete(
@@ -24,8 +25,12 @@ use Illuminate\Http\JsonResponse;
  */
 class DeleteBankAccountController extends Controller
 {
-    public function __invoke(BankAccount $bankAccount): JsonResponse
+    public function __invoke(int $id): JsonResponse
     {
+        $bankAccount = BankAccount::findOrFail($id);
+
+        Gate::authorize('delete', $bankAccount);
+
         if ($bankAccount->adjustmentLines()->exists() || $bankAccount->expenses()->exists()) {
             return response()->json([
                 'message' => 'Cannot delete bank account with existing transactions',

--- a/code/api/app/Http/Controllers/CashAdjustments/BankAccounts/ShowBankAccountController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/BankAccounts/ShowBankAccountController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\CashAdjustments\BankAccounts;
 use App\Http\Controllers\Controller;
 use App\Models\BankAccount;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Get(
@@ -23,8 +24,12 @@ use Illuminate\Http\JsonResponse;
  */
 class ShowBankAccountController extends Controller
 {
-    public function __invoke(BankAccount $bankAccount): JsonResponse
+    public function __invoke(int $id): JsonResponse
     {
+        $bankAccount = BankAccount::findOrFail($id);
+
+        Gate::authorize('view', $bankAccount);
+
         $bankAccount->load('branch');
 
         return response()->json([

--- a/code/api/app/Http/Controllers/CashAdjustments/BankAccounts/UpdateBankAccountController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/BankAccounts/UpdateBankAccountController.php
@@ -31,11 +31,11 @@ use Illuminate\Http\JsonResponse;
  */
 class UpdateBankAccountController extends Controller
 {
-    public function __invoke(UpdateBankAccountRequest $request, BankAccount $bankAccount): JsonResponse
+    public function __invoke(UpdateBankAccountRequest $request, int $id): JsonResponse
     {
-        $validated = $request->validated();
+        $bankAccount = BankAccount::findOrFail($id);
 
-        $bankAccount->update($validated);
+        $bankAccount->update($request->validated());
 
         return response()->json([
             'message' => 'Bank account updated successfully',

--- a/code/api/app/Http/Controllers/CashAdjustments/CashAdjustments/DeleteCashAdjustmentController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashAdjustments/DeleteCashAdjustmentController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\CashAdjustment;
 use App\Services\CashAdjustments\CashAdjustmentService;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Delete(
@@ -29,8 +30,12 @@ class DeleteCashAdjustmentController extends Controller
         private CashAdjustmentService $adjustmentService
     ) {}
 
-    public function __invoke(CashAdjustment $cashAdjustment): JsonResponse
+    public function __invoke(int $id): JsonResponse
     {
+        $cashAdjustment = CashAdjustment::findOrFail($id);
+
+        Gate::authorize('delete', $cashAdjustment);
+
         try {
             $this->adjustmentService->deleteAdjustment($cashAdjustment);
 

--- a/code/api/app/Http/Controllers/CashAdjustments/CashAdjustments/PostCashAdjustmentController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashAdjustments/PostCashAdjustmentController.php
@@ -7,6 +7,7 @@ use App\Models\CashAdjustment;
 use App\Services\CashAdjustments\CashAdjustmentService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Post(
@@ -31,8 +32,12 @@ class PostCashAdjustmentController extends Controller
         private CashAdjustmentService $adjustmentService
     ) {}
 
-    public function __invoke(CashAdjustment $cashAdjustment): JsonResponse
+    public function __invoke(int $id): JsonResponse
     {
+        $cashAdjustment = CashAdjustment::findOrFail($id);
+
+        Gate::authorize('post', $cashAdjustment);
+
         try {
             $postedAdjustment = $this->adjustmentService->postAdjustment(
                 $cashAdjustment,

--- a/code/api/app/Http/Controllers/CashAdjustments/CashAdjustments/ShowCashAdjustmentController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashAdjustments/ShowCashAdjustmentController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\CashAdjustments\CashAdjustments;
 use App\Http\Controllers\Controller;
 use App\Models\CashAdjustment;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Get(
@@ -23,8 +24,12 @@ use Illuminate\Http\JsonResponse;
  */
 class ShowCashAdjustmentController extends Controller
 {
-    public function __invoke(CashAdjustment $cashAdjustment): JsonResponse
+    public function __invoke(int $id): JsonResponse
     {
+        $cashAdjustment = CashAdjustment::findOrFail($id);
+
+        Gate::authorize('view', $cashAdjustment);
+
         $cashAdjustment->load([
             'cashSession.cashRegister',
             'lines.cardTerminal',

--- a/code/api/app/Http/Controllers/CashAdjustments/CashExpenses/DeleteCashExpenseController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashExpenses/DeleteCashExpenseController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\CashExpense;
 use App\Services\CashAdjustments\CashExpenseService;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Delete(
@@ -29,8 +30,12 @@ class DeleteCashExpenseController extends Controller
         private CashExpenseService $expenseService
     ) {}
 
-    public function __invoke(CashExpense $cashExpense): JsonResponse
+    public function __invoke(int $id): JsonResponse
     {
+        $cashExpense = CashExpense::findOrFail($id);
+
+        Gate::authorize('delete', $cashExpense);
+
         try {
             $this->expenseService->deleteExpense($cashExpense);
 

--- a/code/api/app/Http/Controllers/CashAdjustments/CashExpenses/PostCashExpenseController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashExpenses/PostCashExpenseController.php
@@ -7,6 +7,7 @@ use App\Models\CashExpense;
 use App\Services\CashAdjustments\CashExpenseService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Post(
@@ -31,8 +32,12 @@ class PostCashExpenseController extends Controller
         private CashExpenseService $expenseService
     ) {}
 
-    public function __invoke(CashExpense $cashExpense): JsonResponse
+    public function __invoke(int $id): JsonResponse
     {
+        $cashExpense = CashExpense::findOrFail($id);
+
+        Gate::authorize('post', $cashExpense);
+
         try {
             $postedExpense = $this->expenseService->postExpense(
                 $cashExpense,

--- a/code/api/app/Http/Controllers/CashAdjustments/CashExpenses/ShowCashExpenseController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashExpenses/ShowCashExpenseController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\CashAdjustments\CashExpenses;
 use App\Http\Controllers\Controller;
 use App\Models\CashExpense;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Get(
@@ -23,8 +24,12 @@ use Illuminate\Http\JsonResponse;
  */
 class ShowCashExpenseController extends Controller
 {
-    public function __invoke(CashExpense $cashExpense): JsonResponse
+    public function __invoke(int $id): JsonResponse
     {
+        $cashExpense = CashExpense::findOrFail($id);
+
+        Gate::authorize('view', $cashExpense);
+
         $cashExpense->load([
             'cashSession.cashRegister',
             'cardTerminal',

--- a/code/api/app/Http/Controllers/CashAdjustments/CashExpenses/UpdateCashExpenseController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashExpenses/UpdateCashExpenseController.php
@@ -36,8 +36,10 @@ class UpdateCashExpenseController extends Controller
         private CashExpenseService $expenseService
     ) {}
 
-    public function __invoke(UpdateCashExpenseRequest $request, CashExpense $cashExpense): JsonResponse
+    public function __invoke(UpdateCashExpenseRequest $request, int $id): JsonResponse
     {
+        $cashExpense = CashExpense::findOrFail($id);
+
         $validated = $request->validated();
 
         try {

--- a/code/api/app/Http/Controllers/CashAdjustments/CashRegisters/DeleteCashRegisterController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashRegisters/DeleteCashRegisterController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\CashAdjustments\CashRegisters;
 use App\Http\Controllers\Controller;
 use App\Models\CashRegister;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Delete(
@@ -24,8 +25,12 @@ use Illuminate\Http\JsonResponse;
  */
 class DeleteCashRegisterController extends Controller
 {
-    public function __invoke(CashRegister $cashRegister): JsonResponse
+    public function __invoke(int $id): JsonResponse
     {
+        $cashRegister = CashRegister::findOrFail($id);
+
+        Gate::authorize('delete', $cashRegister);
+
         // Check if register has sessions
         if ($cashRegister->sessions()->exists()) {
             return response()->json([

--- a/code/api/app/Http/Controllers/CashAdjustments/CashRegisters/ShowCashRegisterController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashRegisters/ShowCashRegisterController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\CashAdjustments\CashRegisters;
 use App\Http\Controllers\Controller;
 use App\Models\CashRegister;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Get(
@@ -23,8 +24,12 @@ use Illuminate\Http\JsonResponse;
  */
 class ShowCashRegisterController extends Controller
 {
-    public function __invoke(CashRegister $cashRegister): JsonResponse
+    public function __invoke(int $id): JsonResponse
     {
+        $cashRegister = CashRegister::findOrFail($id);
+
+        Gate::authorize('view', $cashRegister);
+
         $cashRegister->load(['branch', 'operatingUnit', 'sessions' => function ($query) {
             $query->latest('operating_date')->limit(5);
         }]);

--- a/code/api/app/Http/Controllers/CashAdjustments/CashRegisters/UpdateCashRegisterController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashRegisters/UpdateCashRegisterController.php
@@ -31,11 +31,11 @@ use Illuminate\Http\JsonResponse;
  */
 class UpdateCashRegisterController extends Controller
 {
-    public function __invoke(UpdateCashRegisterRequest $request, CashRegister $cashRegister): JsonResponse
+    public function __invoke(UpdateCashRegisterRequest $request, int $id): JsonResponse
     {
-        $validated = $request->validated();
+        $cashRegister = CashRegister::findOrFail($id);
 
-        $cashRegister->update($validated);
+        $cashRegister->update($request->validated());
 
         return response()->json([
             'message' => 'Cash register updated successfully',

--- a/code/api/app/Http/Controllers/CashAdjustments/CashSessions/GetSessionSummaryController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashSessions/GetSessionSummaryController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\CashSession;
 use App\Services\CashAdjustments\CashSessionService;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Get(
@@ -29,8 +30,12 @@ class GetSessionSummaryController extends Controller
         private CashSessionService $sessionService
     ) {}
 
-    public function __invoke(CashSession $cashSession): JsonResponse
+    public function __invoke(int $id): JsonResponse
     {
+        $cashSession = CashSession::findOrFail($id);
+
+        Gate::authorize('view', $cashSession);
+
         $summary = $this->sessionService->getSessionSummary($cashSession);
 
         return response()->json([

--- a/code/api/app/Http/Controllers/CashAdjustments/CashSessions/PostCashSessionController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashSessions/PostCashSessionController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\CashSession;
 use App\Services\CashAdjustments\CashSessionService;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Post(
@@ -30,8 +31,12 @@ class PostCashSessionController extends Controller
         private CashSessionService $sessionService
     ) {}
 
-    public function __invoke(CashSession $cashSession): JsonResponse
+    public function __invoke(int $id): JsonResponse
     {
+        $cashSession = CashSession::findOrFail($id);
+
+        Gate::authorize('post', $cashSession);
+
         try {
             $postedSession = $this->sessionService->postSession($cashSession);
 

--- a/code/api/app/Http/Controllers/CashAdjustments/CashSessions/ShowCashSessionController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashSessions/ShowCashSessionController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\CashAdjustments\CashSessions;
 use App\Http\Controllers\Controller;
 use App\Models\CashSession;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Get(
@@ -23,8 +24,12 @@ use Illuminate\Http\JsonResponse;
  */
 class ShowCashSessionController extends Controller
 {
-    public function __invoke(CashSession $cashSession): JsonResponse
+    public function __invoke(int $id): JsonResponse
     {
+        $cashSession = CashSession::findOrFail($id);
+
+        Gate::authorize('view', $cashSession);
+
         $cashSession->load([
             'cashRegister.branch',
             'adjustments.lines',

--- a/code/api/app/Http/Controllers/CashAdjustments/CashSessions/UpdateCashSessionController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashSessions/UpdateCashSessionController.php
@@ -31,11 +31,11 @@ use Illuminate\Http\JsonResponse;
  */
 class UpdateCashSessionController extends Controller
 {
-    public function __invoke(UpdateCashSessionRequest $request, CashSession $cashSession): JsonResponse
+    public function __invoke(UpdateCashSessionRequest $request, int $id): JsonResponse
     {
-        $validated = $request->validated();
+        $cashSession = CashSession::findOrFail($id);
 
-        $cashSession->update($validated);
+        $cashSession->update($request->validated());
 
         return response()->json([
             'message' => 'Cash session updated successfully',

--- a/code/api/app/Http/Controllers/CashAdjustments/CashTerminals/DeleteCashTerminalController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashTerminals/DeleteCashTerminalController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\CashAdjustments\CashTerminals;
 use App\Http\Controllers\Controller;
 use App\Models\CashTerminal;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Delete(
@@ -24,8 +25,12 @@ use Illuminate\Http\JsonResponse;
  */
 class DeleteCashTerminalController extends Controller
 {
-    public function __invoke(CashTerminal $cashTerminal): JsonResponse
+    public function __invoke(int $id): JsonResponse
     {
+        $cashTerminal = CashTerminal::findOrFail($id);
+
+        Gate::authorize('delete', $cashTerminal);
+
         if ($cashTerminal->adjustmentLines()->exists() || $cashTerminal->expenses()->exists()) {
             return response()->json([
                 'message' => 'Cannot delete terminal with existing transactions',

--- a/code/api/app/Http/Controllers/CashAdjustments/CashTerminals/ShowCashTerminalController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashTerminals/ShowCashTerminalController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\CashAdjustments\CashTerminals;
 use App\Http\Controllers\Controller;
 use App\Models\CashTerminal;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Get(
@@ -23,8 +24,12 @@ use Illuminate\Http\JsonResponse;
  */
 class ShowCashTerminalController extends Controller
 {
-    public function __invoke(CashTerminal $cashTerminal): JsonResponse
+    public function __invoke(int $id): JsonResponse
     {
+        $cashTerminal = CashTerminal::findOrFail($id);
+
+        Gate::authorize('view', $cashTerminal);
+
         $cashTerminal->load('branch');
 
         return response()->json([

--- a/code/api/app/Http/Controllers/CashAdjustments/CashTerminals/UpdateCashTerminalController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashTerminals/UpdateCashTerminalController.php
@@ -31,11 +31,11 @@ use Illuminate\Http\JsonResponse;
  */
 class UpdateCashTerminalController extends Controller
 {
-    public function __invoke(UpdateCashTerminalRequest $request, CashTerminal $cashTerminal): JsonResponse
+    public function __invoke(UpdateCashTerminalRequest $request, int $id): JsonResponse
     {
-        $validated = $request->validated();
+        $cashTerminal = CashTerminal::findOrFail($id);
 
-        $cashTerminal->update($validated);
+        $cashTerminal->update($request->validated());
 
         return response()->json([
             'message' => 'Cash terminal updated successfully',

--- a/code/api/app/Http/Requests/CashAdjustments/BankAccounts/UpdateBankAccountRequest.php
+++ b/code/api/app/Http/Requests/CashAdjustments/BankAccounts/UpdateBankAccountRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\CashAdjustments\BankAccounts;
 
 use App\Http\Requests\Concerns\CastsRequestFields;
+use App\Models\BankAccount;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
@@ -23,7 +24,13 @@ class UpdateBankAccountRequest extends FormRequest
 
     public function authorize(): bool
     {
-        return $this->user()->can('update', $this->route('bankAccount'));
+        $bankAccount = BankAccount::find($this->route('id'));
+
+        if (! $bankAccount) {
+            abort(404);
+        }
+
+        return $this->user()->can('update', $bankAccount);
     }
 
     public function rules(): array

--- a/code/api/app/Http/Requests/CashAdjustments/CashExpenses/UpdateCashExpenseRequest.php
+++ b/code/api/app/Http/Requests/CashAdjustments/CashExpenses/UpdateCashExpenseRequest.php
@@ -5,6 +5,7 @@ namespace App\Http\Requests\CashAdjustments\CashExpenses;
 use App\Http\Requests\Concerns\CastsRequestFields;
 use App\Http\Requests\Concerns\SharesValidationMessages;
 use App\Http\Requests\Concerns\ValidatesTenderTypeReference;
+use App\Models\CashExpense;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Validator;
 
@@ -30,15 +31,21 @@ class UpdateCashExpenseRequest extends FormRequest
     use SharesValidationMessages;
     use ValidatesTenderTypeReference;
 
+    private ?CashExpense $cashExpense = null;
+
     public function authorize(): bool
     {
-        $expense = $this->route('cashExpense');
+        $this->cashExpense = CashExpense::find($this->route('id'));
 
-        if ($expense->isPosted()) {
+        if (! $this->cashExpense) {
+            abort(404);
+        }
+
+        if ($this->cashExpense->isPosted()) {
             return false;
         }
 
-        return $this->user()->can('update', $expense);
+        return $this->user()->can('update', $this->cashExpense);
     }
 
     public function rules(): array
@@ -65,13 +72,11 @@ class UpdateCashExpenseRequest extends FormRequest
     public function withValidator(Validator $validator): void
     {
         $validator->after(function ($validator) {
-            $expense = $this->route('cashExpense');
-
             $this->requireTenderTypeReference(
                 $validator,
-                $this->input('tender_type', $expense->tender_type),
-                $this->input('card_terminal_id', $expense->card_terminal_id),
-                $this->input('bank_account_id', $expense->bank_account_id)
+                $this->input('tender_type', $this->cashExpense->tender_type),
+                $this->input('card_terminal_id', $this->cashExpense->card_terminal_id),
+                $this->input('bank_account_id', $this->cashExpense->bank_account_id)
             );
         });
     }

--- a/code/api/app/Http/Requests/CashAdjustments/CashRegisters/UpdateCashRegisterRequest.php
+++ b/code/api/app/Http/Requests/CashAdjustments/CashRegisters/UpdateCashRegisterRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests\CashAdjustments\CashRegisters;
 
 use App\Http\Requests\Concerns\CastsRequestFields;
 use App\Http\Requests\Concerns\SharesValidationMessages;
+use App\Models\CashRegister;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
@@ -23,18 +24,24 @@ class UpdateCashRegisterRequest extends FormRequest
     use CastsRequestFields;
     use SharesValidationMessages;
 
+    private ?CashRegister $cashRegister = null;
+
     public function authorize(): bool
     {
-        return $this->user()->can('update', $this->route('cashRegister'));
+        $this->cashRegister = CashRegister::find($this->route('id'));
+
+        if (! $this->cashRegister) {
+            abort(404);
+        }
+
+        return $this->user()->can('update', $this->cashRegister);
     }
 
     public function rules(): array
     {
-        $cashRegisterId = $this->route('cashRegister')->id;
-
         return [
             'operating_unit_id' => 'nullable|integer|exists:operating_units,id',
-            'code' => 'sometimes|string|max:50|unique:cash_registers,code,'.$cashRegisterId,
+            'code' => 'sometimes|string|max:50|unique:cash_registers,code,'.$this->cashRegister->id,
             'name' => 'sometimes|string|max:255',
             'type' => 'sometimes|in:ON_PREMISE,DELIVERY,EVENT',
             'is_active' => 'boolean',

--- a/code/api/app/Http/Requests/CashAdjustments/CashSessions/UpdateCashSessionRequest.php
+++ b/code/api/app/Http/Requests/CashAdjustments/CashSessions/UpdateCashSessionRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests\CashAdjustments\CashSessions;
 
 use App\Http\Requests\Concerns\CastsRequestFields;
 use App\Http\Requests\Concerns\SharesValidationMessages;
+use App\Models\CashSession;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
@@ -22,7 +23,11 @@ class UpdateCashSessionRequest extends FormRequest
 
     public function authorize(): bool
     {
-        $session = $this->route('cashSession');
+        $session = CashSession::find($this->route('id'));
+
+        if (! $session) {
+            abort(404);
+        }
 
         if ($session->isPosted()) {
             return false;

--- a/code/api/app/Http/Requests/CashAdjustments/CashTerminals/UpdateCashTerminalRequest.php
+++ b/code/api/app/Http/Requests/CashAdjustments/CashTerminals/UpdateCashTerminalRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests\CashAdjustments\CashTerminals;
 
 use App\Http\Requests\Concerns\CastsRequestFields;
 use App\Http\Requests\Concerns\SharesValidationMessages;
+use App\Models\CashTerminal;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
@@ -25,7 +26,13 @@ class UpdateCashTerminalRequest extends FormRequest
 
     public function authorize(): bool
     {
-        return $this->user()->can('update', $this->route('cashTerminal'));
+        $cashTerminal = CashTerminal::find($this->route('id'));
+
+        if (! $cashTerminal) {
+            abort(404);
+        }
+
+        return $this->user()->can('update', $cashTerminal);
     }
 
     public function rules(): array

--- a/code/api/app/Policies/BankAccountPolicy.php
+++ b/code/api/app/Policies/BankAccountPolicy.php
@@ -4,9 +4,12 @@ namespace App\Policies;
 
 use App\Models\BankAccount;
 use App\Models\User;
+use App\Policies\Concerns\ChecksBranchAccess;
 
 class BankAccountPolicy
 {
+    use ChecksBranchAccess;
+
     /**
      * Determine whether the user can view any models.
      */
@@ -57,18 +60,6 @@ class BankAccountPolicy
         }
 
         return $this->userHasBranchAccess($user, $bankAccount->branch_id);
-    }
-
-    /**
-     * Check if user has access to the branch
-     */
-    private function userHasBranchAccess(User $user, int $branchId): bool
-    {
-        return $user->operatingUnitUsers()
-            ->whereHas('operatingUnit', function ($query) use ($branchId) {
-                $query->where('branch_id', $branchId);
-            })
-            ->exists();
     }
 
     /**

--- a/code/api/app/Policies/CashAdjustmentPolicy.php
+++ b/code/api/app/Policies/CashAdjustmentPolicy.php
@@ -4,9 +4,12 @@ namespace App\Policies;
 
 use App\Models\CashAdjustment;
 use App\Models\User;
+use App\Policies\Concerns\ChecksBranchAccess;
 
 class CashAdjustmentPolicy
 {
+    use ChecksBranchAccess;
+
     /**
      * Determine whether the user can view any models.
      */
@@ -81,18 +84,6 @@ class CashAdjustmentPolicy
         }
 
         return $this->userHasBranchAccess($user, $cashAdjustment->cashSession->cashRegister->branch_id);
-    }
-
-    /**
-     * Check if user has access to the branch
-     */
-    private function userHasBranchAccess(User $user, int $branchId): bool
-    {
-        return $user->operatingUnitUsers()
-            ->whereHas('operatingUnit', function ($query) use ($branchId) {
-                $query->where('branch_id', $branchId);
-            })
-            ->exists();
     }
 
     /**

--- a/code/api/app/Policies/CashExpensePolicy.php
+++ b/code/api/app/Policies/CashExpensePolicy.php
@@ -4,9 +4,12 @@ namespace App\Policies;
 
 use App\Models\CashExpense;
 use App\Models\User;
+use App\Policies\Concerns\ChecksBranchAccess;
 
 class CashExpensePolicy
 {
+    use ChecksBranchAccess;
+
     /**
      * Determine whether the user can view any models.
      */
@@ -81,18 +84,6 @@ class CashExpensePolicy
         }
 
         return $this->userHasBranchAccess($user, $cashExpense->cashSession->cashRegister->branch_id);
-    }
-
-    /**
-     * Check if user has access to the branch
-     */
-    private function userHasBranchAccess(User $user, int $branchId): bool
-    {
-        return $user->operatingUnitUsers()
-            ->whereHas('operatingUnit', function ($query) use ($branchId) {
-                $query->where('branch_id', $branchId);
-            })
-            ->exists();
     }
 
     /**

--- a/code/api/app/Policies/CashRegisterPolicy.php
+++ b/code/api/app/Policies/CashRegisterPolicy.php
@@ -4,9 +4,12 @@ namespace App\Policies;
 
 use App\Models\CashRegister;
 use App\Models\User;
+use App\Policies\Concerns\ChecksBranchAccess;
 
 class CashRegisterPolicy
 {
+    use ChecksBranchAccess;
+
     /**
      * Determine whether the user can view any models.
      */
@@ -57,18 +60,6 @@ class CashRegisterPolicy
         }
 
         return $this->userHasBranchAccess($user, $cashRegister->branch_id);
-    }
-
-    /**
-     * Check if user has access to the branch
-     */
-    private function userHasBranchAccess(User $user, int $branchId): bool
-    {
-        return $user->operatingUnitUsers()
-            ->whereHas('operatingUnit', function ($query) use ($branchId) {
-                $query->where('branch_id', $branchId);
-            })
-            ->exists();
     }
 
     /**

--- a/code/api/app/Policies/CashSessionPolicy.php
+++ b/code/api/app/Policies/CashSessionPolicy.php
@@ -4,9 +4,12 @@ namespace App\Policies;
 
 use App\Models\CashSession;
 use App\Models\User;
+use App\Policies\Concerns\ChecksBranchAccess;
 
 class CashSessionPolicy
 {
+    use ChecksBranchAccess;
+
     /**
      * Determine whether the user can view any models.
      */
@@ -73,18 +76,6 @@ class CashSessionPolicy
         }
 
         return $this->userHasBranchAccess($user, $cashSession->cashRegister->branch_id);
-    }
-
-    /**
-     * Check if user has access to the branch
-     */
-    private function userHasBranchAccess(User $user, int $branchId): bool
-    {
-        return $user->operatingUnitUsers()
-            ->whereHas('operatingUnit', function ($query) use ($branchId) {
-                $query->where('branch_id', $branchId);
-            })
-            ->exists();
     }
 
     /**

--- a/code/api/app/Policies/CashTerminalPolicy.php
+++ b/code/api/app/Policies/CashTerminalPolicy.php
@@ -4,9 +4,12 @@ namespace App\Policies;
 
 use App\Models\CashTerminal;
 use App\Models\User;
+use App\Policies\Concerns\ChecksBranchAccess;
 
 class CashTerminalPolicy
 {
+    use ChecksBranchAccess;
+
     /**
      * Determine whether the user can view any models.
      */
@@ -57,18 +60,6 @@ class CashTerminalPolicy
         }
 
         return $this->userHasBranchAccess($user, $cashTerminal->branch_id);
-    }
-
-    /**
-     * Check if user has access to the branch
-     */
-    private function userHasBranchAccess(User $user, int $branchId): bool
-    {
-        return $user->operatingUnitUsers()
-            ->whereHas('operatingUnit', function ($query) use ($branchId) {
-                $query->where('branch_id', $branchId);
-            })
-            ->exists();
     }
 
     /**

--- a/code/api/app/Policies/Concerns/ChecksBranchAccess.php
+++ b/code/api/app/Policies/Concerns/ChecksBranchAccess.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Policies\Concerns;
+
+use App\Models\User;
+
+trait ChecksBranchAccess
+{
+    /**
+     * Whether the user has an active operating-unit assignment within the
+     * given branch. Used by CashAdjustments policies to scope access to a
+     * resource's branch.
+     */
+    private function userHasBranchAccess(User $user, int $branchId): bool
+    {
+        return $user->operatingUnits()
+            ->wherePivot('is_active', true)
+            ->where('branch_id', $branchId)
+            ->exists();
+    }
+}

--- a/code/api/tests/Feature/CashAdjustments/BankAccounts/BankAccountAuthorizationTest.php
+++ b/code/api/tests/Feature/CashAdjustments/BankAccounts/BankAccountAuthorizationTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\Feature\CashAdjustments\BankAccounts;
+
+use App\Models\BankAccount;
+use App\Models\Branch;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\CashAdjustments\Concerns\SetsUpBranchAccess;
+use Tests\TestCase;
+
+/**
+ * Regression coverage for #291: Show/Update/Delete previously operated on a
+ * blank model with no resource-level authorization at all.
+ */
+class BankAccountAuthorizationTest extends TestCase
+{
+    use RefreshDatabase;
+    use SetsUpBranchAccess;
+
+    #[Test]
+    public function show_returns_the_actual_requested_account(): void
+    {
+        $branch = Branch::factory()->create();
+        $account = BankAccount::factory()->for($branch)->create(['alias' => 'Cuenta Real']);
+        $this->actingAsUserWithBranchAccess($branch, 'bank_accounts.view');
+
+        $response = $this->getJson("/api/v1/bank-accounts/{$account->id}");
+
+        $response->assertStatus(200)->assertJsonPath('data.id', $account->id);
+    }
+
+    #[Test]
+    public function show_rejects_a_user_without_branch_access(): void
+    {
+        $branch = Branch::factory()->create();
+        $account = BankAccount::factory()->for($branch)->create();
+        $this->actingAsUserWithoutBranchAccess('bank_accounts.view');
+
+        $response = $this->getJson("/api/v1/bank-accounts/{$account->id}");
+
+        $response->assertStatus(403);
+    }
+
+    #[Test]
+    public function show_returns_404_for_a_nonexistent_account(): void
+    {
+        $branch = Branch::factory()->create();
+        $this->actingAsUserWithBranchAccess($branch, 'bank_accounts.view');
+
+        $response = $this->getJson('/api/v1/bank-accounts/999999');
+
+        $response->assertStatus(404);
+    }
+
+    #[Test]
+    public function update_actually_updates_the_requested_account(): void
+    {
+        $branch = Branch::factory()->create();
+        $account = BankAccount::factory()->for($branch)->create(['alias' => 'Old Alias']);
+        $this->actingAsUserWithBranchAccess($branch, 'bank_accounts.update');
+
+        $response = $this->putJson("/api/v1/bank-accounts/{$account->id}", ['alias' => 'New Alias']);
+
+        $response->assertStatus(200)->assertJsonPath('data.alias', 'New Alias');
+        $this->assertDatabaseHas('bank_accounts', ['id' => $account->id, 'alias' => 'New Alias']);
+    }
+
+    #[Test]
+    public function update_rejects_a_user_without_branch_access(): void
+    {
+        $branch = Branch::factory()->create();
+        $account = BankAccount::factory()->for($branch)->create(['alias' => 'Untouched']);
+        $this->actingAsUserWithoutBranchAccess('bank_accounts.update');
+
+        $response = $this->putJson("/api/v1/bank-accounts/{$account->id}", ['alias' => 'Nope']);
+
+        $response->assertStatus(403);
+        $this->assertDatabaseHas('bank_accounts', ['id' => $account->id, 'alias' => 'Untouched']);
+    }
+
+    #[Test]
+    public function delete_actually_deletes_the_requested_account(): void
+    {
+        $branch = Branch::factory()->create();
+        $account = BankAccount::factory()->for($branch)->create();
+        $this->actingAsUserWithBranchAccess($branch, 'bank_accounts.delete');
+
+        $response = $this->deleteJson("/api/v1/bank-accounts/{$account->id}");
+
+        $response->assertStatus(200);
+        $this->assertDatabaseMissing('bank_accounts', ['id' => $account->id]);
+    }
+
+    #[Test]
+    public function delete_rejects_a_user_without_branch_access(): void
+    {
+        $branch = Branch::factory()->create();
+        $account = BankAccount::factory()->for($branch)->create();
+        $this->actingAsUserWithoutBranchAccess('bank_accounts.delete');
+
+        $response = $this->deleteJson("/api/v1/bank-accounts/{$account->id}");
+
+        $response->assertStatus(403);
+        $this->assertDatabaseHas('bank_accounts', ['id' => $account->id]);
+    }
+}

--- a/code/api/tests/Feature/CashAdjustments/CashAdjustments/CashAdjustmentAuthorizationTest.php
+++ b/code/api/tests/Feature/CashAdjustments/CashAdjustments/CashAdjustmentAuthorizationTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Feature\CashAdjustments\CashAdjustments;
+
+use App\Models\Branch;
+use App\Models\CashAdjustment;
+use App\Models\CashRegister;
+use App\Models\CashSession;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\CashAdjustments\Concerns\SetsUpBranchAccess;
+use Tests\TestCase;
+
+/**
+ * Regression coverage for #291: Show/Delete/Post previously operated on a
+ * blank model with no resource-level authorization at all.
+ */
+class CashAdjustmentAuthorizationTest extends TestCase
+{
+    use RefreshDatabase;
+    use SetsUpBranchAccess;
+
+    private function adjustmentForBranch(Branch $branch): CashAdjustment
+    {
+        $register = CashRegister::factory()->for($branch)->create();
+        $session = CashSession::factory()->for($register, 'cashRegister')->draft()->create();
+
+        return CashAdjustment::factory()->for($session, 'cashSession')->draft()->create();
+    }
+
+    #[Test]
+    public function show_returns_the_actual_requested_adjustment(): void
+    {
+        $branch = Branch::factory()->create();
+        $adjustment = $this->adjustmentForBranch($branch);
+        $this->actingAsUserWithBranchAccess($branch, 'cash_adjustments.view');
+
+        $response = $this->getJson("/api/v1/cash-adjustments/{$adjustment->id}");
+
+        $response->assertStatus(200)->assertJsonPath('data.id', $adjustment->id);
+    }
+
+    #[Test]
+    public function show_rejects_a_user_without_branch_access(): void
+    {
+        $branch = Branch::factory()->create();
+        $adjustment = $this->adjustmentForBranch($branch);
+        $this->actingAsUserWithoutBranchAccess('cash_adjustments.view');
+
+        $response = $this->getJson("/api/v1/cash-adjustments/{$adjustment->id}");
+
+        $response->assertStatus(403);
+    }
+
+    #[Test]
+    public function show_returns_404_for_a_nonexistent_adjustment(): void
+    {
+        $branch = Branch::factory()->create();
+        $this->actingAsUserWithBranchAccess($branch, 'cash_adjustments.view');
+
+        $response = $this->getJson('/api/v1/cash-adjustments/999999');
+
+        $response->assertStatus(404);
+    }
+
+    #[Test]
+    public function delete_actually_deletes_the_requested_adjustment(): void
+    {
+        $branch = Branch::factory()->create();
+        $adjustment = $this->adjustmentForBranch($branch);
+        $this->actingAsUserWithBranchAccess($branch, 'cash_adjustments.delete');
+
+        $response = $this->deleteJson("/api/v1/cash-adjustments/{$adjustment->id}");
+
+        $response->assertStatus(200);
+        $this->assertDatabaseMissing('cash_adjustments', ['id' => $adjustment->id]);
+    }
+
+    #[Test]
+    public function delete_rejects_a_user_without_branch_access(): void
+    {
+        $branch = Branch::factory()->create();
+        $adjustment = $this->adjustmentForBranch($branch);
+        $this->actingAsUserWithoutBranchAccess('cash_adjustments.delete');
+
+        $response = $this->deleteJson("/api/v1/cash-adjustments/{$adjustment->id}");
+
+        $response->assertStatus(403);
+        $this->assertDatabaseHas('cash_adjustments', ['id' => $adjustment->id]);
+    }
+
+    #[Test]
+    public function post_marks_the_requested_adjustment_as_posted(): void
+    {
+        $branch = Branch::factory()->create();
+        $adjustment = $this->adjustmentForBranch($branch);
+        $this->actingAsUserWithBranchAccess($branch, 'cash_adjustments.post');
+
+        $response = $this->postJson("/api/v1/cash-adjustments/{$adjustment->id}/post");
+
+        $response->assertStatus(200);
+        $this->assertNotNull($adjustment->fresh()->posted_at);
+    }
+
+    #[Test]
+    public function post_rejects_a_user_without_branch_access(): void
+    {
+        $branch = Branch::factory()->create();
+        $adjustment = $this->adjustmentForBranch($branch);
+        $this->actingAsUserWithoutBranchAccess('cash_adjustments.post');
+
+        $response = $this->postJson("/api/v1/cash-adjustments/{$adjustment->id}/post");
+
+        $response->assertStatus(403);
+        $this->assertNull($adjustment->fresh()->posted_at);
+    }
+}

--- a/code/api/tests/Feature/CashAdjustments/CashExpenses/CashExpenseAuthorizationTest.php
+++ b/code/api/tests/Feature/CashAdjustments/CashExpenses/CashExpenseAuthorizationTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Tests\Feature\CashAdjustments\CashExpenses;
+
+use App\Models\Branch;
+use App\Models\CashExpense;
+use App\Models\CashRegister;
+use App\Models\CashSession;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\CashAdjustments\Concerns\SetsUpBranchAccess;
+use Tests\TestCase;
+
+/**
+ * Regression coverage for #291: Show/Update/Delete/Post previously operated
+ * on a blank model with no resource-level authorization at all.
+ */
+class CashExpenseAuthorizationTest extends TestCase
+{
+    use RefreshDatabase;
+    use SetsUpBranchAccess;
+
+    private function expenseForBranch(Branch $branch): CashExpense
+    {
+        $register = CashRegister::factory()->for($branch)->create();
+        $session = CashSession::factory()->for($register, 'cashRegister')->draft()->create();
+
+        return CashExpense::factory()->for($session, 'cashSession')->cash()->draft()->create();
+    }
+
+    #[Test]
+    public function show_returns_the_actual_requested_expense(): void
+    {
+        $branch = Branch::factory()->create();
+        $expense = $this->expenseForBranch($branch);
+        $this->actingAsUserWithBranchAccess($branch, 'cash_expenses.view');
+
+        $response = $this->getJson("/api/v1/cash-expenses/{$expense->id}");
+
+        $response->assertStatus(200)->assertJsonPath('data.id', $expense->id);
+    }
+
+    #[Test]
+    public function show_rejects_a_user_without_branch_access(): void
+    {
+        $branch = Branch::factory()->create();
+        $expense = $this->expenseForBranch($branch);
+        $this->actingAsUserWithoutBranchAccess('cash_expenses.view');
+
+        $response = $this->getJson("/api/v1/cash-expenses/{$expense->id}");
+
+        $response->assertStatus(403);
+    }
+
+    #[Test]
+    public function show_returns_404_for_a_nonexistent_expense(): void
+    {
+        $branch = Branch::factory()->create();
+        $this->actingAsUserWithBranchAccess($branch, 'cash_expenses.view');
+
+        $response = $this->getJson('/api/v1/cash-expenses/999999');
+
+        $response->assertStatus(404);
+    }
+
+    #[Test]
+    public function update_actually_updates_the_requested_expense(): void
+    {
+        $branch = Branch::factory()->create();
+        $expense = $this->expenseForBranch($branch);
+        $this->actingAsUserWithBranchAccess($branch, 'cash_expenses.update');
+
+        $response = $this->putJson("/api/v1/cash-expenses/{$expense->id}", ['category' => 'UTILITIES']);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('cash_expenses', ['id' => $expense->id, 'category' => 'UTILITIES']);
+    }
+
+    #[Test]
+    public function update_rejects_a_user_without_branch_access(): void
+    {
+        $branch = Branch::factory()->create();
+        $expense = $this->expenseForBranch($branch);
+        $this->actingAsUserWithoutBranchAccess('cash_expenses.update');
+
+        $response = $this->putJson("/api/v1/cash-expenses/{$expense->id}", ['category' => 'UTILITIES']);
+
+        $response->assertStatus(403);
+    }
+
+    #[Test]
+    public function delete_actually_deletes_the_requested_expense(): void
+    {
+        $branch = Branch::factory()->create();
+        $expense = $this->expenseForBranch($branch);
+        $this->actingAsUserWithBranchAccess($branch, 'cash_expenses.delete');
+
+        $response = $this->deleteJson("/api/v1/cash-expenses/{$expense->id}");
+
+        $response->assertStatus(200);
+        $this->assertDatabaseMissing('cash_expenses', ['id' => $expense->id]);
+    }
+
+    #[Test]
+    public function delete_rejects_a_user_without_branch_access(): void
+    {
+        $branch = Branch::factory()->create();
+        $expense = $this->expenseForBranch($branch);
+        $this->actingAsUserWithoutBranchAccess('cash_expenses.delete');
+
+        $response = $this->deleteJson("/api/v1/cash-expenses/{$expense->id}");
+
+        $response->assertStatus(403);
+        $this->assertDatabaseHas('cash_expenses', ['id' => $expense->id]);
+    }
+
+    #[Test]
+    public function post_marks_the_requested_expense_as_posted(): void
+    {
+        $branch = Branch::factory()->create();
+        $expense = $this->expenseForBranch($branch);
+        $this->actingAsUserWithBranchAccess($branch, 'cash_expenses.post');
+
+        $response = $this->postJson("/api/v1/cash-expenses/{$expense->id}/post");
+
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('cash_expenses', ['id' => $expense->id]);
+        $this->assertNotNull($expense->fresh()->posted_at);
+    }
+
+    #[Test]
+    public function post_rejects_a_user_without_branch_access(): void
+    {
+        $branch = Branch::factory()->create();
+        $expense = $this->expenseForBranch($branch);
+        $this->actingAsUserWithoutBranchAccess('cash_expenses.post');
+
+        $response = $this->postJson("/api/v1/cash-expenses/{$expense->id}/post");
+
+        $response->assertStatus(403);
+        $this->assertNull($expense->fresh()->posted_at);
+    }
+}

--- a/code/api/tests/Feature/CashAdjustments/CashRegisters/CashRegisterAuthorizationTest.php
+++ b/code/api/tests/Feature/CashAdjustments/CashRegisters/CashRegisterAuthorizationTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Tests\Feature\CashAdjustments\CashRegisters;
+
+use App\Models\Branch;
+use App\Models\CashRegister;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\CashAdjustments\Concerns\SetsUpBranchAccess;
+use Tests\TestCase;
+
+/**
+ * Regression coverage for #291: Show/Update/Delete previously operated on a
+ * blank model (route segment {id} didn't match the CashRegister $cashRegister
+ * binding) with no resource-level authorization at all.
+ */
+class CashRegisterAuthorizationTest extends TestCase
+{
+    use RefreshDatabase;
+    use SetsUpBranchAccess;
+
+    #[Test]
+    public function show_returns_the_actual_requested_register(): void
+    {
+        $branch = Branch::factory()->create();
+        $register = CashRegister::factory()->for($branch)->create(['name' => 'Caja Real']);
+        $this->actingAsUserWithBranchAccess($branch, 'cash_registers.view');
+
+        $response = $this->getJson("/api/v1/cash-registers/{$register->id}");
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.id', $register->id)
+            ->assertJsonPath('data.name', 'Caja Real')
+            ->assertJsonPath('data.branch.id', $branch->id);
+    }
+
+    #[Test]
+    public function show_rejects_a_user_without_branch_access(): void
+    {
+        $branch = Branch::factory()->create();
+        $register = CashRegister::factory()->for($branch)->create();
+        $this->actingAsUserWithoutBranchAccess('cash_registers.view');
+
+        $response = $this->getJson("/api/v1/cash-registers/{$register->id}");
+
+        $response->assertStatus(403);
+    }
+
+    #[Test]
+    public function show_rejects_a_user_without_the_permission(): void
+    {
+        $branch = Branch::factory()->create();
+        $register = CashRegister::factory()->for($branch)->create();
+        $this->actingAsUserWithBranchAccess($branch, 'some.other.permission');
+
+        $response = $this->getJson("/api/v1/cash-registers/{$register->id}");
+
+        $response->assertStatus(403);
+    }
+
+    #[Test]
+    public function show_returns_404_for_a_nonexistent_register(): void
+    {
+        $branch = Branch::factory()->create();
+        $this->actingAsUserWithBranchAccess($branch, 'cash_registers.view');
+
+        $response = $this->getJson('/api/v1/cash-registers/999999');
+
+        $response->assertStatus(404);
+    }
+
+    #[Test]
+    public function update_actually_updates_the_requested_register(): void
+    {
+        $branch = Branch::factory()->create();
+        $register = CashRegister::factory()->for($branch)->create(['name' => 'Old Name']);
+        $this->actingAsUserWithBranchAccess($branch, 'cash_registers.update');
+
+        $response = $this->putJson("/api/v1/cash-registers/{$register->id}", [
+            'name' => 'New Name',
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.name', 'New Name');
+
+        $this->assertDatabaseHas('cash_registers', [
+            'id' => $register->id,
+            'name' => 'New Name',
+        ]);
+    }
+
+    #[Test]
+    public function update_rejects_a_user_without_branch_access(): void
+    {
+        $branch = Branch::factory()->create();
+        $register = CashRegister::factory()->for($branch)->create(['name' => 'Untouched']);
+        $this->actingAsUserWithoutBranchAccess('cash_registers.update');
+
+        $response = $this->putJson("/api/v1/cash-registers/{$register->id}", [
+            'name' => 'Should Not Apply',
+        ]);
+
+        $response->assertStatus(403);
+        $this->assertDatabaseHas('cash_registers', ['id' => $register->id, 'name' => 'Untouched']);
+    }
+
+    #[Test]
+    public function update_returns_404_for_a_nonexistent_register(): void
+    {
+        $branch = Branch::factory()->create();
+        $this->actingAsUserWithBranchAccess($branch, 'cash_registers.update');
+
+        $response = $this->putJson('/api/v1/cash-registers/999999', ['name' => 'X']);
+
+        $response->assertStatus(404);
+    }
+
+    #[Test]
+    public function delete_actually_deletes_the_requested_register(): void
+    {
+        $branch = Branch::factory()->create();
+        $register = CashRegister::factory()->for($branch)->create();
+        $this->actingAsUserWithBranchAccess($branch, 'cash_registers.delete');
+
+        $response = $this->deleteJson("/api/v1/cash-registers/{$register->id}");
+
+        $response->assertStatus(200);
+        $this->assertDatabaseMissing('cash_registers', ['id' => $register->id]);
+    }
+
+    #[Test]
+    public function delete_rejects_a_user_without_branch_access(): void
+    {
+        $branch = Branch::factory()->create();
+        $register = CashRegister::factory()->for($branch)->create();
+        $this->actingAsUserWithoutBranchAccess('cash_registers.delete');
+
+        $response = $this->deleteJson("/api/v1/cash-registers/{$register->id}");
+
+        $response->assertStatus(403);
+        $this->assertDatabaseHas('cash_registers', ['id' => $register->id]);
+    }
+}

--- a/code/api/tests/Feature/CashAdjustments/CashSessions/CashSessionAuthorizationTest.php
+++ b/code/api/tests/Feature/CashAdjustments/CashSessions/CashSessionAuthorizationTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\Feature\CashAdjustments\CashSessions;
+
+use App\Models\Branch;
+use App\Models\CashRegister;
+use App\Models\CashSession;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\CashAdjustments\Concerns\SetsUpBranchAccess;
+use Tests\TestCase;
+
+/**
+ * Regression coverage for #291: Show/Update/Post previously operated on a
+ * blank model (branch access derived from cashSession->cashRegister->branch_id
+ * of an empty model) with no resource-level authorization at all.
+ */
+class CashSessionAuthorizationTest extends TestCase
+{
+    use RefreshDatabase;
+    use SetsUpBranchAccess;
+
+    private function sessionForBranch(Branch $branch): CashSession
+    {
+        $register = CashRegister::factory()->for($branch)->create();
+
+        return CashSession::factory()->for($register, 'cashRegister')->draft()->create();
+    }
+
+    #[Test]
+    public function show_returns_the_actual_requested_session(): void
+    {
+        $branch = Branch::factory()->create();
+        $session = $this->sessionForBranch($branch);
+        $this->actingAsUserWithBranchAccess($branch, 'cash_sessions.view');
+
+        $response = $this->getJson("/api/v1/cash-sessions/{$session->id}");
+
+        $response->assertStatus(200)->assertJsonPath('data.id', $session->id);
+    }
+
+    #[Test]
+    public function show_rejects_a_user_without_branch_access(): void
+    {
+        $branch = Branch::factory()->create();
+        $session = $this->sessionForBranch($branch);
+        $this->actingAsUserWithoutBranchAccess('cash_sessions.view');
+
+        $response = $this->getJson("/api/v1/cash-sessions/{$session->id}");
+
+        $response->assertStatus(403);
+    }
+
+    #[Test]
+    public function show_returns_404_for_a_nonexistent_session(): void
+    {
+        $branch = Branch::factory()->create();
+        $this->actingAsUserWithBranchAccess($branch, 'cash_sessions.view');
+
+        $response = $this->getJson('/api/v1/cash-sessions/999999');
+
+        $response->assertStatus(404);
+    }
+
+    #[Test]
+    public function update_actually_updates_the_requested_session(): void
+    {
+        $branch = Branch::factory()->create();
+        $session = $this->sessionForBranch($branch);
+        $this->actingAsUserWithBranchAccess($branch, 'cash_sessions.update');
+
+        $response = $this->putJson("/api/v1/cash-sessions/{$session->id}", ['opening_balance' => 500]);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('cash_sessions', ['id' => $session->id, 'opening_balance' => 500]);
+    }
+
+    #[Test]
+    public function update_rejects_a_user_without_branch_access(): void
+    {
+        $branch = Branch::factory()->create();
+        $session = $this->sessionForBranch($branch);
+        $this->actingAsUserWithoutBranchAccess('cash_sessions.update');
+
+        $response = $this->putJson("/api/v1/cash-sessions/{$session->id}", ['opening_balance' => 500]);
+
+        $response->assertStatus(403);
+    }
+
+    #[Test]
+    public function post_marks_the_requested_session_as_posted(): void
+    {
+        $branch = Branch::factory()->create();
+        $session = $this->sessionForBranch($branch);
+        $this->actingAsUserWithBranchAccess($branch, 'cash_sessions.post');
+
+        $response = $this->postJson("/api/v1/cash-sessions/{$session->id}/post");
+
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('cash_sessions', ['id' => $session->id, 'status' => CashSession::STATUS_POSTED]);
+    }
+
+    #[Test]
+    public function post_rejects_a_user_without_branch_access(): void
+    {
+        $branch = Branch::factory()->create();
+        $session = $this->sessionForBranch($branch);
+        $this->actingAsUserWithoutBranchAccess('cash_sessions.post');
+
+        $response = $this->postJson("/api/v1/cash-sessions/{$session->id}/post");
+
+        $response->assertStatus(403);
+        $this->assertDatabaseHas('cash_sessions', ['id' => $session->id, 'status' => CashSession::STATUS_DRAFT]);
+    }
+}

--- a/code/api/tests/Feature/CashAdjustments/CashTerminals/CashTerminalAuthorizationTest.php
+++ b/code/api/tests/Feature/CashAdjustments/CashTerminals/CashTerminalAuthorizationTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\Feature\CashAdjustments\CashTerminals;
+
+use App\Models\Branch;
+use App\Models\CashTerminal;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\CashAdjustments\Concerns\SetsUpBranchAccess;
+use Tests\TestCase;
+
+/**
+ * Regression coverage for #291: Show/Update/Delete previously operated on a
+ * blank model with no resource-level authorization at all.
+ */
+class CashTerminalAuthorizationTest extends TestCase
+{
+    use RefreshDatabase;
+    use SetsUpBranchAccess;
+
+    #[Test]
+    public function show_returns_the_actual_requested_terminal(): void
+    {
+        $branch = Branch::factory()->create();
+        $terminal = CashTerminal::factory()->for($branch)->create(['name' => 'Terminal Real']);
+        $this->actingAsUserWithBranchAccess($branch, 'cash_terminals.view');
+
+        $response = $this->getJson("/api/v1/cash-terminals/{$terminal->id}");
+
+        $response->assertStatus(200)->assertJsonPath('data.id', $terminal->id);
+    }
+
+    #[Test]
+    public function show_rejects_a_user_without_branch_access(): void
+    {
+        $branch = Branch::factory()->create();
+        $terminal = CashTerminal::factory()->for($branch)->create();
+        $this->actingAsUserWithoutBranchAccess('cash_terminals.view');
+
+        $response = $this->getJson("/api/v1/cash-terminals/{$terminal->id}");
+
+        $response->assertStatus(403);
+    }
+
+    #[Test]
+    public function show_returns_404_for_a_nonexistent_terminal(): void
+    {
+        $branch = Branch::factory()->create();
+        $this->actingAsUserWithBranchAccess($branch, 'cash_terminals.view');
+
+        $response = $this->getJson('/api/v1/cash-terminals/999999');
+
+        $response->assertStatus(404);
+    }
+
+    #[Test]
+    public function update_actually_updates_the_requested_terminal(): void
+    {
+        $branch = Branch::factory()->create();
+        $terminal = CashTerminal::factory()->for($branch)->create(['name' => 'Old Name']);
+        $this->actingAsUserWithBranchAccess($branch, 'cash_terminals.update');
+
+        $response = $this->putJson("/api/v1/cash-terminals/{$terminal->id}", ['name' => 'New Name']);
+
+        $response->assertStatus(200)->assertJsonPath('data.name', 'New Name');
+        $this->assertDatabaseHas('cash_terminals', ['id' => $terminal->id, 'name' => 'New Name']);
+    }
+
+    #[Test]
+    public function update_rejects_a_user_without_branch_access(): void
+    {
+        $branch = Branch::factory()->create();
+        $terminal = CashTerminal::factory()->for($branch)->create(['name' => 'Untouched']);
+        $this->actingAsUserWithoutBranchAccess('cash_terminals.update');
+
+        $response = $this->putJson("/api/v1/cash-terminals/{$terminal->id}", ['name' => 'Nope']);
+
+        $response->assertStatus(403);
+        $this->assertDatabaseHas('cash_terminals', ['id' => $terminal->id, 'name' => 'Untouched']);
+    }
+
+    #[Test]
+    public function delete_actually_deletes_the_requested_terminal(): void
+    {
+        $branch = Branch::factory()->create();
+        $terminal = CashTerminal::factory()->for($branch)->create();
+        $this->actingAsUserWithBranchAccess($branch, 'cash_terminals.delete');
+
+        $response = $this->deleteJson("/api/v1/cash-terminals/{$terminal->id}");
+
+        $response->assertStatus(200);
+        $this->assertDatabaseMissing('cash_terminals', ['id' => $terminal->id]);
+    }
+
+    #[Test]
+    public function delete_rejects_a_user_without_branch_access(): void
+    {
+        $branch = Branch::factory()->create();
+        $terminal = CashTerminal::factory()->for($branch)->create();
+        $this->actingAsUserWithoutBranchAccess('cash_terminals.delete');
+
+        $response = $this->deleteJson("/api/v1/cash-terminals/{$terminal->id}");
+
+        $response->assertStatus(403);
+        $this->assertDatabaseHas('cash_terminals', ['id' => $terminal->id]);
+    }
+}

--- a/code/api/tests/Feature/CashAdjustments/Concerns/SetsUpBranchAccess.php
+++ b/code/api/tests/Feature/CashAdjustments/Concerns/SetsUpBranchAccess.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Feature\CashAdjustments\Concerns;
+
+use App\Models\Branch;
+use App\Models\OperatingUnit;
+use App\Models\User;
+use Laravel\Passport\Passport;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+trait SetsUpBranchAccess
+{
+    /**
+     * Create a user with the given permission(s) and an active operating-unit
+     * assignment within $branch, then authenticate as them via Passport.
+     *
+     * @param  string|list<string>  $permissions
+     */
+    private function actingAsUserWithBranchAccess(Branch $branch, string|array $permissions): User
+    {
+        $user = $this->userWithPermissions($permissions);
+
+        $operatingUnit = OperatingUnit::create([
+            'branch_id' => $branch->id,
+            'name' => 'Test Operating Unit',
+            'type' => OperatingUnit::TYPE_BRANCH_MAIN,
+            'is_active' => true,
+        ]);
+
+        $user->operatingUnits()->attach($operatingUnit->id, [
+            'assignment_role' => 'OWNER',
+            'is_active' => true,
+        ]);
+
+        Passport::actingAs($user);
+
+        return $user;
+    }
+
+    /**
+     * Create a user with the given permission(s) but no operating-unit
+     * assignment for any branch — used to assert 403 on branch-scoped access.
+     *
+     * @param  string|list<string>  $permissions
+     */
+    private function actingAsUserWithoutBranchAccess(string|array $permissions): User
+    {
+        $user = $this->userWithPermissions($permissions);
+
+        Passport::actingAs($user);
+
+        return $user;
+    }
+
+    /**
+     * @param  string|list<string>  $permissions
+     */
+    private function userWithPermissions(string|array $permissions): User
+    {
+        $role = Role::firstOrCreate(['name' => 'admin', 'guard_name' => 'api']);
+
+        foreach ((array) $permissions as $permission) {
+            Permission::firstOrCreate(['name' => $permission, 'guard_name' => 'api']);
+            $role->givePermissionTo($permission);
+        }
+
+        $user = User::factory()->create();
+        $user->assignRole('admin');
+
+        return $user;
+    }
+}

--- a/doc/tasks/2026-07/291-cashadjustments-broken-authorization.md
+++ b/doc/tasks/2026-07/291-cashadjustments-broken-authorization.md
@@ -1,0 +1,71 @@
+# 🐛 Task #291: CashAdjustments Show/Update/Delete/Post endpoints operate on blank models with no resource-level authorization
+
+## 📖 Story
+
+**English:**
+As a developer, I need to fix the CashAdjustments domain's broken route-model-binding and missing resource-level authorization, so that Show/Update/Delete/Post endpoints across all 6 resource types (CashRegister, CashTerminal, BankAccount, CashSession, CashExpense, CashAdjustment) operate on the correct record and are properly access-controlled, instead of silently operating on blank models with no permission/branch checks.
+
+**Español:**
+Como desarrollador, necesito corregir el binding de modelos y la autorización faltante en el dominio de CashAdjustments, para que los endpoints Show/Update/Delete/Post de los 6 tipos de recurso (CashRegister, CashTerminal, BankAccount, CashSession, CashExpense, CashAdjustment) operen sobre el registro correcto y estén correctamente controlados por permisos/sucursal, en vez de operar silenciosamente sobre modelos vacíos sin ningún control.
+
+---
+
+## 🔍 Root cause (3 compounding bugs)
+
+1. **Route/controller model-binding mismatch**: routes use generic `RouteParams::ID` (`/{id}`), but controllers type-hinted an Eloquent model with a *different* variable name (e.g. `CashRegister $cashRegister`). Laravel's implicit binding requires the segment name to match, so it silently fell back to constructing a **blank model** via the DI container instead of erroring. Confirmed empirically: `GET /api/v1/cash-registers/{id}` on a real seeded register returned `200` with `"branch": null`.
+2. **Zero resource-level authorization** on `Show`/`Delete`/`Post` controllers — no `$this->authorize()`/`Gate::authorize()` calls anywhere, and routes only apply `auth:api` (login check), no `can:` middleware. Any authenticated user could view/delete/post any resource regardless of permission or branch.
+3. **Broken policies and FormRequests**: all 6 `*Policy::userHasBranchAccess()` called `$user->operatingUnitUsers()` — not a real relation (`User` only defines `operatingUnits(): BelongsToMany`) — `BadMethodCallException`. 5 `Update*Request::authorize()` methods called `$this->route('<modelName>')`, always `null` for the same reason as #1.
+
+Zero Feature tests existed for `Show`/`Update`/`Delete`/`Post` on any of the 6 resources — only `Create` was tested — which is why this went unnoticed.
+
+---
+
+## ✅ Technical Tasks
+
+- [x] 🔨 Extract `App\Policies\Concerns\ChecksBranchAccess` trait with the corrected `userHasBranchAccess()` (`$user->operatingUnits()->wherePivot('is_active', true)->where('branch_id', $branchId)->exists()`), used by all 6 policies instead of each repeating the broken method
+- [x] 🔨 Change `Show`/`Update`/`Delete`/`Post` controllers across all 6 resources to `int $id` + `Model::findOrFail($id)`, matching the codebase-wide convention already used by Items/InventoryLocation
+- [x] 🔨 Add explicit `Gate::authorize(...)` calls to `Show`/`Delete`/`Post` controllers (previously missing entirely) — `Update` gets authorization via its FormRequest as before
+- [x] 🔨 Fix the 5 `Update*Request::authorize()`/`rules()`/`withValidator()` methods referencing `route('<modelName>')` to resolve the model from `route('id')` instead, `abort(404)` when not found
+- [x] ✅ Add Feature tests (`*AuthorizationTest.php`, one per resource, 46 tests total) covering: correct record returned/mutated (not blank), 403 for wrong branch, 403 for missing permission, 404 for nonexistent id
+- [x] 🧪 Full PHPUnit suite green (1337/1337), Pint clean (39 files)
+
+---
+
+## 🎯 Acceptance Criteria
+
+- [x] `Show`/`Update`/`Delete`/`Post` operate on the actual requested record across all 6 resource types
+- [x] Users without the branch assignment or permission get `403`, not silent success
+- [x] Nonexistent ids get `404`
+- [x] No behavior change to `Create`/`List` (untouched) or to any already-correct business logic (isPosted checks, tender-type validation, delete-with-existing-transactions guards)
+
+---
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `1.5h` (mostly mechanical once the pattern is established per domain)
+- **Pessimistic:** `3h` (6 domains × 4 layers each — policy, controller, request, tests — plus verifying no regressions in already-fragile CashAdjustments logic)
+- **Tracked:** `1.5h`
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-07-23", "start": "20:30", "end": "22:00" }
+]
+```
+
+## 📊 Retrospective
+- **Actual total:** 1h 30m
+- **vs optimistic:** on target
+- **vs pessimistic:** −1h 30m under
+
+**Justification:**
+
+Landed at the optimistic estimate. The investigation phase (confirming the bug empirically via `php artisan tinker` and a throwaway probe test, then cross-referencing every other domain's routing convention to find the established `int $id` pattern) took real time but paid for itself immediately — it revealed the correct, codebase-consistent fix on the first attempt instead of guessing at a bespoke solution. Once the CashRegister domain was fixed and its test file passed cleanly (9/9), the remaining 5 domains were a direct repeat of the same pattern with domain-specific field/action differences (CashSession/CashExpense/CashAdjustment's `post`/`isPosted` logic, CashExpense's already-existing tender-type validation from #289 that had to be preserved carefully). One full-suite run showed 31 unrelated `QueryException: relation "permissions" does not exist` failures in Attendance/Payroll tests — confirmed as pre-existing test-environment flakiness (not caused by this change) by re-running clean with 0 failures.
+
+---
+
+## 🔗 References
+
+- GitHub issue: [#291](https://github.com/pakodiazdev/sushigo/issues/291)
+- Discovered during PR #288 review (SonarCloud duplication cleanup, unrelated)


### PR DESCRIPTION
## Summary
Closes #291

Fixes a real, unrelated bug discovered during PR #288's SonarCloud duplication review — the entire CashAdjustments domain's single-resource endpoints (`Show`/`Update`/`Delete`/`Post` — everything except `Create`/`List`) were broken across all 6 resource types: **CashRegister, CashTerminal, BankAccount, CashSession, CashExpense, CashAdjustment**.

### 3 compounding bugs, now fixed

1. **Route/controller model-binding mismatch → controllers operated on blank models.** Routes use the generic `RouteParams::ID` (`/{id}`), but controllers type-hinted an Eloquent model with a *different* variable name (e.g. `CashRegister $cashRegister`). Laravel's implicit binding requires the route segment name to match, so it silently fell back to constructing a **blank `new CashRegister()`** via the container instead of erroring. Confirmed empirically: `GET /api/v1/cash-registers/{id}` on a real seeded register returned `200` with `"branch": null, "operating_unit": null, "sessions": []`. Fixed by switching to `int $id` + `Model::findOrFail($id)`, matching the convention already used everywhere else in the codebase (Items, InventoryLocation).

2. **Zero resource-level authorization on `Show`/`Delete`/`Post`.** None of those controllers called `$this->authorize()`/`Gate::authorize()`, and the routes only apply `auth:api` (login check) — no `can:` middleware either. Any authenticated user, regardless of permission or branch assignment, could view/delete/post any resource. Only `Update` had any authorization at all, via its FormRequest. Fixed by adding explicit `Gate::authorize(...)` calls.

3. **Broken policies and FormRequests.** All 6 `*Policy::userHasBranchAccess()` called `$user->operatingUnitUsers()` — not a real relation (`User` only defines `operatingUnits(): BelongsToMany`) — confirmed via `php artisan tinker`: `BadMethodCallException: Call to undefined method App\Models\User::operatingUnitUsers()`. 5 `Update*Request::authorize()` methods called `$this->route('<modelName>')`, always `null` for the same route-param-mismatch reason as #1, crashing instead of failing authorization cleanly.

### Why this was never caught

Zero Feature tests existed for `Show`/`Update`/`Delete`/`Post` on any of the 6 resources — only `Create` was tested.

## Changes

- 🔨 `Show`/`Update`/`Delete`/`Post` controllers (21 files) → `int $id` + `Model::findOrFail($id)`
- 🔒 `Gate::authorize(...)` added to `Show`/`Delete`/`Post` controllers (previously missing entirely)
- 🐛 5 `Update*Request` classes: `authorize()`/`rules()`/`withValidator()` now resolve the model from `route('id')`, `abort(404)` when missing
- 🧩 New `App\Policies\Concerns\ChecksBranchAccess` trait, used by all 6 policies: `$user->operatingUnits()->wherePivot('is_active', true)->where('branch_id', $branchId)->exists()`
- ✅ 46 new Feature tests (`*AuthorizationTest.php`, one per resource) covering correct-record binding, 403 wrong branch, 403 missing permission, 404 nonexistent id

No behavior change to `Create`/`List` (untouched) or to already-correct business logic (`isPosted` checks, tender-type validation from #289, delete-with-existing-transactions guards).

## Test plan
- [x] Full PHPUnit suite: 1337 passed / 3934 assertions (`php artisan test`) — 0 failures on a clean run (one earlier run showed 31 unrelated `QueryException` failures in Attendance/Payroll tests, confirmed as pre-existing test-environment flakiness, not caused by this change, by re-running clean)
- [x] `./vendor/bin/pint --dirty --test` — PASS, 39 files
- [x] `php -l` on all 40 touched/created files — no syntax errors
- [x] 46 new authorization tests, all passing

## Manual Testing
1. Seed a `CashRegister` for branch A. As a user assigned to branch A with `cash_registers.view`, `GET /api/v1/cash-registers/{id}` — expect `200` with the real register data (name, branch, operating_unit populated, not null).
2. Same setup, but as a user with `cash_registers.view` who is **not** assigned to branch A — expect `403`.
3. `GET /api/v1/cash-registers/999999` (nonexistent) — expect `404`.
4. Repeat 1–3 for `PUT`/`DELETE /api/v1/cash-registers/{id}`, and for the equivalent endpoints on `cash-terminals`, `bank-accounts`, `cash-sessions` (including `POST .../post` and `GET .../summary`), `cash-expenses` (including `POST .../post`), `cash-adjustments` (including `POST .../post`).

## Workspace
`sushigo-c` — `fix/291-cashadjustments-broken-authorization`

🤖 Generated with [Claude Code](https://claude.com/claude-code)