### PR TITLE
🔨 [#293][c] - Expose public_id (ULID) instead of numeric id for CashAdjustments resources 🔒

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -292,7 +292,21 @@ Every PR title **must** include the workspace letter, in its own bracket right a
 
 ### PR Description (mandatory)
 
-Every PR opened from dev-lab **must** include a `## Workspace` footer identifying where it was developed:
+Every PR body **must** include a `Closes #NNN` line referencing the issue the PR resolves, plus a `Devin Review:` line right under it linking to that same PR's DeepWiki page. Place both near the top of the `## Summary` section:
+
+```
+## Summary
+Closes #009
+Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/294
+
+- ...
+```
+
+**Why:** `Closes #NNN` lets GitHub auto-close the issue on merge — a merged PR without it leaves the issue open for someone to close by hand. `Devin Review:` links to the DeepWiki mirror of this PR, which surfaces the automated review (Devin) for free without needing write access to a paid tool — keeping it next to `Closes #NNN` puts it one click away for any reviewer.
+
+**How:** the PR number isn't known until the PR exists, so add the `Devin Review:` line in a follow-up edit right after `gh pr create` returns the number — `gh pr edit <N> --body "..."` — before requesting review.
+
+Every PR opened from dev-lab **must** also include a `## Workspace` footer identifying where it was developed:
 
 ```
 ## Workspace

--- a/code/api/app/Http/Controllers/CashAdjustments/BankAccounts/DeleteBankAccountController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/BankAccounts/DeleteBankAccountController.php
@@ -9,12 +9,12 @@ use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Delete(
- *   path="/api/v1/bank-accounts/{id}",
+ *   path="/api/v1/bank-accounts/{bankAccount}",
  *   summary="Delete Bank Account",
  *   tags={"Bank Accounts"},
  *   security={{"bearerAuth":{}}},
  *
- *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer"), description="Bank Account ID"),
+ *   @OA\Parameter(name="bankAccount", in="path", required=true, @OA\Schema(type="string"), description="Bank Account public_id (ULID)"),
  *
  *   @OA\Response(response=200, description="Bank account deleted successfully"),
  *   @OA\Response(response=401, description="Unauthenticated"),
@@ -25,10 +25,8 @@ use Illuminate\Support\Facades\Gate;
  */
 class DeleteBankAccountController extends Controller
 {
-    public function __invoke(int $id): JsonResponse
+    public function __invoke(BankAccount $bankAccount): JsonResponse
     {
-        $bankAccount = BankAccount::findOrFail($id);
-
         Gate::authorize('delete', $bankAccount);
 
         if ($bankAccount->adjustmentLines()->exists() || $bankAccount->expenses()->exists()) {

--- a/code/api/app/Http/Controllers/CashAdjustments/BankAccounts/ShowBankAccountController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/BankAccounts/ShowBankAccountController.php
@@ -9,12 +9,12 @@ use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Get(
- *   path="/api/v1/bank-accounts/{id}",
+ *   path="/api/v1/bank-accounts/{bankAccount}",
  *   summary="Show Bank Account",
  *   tags={"Bank Accounts"},
  *   security={{"bearerAuth":{}}},
  *
- *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer"), description="Bank Account ID"),
+ *   @OA\Parameter(name="bankAccount", in="path", required=true, @OA\Schema(type="string"), description="Bank Account public_id (ULID)"),
  *
  *   @OA\Response(response=200, description="Bank account retrieved successfully"),
  *   @OA\Response(response=401, description="Unauthenticated"),
@@ -24,10 +24,8 @@ use Illuminate\Support\Facades\Gate;
  */
 class ShowBankAccountController extends Controller
 {
-    public function __invoke(int $id): JsonResponse
+    public function __invoke(BankAccount $bankAccount): JsonResponse
     {
-        $bankAccount = BankAccount::findOrFail($id);
-
         Gate::authorize('view', $bankAccount);
 
         $bankAccount->load('branch');

--- a/code/api/app/Http/Controllers/CashAdjustments/BankAccounts/UpdateBankAccountController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/BankAccounts/UpdateBankAccountController.php
@@ -9,12 +9,12 @@ use Illuminate\Http\JsonResponse;
 
 /**
  * @OA\Put(
- *   path="/api/v1/bank-accounts/{id}",
+ *   path="/api/v1/bank-accounts/{bankAccount}",
  *   summary="Update Bank Account",
  *   tags={"Bank Accounts"},
  *   security={{"bearerAuth":{}}},
  *
- *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer"), description="Bank Account ID"),
+ *   @OA\Parameter(name="bankAccount", in="path", required=true, @OA\Schema(type="string"), description="Bank Account public_id (ULID)"),
  *
  *   @OA\RequestBody(
  *     required=true,
@@ -31,10 +31,8 @@ use Illuminate\Http\JsonResponse;
  */
 class UpdateBankAccountController extends Controller
 {
-    public function __invoke(UpdateBankAccountRequest $request, int $id): JsonResponse
+    public function __invoke(UpdateBankAccountRequest $request, BankAccount $bankAccount): JsonResponse
     {
-        $bankAccount = BankAccount::findOrFail($id);
-
         $bankAccount->update($request->validated());
 
         return response()->json([

--- a/code/api/app/Http/Controllers/CashAdjustments/CashAdjustments/CreateCashAdjustmentController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashAdjustments/CreateCashAdjustmentController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers\CashAdjustments\CashAdjustments;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\CashAdjustments\CashAdjustments\StoreCashAdjustmentRequest;
-use App\Models\CashSession;
 use App\Services\CashAdjustments\CashAdjustmentService;
 use Illuminate\Http\JsonResponse;
 
@@ -39,13 +38,11 @@ class CreateCashAdjustmentController extends Controller
         $validated = $request->validated();
 
         try {
-            $session = CashSession::findOrFail($validated['cash_session_id']);
-
             $adjustment = $this->adjustmentService->createAdjustment(
-                session: $session,
+                session: $request->cashSession(),
                 type: $validated['type'],
                 direction: $validated['direction'],
-                lines: $validated['lines'],
+                lines: $request->linesData(),
                 sourceSystem: $validated['source_system'] ?? null,
                 notes: $validated['notes'] ?? null,
                 meta: $validated['meta'] ?? []

--- a/code/api/app/Http/Controllers/CashAdjustments/CashAdjustments/DeleteCashAdjustmentController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashAdjustments/DeleteCashAdjustmentController.php
@@ -10,12 +10,12 @@ use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Delete(
- *   path="/api/v1/cash-adjustments/{id}",
+ *   path="/api/v1/cash-adjustments/{cashAdjustment}",
  *   summary="Delete Cash Adjustment",
  *   tags={"Cash Adjustments"},
  *   security={{"bearerAuth":{}}},
  *
- *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer"), description="Cash Adjustment ID"),
+ *   @OA\Parameter(name="cashAdjustment", in="path", required=true, @OA\Schema(type="string"), description="Cash Adjustment public_id (ULID)"),
  *
  *   @OA\Response(response=200, description="Cash adjustment deleted successfully"),
  *   @OA\Response(response=401, description="Unauthenticated"),
@@ -30,10 +30,8 @@ class DeleteCashAdjustmentController extends Controller
         private CashAdjustmentService $adjustmentService
     ) {}
 
-    public function __invoke(int $id): JsonResponse
+    public function __invoke(CashAdjustment $cashAdjustment): JsonResponse
     {
-        $cashAdjustment = CashAdjustment::findOrFail($id);
-
         Gate::authorize('delete', $cashAdjustment);
 
         try {

--- a/code/api/app/Http/Controllers/CashAdjustments/CashAdjustments/ListCashAdjustmentsController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashAdjustments/ListCashAdjustmentsController.php
@@ -2,8 +2,10 @@
 
 namespace App\Http\Controllers\CashAdjustments\CashAdjustments;
 
+use App\Http\Controllers\Concerns\ResolvesPublicIdFilters;
 use App\Http\Controllers\Controller;
 use App\Models\CashAdjustment;
+use App\Models\CashSession;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -14,7 +16,7 @@ use Illuminate\Http\Request;
  *   tags={"Cash Adjustments"},
  *   security={{"bearerAuth":{}}},
  *
- *   @OA\Parameter(name="cash_session_id", in="query", @OA\Schema(type="integer"), description="Filter by cash session ID"),
+ *   @OA\Parameter(name="cash_session_id", in="query", @OA\Schema(type="string"), description="Filter by Cash Session public_id (ULID)"),
  *   @OA\Parameter(name="type", in="query", @OA\Schema(type="string", enum={"EXTERNAL_IMPORT", "CORRECTION"}), description="Filter by adjustment type"),
  *   @OA\Parameter(name="direction", in="query", @OA\Schema(type="string", enum={"INFLOW", "OUTFLOW"}), description="Filter by direction"),
  *   @OA\Parameter(name="posted", in="query", @OA\Schema(type="boolean"), description="Filter by posted status"),
@@ -27,12 +29,17 @@ use Illuminate\Http\Request;
  */
 class ListCashAdjustmentsController extends Controller
 {
+    use ResolvesPublicIdFilters;
+
     public function __invoke(Request $request): JsonResponse
     {
         $query = CashAdjustment::with(['cashSession.cashRegister', 'lines', 'postedBy']);
 
         if ($request->has('cash_session_id')) {
-            $query->where('cash_session_id', $request->input('cash_session_id'));
+            $query->where(
+                'cash_session_id',
+                $this->resolvePublicIdFilter(CashSession::class, $request->input('cash_session_id'))
+            );
         }
 
         if ($request->has('type')) {

--- a/code/api/app/Http/Controllers/CashAdjustments/CashAdjustments/PostCashAdjustmentController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashAdjustments/PostCashAdjustmentController.php
@@ -11,13 +11,13 @@ use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Post(
- *   path="/api/v1/cash-adjustments/{id}/post",
+ *   path="/api/v1/cash-adjustments/{cashAdjustment}/post",
  *   summary="Post Cash Adjustment",
  *   description="Finalizes adjustment and marks it as posted",
  *   tags={"Cash Adjustments"},
  *   security={{"bearerAuth":{}}},
  *
- *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer"), description="Cash Adjustment ID"),
+ *   @OA\Parameter(name="cashAdjustment", in="path", required=true, @OA\Schema(type="string"), description="Cash Adjustment public_id (ULID)"),
  *
  *   @OA\Response(response=200, description="Cash adjustment posted successfully"),
  *   @OA\Response(response=401, description="Unauthenticated"),
@@ -32,10 +32,8 @@ class PostCashAdjustmentController extends Controller
         private CashAdjustmentService $adjustmentService
     ) {}
 
-    public function __invoke(int $id): JsonResponse
+    public function __invoke(CashAdjustment $cashAdjustment): JsonResponse
     {
-        $cashAdjustment = CashAdjustment::findOrFail($id);
-
         Gate::authorize('post', $cashAdjustment);
 
         try {

--- a/code/api/app/Http/Controllers/CashAdjustments/CashAdjustments/ShowCashAdjustmentController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashAdjustments/ShowCashAdjustmentController.php
@@ -9,12 +9,12 @@ use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Get(
- *   path="/api/v1/cash-adjustments/{id}",
+ *   path="/api/v1/cash-adjustments/{cashAdjustment}",
  *   summary="Show Cash Adjustment",
  *   tags={"Cash Adjustments"},
  *   security={{"bearerAuth":{}}},
  *
- *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer"), description="Cash Adjustment ID"),
+ *   @OA\Parameter(name="cashAdjustment", in="path", required=true, @OA\Schema(type="string"), description="Cash Adjustment public_id (ULID)"),
  *
  *   @OA\Response(response=200, description="Cash adjustment retrieved successfully"),
  *   @OA\Response(response=401, description="Unauthenticated"),
@@ -24,10 +24,8 @@ use Illuminate\Support\Facades\Gate;
  */
 class ShowCashAdjustmentController extends Controller
 {
-    public function __invoke(int $id): JsonResponse
+    public function __invoke(CashAdjustment $cashAdjustment): JsonResponse
     {
-        $cashAdjustment = CashAdjustment::findOrFail($id);
-
         Gate::authorize('view', $cashAdjustment);
 
         $cashAdjustment->load([

--- a/code/api/app/Http/Controllers/CashAdjustments/CashExpenses/CreateCashExpenseController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashExpenses/CreateCashExpenseController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\CashAdjustments\CashExpenses;
 use App\DataTransferObjects\CashAdjustments\RegisterExpenseData;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\CashAdjustments\CashExpenses\StoreCashExpenseRequest;
-use App\Models\CashSession;
 use App\Services\CashAdjustments\CashExpenseService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
@@ -41,18 +40,16 @@ class CreateCashExpenseController extends Controller
         $validated = $request->validated();
 
         try {
-            $session = CashSession::findOrFail($validated['cash_session_id']);
-
             $expense = $this->expenseService->registerExpense(new RegisterExpenseData(
-                session: $session,
+                session: $request->cashSession(),
                 tenderType: $validated['tender_type'],
                 amount: $validated['amount'],
                 category: $validated['category'],
                 vendor: $validated['vendor'] ?? null,
                 reference: $validated['reference'] ?? null,
                 notes: $validated['notes'] ?? null,
-                cardTerminalId: $validated['card_terminal_id'] ?? null,
-                bankAccountId: $validated['bank_account_id'] ?? null,
+                cardTerminalId: $request->cardTerminalId(),
+                bankAccountId: $request->bankAccountId(),
                 createdBy: Auth::user(),
                 incurredAt: $validated['incurred_at'] ?? null,
                 meta: $validated['meta'] ?? []

--- a/code/api/app/Http/Controllers/CashAdjustments/CashExpenses/DeleteCashExpenseController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashExpenses/DeleteCashExpenseController.php
@@ -10,12 +10,12 @@ use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Delete(
- *   path="/api/v1/cash-expenses/{id}",
+ *   path="/api/v1/cash-expenses/{cashExpense}",
  *   summary="Delete Cash Expense",
  *   tags={"Cash Expenses"},
  *   security={{"bearerAuth":{}}},
  *
- *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer"), description="Cash Expense ID"),
+ *   @OA\Parameter(name="cashExpense", in="path", required=true, @OA\Schema(type="string"), description="Cash Expense public_id (ULID)"),
  *
  *   @OA\Response(response=200, description="Cash expense deleted successfully"),
  *   @OA\Response(response=401, description="Unauthenticated"),
@@ -30,10 +30,8 @@ class DeleteCashExpenseController extends Controller
         private CashExpenseService $expenseService
     ) {}
 
-    public function __invoke(int $id): JsonResponse
+    public function __invoke(CashExpense $cashExpense): JsonResponse
     {
-        $cashExpense = CashExpense::findOrFail($id);
-
         Gate::authorize('delete', $cashExpense);
 
         try {

--- a/code/api/app/Http/Controllers/CashAdjustments/CashExpenses/ListCashExpensesController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashExpenses/ListCashExpensesController.php
@@ -2,8 +2,10 @@
 
 namespace App\Http\Controllers\CashAdjustments\CashExpenses;
 
+use App\Http\Controllers\Concerns\ResolvesPublicIdFilters;
 use App\Http\Controllers\Controller;
 use App\Models\CashExpense;
+use App\Models\CashSession;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -14,7 +16,7 @@ use Illuminate\Http\Request;
  *   tags={"Cash Expenses"},
  *   security={{"bearerAuth":{}}},
  *
- *   @OA\Parameter(name="cash_session_id", in="query", @OA\Schema(type="integer"), description="Filter by cash session ID"),
+ *   @OA\Parameter(name="cash_session_id", in="query", @OA\Schema(type="string"), description="Filter by Cash Session public_id (ULID)"),
  *   @OA\Parameter(name="category", in="query", @OA\Schema(type="string"), description="Filter by expense category"),
  *   @OA\Parameter(name="tender_type", in="query", @OA\Schema(type="string", enum={"CASH", "CARD", "TRANSFER"}), description="Filter by tender type"),
  *   @OA\Parameter(name="incurred_from", in="query", @OA\Schema(type="string", format="date-time"), description="Filter from date"),
@@ -28,6 +30,8 @@ use Illuminate\Http\Request;
  */
 class ListCashExpensesController extends Controller
 {
+    use ResolvesPublicIdFilters;
+
     public function __invoke(Request $request): JsonResponse
     {
         $query = CashExpense::with([
@@ -39,7 +43,10 @@ class ListCashExpensesController extends Controller
         ]);
 
         if ($request->has('cash_session_id')) {
-            $query->where('cash_session_id', $request->input('cash_session_id'));
+            $query->where(
+                'cash_session_id',
+                $this->resolvePublicIdFilter(CashSession::class, $request->input('cash_session_id'))
+            );
         }
 
         if ($request->has('category')) {

--- a/code/api/app/Http/Controllers/CashAdjustments/CashExpenses/PostCashExpenseController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashExpenses/PostCashExpenseController.php
@@ -11,13 +11,13 @@ use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Post(
- *   path="/api/v1/cash-expenses/{id}/post",
+ *   path="/api/v1/cash-expenses/{cashExpense}/post",
  *   summary="Post Cash Expense",
  *   description="Finalizes expense and marks it as posted",
  *   tags={"Cash Expenses"},
  *   security={{"bearerAuth":{}}},
  *
- *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer"), description="Cash Expense ID"),
+ *   @OA\Parameter(name="cashExpense", in="path", required=true, @OA\Schema(type="string"), description="Cash Expense public_id (ULID)"),
  *
  *   @OA\Response(response=200, description="Cash expense posted successfully"),
  *   @OA\Response(response=401, description="Unauthenticated"),
@@ -32,10 +32,8 @@ class PostCashExpenseController extends Controller
         private CashExpenseService $expenseService
     ) {}
 
-    public function __invoke(int $id): JsonResponse
+    public function __invoke(CashExpense $cashExpense): JsonResponse
     {
-        $cashExpense = CashExpense::findOrFail($id);
-
         Gate::authorize('post', $cashExpense);
 
         try {

--- a/code/api/app/Http/Controllers/CashAdjustments/CashExpenses/ShowCashExpenseController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashExpenses/ShowCashExpenseController.php
@@ -9,12 +9,12 @@ use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Get(
- *   path="/api/v1/cash-expenses/{id}",
+ *   path="/api/v1/cash-expenses/{cashExpense}",
  *   summary="Show Cash Expense",
  *   tags={"Cash Expenses"},
  *   security={{"bearerAuth":{}}},
  *
- *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer"), description="Cash Expense ID"),
+ *   @OA\Parameter(name="cashExpense", in="path", required=true, @OA\Schema(type="string"), description="Cash Expense public_id (ULID)"),
  *
  *   @OA\Response(response=200, description="Cash expense retrieved successfully"),
  *   @OA\Response(response=401, description="Unauthenticated"),
@@ -24,10 +24,8 @@ use Illuminate\Support\Facades\Gate;
  */
 class ShowCashExpenseController extends Controller
 {
-    public function __invoke(int $id): JsonResponse
+    public function __invoke(CashExpense $cashExpense): JsonResponse
     {
-        $cashExpense = CashExpense::findOrFail($id);
-
         Gate::authorize('view', $cashExpense);
 
         $cashExpense->load([

--- a/code/api/app/Http/Controllers/CashAdjustments/CashExpenses/UpdateCashExpenseController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashExpenses/UpdateCashExpenseController.php
@@ -10,12 +10,12 @@ use Illuminate\Http\JsonResponse;
 
 /**
  * @OA\Put(
- *   path="/api/v1/cash-expenses/{id}",
+ *   path="/api/v1/cash-expenses/{cashExpense}",
  *   summary="Update Cash Expense",
  *   tags={"Cash Expenses"},
  *   security={{"bearerAuth":{}}},
  *
- *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer"), description="Cash Expense ID"),
+ *   @OA\Parameter(name="cashExpense", in="path", required=true, @OA\Schema(type="string"), description="Cash Expense public_id (ULID)"),
  *
  *   @OA\RequestBody(
  *     required=true,
@@ -36,14 +36,10 @@ class UpdateCashExpenseController extends Controller
         private CashExpenseService $expenseService
     ) {}
 
-    public function __invoke(UpdateCashExpenseRequest $request, int $id): JsonResponse
+    public function __invoke(UpdateCashExpenseRequest $request, CashExpense $cashExpense): JsonResponse
     {
-        $cashExpense = CashExpense::findOrFail($id);
-
-        $validated = $request->validated();
-
         try {
-            $updatedExpense = $this->expenseService->updateExpense($cashExpense, $validated);
+            $updatedExpense = $this->expenseService->updateExpense($cashExpense, $request->expenseData());
 
             return response()->json([
                 'message' => 'Expense updated successfully',

--- a/code/api/app/Http/Controllers/CashAdjustments/CashRegisters/DeleteCashRegisterController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashRegisters/DeleteCashRegisterController.php
@@ -9,12 +9,12 @@ use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Delete(
- *   path="/api/v1/cash-registers/{id}",
+ *   path="/api/v1/cash-registers/{cashRegister}",
  *   summary="Delete Cash Register",
  *   tags={"Cash Registers"},
  *   security={{"bearerAuth":{}}},
  *
- *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer"), description="Cash Register ID"),
+ *   @OA\Parameter(name="cashRegister", in="path", required=true, @OA\Schema(type="string"), description="Cash Register public_id (ULID)"),
  *
  *   @OA\Response(response=200, description="Cash register deleted successfully"),
  *   @OA\Response(response=401, description="Unauthenticated"),
@@ -25,10 +25,8 @@ use Illuminate\Support\Facades\Gate;
  */
 class DeleteCashRegisterController extends Controller
 {
-    public function __invoke(int $id): JsonResponse
+    public function __invoke(CashRegister $cashRegister): JsonResponse
     {
-        $cashRegister = CashRegister::findOrFail($id);
-
         Gate::authorize('delete', $cashRegister);
 
         // Check if register has sessions

--- a/code/api/app/Http/Controllers/CashAdjustments/CashRegisters/ShowCashRegisterController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashRegisters/ShowCashRegisterController.php
@@ -9,12 +9,12 @@ use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Get(
- *   path="/api/v1/cash-registers/{id}",
+ *   path="/api/v1/cash-registers/{cashRegister}",
  *   summary="Show Cash Register",
  *   tags={"Cash Registers"},
  *   security={{"bearerAuth":{}}},
  *
- *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer"), description="Cash Register ID"),
+ *   @OA\Parameter(name="cashRegister", in="path", required=true, @OA\Schema(type="string"), description="Cash Register public_id (ULID)"),
  *
  *   @OA\Response(response=200, description="Cash register retrieved successfully"),
  *   @OA\Response(response=401, description="Unauthenticated"),
@@ -24,10 +24,8 @@ use Illuminate\Support\Facades\Gate;
  */
 class ShowCashRegisterController extends Controller
 {
-    public function __invoke(int $id): JsonResponse
+    public function __invoke(CashRegister $cashRegister): JsonResponse
     {
-        $cashRegister = CashRegister::findOrFail($id);
-
         Gate::authorize('view', $cashRegister);
 
         $cashRegister->load(['branch', 'operatingUnit', 'sessions' => function ($query) {

--- a/code/api/app/Http/Controllers/CashAdjustments/CashRegisters/UpdateCashRegisterController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashRegisters/UpdateCashRegisterController.php
@@ -9,12 +9,12 @@ use Illuminate\Http\JsonResponse;
 
 /**
  * @OA\Put(
- *   path="/api/v1/cash-registers/{id}",
+ *   path="/api/v1/cash-registers/{cashRegister}",
  *   summary="Update Cash Register",
  *   tags={"Cash Registers"},
  *   security={{"bearerAuth":{}}},
  *
- *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer"), description="Cash Register ID"),
+ *   @OA\Parameter(name="cashRegister", in="path", required=true, @OA\Schema(type="string"), description="Cash Register public_id (ULID)"),
  *
  *   @OA\RequestBody(
  *     required=true,
@@ -31,10 +31,8 @@ use Illuminate\Http\JsonResponse;
  */
 class UpdateCashRegisterController extends Controller
 {
-    public function __invoke(UpdateCashRegisterRequest $request, int $id): JsonResponse
+    public function __invoke(UpdateCashRegisterRequest $request, CashRegister $cashRegister): JsonResponse
     {
-        $cashRegister = CashRegister::findOrFail($id);
-
         $cashRegister->update($request->validated());
 
         return response()->json([

--- a/code/api/app/Http/Controllers/CashAdjustments/CashSessions/CreateCashSessionController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashSessions/CreateCashSessionController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers\CashAdjustments\CashSessions;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\CashAdjustments\CashSessions\StoreCashSessionRequest;
-use App\Models\CashRegister;
 use App\Services\CashAdjustments\CashSessionService;
 use Illuminate\Http\JsonResponse;
 
@@ -38,7 +37,7 @@ class CreateCashSessionController extends Controller
         $validated = $request->validated();
 
         try {
-            $cashRegister = CashRegister::findOrFail($validated['cash_register_id']);
+            $cashRegister = $request->cashRegister();
 
             $session = $this->sessionService->openSession(
                 cashRegister: $cashRegister,

--- a/code/api/app/Http/Controllers/CashAdjustments/CashSessions/GetSessionSummaryController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashSessions/GetSessionSummaryController.php
@@ -10,13 +10,13 @@ use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Get(
- *   path="/api/v1/cash-sessions/{id}/summary",
+ *   path="/api/v1/cash-sessions/{cashSession}/summary",
  *   summary="Get Cash Session Summary",
  *   description="Returns detailed summary with income/expense breakdown by tender type",
  *   tags={"Cash Sessions"},
  *   security={{"bearerAuth":{}}},
  *
- *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer"), description="Cash Session ID"),
+ *   @OA\Parameter(name="cashSession", in="path", required=true, @OA\Schema(type="string"), description="Cash Session public_id (ULID)"),
  *
  *   @OA\Response(response=200, description="Session summary retrieved successfully"),
  *   @OA\Response(response=401, description="Unauthenticated"),
@@ -30,10 +30,8 @@ class GetSessionSummaryController extends Controller
         private CashSessionService $sessionService
     ) {}
 
-    public function __invoke(int $id): JsonResponse
+    public function __invoke(CashSession $cashSession): JsonResponse
     {
-        $cashSession = CashSession::findOrFail($id);
-
         Gate::authorize('view', $cashSession);
 
         $summary = $this->sessionService->getSessionSummary($cashSession);

--- a/code/api/app/Http/Controllers/CashAdjustments/CashSessions/ListCashSessionsController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashSessions/ListCashSessionsController.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Controllers\CashAdjustments\CashSessions;
 
+use App\Http\Controllers\Concerns\ResolvesPublicIdFilters;
 use App\Http\Controllers\Controller;
+use App\Models\CashRegister;
 use App\Models\CashSession;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -14,7 +16,7 @@ use Illuminate\Http\Request;
  *   tags={"Cash Sessions"},
  *   security={{"bearerAuth":{}}},
  *
- *   @OA\Parameter(name="cash_register_id", in="query", @OA\Schema(type="integer"), description="Filter by cash register ID"),
+ *   @OA\Parameter(name="cash_register_id", in="query", @OA\Schema(type="string"), description="Filter by Cash Register public_id (ULID)"),
  *   @OA\Parameter(name="operating_date_from", in="query", @OA\Schema(type="string", format="date"), description="Filter from date (YYYY-MM-DD)"),
  *   @OA\Parameter(name="operating_date_to", in="query", @OA\Schema(type="string", format="date"), description="Filter to date (YYYY-MM-DD)"),
  *   @OA\Parameter(name="status", in="query", @OA\Schema(type="string", enum={"DRAFT", "POSTED"}), description="Filter by status"),
@@ -27,12 +29,17 @@ use Illuminate\Http\Request;
  */
 class ListCashSessionsController extends Controller
 {
+    use ResolvesPublicIdFilters;
+
     public function __invoke(Request $request): JsonResponse
     {
         $query = CashSession::with(['cashRegister.branch']);
 
         if ($request->has('cash_register_id')) {
-            $query->byRegister($request->input('cash_register_id'));
+            $query->where(
+                'cash_register_id',
+                $this->resolvePublicIdFilter(CashRegister::class, $request->input('cash_register_id'))
+            );
         }
 
         if ($request->has('status')) {

--- a/code/api/app/Http/Controllers/CashAdjustments/CashSessions/PostCashSessionController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashSessions/PostCashSessionController.php
@@ -10,13 +10,13 @@ use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Post(
- *   path="/api/v1/cash-sessions/{id}/post",
+ *   path="/api/v1/cash-sessions/{cashSession}/post",
  *   summary="Post Cash Session",
  *   description="Finalizes a cash session by calculating closing balance and changing status to POSTED",
  *   tags={"Cash Sessions"},
  *   security={{"bearerAuth":{}}},
  *
- *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer"), description="Cash Session ID"),
+ *   @OA\Parameter(name="cashSession", in="path", required=true, @OA\Schema(type="string"), description="Cash Session public_id (ULID)"),
  *
  *   @OA\Response(response=200, description="Cash session posted successfully"),
  *   @OA\Response(response=401, description="Unauthenticated"),
@@ -31,10 +31,8 @@ class PostCashSessionController extends Controller
         private CashSessionService $sessionService
     ) {}
 
-    public function __invoke(int $id): JsonResponse
+    public function __invoke(CashSession $cashSession): JsonResponse
     {
-        $cashSession = CashSession::findOrFail($id);
-
         Gate::authorize('post', $cashSession);
 
         try {

--- a/code/api/app/Http/Controllers/CashAdjustments/CashSessions/ShowCashSessionController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashSessions/ShowCashSessionController.php
@@ -9,12 +9,12 @@ use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Get(
- *   path="/api/v1/cash-sessions/{id}",
+ *   path="/api/v1/cash-sessions/{cashSession}",
  *   summary="Show Cash Session",
  *   tags={"Cash Sessions"},
  *   security={{"bearerAuth":{}}},
  *
- *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer"), description="Cash Session ID"),
+ *   @OA\Parameter(name="cashSession", in="path", required=true, @OA\Schema(type="string"), description="Cash Session public_id (ULID)"),
  *
  *   @OA\Response(response=200, description="Cash session retrieved successfully"),
  *   @OA\Response(response=401, description="Unauthenticated"),
@@ -24,10 +24,8 @@ use Illuminate\Support\Facades\Gate;
  */
 class ShowCashSessionController extends Controller
 {
-    public function __invoke(int $id): JsonResponse
+    public function __invoke(CashSession $cashSession): JsonResponse
     {
-        $cashSession = CashSession::findOrFail($id);
-
         Gate::authorize('view', $cashSession);
 
         $cashSession->load([

--- a/code/api/app/Http/Controllers/CashAdjustments/CashSessions/UpdateCashSessionController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashSessions/UpdateCashSessionController.php
@@ -9,12 +9,12 @@ use Illuminate\Http\JsonResponse;
 
 /**
  * @OA\Put(
- *   path="/api/v1/cash-sessions/{id}",
+ *   path="/api/v1/cash-sessions/{cashSession}",
  *   summary="Update Cash Session",
  *   tags={"Cash Sessions"},
  *   security={{"bearerAuth":{}}},
  *
- *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer"), description="Cash Session ID"),
+ *   @OA\Parameter(name="cashSession", in="path", required=true, @OA\Schema(type="string"), description="Cash Session public_id (ULID)"),
  *
  *   @OA\RequestBody(
  *     required=true,
@@ -31,10 +31,8 @@ use Illuminate\Http\JsonResponse;
  */
 class UpdateCashSessionController extends Controller
 {
-    public function __invoke(UpdateCashSessionRequest $request, int $id): JsonResponse
+    public function __invoke(UpdateCashSessionRequest $request, CashSession $cashSession): JsonResponse
     {
-        $cashSession = CashSession::findOrFail($id);
-
         $cashSession->update($request->validated());
 
         return response()->json([

--- a/code/api/app/Http/Controllers/CashAdjustments/CashTerminals/DeleteCashTerminalController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashTerminals/DeleteCashTerminalController.php
@@ -9,12 +9,12 @@ use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Delete(
- *   path="/api/v1/cash-terminals/{id}",
+ *   path="/api/v1/cash-terminals/{cashTerminal}",
  *   summary="Delete Cash Terminal",
  *   tags={"Cash Terminals"},
  *   security={{"bearerAuth":{}}},
  *
- *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer"), description="Cash Terminal ID"),
+ *   @OA\Parameter(name="cashTerminal", in="path", required=true, @OA\Schema(type="string"), description="Cash Terminal public_id (ULID)"),
  *
  *   @OA\Response(response=200, description="Cash terminal deleted successfully"),
  *   @OA\Response(response=401, description="Unauthenticated"),
@@ -25,10 +25,8 @@ use Illuminate\Support\Facades\Gate;
  */
 class DeleteCashTerminalController extends Controller
 {
-    public function __invoke(int $id): JsonResponse
+    public function __invoke(CashTerminal $cashTerminal): JsonResponse
     {
-        $cashTerminal = CashTerminal::findOrFail($id);
-
         Gate::authorize('delete', $cashTerminal);
 
         if ($cashTerminal->adjustmentLines()->exists() || $cashTerminal->expenses()->exists()) {

--- a/code/api/app/Http/Controllers/CashAdjustments/CashTerminals/ShowCashTerminalController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashTerminals/ShowCashTerminalController.php
@@ -9,12 +9,12 @@ use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Get(
- *   path="/api/v1/cash-terminals/{id}",
+ *   path="/api/v1/cash-terminals/{cashTerminal}",
  *   summary="Show Cash Terminal",
  *   tags={"Cash Terminals"},
  *   security={{"bearerAuth":{}}},
  *
- *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer"), description="Cash Terminal ID"),
+ *   @OA\Parameter(name="cashTerminal", in="path", required=true, @OA\Schema(type="string"), description="Cash Terminal public_id (ULID)"),
  *
  *   @OA\Response(response=200, description="Cash terminal retrieved successfully"),
  *   @OA\Response(response=401, description="Unauthenticated"),
@@ -24,10 +24,8 @@ use Illuminate\Support\Facades\Gate;
  */
 class ShowCashTerminalController extends Controller
 {
-    public function __invoke(int $id): JsonResponse
+    public function __invoke(CashTerminal $cashTerminal): JsonResponse
     {
-        $cashTerminal = CashTerminal::findOrFail($id);
-
         Gate::authorize('view', $cashTerminal);
 
         $cashTerminal->load('branch');

--- a/code/api/app/Http/Controllers/CashAdjustments/CashTerminals/UpdateCashTerminalController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashTerminals/UpdateCashTerminalController.php
@@ -9,12 +9,12 @@ use Illuminate\Http\JsonResponse;
 
 /**
  * @OA\Put(
- *   path="/api/v1/cash-terminals/{id}",
+ *   path="/api/v1/cash-terminals/{cashTerminal}",
  *   summary="Update Cash Terminal",
  *   tags={"Cash Terminals"},
  *   security={{"bearerAuth":{}}},
  *
- *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer"), description="Cash Terminal ID"),
+ *   @OA\Parameter(name="cashTerminal", in="path", required=true, @OA\Schema(type="string"), description="Cash Terminal public_id (ULID)"),
  *
  *   @OA\RequestBody(
  *     required=true,
@@ -31,10 +31,8 @@ use Illuminate\Http\JsonResponse;
  */
 class UpdateCashTerminalController extends Controller
 {
-    public function __invoke(UpdateCashTerminalRequest $request, int $id): JsonResponse
+    public function __invoke(UpdateCashTerminalRequest $request, CashTerminal $cashTerminal): JsonResponse
     {
-        $cashTerminal = CashTerminal::findOrFail($id);
-
         $cashTerminal->update($request->validated());
 
         return response()->json([

--- a/code/api/app/Http/Controllers/Concerns/ResolvesPublicIdFilters.php
+++ b/code/api/app/Http/Controllers/Concerns/ResolvesPublicIdFilters.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers\Concerns;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Resolves a ULID public_id query-param filter into the numeric FK the
+ * underlying table column stores (see #293 — List endpoints filter by the
+ * same numeric FKs the migration hid from output, so a caller driving
+ * requests purely from API responses can no longer supply a valid value).
+ */
+trait ResolvesPublicIdFilters
+{
+    /**
+     * @param  class-string<Model>  $modelClass
+     */
+    protected function resolvePublicIdFilter(string $modelClass, ?string $publicId): ?int
+    {
+        if (! $publicId) {
+            return null;
+        }
+
+        return $modelClass::where('public_id', $publicId)->value('id');
+    }
+}

--- a/code/api/app/Http/Requests/CashAdjustments/BankAccounts/UpdateBankAccountRequest.php
+++ b/code/api/app/Http/Requests/CashAdjustments/BankAccounts/UpdateBankAccountRequest.php
@@ -3,7 +3,6 @@
 namespace App\Http\Requests\CashAdjustments\BankAccounts;
 
 use App\Http\Requests\Concerns\CastsRequestFields;
-use App\Models\BankAccount;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
@@ -24,13 +23,7 @@ class UpdateBankAccountRequest extends FormRequest
 
     public function authorize(): bool
     {
-        $bankAccount = BankAccount::find($this->route('id'));
-
-        if (! $bankAccount) {
-            abort(404);
-        }
-
-        return $this->user()->can('update', $bankAccount);
+        return $this->user()->can('update', $this->route('bankAccount'));
     }
 
     public function rules(): array

--- a/code/api/app/Http/Requests/CashAdjustments/CashAdjustments/StoreCashAdjustmentRequest.php
+++ b/code/api/app/Http/Requests/CashAdjustments/CashAdjustments/StoreCashAdjustmentRequest.php
@@ -2,8 +2,13 @@
 
 namespace App\Http\Requests\CashAdjustments\CashAdjustments;
 
+use App\Http\Requests\Concerns\ResolvesPublicIdReferences;
 use App\Http\Requests\Concerns\SharesValidationMessages;
 use App\Http\Requests\Concerns\ValidatesTenderTypeReference;
+use App\Models\BankAccount;
+use App\Models\CashAdjustment;
+use App\Models\CashSession;
+use App\Models\CashTerminal;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Validator;
 
@@ -12,7 +17,7 @@ use Illuminate\Validation\Validator;
  *   schema="StoreCashAdjustmentRequest",
  *   required={"cash_session_id", "type", "direction", "lines"},
  *
- *   @OA\Property(property="cash_session_id", type="integer", example=1, description="Cash Session ID"),
+ *   @OA\Property(property="cash_session_id", type="string", example="01JKABC0987654321ZYXWVUTS", description="Cash Session public_id (ULID)"),
  *   @OA\Property(property="source_system", type="string", maxLength=100, example="POS", description="Source system name", nullable=true),
  *   @OA\Property(property="type", type="string", enum={"EXTERNAL_IMPORT", "CORRECTION"}, example="EXTERNAL_IMPORT", description="Adjustment type"),
  *   @OA\Property(property="direction", type="string", enum={"INFLOW", "OUTFLOW"}, example="INFLOW", description="Cash flow direction"),
@@ -30,8 +35,8 @@ use Illuminate\Validation\Validator;
  *       @OA\Property(property="tender_type", type="string", enum={"CASH", "CARD", "TRANSFER"}, example="CASH", description="Tender type"),
  *       @OA\Property(property="amount", type="number", format="decimal", example=500.00, description="Line amount"),
  *       @OA\Property(property="currency", type="string", example="MXN", description="Currency code (default: MXN)"),
- *       @OA\Property(property="card_terminal_id", type="integer", example=1, description="Terminal ID (required for CARD)", nullable=true),
- *       @OA\Property(property="bank_account_id", type="integer", example=1, description="Bank account ID (required for TRANSFER)", nullable=true),
+ *       @OA\Property(property="card_terminal_id", type="string", example="01JKABC0987654321ZYXWVUTS", description="Cash Terminal public_id (required for CARD)", nullable=true),
+ *       @OA\Property(property="bank_account_id", type="string", example="01JKABC0987654321ZYXWVUTS", description="Bank Account public_id (required for TRANSFER)", nullable=true),
  *       @OA\Property(property="reference", type="string", maxLength=255, example="TXN-123", description="Transaction reference", nullable=true),
  *       @OA\Property(property="meta", type="object", example={"tip": 50}, description="Line metadata", nullable=true),
  *     )
@@ -40,18 +45,19 @@ use Illuminate\Validation\Validator;
  */
 class StoreCashAdjustmentRequest extends FormRequest
 {
+    use ResolvesPublicIdReferences;
     use SharesValidationMessages;
     use ValidatesTenderTypeReference;
 
     public function authorize(): bool
     {
-        return $this->user()->can('create', \App\Models\CashAdjustment::class);
+        return $this->user()->can('create', CashAdjustment::class);
     }
 
     public function rules(): array
     {
         return [
-            'cash_session_id' => 'required|integer|exists:cash_sessions,id',
+            'cash_session_id' => 'required|string|exists:cash_sessions,public_id',
             'source_system' => 'nullable|string|max:100',
             'type' => 'required|in:EXTERNAL_IMPORT,CORRECTION',
             'direction' => 'required|in:INFLOW,OUTFLOW',
@@ -62,8 +68,8 @@ class StoreCashAdjustmentRequest extends FormRequest
             'lines.*.tender_type' => 'required|in:CASH,CARD,TRANSFER',
             'lines.*.amount' => 'required|numeric|min:0.01|max:999999.99',
             'lines.*.currency' => 'sometimes|string|size:3',
-            'lines.*.card_terminal_id' => 'nullable|integer|exists:cash_terminals,id',
-            'lines.*.bank_account_id' => 'nullable|integer|exists:bank_accounts,id',
+            'lines.*.card_terminal_id' => 'nullable|string|exists:cash_terminals,public_id',
+            'lines.*.bank_account_id' => 'nullable|string|exists:bank_accounts,public_id',
             'lines.*.reference' => 'nullable|string|max:255',
             'lines.*.meta' => 'nullable|array',
         ];
@@ -122,5 +128,29 @@ class StoreCashAdjustmentRequest extends FormRequest
 
             $this->merge(['lines' => $lines]);
         }
+    }
+
+    public function cashSession(): CashSession
+    {
+        return $this->resolveModelByPublicId(CashSession::class, 'cash_session_id');
+    }
+
+    /**
+     * Validated lines with card_terminal_id/bank_account_id resolved from
+     * public_id to the numeric FK the cash_adjustment_lines columns store.
+     */
+    public function linesData(): array
+    {
+        return collect($this->validated('lines', []))->map(function (array $line) {
+            if (array_key_exists('card_terminal_id', $line)) {
+                $line['card_terminal_id'] = $this->resolvePublicIdValue(CashTerminal::class, $line['card_terminal_id']);
+            }
+
+            if (array_key_exists('bank_account_id', $line)) {
+                $line['bank_account_id'] = $this->resolvePublicIdValue(BankAccount::class, $line['bank_account_id']);
+            }
+
+            return $line;
+        })->all();
     }
 }

--- a/code/api/app/Http/Requests/CashAdjustments/CashExpenses/StoreCashExpenseRequest.php
+++ b/code/api/app/Http/Requests/CashAdjustments/CashExpenses/StoreCashExpenseRequest.php
@@ -3,9 +3,13 @@
 namespace App\Http\Requests\CashAdjustments\CashExpenses;
 
 use App\Http\Requests\Concerns\CastsRequestFields;
+use App\Http\Requests\Concerns\ResolvesPublicIdReferences;
 use App\Http\Requests\Concerns\SharesValidationMessages;
 use App\Http\Requests\Concerns\ValidatesTenderTypeReference;
+use App\Models\BankAccount;
 use App\Models\CashExpense;
+use App\Models\CashSession;
+use App\Models\CashTerminal;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Validator;
 
@@ -14,15 +18,15 @@ use Illuminate\Validation\Validator;
  *   schema="StoreCashExpenseRequest",
  *   required={"cash_session_id", "tender_type", "amount", "category"},
  *
- *   @OA\Property(property="cash_session_id", type="integer", example=1, description="Cash Session ID"),
+ *   @OA\Property(property="cash_session_id", type="string", example="01JKABC0987654321ZYXWVUTS", description="Cash Session public_id (ULID)"),
  *   @OA\Property(property="tender_type", type="string", enum={"CASH", "CARD", "TRANSFER"}, example="CASH", description="Payment tender type"),
  *   @OA\Property(property="amount", type="number", format="decimal", example=150.00, description="Expense amount"),
  *   @OA\Property(property="category", type="string", maxLength=100, example="SUPPLIES", description="Expense category (e.g., SUPPLIES, MAINTENANCE, UTILITIES)"),
  *   @OA\Property(property="vendor", type="string", maxLength=255, example="Office Depot", description="Vendor name", nullable=true),
  *   @OA\Property(property="reference", type="string", maxLength=255, example="INV-12345", description="Invoice or receipt reference", nullable=true),
  *   @OA\Property(property="notes", type="string", maxLength=1000, example="Office supplies purchase", description="Additional notes", nullable=true),
- *   @OA\Property(property="card_terminal_id", type="integer", example=1, description="Terminal ID (required for CARD)", nullable=true),
- *   @OA\Property(property="bank_account_id", type="integer", example=1, description="Bank account ID (required for TRANSFER)", nullable=true),
+ *   @OA\Property(property="card_terminal_id", type="string", example="01JKABC0987654321ZYXWVUTS", description="Cash Terminal public_id (required for CARD)", nullable=true),
+ *   @OA\Property(property="bank_account_id", type="string", example="01JKABC0987654321ZYXWVUTS", description="Bank Account public_id (required for TRANSFER)", nullable=true),
  *   @OA\Property(property="incurred_at", type="string", format="date-time", example="2025-12-13T10:30:00Z", description="Expense date/time (defaults to now)", nullable=true),
  *   @OA\Property(property="meta", type="object", example={"receipt_url": "https://..."}, description="Additional metadata", nullable=true),
  * )
@@ -30,6 +34,7 @@ use Illuminate\Validation\Validator;
 class StoreCashExpenseRequest extends FormRequest
 {
     use CastsRequestFields;
+    use ResolvesPublicIdReferences;
     use SharesValidationMessages;
     use ValidatesTenderTypeReference;
 
@@ -41,15 +46,15 @@ class StoreCashExpenseRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'cash_session_id' => 'required|integer|exists:cash_sessions,id',
+            'cash_session_id' => 'required|string|exists:cash_sessions,public_id',
             'tender_type' => 'required|in:CASH,CARD,TRANSFER',
             'amount' => 'required|numeric|min:0.01|max:999999.99',
             'category' => 'required|string|max:100',
             'vendor' => 'nullable|string|max:255',
             'reference' => 'nullable|string|max:255',
             'notes' => 'nullable|string|max:1000',
-            'card_terminal_id' => 'nullable|integer|exists:cash_terminals,id',
-            'bank_account_id' => 'nullable|integer|exists:bank_accounts,id',
+            'card_terminal_id' => 'nullable|string|exists:cash_terminals,public_id',
+            'bank_account_id' => 'nullable|string|exists:bank_accounts,public_id',
             'incurred_at' => 'nullable|date',
             'meta' => 'nullable|array',
         ];
@@ -82,5 +87,20 @@ class StoreCashExpenseRequest extends FormRequest
     public function prepareForValidation(): void
     {
         $this->castToFloat('amount');
+    }
+
+    public function cashSession(): CashSession
+    {
+        return $this->resolveModelByPublicId(CashSession::class, 'cash_session_id');
+    }
+
+    public function cardTerminalId(): ?int
+    {
+        return $this->resolvePublicId(CashTerminal::class, 'card_terminal_id');
+    }
+
+    public function bankAccountId(): ?int
+    {
+        return $this->resolvePublicId(BankAccount::class, 'bank_account_id');
     }
 }

--- a/code/api/app/Http/Requests/CashAdjustments/CashExpenses/UpdateCashExpenseRequest.php
+++ b/code/api/app/Http/Requests/CashAdjustments/CashExpenses/UpdateCashExpenseRequest.php
@@ -3,9 +3,11 @@
 namespace App\Http\Requests\CashAdjustments\CashExpenses;
 
 use App\Http\Requests\Concerns\CastsRequestFields;
+use App\Http\Requests\Concerns\ResolvesPublicIdReferences;
 use App\Http\Requests\Concerns\SharesValidationMessages;
 use App\Http\Requests\Concerns\ValidatesTenderTypeReference;
-use App\Models\CashExpense;
+use App\Models\BankAccount;
+use App\Models\CashTerminal;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Validator;
 
@@ -19,8 +21,8 @@ use Illuminate\Validation\Validator;
  *   @OA\Property(property="vendor", type="string", maxLength=255, example="Office Depot", description="Vendor name", nullable=true),
  *   @OA\Property(property="reference", type="string", maxLength=255, example="INV-12345", description="Invoice reference", nullable=true),
  *   @OA\Property(property="notes", type="string", maxLength=1000, example="Office supplies", description="Additional notes", nullable=true),
- *   @OA\Property(property="card_terminal_id", type="integer", example=1, description="Terminal ID (for CARD)", nullable=true),
- *   @OA\Property(property="bank_account_id", type="integer", example=1, description="Bank account ID (for TRANSFER)", nullable=true),
+ *   @OA\Property(property="card_terminal_id", type="string", example="01JKABC0987654321ZYXWVUTS", description="Cash Terminal public_id (for CARD)", nullable=true),
+ *   @OA\Property(property="bank_account_id", type="string", example="01JKABC0987654321ZYXWVUTS", description="Bank Account public_id (for TRANSFER)", nullable=true),
  *   @OA\Property(property="incurred_at", type="string", format="date-time", example="2025-12-13T10:30:00Z", description="Expense date/time"),
  *   @OA\Property(property="meta", type="object", example={"receipt_url": "https://..."}, description="Additional metadata", nullable=true),
  * )
@@ -28,24 +30,19 @@ use Illuminate\Validation\Validator;
 class UpdateCashExpenseRequest extends FormRequest
 {
     use CastsRequestFields;
+    use ResolvesPublicIdReferences;
     use SharesValidationMessages;
     use ValidatesTenderTypeReference;
 
-    private ?CashExpense $cashExpense = null;
-
     public function authorize(): bool
     {
-        $this->cashExpense = CashExpense::find($this->route('id'));
+        $cashExpense = $this->route('cashExpense');
 
-        if (! $this->cashExpense) {
-            abort(404);
-        }
-
-        if ($this->cashExpense->isPosted()) {
+        if ($cashExpense->isPosted()) {
             return false;
         }
 
-        return $this->user()->can('update', $this->cashExpense);
+        return $this->user()->can('update', $cashExpense);
     }
 
     public function rules(): array
@@ -57,8 +54,8 @@ class UpdateCashExpenseRequest extends FormRequest
             'vendor' => 'nullable|string|max:255',
             'reference' => 'nullable|string|max:255',
             'notes' => 'nullable|string|max:1000',
-            'card_terminal_id' => 'nullable|integer|exists:cash_terminals,id',
-            'bank_account_id' => 'nullable|integer|exists:bank_accounts,id',
+            'card_terminal_id' => 'nullable|string|exists:cash_terminals,public_id',
+            'bank_account_id' => 'nullable|string|exists:bank_accounts,public_id',
             'incurred_at' => 'sometimes|date',
             'meta' => 'nullable|array',
         ];
@@ -72,11 +69,13 @@ class UpdateCashExpenseRequest extends FormRequest
     public function withValidator(Validator $validator): void
     {
         $validator->after(function ($validator) {
+            $cashExpense = $this->route('cashExpense');
+
             $this->requireTenderTypeReference(
                 $validator,
-                $this->input('tender_type', $this->cashExpense->tender_type),
-                $this->input('card_terminal_id', $this->cashExpense->card_terminal_id),
-                $this->input('bank_account_id', $this->cashExpense->bank_account_id)
+                $this->input('tender_type', $cashExpense->tender_type),
+                $this->input('card_terminal_id', $cashExpense->card_terminal_id),
+                $this->input('bank_account_id', $cashExpense->bank_account_id)
             );
         });
     }
@@ -84,5 +83,24 @@ class UpdateCashExpenseRequest extends FormRequest
     public function prepareForValidation(): void
     {
         $this->castToFloat('amount');
+    }
+
+    /**
+     * Validated data with card_terminal_id/bank_account_id resolved from
+     * public_id to the numeric FK the model column stores.
+     */
+    public function expenseData(): array
+    {
+        $data = $this->validated();
+
+        if (array_key_exists('card_terminal_id', $data)) {
+            $data['card_terminal_id'] = $this->resolvePublicId(CashTerminal::class, 'card_terminal_id');
+        }
+
+        if (array_key_exists('bank_account_id', $data)) {
+            $data['bank_account_id'] = $this->resolvePublicId(BankAccount::class, 'bank_account_id');
+        }
+
+        return $data;
     }
 }

--- a/code/api/app/Http/Requests/CashAdjustments/CashRegisters/UpdateCashRegisterRequest.php
+++ b/code/api/app/Http/Requests/CashAdjustments/CashRegisters/UpdateCashRegisterRequest.php
@@ -4,7 +4,6 @@ namespace App\Http\Requests\CashAdjustments\CashRegisters;
 
 use App\Http\Requests\Concerns\CastsRequestFields;
 use App\Http\Requests\Concerns\SharesValidationMessages;
-use App\Models\CashRegister;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
@@ -24,24 +23,18 @@ class UpdateCashRegisterRequest extends FormRequest
     use CastsRequestFields;
     use SharesValidationMessages;
 
-    private ?CashRegister $cashRegister = null;
-
     public function authorize(): bool
     {
-        $this->cashRegister = CashRegister::find($this->route('id'));
-
-        if (! $this->cashRegister) {
-            abort(404);
-        }
-
-        return $this->user()->can('update', $this->cashRegister);
+        return $this->user()->can('update', $this->route('cashRegister'));
     }
 
     public function rules(): array
     {
+        $cashRegisterId = $this->route('cashRegister')->id;
+
         return [
             'operating_unit_id' => 'nullable|integer|exists:operating_units,id',
-            'code' => 'sometimes|string|max:50|unique:cash_registers,code,'.$this->cashRegister->id,
+            'code' => 'sometimes|string|max:50|unique:cash_registers,code,'.$cashRegisterId,
             'name' => 'sometimes|string|max:255',
             'type' => 'sometimes|in:ON_PREMISE,DELIVERY,EVENT',
             'is_active' => 'boolean',

--- a/code/api/app/Http/Requests/CashAdjustments/CashSessions/StoreCashSessionRequest.php
+++ b/code/api/app/Http/Requests/CashAdjustments/CashSessions/StoreCashSessionRequest.php
@@ -3,7 +3,9 @@
 namespace App\Http\Requests\CashAdjustments\CashSessions;
 
 use App\Http\Requests\Concerns\CastsRequestFields;
+use App\Http\Requests\Concerns\ResolvesPublicIdReferences;
 use App\Http\Requests\Concerns\SharesValidationMessages;
+use App\Models\CashRegister;
 use App\Models\CashSession;
 use Illuminate\Foundation\Http\FormRequest;
 
@@ -12,7 +14,7 @@ use Illuminate\Foundation\Http\FormRequest;
  *   schema="StoreCashSessionRequest",
  *   required={"cash_register_id", "operating_date"},
  *
- *   @OA\Property(property="cash_register_id", type="integer", example=1, description="Cash Register ID"),
+ *   @OA\Property(property="cash_register_id", type="string", example="01JKABC0987654321ZYXWVUTS", description="Cash Register public_id (ULID)"),
  *   @OA\Property(property="operating_date", type="string", format="date", example="2025-12-13", description="Operating date (YYYY-MM-DD)"),
  *   @OA\Property(property="opening_balance", type="number", format="decimal", example=1000.00, description="Opening balance (defaults to previous day closing)", nullable=true),
  *   @OA\Property(property="meta", type="object", example={"note": "Morning shift"}, description="Additional metadata", nullable=true),
@@ -21,6 +23,7 @@ use Illuminate\Foundation\Http\FormRequest;
 class StoreCashSessionRequest extends FormRequest
 {
     use CastsRequestFields;
+    use ResolvesPublicIdReferences;
     use SharesValidationMessages;
 
     public function authorize(): bool
@@ -31,7 +34,7 @@ class StoreCashSessionRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'cash_register_id' => 'required|integer|exists:cash_registers,id',
+            'cash_register_id' => 'required|string|exists:cash_registers,public_id',
             'operating_date' => 'required|date|date_format:Y-m-d',
             'opening_balance' => 'nullable|numeric|min:0|max:999999.99',
             'meta' => 'nullable|array',
@@ -53,5 +56,10 @@ class StoreCashSessionRequest extends FormRequest
     public function prepareForValidation(): void
     {
         $this->castToFloat('opening_balance');
+    }
+
+    public function cashRegister(): CashRegister
+    {
+        return $this->resolveModelByPublicId(CashRegister::class, 'cash_register_id');
     }
 }

--- a/code/api/app/Http/Requests/CashAdjustments/CashSessions/UpdateCashSessionRequest.php
+++ b/code/api/app/Http/Requests/CashAdjustments/CashSessions/UpdateCashSessionRequest.php
@@ -4,7 +4,6 @@ namespace App\Http\Requests\CashAdjustments\CashSessions;
 
 use App\Http\Requests\Concerns\CastsRequestFields;
 use App\Http\Requests\Concerns\SharesValidationMessages;
-use App\Models\CashSession;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
@@ -23,11 +22,7 @@ class UpdateCashSessionRequest extends FormRequest
 
     public function authorize(): bool
     {
-        $session = CashSession::find($this->route('id'));
-
-        if (! $session) {
-            abort(404);
-        }
+        $session = $this->route('cashSession');
 
         if ($session->isPosted()) {
             return false;

--- a/code/api/app/Http/Requests/CashAdjustments/CashTerminals/UpdateCashTerminalRequest.php
+++ b/code/api/app/Http/Requests/CashAdjustments/CashTerminals/UpdateCashTerminalRequest.php
@@ -4,7 +4,6 @@ namespace App\Http\Requests\CashAdjustments\CashTerminals;
 
 use App\Http\Requests\Concerns\CastsRequestFields;
 use App\Http\Requests\Concerns\SharesValidationMessages;
-use App\Models\CashTerminal;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
@@ -26,13 +25,7 @@ class UpdateCashTerminalRequest extends FormRequest
 
     public function authorize(): bool
     {
-        $cashTerminal = CashTerminal::find($this->route('id'));
-
-        if (! $cashTerminal) {
-            abort(404);
-        }
-
-        return $this->user()->can('update', $cashTerminal);
+        return $this->user()->can('update', $this->route('cashTerminal'));
     }
 
     public function rules(): array

--- a/code/api/app/Http/Requests/Concerns/ResolvesPublicIdReferences.php
+++ b/code/api/app/Http/Requests/Concerns/ResolvesPublicIdReferences.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests\Concerns;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Resolves ULID public_id foreign-key inputs into the models/numeric ids the
+ * Service layer still expects internally (see #293 — API responses expose
+ * public_id, but the database FK columns remain numeric).
+ */
+trait ResolvesPublicIdReferences
+{
+    /**
+     * @param  class-string<Model>  $modelClass
+     */
+    protected function resolveModelByPublicId(string $modelClass, string $field): Model
+    {
+        return $modelClass::where('public_id', $this->validated($field))->firstOrFail();
+    }
+
+    /**
+     * @param  class-string<Model>  $modelClass
+     */
+    protected function resolvePublicId(string $modelClass, string $field): ?int
+    {
+        return $this->resolvePublicIdValue($modelClass, $this->validated($field));
+    }
+
+    /**
+     * @param  class-string<Model>  $modelClass
+     */
+    protected function resolvePublicIdValue(string $modelClass, ?string $publicId): ?int
+    {
+        if (! $publicId) {
+            return null;
+        }
+
+        return $modelClass::where('public_id', $publicId)->value('id');
+    }
+}

--- a/code/api/app/Models/BankAccount.php
+++ b/code/api/app/Models/BankAccount.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Support\Traits\HasPublicId;
+use App\Support\Traits\SerializesPublicIdAsId;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -9,7 +11,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class BankAccount extends Model
 {
-    use HasFactory;
+    use HasFactory, HasPublicId, SerializesPublicIdAsId;
 
     protected $fillable = [
         'branch_id',

--- a/code/api/app/Models/CashAdjustment.php
+++ b/code/api/app/Models/CashAdjustment.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Support\Traits\HasPublicId;
+use App\Support\Traits\SerializesPublicIdAsId;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -9,7 +11,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class CashAdjustment extends Model
 {
-    use HasFactory;
+    use HasFactory, HasPublicId, SerializesPublicIdAsId;
 
     protected $fillable = [
         'cash_session_id',
@@ -25,6 +27,16 @@ class CashAdjustment extends Model
     protected $casts = [
         'posted_at' => 'datetime',
         'meta' => 'array',
+    ];
+
+    /**
+     * cash_session_id points at CashSession, which — like this model —
+     * exposes public_id instead of its numeric id (see #293). Hide the raw
+     * FK so it doesn't leak the numeric id; consumers should use the loaded
+     * cashSession relation's id (already a ULID) instead.
+     */
+    protected $hidden = [
+        'cash_session_id',
     ];
 
     // Type constants

--- a/code/api/app/Models/CashAdjustmentLine.php
+++ b/code/api/app/Models/CashAdjustmentLine.php
@@ -29,6 +29,21 @@ class CashAdjustmentLine extends Model
         'created_at' => 'datetime',
     ];
 
+    /**
+     * cash_adjustment_id/card_terminal_id/bank_account_id point at
+     * CashAdjustment/CashTerminal/BankAccount, which expose public_id
+     * instead of their numeric id (see #293). Hide the raw FKs so they don't
+     * leak numeric ids; consumers should use the loaded cashAdjustment/
+     * cardTerminal/bankAccount relations' ids (already ULIDs) instead.
+     * This model itself has no public_id of its own — it's never
+     * independently routable (always nested under a CashAdjustment).
+     */
+    protected $hidden = [
+        'cash_adjustment_id',
+        'card_terminal_id',
+        'bank_account_id',
+    ];
+
     // Tender type constants
     public const TENDER_CASH = 'CASH';
 

--- a/code/api/app/Models/CashExpense.php
+++ b/code/api/app/Models/CashExpense.php
@@ -2,13 +2,15 @@
 
 namespace App\Models;
 
+use App\Support\Traits\HasPublicId;
+use App\Support\Traits\SerializesPublicIdAsId;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class CashExpense extends Model
 {
-    use HasFactory;
+    use HasFactory, HasPublicId, SerializesPublicIdAsId;
 
     protected $fillable = [
         'cash_session_id',
@@ -32,6 +34,18 @@ class CashExpense extends Model
         'incurred_at' => 'datetime',
         'posted_at' => 'datetime',
         'meta' => 'array',
+    ];
+
+    /**
+     * cash_session_id/card_terminal_id/bank_account_id point at models that
+     * — like this one — expose public_id instead of their numeric id (see
+     * #293). Hide the raw FKs so they don't leak numeric ids; consumers
+     * should use the loaded relations' ids (already ULIDs) instead.
+     */
+    protected $hidden = [
+        'cash_session_id',
+        'card_terminal_id',
+        'bank_account_id',
     ];
 
     // Tender type constants

--- a/code/api/app/Models/CashRegister.php
+++ b/code/api/app/Models/CashRegister.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Support\Traits\HasPublicId;
+use App\Support\Traits\SerializesPublicIdAsId;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -9,7 +11,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class CashRegister extends Model
 {
-    use HasFactory;
+    use HasFactory, HasPublicId, SerializesPublicIdAsId;
 
     protected $fillable = [
         'branch_id',

--- a/code/api/app/Models/CashSession.php
+++ b/code/api/app/Models/CashSession.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Support\Traits\HasPublicId;
+use App\Support\Traits\SerializesPublicIdAsId;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -9,7 +11,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class CashSession extends Model
 {
-    use HasFactory;
+    use HasFactory, HasPublicId, SerializesPublicIdAsId;
 
     protected $fillable = [
         'cash_register_id',
@@ -25,6 +27,16 @@ class CashSession extends Model
         'opening_balance' => 'decimal:4',
         'closing_balance' => 'decimal:4',
         'meta' => 'array',
+    ];
+
+    /**
+     * cash_register_id points at CashRegister, which — like this model —
+     * exposes public_id instead of its numeric id (see #293). Hide the raw
+     * FK so it doesn't leak the numeric id; consumers should use the loaded
+     * cashRegister relation's id (already a ULID) instead.
+     */
+    protected $hidden = [
+        'cash_register_id',
     ];
 
     // Status constants

--- a/code/api/app/Models/CashTerminal.php
+++ b/code/api/app/Models/CashTerminal.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Support\Traits\HasPublicId;
+use App\Support\Traits\SerializesPublicIdAsId;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -9,7 +11,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class CashTerminal extends Model
 {
-    use HasFactory;
+    use HasFactory, HasPublicId, SerializesPublicIdAsId;
 
     protected $fillable = [
         'branch_id',

--- a/code/api/app/Support/CashAdjustmentRouteParams.php
+++ b/code/api/app/Support/CashAdjustmentRouteParams.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Support;
+
+/**
+ * Route-parameter segments for the CashAdjustments domain routes — see
+ * routes/api/cash-adjustments.php.
+ *
+ * Each segment name matches its controller's Eloquent-typed parameter (e.g.
+ * {cashRegister} -> CashRegister $cashRegister) so Laravel's implicit model
+ * binding resolves via the model's public_id (see #293), instead of the
+ * generic RouteParams::ID used elsewhere in the app.
+ *
+ * Defined as class constants — not top-level `const` in the route file
+ * itself — for the same reason documented on RouteParams: routes/api.php is
+ * `require`d fresh on every application boot (Laravel's loadRoutesFrom does
+ * not use require_once), so top-level constants would fatal with "already
+ * defined" on a second boot in the same PHP process (e.g. across tests).
+ */
+final class CashAdjustmentRouteParams
+{
+    public const CASH_REGISTER = '/{cashRegister}';
+
+    public const CASH_TERMINAL = '/{cashTerminal}';
+
+    public const BANK_ACCOUNT = '/{bankAccount}';
+
+    public const CASH_SESSION = '/{cashSession}';
+
+    public const CASH_ADJUSTMENT = '/{cashAdjustment}';
+
+    public const CASH_EXPENSE = '/{cashExpense}';
+
+    public const POST_ACTION = '/post';
+}

--- a/code/api/app/Support/Traits/SerializesPublicIdAsId.php
+++ b/code/api/app/Support/Traits/SerializesPublicIdAsId.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Support\Traits;
+
+trait SerializesPublicIdAsId
+{
+    /**
+     * Replace the numeric primary key with the ULID public_id under the
+     * 'id' key in array/JSON output — applies everywhere the model gets
+     * serialized (Show/Update responses, paginated List responses, and
+     * nested relations on other models using this same trait), without
+     * requiring a dedicated API Resource class per model. The numeric id
+     * remains the real primary key for internal use (queries, FKs); only
+     * the serialized representation changes.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $array = parent::toArray();
+
+        $array['id'] = $this->public_id;
+        unset($array['public_id']);
+
+        return $array;
+    }
+}

--- a/code/api/database/migrations/2026_07_23_224028_add_public_id_to_cash_adjustments_tables.php
+++ b/code/api/database/migrations/2026_07_23_224028_add_public_id_to_cash_adjustments_tables.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    /**
+     * Tables in the CashAdjustments domain that exposed their raw
+     * sequential id in URLs and JSON responses. See #293.
+     */
+    private const TABLES = [
+        'cash_registers',
+        'cash_terminals',
+        'bank_accounts',
+        'cash_sessions',
+        'cash_expenses',
+        'cash_adjustments',
+    ];
+
+    public function up(): void
+    {
+        foreach (self::TABLES as $table) {
+            Schema::table($table, function (Blueprint $blueprint) {
+                $blueprint->char('public_id', 26)->after('id')->nullable();
+            });
+
+            DB::table($table)->whereNull('public_id')->eachById(function ($row) use ($table) {
+                DB::table($table)
+                    ->where('id', $row->id)
+                    ->update(['public_id' => (string) Str::ulid()]);
+            });
+
+            Schema::table($table, function (Blueprint $blueprint) {
+                $blueprint->char('public_id', 26)->nullable(false)->unique()->change();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        foreach (self::TABLES as $table) {
+            Schema::table($table, function (Blueprint $blueprint) {
+                $blueprint->dropColumn('public_id');
+            });
+        }
+    }
+};

--- a/code/api/routes/api/cash-adjustments.php
+++ b/code/api/routes/api/cash-adjustments.php
@@ -32,10 +32,14 @@ use App\Http\Controllers\CashAdjustments\CashTerminals\DeleteCashTerminalControl
 use App\Http\Controllers\CashAdjustments\CashTerminals\ListCashTerminalsController;
 use App\Http\Controllers\CashAdjustments\CashTerminals\ShowCashTerminalController;
 use App\Http\Controllers\CashAdjustments\CashTerminals\UpdateCashTerminalController;
-use App\Support\RouteParams;
+use App\Support\CashAdjustmentRouteParams;
 use Illuminate\Support\Facades\Route;
 
 // Cash Adjustments Module (All Protected)
+// Route segments below use ULID public_id binding — see #293. Each segment
+// name matches its controller's Eloquent-typed parameter (e.g. {cashRegister}
+// -> CashRegister $cashRegister) so Laravel's implicit model binding resolves
+// correctly via CashRegister::getRouteKeyName() = 'public_id'.
 Route::middleware('auth:api')->group(function () {
     // Cash Registers
     Route::prefix('cash-registers')->group(function () {
@@ -43,11 +47,11 @@ Route::middleware('auth:api')->group(function () {
             ->name('cash-registers.list');
         Route::post('/', CreateCashRegisterController::class)
             ->name('cash-registers.create');
-        Route::get(RouteParams::ID, ShowCashRegisterController::class)
+        Route::get(CashAdjustmentRouteParams::CASH_REGISTER, ShowCashRegisterController::class)
             ->name('cash-registers.show');
-        Route::put(RouteParams::ID, UpdateCashRegisterController::class)
+        Route::put(CashAdjustmentRouteParams::CASH_REGISTER, UpdateCashRegisterController::class)
             ->name('cash-registers.update');
-        Route::delete(RouteParams::ID, DeleteCashRegisterController::class)
+        Route::delete(CashAdjustmentRouteParams::CASH_REGISTER, DeleteCashRegisterController::class)
             ->name('cash-registers.delete');
     });
 
@@ -57,11 +61,11 @@ Route::middleware('auth:api')->group(function () {
             ->name('cash-terminals.list');
         Route::post('/', CreateCashTerminalController::class)
             ->name('cash-terminals.create');
-        Route::get(RouteParams::ID, ShowCashTerminalController::class)
+        Route::get(CashAdjustmentRouteParams::CASH_TERMINAL, ShowCashTerminalController::class)
             ->name('cash-terminals.show');
-        Route::put(RouteParams::ID, UpdateCashTerminalController::class)
+        Route::put(CashAdjustmentRouteParams::CASH_TERMINAL, UpdateCashTerminalController::class)
             ->name('cash-terminals.update');
-        Route::delete(RouteParams::ID, DeleteCashTerminalController::class)
+        Route::delete(CashAdjustmentRouteParams::CASH_TERMINAL, DeleteCashTerminalController::class)
             ->name('cash-terminals.delete');
     });
 
@@ -71,11 +75,11 @@ Route::middleware('auth:api')->group(function () {
             ->name('bank-accounts.list');
         Route::post('/', CreateBankAccountController::class)
             ->name('bank-accounts.create');
-        Route::get(RouteParams::ID, ShowBankAccountController::class)
+        Route::get(CashAdjustmentRouteParams::BANK_ACCOUNT, ShowBankAccountController::class)
             ->name('bank-accounts.show');
-        Route::put(RouteParams::ID, UpdateBankAccountController::class)
+        Route::put(CashAdjustmentRouteParams::BANK_ACCOUNT, UpdateBankAccountController::class)
             ->name('bank-accounts.update');
-        Route::delete(RouteParams::ID, DeleteBankAccountController::class)
+        Route::delete(CashAdjustmentRouteParams::BANK_ACCOUNT, DeleteBankAccountController::class)
             ->name('bank-accounts.delete');
     });
 
@@ -85,13 +89,13 @@ Route::middleware('auth:api')->group(function () {
             ->name('cash-sessions.list');
         Route::post('/', CreateCashSessionController::class)
             ->name('cash-sessions.create');
-        Route::get(RouteParams::ID, ShowCashSessionController::class)
+        Route::get(CashAdjustmentRouteParams::CASH_SESSION, ShowCashSessionController::class)
             ->name('cash-sessions.show');
-        Route::put(RouteParams::ID, UpdateCashSessionController::class)
+        Route::put(CashAdjustmentRouteParams::CASH_SESSION, UpdateCashSessionController::class)
             ->name('cash-sessions.update');
-        Route::post(RouteParams::ID_POST, PostCashSessionController::class)
+        Route::post(CashAdjustmentRouteParams::CASH_SESSION.CashAdjustmentRouteParams::POST_ACTION, PostCashSessionController::class)
             ->name('cash-sessions.post');
-        Route::get('/{id}/summary', GetSessionSummaryController::class)
+        Route::get(CashAdjustmentRouteParams::CASH_SESSION.'/summary', GetSessionSummaryController::class)
             ->name('cash-sessions.summary');
     });
 
@@ -101,11 +105,11 @@ Route::middleware('auth:api')->group(function () {
             ->name('cash-adjustments.list');
         Route::post('/', CreateCashAdjustmentController::class)
             ->name('cash-adjustments.create');
-        Route::get(RouteParams::ID, ShowCashAdjustmentController::class)
+        Route::get(CashAdjustmentRouteParams::CASH_ADJUSTMENT, ShowCashAdjustmentController::class)
             ->name('cash-adjustments.show');
-        Route::delete(RouteParams::ID, DeleteCashAdjustmentController::class)
+        Route::delete(CashAdjustmentRouteParams::CASH_ADJUSTMENT, DeleteCashAdjustmentController::class)
             ->name('cash-adjustments.delete');
-        Route::post(RouteParams::ID_POST, PostCashAdjustmentController::class)
+        Route::post(CashAdjustmentRouteParams::CASH_ADJUSTMENT.CashAdjustmentRouteParams::POST_ACTION, PostCashAdjustmentController::class)
             ->name('cash-adjustments.post');
     });
 
@@ -115,13 +119,13 @@ Route::middleware('auth:api')->group(function () {
             ->name('cash-expenses.list');
         Route::post('/', CreateCashExpenseController::class)
             ->name('cash-expenses.create');
-        Route::get(RouteParams::ID, ShowCashExpenseController::class)
+        Route::get(CashAdjustmentRouteParams::CASH_EXPENSE, ShowCashExpenseController::class)
             ->name('cash-expenses.show');
-        Route::put(RouteParams::ID, UpdateCashExpenseController::class)
+        Route::put(CashAdjustmentRouteParams::CASH_EXPENSE, UpdateCashExpenseController::class)
             ->name('cash-expenses.update');
-        Route::delete(RouteParams::ID, DeleteCashExpenseController::class)
+        Route::delete(CashAdjustmentRouteParams::CASH_EXPENSE, DeleteCashExpenseController::class)
             ->name('cash-expenses.delete');
-        Route::post(RouteParams::ID_POST, PostCashExpenseController::class)
+        Route::post(CashAdjustmentRouteParams::CASH_EXPENSE.CashAdjustmentRouteParams::POST_ACTION, PostCashExpenseController::class)
             ->name('cash-expenses.post');
     });
 });

--- a/code/api/tests/Feature/CashAdjustments/BankAccounts/BankAccountAuthorizationTest.php
+++ b/code/api/tests/Feature/CashAdjustments/BankAccounts/BankAccountAuthorizationTest.php
@@ -25,9 +25,9 @@ class BankAccountAuthorizationTest extends TestCase
         $account = BankAccount::factory()->for($branch)->create(['alias' => 'Cuenta Real']);
         $this->actingAsUserWithBranchAccess($branch, 'bank_accounts.view');
 
-        $response = $this->getJson("/api/v1/bank-accounts/{$account->id}");
+        $response = $this->getJson("/api/v1/bank-accounts/{$account->public_id}");
 
-        $response->assertStatus(200)->assertJsonPath('data.id', $account->id);
+        $response->assertStatus(200)->assertJsonPath('data.id', $account->public_id);
     }
 
     #[Test]
@@ -37,7 +37,7 @@ class BankAccountAuthorizationTest extends TestCase
         $account = BankAccount::factory()->for($branch)->create();
         $this->actingAsUserWithoutBranchAccess('bank_accounts.view');
 
-        $response = $this->getJson("/api/v1/bank-accounts/{$account->id}");
+        $response = $this->getJson("/api/v1/bank-accounts/{$account->public_id}");
 
         $response->assertStatus(403);
     }
@@ -60,7 +60,7 @@ class BankAccountAuthorizationTest extends TestCase
         $account = BankAccount::factory()->for($branch)->create(['alias' => 'Old Alias']);
         $this->actingAsUserWithBranchAccess($branch, 'bank_accounts.update');
 
-        $response = $this->putJson("/api/v1/bank-accounts/{$account->id}", ['alias' => 'New Alias']);
+        $response = $this->putJson("/api/v1/bank-accounts/{$account->public_id}", ['alias' => 'New Alias']);
 
         $response->assertStatus(200)->assertJsonPath('data.alias', 'New Alias');
         $this->assertDatabaseHas('bank_accounts', ['id' => $account->id, 'alias' => 'New Alias']);
@@ -73,7 +73,7 @@ class BankAccountAuthorizationTest extends TestCase
         $account = BankAccount::factory()->for($branch)->create(['alias' => 'Untouched']);
         $this->actingAsUserWithoutBranchAccess('bank_accounts.update');
 
-        $response = $this->putJson("/api/v1/bank-accounts/{$account->id}", ['alias' => 'Nope']);
+        $response = $this->putJson("/api/v1/bank-accounts/{$account->public_id}", ['alias' => 'Nope']);
 
         $response->assertStatus(403);
         $this->assertDatabaseHas('bank_accounts', ['id' => $account->id, 'alias' => 'Untouched']);
@@ -86,7 +86,7 @@ class BankAccountAuthorizationTest extends TestCase
         $account = BankAccount::factory()->for($branch)->create();
         $this->actingAsUserWithBranchAccess($branch, 'bank_accounts.delete');
 
-        $response = $this->deleteJson("/api/v1/bank-accounts/{$account->id}");
+        $response = $this->deleteJson("/api/v1/bank-accounts/{$account->public_id}");
 
         $response->assertStatus(200);
         $this->assertDatabaseMissing('bank_accounts', ['id' => $account->id]);
@@ -99,7 +99,7 @@ class BankAccountAuthorizationTest extends TestCase
         $account = BankAccount::factory()->for($branch)->create();
         $this->actingAsUserWithoutBranchAccess('bank_accounts.delete');
 
-        $response = $this->deleteJson("/api/v1/bank-accounts/{$account->id}");
+        $response = $this->deleteJson("/api/v1/bank-accounts/{$account->public_id}");
 
         $response->assertStatus(403);
         $this->assertDatabaseHas('bank_accounts', ['id' => $account->id]);

--- a/code/api/tests/Feature/CashAdjustments/CashAdjustments/CashAdjustmentAuthorizationTest.php
+++ b/code/api/tests/Feature/CashAdjustments/CashAdjustments/CashAdjustmentAuthorizationTest.php
@@ -4,9 +4,12 @@ namespace Tests\Feature\CashAdjustments\CashAdjustments;
 
 use App\Models\Branch;
 use App\Models\CashAdjustment;
+use App\Models\CashAdjustmentLine;
 use App\Models\CashRegister;
 use App\Models\CashSession;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Feature\CashAdjustments\Concerns\SetsUpBranchAccess;
 use Tests\TestCase;
@@ -29,15 +32,29 @@ class CashAdjustmentAuthorizationTest extends TestCase
     }
 
     #[Test]
+    public function show_does_not_leak_the_numeric_adjustment_fk_on_nested_lines(): void
+    {
+        $branch = Branch::factory()->create();
+        $adjustment = $this->adjustmentForBranch($branch);
+        CashAdjustmentLine::factory()->for($adjustment, 'cashAdjustment')->cash()->create();
+        $this->actingAsUserWithBranchAccess($branch, 'cash_adjustments.view');
+
+        $response = $this->getJson("/api/v1/cash-adjustments/{$adjustment->public_id}");
+
+        $response->assertStatus(200)
+            ->assertJsonMissingPath('data.lines.0.cash_adjustment_id');
+    }
+
+    #[Test]
     public function show_returns_the_actual_requested_adjustment(): void
     {
         $branch = Branch::factory()->create();
         $adjustment = $this->adjustmentForBranch($branch);
         $this->actingAsUserWithBranchAccess($branch, 'cash_adjustments.view');
 
-        $response = $this->getJson("/api/v1/cash-adjustments/{$adjustment->id}");
+        $response = $this->getJson("/api/v1/cash-adjustments/{$adjustment->public_id}");
 
-        $response->assertStatus(200)->assertJsonPath('data.id', $adjustment->id);
+        $response->assertStatus(200)->assertJsonPath('data.id', $adjustment->public_id);
     }
 
     #[Test]
@@ -47,7 +64,7 @@ class CashAdjustmentAuthorizationTest extends TestCase
         $adjustment = $this->adjustmentForBranch($branch);
         $this->actingAsUserWithoutBranchAccess('cash_adjustments.view');
 
-        $response = $this->getJson("/api/v1/cash-adjustments/{$adjustment->id}");
+        $response = $this->getJson("/api/v1/cash-adjustments/{$adjustment->public_id}");
 
         $response->assertStatus(403);
     }
@@ -64,13 +81,31 @@ class CashAdjustmentAuthorizationTest extends TestCase
     }
 
     #[Test]
+    public function list_filters_by_cash_session_public_id(): void
+    {
+        $branch = Branch::factory()->create();
+        $adjustment = $this->adjustmentForBranch($branch);
+        CashAdjustment::factory()->for(
+            CashSession::factory()->for(CashRegister::factory()->for($branch)->create(), 'cashRegister')->draft(),
+            'cashSession'
+        )->draft()->create();
+        Passport::actingAs(User::factory()->create());
+
+        $response = $this->getJson('/api/v1/cash-adjustments?cash_session_id='.$adjustment->cashSession->public_id);
+
+        $response->assertStatus(200)
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $adjustment->public_id);
+    }
+
+    #[Test]
     public function delete_actually_deletes_the_requested_adjustment(): void
     {
         $branch = Branch::factory()->create();
         $adjustment = $this->adjustmentForBranch($branch);
         $this->actingAsUserWithBranchAccess($branch, 'cash_adjustments.delete');
 
-        $response = $this->deleteJson("/api/v1/cash-adjustments/{$adjustment->id}");
+        $response = $this->deleteJson("/api/v1/cash-adjustments/{$adjustment->public_id}");
 
         $response->assertStatus(200);
         $this->assertDatabaseMissing('cash_adjustments', ['id' => $adjustment->id]);
@@ -83,7 +118,7 @@ class CashAdjustmentAuthorizationTest extends TestCase
         $adjustment = $this->adjustmentForBranch($branch);
         $this->actingAsUserWithoutBranchAccess('cash_adjustments.delete');
 
-        $response = $this->deleteJson("/api/v1/cash-adjustments/{$adjustment->id}");
+        $response = $this->deleteJson("/api/v1/cash-adjustments/{$adjustment->public_id}");
 
         $response->assertStatus(403);
         $this->assertDatabaseHas('cash_adjustments', ['id' => $adjustment->id]);
@@ -96,7 +131,7 @@ class CashAdjustmentAuthorizationTest extends TestCase
         $adjustment = $this->adjustmentForBranch($branch);
         $this->actingAsUserWithBranchAccess($branch, 'cash_adjustments.post');
 
-        $response = $this->postJson("/api/v1/cash-adjustments/{$adjustment->id}/post");
+        $response = $this->postJson("/api/v1/cash-adjustments/{$adjustment->public_id}/post");
 
         $response->assertStatus(200);
         $this->assertNotNull($adjustment->fresh()->posted_at);
@@ -109,7 +144,7 @@ class CashAdjustmentAuthorizationTest extends TestCase
         $adjustment = $this->adjustmentForBranch($branch);
         $this->actingAsUserWithoutBranchAccess('cash_adjustments.post');
 
-        $response = $this->postJson("/api/v1/cash-adjustments/{$adjustment->id}/post");
+        $response = $this->postJson("/api/v1/cash-adjustments/{$adjustment->public_id}/post");
 
         $response->assertStatus(403);
         $this->assertNull($adjustment->fresh()->posted_at);

--- a/code/api/tests/Feature/CashAdjustments/CashAdjustments/CreateCashAdjustmentTest.php
+++ b/code/api/tests/Feature/CashAdjustments/CashAdjustments/CreateCashAdjustmentTest.php
@@ -2,9 +2,11 @@
 
 namespace Tests\Feature\CashAdjustments\CashAdjustments;
 
+use App\Models\BankAccount;
 use App\Models\Branch;
 use App\Models\CashRegister;
 use App\Models\CashSession;
+use App\Models\CashTerminal;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Passport\Passport;
@@ -46,12 +48,58 @@ class CreateCashAdjustmentTest extends TestCase
     }
 
     #[Test]
+    public function it_creates_a_card_line_linked_to_a_terminal(): void
+    {
+        $this->actingAsUserWithPermission();
+        $terminal = CashTerminal::factory()->create();
+
+        $response = $this->postJson('/api/v1/cash-adjustments', [
+            'cash_session_id' => $this->session->public_id,
+            'type' => 'CORRECTION',
+            'direction' => 'INFLOW',
+            'lines' => [
+                ['tender_type' => 'CARD', 'amount' => 100.00, 'card_terminal_id' => $terminal->public_id],
+            ],
+        ]);
+
+        $response->assertStatus(201);
+
+        $this->assertDatabaseHas('cash_adjustment_lines', [
+            'tender_type' => 'CARD',
+            'card_terminal_id' => $terminal->id,
+        ]);
+    }
+
+    #[Test]
+    public function it_creates_a_transfer_line_linked_to_a_bank_account(): void
+    {
+        $this->actingAsUserWithPermission();
+        $bankAccount = BankAccount::factory()->create();
+
+        $response = $this->postJson('/api/v1/cash-adjustments', [
+            'cash_session_id' => $this->session->public_id,
+            'type' => 'CORRECTION',
+            'direction' => 'INFLOW',
+            'lines' => [
+                ['tender_type' => 'TRANSFER', 'amount' => 100.00, 'bank_account_id' => $bankAccount->public_id],
+            ],
+        ]);
+
+        $response->assertStatus(201);
+
+        $this->assertDatabaseHas('cash_adjustment_lines', [
+            'tender_type' => 'TRANSFER',
+            'bank_account_id' => $bankAccount->id,
+        ]);
+    }
+
+    #[Test]
     public function it_rejects_a_card_line_without_terminal(): void
     {
         $this->actingAsUserWithPermission();
 
         $response = $this->postJson('/api/v1/cash-adjustments', [
-            'cash_session_id' => $this->session->id,
+            'cash_session_id' => $this->session->public_id,
             'type' => 'CORRECTION',
             'direction' => 'INFLOW',
             'lines' => [
@@ -71,7 +119,7 @@ class CreateCashAdjustmentTest extends TestCase
         $this->actingAsUserWithPermission();
 
         $response = $this->postJson('/api/v1/cash-adjustments', [
-            'cash_session_id' => $this->session->id,
+            'cash_session_id' => $this->session->public_id,
             'type' => 'CORRECTION',
             'direction' => 'INFLOW',
             'lines' => [

--- a/code/api/tests/Feature/CashAdjustments/CashExpenses/CashExpenseAuthorizationTest.php
+++ b/code/api/tests/Feature/CashAdjustments/CashExpenses/CashExpenseAuthorizationTest.php
@@ -6,7 +6,10 @@ use App\Models\Branch;
 use App\Models\CashExpense;
 use App\Models\CashRegister;
 use App\Models\CashSession;
+use App\Models\CashTerminal;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Feature\CashAdjustments\Concerns\SetsUpBranchAccess;
 use Tests\TestCase;
@@ -35,9 +38,9 @@ class CashExpenseAuthorizationTest extends TestCase
         $expense = $this->expenseForBranch($branch);
         $this->actingAsUserWithBranchAccess($branch, 'cash_expenses.view');
 
-        $response = $this->getJson("/api/v1/cash-expenses/{$expense->id}");
+        $response = $this->getJson("/api/v1/cash-expenses/{$expense->public_id}");
 
-        $response->assertStatus(200)->assertJsonPath('data.id', $expense->id);
+        $response->assertStatus(200)->assertJsonPath('data.id', $expense->public_id);
     }
 
     #[Test]
@@ -47,7 +50,7 @@ class CashExpenseAuthorizationTest extends TestCase
         $expense = $this->expenseForBranch($branch);
         $this->actingAsUserWithoutBranchAccess('cash_expenses.view');
 
-        $response = $this->getJson("/api/v1/cash-expenses/{$expense->id}");
+        $response = $this->getJson("/api/v1/cash-expenses/{$expense->public_id}");
 
         $response->assertStatus(403);
     }
@@ -64,16 +67,55 @@ class CashExpenseAuthorizationTest extends TestCase
     }
 
     #[Test]
+    public function list_filters_by_cash_session_public_id(): void
+    {
+        $branch = Branch::factory()->create();
+        $expense = $this->expenseForBranch($branch);
+        CashExpense::factory()->for(
+            CashSession::factory()->for(CashRegister::factory()->for($branch)->create(), 'cashRegister')->draft(),
+            'cashSession'
+        )->cash()->draft()->create();
+        Passport::actingAs(User::factory()->create());
+
+        $response = $this->getJson('/api/v1/cash-expenses?cash_session_id='.$expense->cashSession->public_id);
+
+        $response->assertStatus(200)
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $expense->public_id);
+    }
+
+    #[Test]
     public function update_actually_updates_the_requested_expense(): void
     {
         $branch = Branch::factory()->create();
         $expense = $this->expenseForBranch($branch);
         $this->actingAsUserWithBranchAccess($branch, 'cash_expenses.update');
 
-        $response = $this->putJson("/api/v1/cash-expenses/{$expense->id}", ['category' => 'UTILITIES']);
+        $response = $this->putJson("/api/v1/cash-expenses/{$expense->public_id}", ['category' => 'UTILITIES']);
 
         $response->assertStatus(200);
         $this->assertDatabaseHas('cash_expenses', ['id' => $expense->id, 'category' => 'UTILITIES']);
+    }
+
+    #[Test]
+    public function update_resolves_card_terminal_public_id_to_the_numeric_fk(): void
+    {
+        $branch = Branch::factory()->create();
+        $expense = $this->expenseForBranch($branch);
+        $terminal = CashTerminal::factory()->for($branch)->create();
+        $this->actingAsUserWithBranchAccess($branch, 'cash_expenses.update');
+
+        $response = $this->putJson("/api/v1/cash-expenses/{$expense->public_id}", [
+            'tender_type' => 'CARD',
+            'card_terminal_id' => $terminal->public_id,
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('cash_expenses', [
+            'id' => $expense->id,
+            'tender_type' => 'CARD',
+            'card_terminal_id' => $terminal->id,
+        ]);
     }
 
     #[Test]
@@ -83,7 +125,7 @@ class CashExpenseAuthorizationTest extends TestCase
         $expense = $this->expenseForBranch($branch);
         $this->actingAsUserWithoutBranchAccess('cash_expenses.update');
 
-        $response = $this->putJson("/api/v1/cash-expenses/{$expense->id}", ['category' => 'UTILITIES']);
+        $response = $this->putJson("/api/v1/cash-expenses/{$expense->public_id}", ['category' => 'UTILITIES']);
 
         $response->assertStatus(403);
     }
@@ -95,7 +137,7 @@ class CashExpenseAuthorizationTest extends TestCase
         $expense = $this->expenseForBranch($branch);
         $this->actingAsUserWithBranchAccess($branch, 'cash_expenses.delete');
 
-        $response = $this->deleteJson("/api/v1/cash-expenses/{$expense->id}");
+        $response = $this->deleteJson("/api/v1/cash-expenses/{$expense->public_id}");
 
         $response->assertStatus(200);
         $this->assertDatabaseMissing('cash_expenses', ['id' => $expense->id]);
@@ -108,7 +150,7 @@ class CashExpenseAuthorizationTest extends TestCase
         $expense = $this->expenseForBranch($branch);
         $this->actingAsUserWithoutBranchAccess('cash_expenses.delete');
 
-        $response = $this->deleteJson("/api/v1/cash-expenses/{$expense->id}");
+        $response = $this->deleteJson("/api/v1/cash-expenses/{$expense->public_id}");
 
         $response->assertStatus(403);
         $this->assertDatabaseHas('cash_expenses', ['id' => $expense->id]);
@@ -121,7 +163,7 @@ class CashExpenseAuthorizationTest extends TestCase
         $expense = $this->expenseForBranch($branch);
         $this->actingAsUserWithBranchAccess($branch, 'cash_expenses.post');
 
-        $response = $this->postJson("/api/v1/cash-expenses/{$expense->id}/post");
+        $response = $this->postJson("/api/v1/cash-expenses/{$expense->public_id}/post");
 
         $response->assertStatus(200);
         $this->assertDatabaseHas('cash_expenses', ['id' => $expense->id]);
@@ -135,7 +177,7 @@ class CashExpenseAuthorizationTest extends TestCase
         $expense = $this->expenseForBranch($branch);
         $this->actingAsUserWithoutBranchAccess('cash_expenses.post');
 
-        $response = $this->postJson("/api/v1/cash-expenses/{$expense->id}/post");
+        $response = $this->postJson("/api/v1/cash-expenses/{$expense->public_id}/post");
 
         $response->assertStatus(403);
         $this->assertNull($expense->fresh()->posted_at);

--- a/code/api/tests/Feature/CashAdjustments/CashExpenses/CreateCashExpenseTest.php
+++ b/code/api/tests/Feature/CashAdjustments/CashExpenses/CreateCashExpenseTest.php
@@ -2,9 +2,11 @@
 
 namespace Tests\Feature\CashAdjustments\CashExpenses;
 
+use App\Models\BankAccount;
 use App\Models\Branch;
 use App\Models\CashRegister;
 use App\Models\CashSession;
+use App\Models\CashTerminal;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Passport\Passport;
@@ -51,7 +53,7 @@ class CreateCashExpenseTest extends TestCase
         $this->actingAsUserWithPermission();
 
         $response = $this->postJson('/api/v1/cash-expenses', [
-            'cash_session_id' => $this->session->id,
+            'cash_session_id' => $this->session->public_id,
             'tender_type' => 'CASH',
             'amount' => 150.00,
             'category' => 'SUPPLIES',
@@ -73,12 +75,60 @@ class CreateCashExpenseTest extends TestCase
     }
 
     #[Test]
+    public function it_creates_a_card_cash_expense_linked_to_a_terminal(): void
+    {
+        $this->actingAsUserWithPermission();
+        $terminal = CashTerminal::factory()->create();
+
+        $response = $this->postJson('/api/v1/cash-expenses', [
+            'cash_session_id' => $this->session->public_id,
+            'tender_type' => 'CARD',
+            'amount' => 150.00,
+            'category' => 'SUPPLIES',
+            'vendor' => 'Office Depot',
+            'card_terminal_id' => $terminal->public_id,
+        ]);
+
+        $response->assertStatus(201);
+
+        $this->assertDatabaseHas('cash_expenses', [
+            'cash_session_id' => $this->session->id,
+            'tender_type' => 'CARD',
+            'card_terminal_id' => $terminal->id,
+        ]);
+    }
+
+    #[Test]
+    public function it_creates_a_transfer_cash_expense_linked_to_a_bank_account(): void
+    {
+        $this->actingAsUserWithPermission();
+        $bankAccount = BankAccount::factory()->create();
+
+        $response = $this->postJson('/api/v1/cash-expenses', [
+            'cash_session_id' => $this->session->public_id,
+            'tender_type' => 'TRANSFER',
+            'amount' => 150.00,
+            'category' => 'SUPPLIES',
+            'vendor' => 'Office Depot',
+            'bank_account_id' => $bankAccount->public_id,
+        ]);
+
+        $response->assertStatus(201);
+
+        $this->assertDatabaseHas('cash_expenses', [
+            'cash_session_id' => $this->session->id,
+            'tender_type' => 'TRANSFER',
+            'bank_account_id' => $bankAccount->id,
+        ]);
+    }
+
+    #[Test]
     public function it_rejects_card_tender_without_terminal(): void
     {
         $this->actingAsUserWithPermission();
 
         $response = $this->postJson('/api/v1/cash-expenses', [
-            'cash_session_id' => $this->session->id,
+            'cash_session_id' => $this->session->public_id,
             'tender_type' => 'CARD',
             'amount' => 150.00,
             'category' => 'SUPPLIES',
@@ -96,7 +146,7 @@ class CreateCashExpenseTest extends TestCase
         $this->actingAsUserWithPermission();
 
         $response = $this->postJson('/api/v1/cash-expenses', [
-            'cash_session_id' => $this->session->id,
+            'cash_session_id' => $this->session->public_id,
             'tender_type' => 'TRANSFER',
             'amount' => 150.00,
             'category' => 'SUPPLIES',
@@ -112,7 +162,7 @@ class CreateCashExpenseTest extends TestCase
     public function it_rejects_unauthenticated_requests(): void
     {
         $response = $this->postJson('/api/v1/cash-expenses', [
-            'cash_session_id' => $this->session->id,
+            'cash_session_id' => $this->session->public_id,
             'tender_type' => 'CASH',
             'amount' => 150.00,
             'category' => 'SUPPLIES',
@@ -128,7 +178,7 @@ class CreateCashExpenseTest extends TestCase
         Passport::actingAs($user);
 
         $response = $this->postJson('/api/v1/cash-expenses', [
-            'cash_session_id' => $this->session->id,
+            'cash_session_id' => $this->session->public_id,
             'tender_type' => 'CASH',
             'amount' => 150.00,
             'category' => 'SUPPLIES',

--- a/code/api/tests/Feature/CashAdjustments/CashRegisters/CashRegisterAuthorizationTest.php
+++ b/code/api/tests/Feature/CashAdjustments/CashRegisters/CashRegisterAuthorizationTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\CashAdjustments\CashRegisters;
 
 use App\Models\Branch;
 use App\Models\CashRegister;
+use App\Models\CashSession;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Feature\CashAdjustments\Concerns\SetsUpBranchAccess;
@@ -13,6 +14,9 @@ use Tests\TestCase;
  * Regression coverage for #291: Show/Update/Delete previously operated on a
  * blank model (route segment {id} didn't match the CashRegister $cashRegister
  * binding) with no resource-level authorization at all.
+ *
+ * Also covers #293: SerializesPublicIdAsId must apply to paginated List
+ * responses and nested relations (e.g. sessions), not just Show/Update.
  */
 class CashRegisterAuthorizationTest extends TestCase
 {
@@ -26,12 +30,46 @@ class CashRegisterAuthorizationTest extends TestCase
         $register = CashRegister::factory()->for($branch)->create(['name' => 'Caja Real']);
         $this->actingAsUserWithBranchAccess($branch, 'cash_registers.view');
 
-        $response = $this->getJson("/api/v1/cash-registers/{$register->id}");
+        $response = $this->getJson("/api/v1/cash-registers/{$register->public_id}");
 
         $response->assertStatus(200)
-            ->assertJsonPath('data.id', $register->id)
+            ->assertJsonPath('data.id', $register->public_id)
             ->assertJsonPath('data.name', 'Caja Real')
-            ->assertJsonPath('data.branch.id', $branch->id);
+            ->assertJsonPath('data.branch.id', $branch->id)
+            ->assertJsonMissingPath('data.public_id');
+    }
+
+    #[Test]
+    public function show_includes_ulid_ids_for_the_nested_sessions_relation(): void
+    {
+        $branch = Branch::factory()->create();
+        $register = CashRegister::factory()->for($branch)->create();
+        $session = CashSession::factory()->for($register, 'cashRegister')->draft()->create();
+        $this->actingAsUserWithBranchAccess($branch, 'cash_registers.view');
+
+        $response = $this->getJson("/api/v1/cash-registers/{$register->public_id}");
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.sessions.0.id', $session->public_id)
+            ->assertJsonMissingPath('data.sessions.0.public_id');
+
+        $this->assertFalse(is_numeric($response->json('data.sessions.0.id')));
+    }
+
+    #[Test]
+    public function list_returns_ulid_ids_for_every_item(): void
+    {
+        $branch = Branch::factory()->create();
+        $register = CashRegister::factory()->for($branch)->create();
+        $this->actingAsUserWithBranchAccess($branch, 'cash_registers.view');
+
+        $response = $this->getJson('/api/v1/cash-registers');
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.0.id', $register->public_id)
+            ->assertJsonMissingPath('data.0.public_id');
+
+        $this->assertFalse(is_numeric($response->json('data.0.id')));
     }
 
     #[Test]
@@ -41,7 +79,7 @@ class CashRegisterAuthorizationTest extends TestCase
         $register = CashRegister::factory()->for($branch)->create();
         $this->actingAsUserWithoutBranchAccess('cash_registers.view');
 
-        $response = $this->getJson("/api/v1/cash-registers/{$register->id}");
+        $response = $this->getJson("/api/v1/cash-registers/{$register->public_id}");
 
         $response->assertStatus(403);
     }
@@ -53,7 +91,7 @@ class CashRegisterAuthorizationTest extends TestCase
         $register = CashRegister::factory()->for($branch)->create();
         $this->actingAsUserWithBranchAccess($branch, 'some.other.permission');
 
-        $response = $this->getJson("/api/v1/cash-registers/{$register->id}");
+        $response = $this->getJson("/api/v1/cash-registers/{$register->public_id}");
 
         $response->assertStatus(403);
     }
@@ -76,7 +114,7 @@ class CashRegisterAuthorizationTest extends TestCase
         $register = CashRegister::factory()->for($branch)->create(['name' => 'Old Name']);
         $this->actingAsUserWithBranchAccess($branch, 'cash_registers.update');
 
-        $response = $this->putJson("/api/v1/cash-registers/{$register->id}", [
+        $response = $this->putJson("/api/v1/cash-registers/{$register->public_id}", [
             'name' => 'New Name',
         ]);
 
@@ -96,7 +134,7 @@ class CashRegisterAuthorizationTest extends TestCase
         $register = CashRegister::factory()->for($branch)->create(['name' => 'Untouched']);
         $this->actingAsUserWithoutBranchAccess('cash_registers.update');
 
-        $response = $this->putJson("/api/v1/cash-registers/{$register->id}", [
+        $response = $this->putJson("/api/v1/cash-registers/{$register->public_id}", [
             'name' => 'Should Not Apply',
         ]);
 
@@ -122,7 +160,7 @@ class CashRegisterAuthorizationTest extends TestCase
         $register = CashRegister::factory()->for($branch)->create();
         $this->actingAsUserWithBranchAccess($branch, 'cash_registers.delete');
 
-        $response = $this->deleteJson("/api/v1/cash-registers/{$register->id}");
+        $response = $this->deleteJson("/api/v1/cash-registers/{$register->public_id}");
 
         $response->assertStatus(200);
         $this->assertDatabaseMissing('cash_registers', ['id' => $register->id]);
@@ -135,7 +173,7 @@ class CashRegisterAuthorizationTest extends TestCase
         $register = CashRegister::factory()->for($branch)->create();
         $this->actingAsUserWithoutBranchAccess('cash_registers.delete');
 
-        $response = $this->deleteJson("/api/v1/cash-registers/{$register->id}");
+        $response = $this->deleteJson("/api/v1/cash-registers/{$register->public_id}");
 
         $response->assertStatus(403);
         $this->assertDatabaseHas('cash_registers', ['id' => $register->id]);

--- a/code/api/tests/Feature/CashAdjustments/CashSessions/CashSessionAuthorizationTest.php
+++ b/code/api/tests/Feature/CashAdjustments/CashSessions/CashSessionAuthorizationTest.php
@@ -5,7 +5,9 @@ namespace Tests\Feature\CashAdjustments\CashSessions;
 use App\Models\Branch;
 use App\Models\CashRegister;
 use App\Models\CashSession;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Feature\CashAdjustments\Concerns\SetsUpBranchAccess;
 use Tests\TestCase;
@@ -34,9 +36,9 @@ class CashSessionAuthorizationTest extends TestCase
         $session = $this->sessionForBranch($branch);
         $this->actingAsUserWithBranchAccess($branch, 'cash_sessions.view');
 
-        $response = $this->getJson("/api/v1/cash-sessions/{$session->id}");
+        $response = $this->getJson("/api/v1/cash-sessions/{$session->public_id}");
 
-        $response->assertStatus(200)->assertJsonPath('data.id', $session->id);
+        $response->assertStatus(200)->assertJsonPath('data.id', $session->public_id);
     }
 
     #[Test]
@@ -46,7 +48,7 @@ class CashSessionAuthorizationTest extends TestCase
         $session = $this->sessionForBranch($branch);
         $this->actingAsUserWithoutBranchAccess('cash_sessions.view');
 
-        $response = $this->getJson("/api/v1/cash-sessions/{$session->id}");
+        $response = $this->getJson("/api/v1/cash-sessions/{$session->public_id}");
 
         $response->assertStatus(403);
     }
@@ -63,13 +65,30 @@ class CashSessionAuthorizationTest extends TestCase
     }
 
     #[Test]
+    public function list_filters_by_cash_register_public_id(): void
+    {
+        $branch = Branch::factory()->create();
+        $register = CashRegister::factory()->for($branch)->create();
+        $otherRegister = CashRegister::factory()->for($branch)->create();
+        $session = CashSession::factory()->for($register, 'cashRegister')->draft()->create();
+        CashSession::factory()->for($otherRegister, 'cashRegister')->draft()->create();
+        Passport::actingAs(User::factory()->create());
+
+        $response = $this->getJson('/api/v1/cash-sessions?cash_register_id='.$register->public_id);
+
+        $response->assertStatus(200)
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $session->public_id);
+    }
+
+    #[Test]
     public function update_actually_updates_the_requested_session(): void
     {
         $branch = Branch::factory()->create();
         $session = $this->sessionForBranch($branch);
         $this->actingAsUserWithBranchAccess($branch, 'cash_sessions.update');
 
-        $response = $this->putJson("/api/v1/cash-sessions/{$session->id}", ['opening_balance' => 500]);
+        $response = $this->putJson("/api/v1/cash-sessions/{$session->public_id}", ['opening_balance' => 500]);
 
         $response->assertStatus(200);
         $this->assertDatabaseHas('cash_sessions', ['id' => $session->id, 'opening_balance' => 500]);
@@ -82,7 +101,7 @@ class CashSessionAuthorizationTest extends TestCase
         $session = $this->sessionForBranch($branch);
         $this->actingAsUserWithoutBranchAccess('cash_sessions.update');
 
-        $response = $this->putJson("/api/v1/cash-sessions/{$session->id}", ['opening_balance' => 500]);
+        $response = $this->putJson("/api/v1/cash-sessions/{$session->public_id}", ['opening_balance' => 500]);
 
         $response->assertStatus(403);
     }
@@ -94,7 +113,7 @@ class CashSessionAuthorizationTest extends TestCase
         $session = $this->sessionForBranch($branch);
         $this->actingAsUserWithBranchAccess($branch, 'cash_sessions.post');
 
-        $response = $this->postJson("/api/v1/cash-sessions/{$session->id}/post");
+        $response = $this->postJson("/api/v1/cash-sessions/{$session->public_id}/post");
 
         $response->assertStatus(200);
         $this->assertDatabaseHas('cash_sessions', ['id' => $session->id, 'status' => CashSession::STATUS_POSTED]);
@@ -107,7 +126,7 @@ class CashSessionAuthorizationTest extends TestCase
         $session = $this->sessionForBranch($branch);
         $this->actingAsUserWithoutBranchAccess('cash_sessions.post');
 
-        $response = $this->postJson("/api/v1/cash-sessions/{$session->id}/post");
+        $response = $this->postJson("/api/v1/cash-sessions/{$session->public_id}/post");
 
         $response->assertStatus(403);
         $this->assertDatabaseHas('cash_sessions', ['id' => $session->id, 'status' => CashSession::STATUS_DRAFT]);

--- a/code/api/tests/Feature/CashAdjustments/CashTerminals/CashTerminalAuthorizationTest.php
+++ b/code/api/tests/Feature/CashAdjustments/CashTerminals/CashTerminalAuthorizationTest.php
@@ -25,9 +25,9 @@ class CashTerminalAuthorizationTest extends TestCase
         $terminal = CashTerminal::factory()->for($branch)->create(['name' => 'Terminal Real']);
         $this->actingAsUserWithBranchAccess($branch, 'cash_terminals.view');
 
-        $response = $this->getJson("/api/v1/cash-terminals/{$terminal->id}");
+        $response = $this->getJson("/api/v1/cash-terminals/{$terminal->public_id}");
 
-        $response->assertStatus(200)->assertJsonPath('data.id', $terminal->id);
+        $response->assertStatus(200)->assertJsonPath('data.id', $terminal->public_id);
     }
 
     #[Test]
@@ -37,7 +37,7 @@ class CashTerminalAuthorizationTest extends TestCase
         $terminal = CashTerminal::factory()->for($branch)->create();
         $this->actingAsUserWithoutBranchAccess('cash_terminals.view');
 
-        $response = $this->getJson("/api/v1/cash-terminals/{$terminal->id}");
+        $response = $this->getJson("/api/v1/cash-terminals/{$terminal->public_id}");
 
         $response->assertStatus(403);
     }
@@ -60,7 +60,7 @@ class CashTerminalAuthorizationTest extends TestCase
         $terminal = CashTerminal::factory()->for($branch)->create(['name' => 'Old Name']);
         $this->actingAsUserWithBranchAccess($branch, 'cash_terminals.update');
 
-        $response = $this->putJson("/api/v1/cash-terminals/{$terminal->id}", ['name' => 'New Name']);
+        $response = $this->putJson("/api/v1/cash-terminals/{$terminal->public_id}", ['name' => 'New Name']);
 
         $response->assertStatus(200)->assertJsonPath('data.name', 'New Name');
         $this->assertDatabaseHas('cash_terminals', ['id' => $terminal->id, 'name' => 'New Name']);
@@ -73,7 +73,7 @@ class CashTerminalAuthorizationTest extends TestCase
         $terminal = CashTerminal::factory()->for($branch)->create(['name' => 'Untouched']);
         $this->actingAsUserWithoutBranchAccess('cash_terminals.update');
 
-        $response = $this->putJson("/api/v1/cash-terminals/{$terminal->id}", ['name' => 'Nope']);
+        $response = $this->putJson("/api/v1/cash-terminals/{$terminal->public_id}", ['name' => 'Nope']);
 
         $response->assertStatus(403);
         $this->assertDatabaseHas('cash_terminals', ['id' => $terminal->id, 'name' => 'Untouched']);
@@ -86,7 +86,7 @@ class CashTerminalAuthorizationTest extends TestCase
         $terminal = CashTerminal::factory()->for($branch)->create();
         $this->actingAsUserWithBranchAccess($branch, 'cash_terminals.delete');
 
-        $response = $this->deleteJson("/api/v1/cash-terminals/{$terminal->id}");
+        $response = $this->deleteJson("/api/v1/cash-terminals/{$terminal->public_id}");
 
         $response->assertStatus(200);
         $this->assertDatabaseMissing('cash_terminals', ['id' => $terminal->id]);
@@ -99,7 +99,7 @@ class CashTerminalAuthorizationTest extends TestCase
         $terminal = CashTerminal::factory()->for($branch)->create();
         $this->actingAsUserWithoutBranchAccess('cash_terminals.delete');
 
-        $response = $this->deleteJson("/api/v1/cash-terminals/{$terminal->id}");
+        $response = $this->deleteJson("/api/v1/cash-terminals/{$terminal->public_id}");
 
         $response->assertStatus(403);
         $this->assertDatabaseHas('cash_terminals', ['id' => $terminal->id]);

--- a/code/api/tests/Feature/CashAdjustments/CastsRequestFieldsTest.php
+++ b/code/api/tests/Feature/CashAdjustments/CastsRequestFieldsTest.php
@@ -110,7 +110,7 @@ class CastsRequestFieldsTest extends TestCase
         $register = CashRegister::factory()->create(['branch_id' => $this->branch->id]);
 
         $this->postJson('/api/v1/cash-sessions', [
-            'cash_register_id' => $register->id,
+            'cash_register_id' => $register->public_id,
             'operating_date' => '2026-01-05',
             'opening_balance' => '1500.50',
         ])
@@ -130,7 +130,7 @@ class CastsRequestFieldsTest extends TestCase
         $session = CashSession::factory()->create(['cash_register_id' => $register->id]);
 
         $this->postJson('/api/v1/cash-expenses', [
-            'cash_session_id' => $session->id,
+            'cash_session_id' => $session->public_id,
             'tender_type' => 'CASH',
             'amount' => '250.75',
             'category' => 'SUPPLIES',

--- a/doc/tasks/2026-07/293-cashadjustments-public-id.md
+++ b/doc/tasks/2026-07/293-cashadjustments-public-id.md
@@ -1,0 +1,70 @@
+# 🔨 Task #293: Expose public_id (ULID) instead of numeric id for CashAdjustments resources
+
+## 📖 Story
+
+**English:**
+As a developer, following up on #291, I need CashAdjustments' 6 resource types (CashRegister, CashTerminal, BankAccount, CashSession, CashExpense, CashAdjustment) to expose a ULID `public_id` instead of the raw sequential numeric id in URLs and JSON responses, matching the established convention already used by 20 models in the HR/Attendance/Payroll domain, so that properly-fixed authorization (#291) doesn't leave a sequential-ID enumeration side-channel.
+
+**Español:**
+Como desarrollador, dando seguimiento a #291, necesito que los 6 tipos de recurso de CashAdjustments expongan un `public_id` ULID en vez del id numérico secuencial crudo en URLs y respuestas JSON, siguiendo la convención ya establecida en 20 modelos del dominio HR/Attendance/Payroll, para que la autorización recién corregida (#291) no deje un canal lateral de enumeración de IDs secuenciales.
+
+---
+
+## ✅ Technical Tasks (backend)
+
+- [x] 🔨 Add `public_id` (ULID) column + `HasPublicId` trait to `CashRegister`, `CashTerminal`, `BankAccount`, `CashSession`, `CashExpense`, `CashAdjustment` — one migration, backfilling any pre-existing rows
+- [x] 🔨 Change routes from generic `RouteParams::ID` to named segments (`{cashRegister}`, `{cashTerminal}`, etc.), reverting `Show`/`Update`/`Delete`/`Post`/`GetSessionSummary` controllers to typed Eloquent implicit binding — simpler than #291's manual `int $id` + `findOrFail`, Laravel handles 404 automatically for unmatched bindings
+- [x] 🔨 **Design change from the original issue plan**: instead of writing 6 dedicated API Resource classes, added `App\Support\Traits\SerializesPublicIdAsId` — a `toArray()` override swapping `id` for `public_id` — applied to the same 6 models. This automatically fixes serialization everywhere a model gets output (`Show`, `Update`, paginated `List` responses via `response()->json($paginator)`, and nested relations between these 6 models — e.g. `CashRegister`'s `sessions` relation) with zero controller changes for `List`, and without risking the Resource classes drifting out of sync with the models' actual columns over time
+- [x] 🔨 Simplify the 5 `Update*Request::authorize()`/`rules()`/`withValidator()` methods back to `$this->route('<modelName>')` now that implicit binding resolves correctly
+- [x] ✅ Update the 46 `*AuthorizationTest.php` tests from #291 to use `public_id` in URLs and JSON assertions
+- [x] 🧪 Full PHPUnit suite green (1344/1344 — 1 unrelated pre-existing flaky failure in `HolidayCrudTest`, a Holiday-domain factory date collision, confirmed passing in isolation), Pint clean (40 files)
+
+## 📋 Technical Tasks (frontend — not started this session)
+
+- [ ] 🔨 `code/webapp/src/services/cash-api.ts`: all `id: number` parameters for these 6 resources become `id: string`
+- [ ] 🔨 Review component/hook logic treating these ids as numbers
+- [ ] 🧪 Manual verification in browser (dev server) per CLAUDE.md's UI-change testing rule
+
+---
+
+## 🎯 Acceptance Criteria
+
+- [x] All 6 CashAdjustments resources expose `public_id` (ULID) as `id` in every API response — Show, Update, List, and nested relations between these 6 models
+- [x] Numeric primary key remains internal-only (FKs, queries) — never serialized
+- [x] Non-ULID-protected relations (Branch, OperatingUnit, User) are left untouched — consistent with how the rest of the app already treats those as non-sensitive/low-cardinality
+- [x] No behavior change beyond the id representation — same business logic, same authorization (#291), same validation
+- [ ] Webapp consumers updated to match (deferred — separate frontend pass)
+
+---
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `2h`
+- **Pessimistic:** `4h` (6 models × migration/trait/routes/controllers/requests/tests, plus discovering the List-controller-has-no-auth-at-all finding mid-audit)
+- **Tracked:** `2.52h` (backend only; frontend pass not yet started)
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-07-23", "start": "22:00", "end": "24:00" },
+  { "date": "2026-07-24", "start": "00:00", "end": "00:31" }
+]
+```
+
+## 📊 Retrospective
+- **Actual total:** 2h 31m
+- **vs optimistic:** +31m over the `2h` optimistic estimate
+- **vs pessimistic:** −1h 29m under the `4h` pessimistic estimate
+
+**Justification:**
+
+The audit phase (verifying the existing `HasPublicId`/ULID convention actually works correctly across 20 models, checking every `RouteParams::ID` route in the entire API for the same binding bug found in #291, and confirming `CashAdjustmentLine` isn't independently routable) took real time but was essential — it's what surfaced the mid-scope discovery that all 6 `List*Controller` classes have zero authorization at all (a separate, more severe bug, deliberately **not** fixed here — flagged for its own issue to keep this PR's diff scoped to what it claims). The implementation itself landed faster than planned because of one design pivot: rather than writing 6 hand-maintained API Resource classes (the original issue plan), a single `SerializesPublicIdAsId` trait applied to the models handles Show/Update/List/nested-relations uniformly via `toArray()`, with no per-controller work for `List` at all — verified directly via `php artisan tinker` before writing any controller code, avoiding a much larger, more error-prone implementation.
+
+---
+
+## 🔗 References
+
+- GitHub issue: [#293](https://github.com/pakodiazdev/sushigo/issues/293)
+- Follow-up to: [#291](https://github.com/pakodiazdev/sushigo/issues/291)
+- Existing convention reused: `App\Support\Traits\HasPublicId`


### PR DESCRIPTION
## Summary
Refs #293 — backend portion. Follow-up to #291.
Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/294

CashAdjustments' 6 resource types (`CashRegister`, `CashTerminal`, `BankAccount`, `CashSession`, `CashExpense`, `CashAdjustment`) exposed a raw sequential numeric `id` in both URLs and JSON responses, unlike 20 models in the HR/Attendance/Payroll domain that already use `App\Support\Traits\HasPublicId` (ULID) for exactly this reason — "safe for external API exposure". This mattered more after #291: before that fix, authorization was completely broken (blank models, no branch checks), so numeric-ID exposure was a lesser concern. Now that `Show` correctly differentiates `404` (doesn't exist) from `403` (exists, wrong branch), a user from one branch could enumerate sequential IDs to learn how many cash registers/terminals/sessions/expenses/adjustments exist **company-wide**, across branches they have no access to.

### What changed

- Added `public_id` (ULID) + `HasPublicId` trait to all 6 models (one migration, backfills any pre-existing rows).
- Routes changed from generic `RouteParams::ID` (`/{id}`) to named segments (`/{cashRegister}`, `/{cashTerminal}`, etc.) matching each controller's Eloquent-typed parameter — this **reverts** #291's `int $id` + `findOrFail` workaround back to plain implicit binding, since the segment names now correctly match and Laravel resolves via `getRouteKeyName() = 'public_id'`. Simpler than #291's version, and Laravel throws its own 404 automatically for unmatched bindings.
- **Design decision — no dedicated Resource classes**: rather than hand-writing 6 API Resource classes (the original plan), added `App\Support\Traits\SerializesPublicIdAsId` — a small `toArray()` override swapping `id` for `public_id` — applied to the same 6 models. Because Eloquent calls a model's own `toArray()` recursively for nested relations and for paginated `List` responses (`response()->json($paginator)`), this one trait fixes serialization everywhere a model gets output — `Show`, `Update`, `List`, and nested relations *between these 6 models* (e.g. `CashRegister`'s `sessions` relation) — with **zero controller changes needed for `List`**, and no risk of a hand-maintained Resource silently drifting out of sync with the model's actual columns. Verified directly via `php artisan tinker` before writing any controller code.
- Non-ULID relations (`Branch`, `OperatingUnit`) are untouched — consistent with how the rest of the app already treats those as non-sensitive/low-cardinality (same treatment as `LeaveType`/`Holiday` elsewhere).
- Simplified the 5 `Update*Request::authorize()`/`rules()`/`withValidator()` methods back to `$this->route('<modelName>')`, removing #291's manual `CashX::find($this->route('id')) + abort(404)` boilerplate.
- Updated the 46 `*AuthorizationTest.php` tests from #291 to use `public_id` in URLs and JSON assertions.

### Deliberately out of scope (flagged in #293, not fixed here)
- **Frontend**: `code/webapp/src/services/cash-api.ts` still types these ids as `number` — needs updating to `string`, plus a browser-verified pass, tracked as a follow-up within #293.
- **A separate, more severe bug found during this audit**: all 6 `List*Controller` classes have **zero authorization or branch-scoping** — any authenticated user can list every record across every branch. Not folded into this PR; will get its own issue.

No production deployment has happened yet, so this is a clean, direct cutover — no dual-support period or data-migration strategy needed.

## Test plan
- [x] Full PHPUnit suite: 1344 tests, 1343 passed / 1 pre-existing flaky failure (`HolidayCrudTest`, a Holiday-domain factory random-date collision unrelated to this PR — confirmed passing in isolation)
- [x] `./vendor/bin/pint --dirty --test` — PASS, 40 files
- [x] `php -l` on all touched/created files — no syntax errors
- [x] All 46 `*AuthorizationTest.php` tests (from #291) updated and passing with `public_id`
- [x] Manual `tinker` verification: top-level `id` = ULID, nested `sessions[0].id` = ULID, nested `branch.id` stays numeric (correct, unaffected)

## Manual Testing
1. `GET /api/v1/cash-registers/{publicId}` with a valid `public_id` — expect `200` with `data.id` as a ULID string, `data.branch.id` as a plain integer (unchanged).
2. `GET /api/v1/cash-registers/1` (the old numeric id) — expect `404`, since routes no longer bind by numeric id.
3. `GET /api/v1/cash-registers` (List) — expect every item's `id` in the paginated response to be a ULID, with no `public_id` key duplicated.
4. `PUT`/`DELETE /api/v1/cash-registers/{publicId}` — same ULID-based binding, same #291 authorization behavior (403/404) as before.
5. Repeat for `cash-terminals`, `bank-accounts`, `cash-sessions` (incl. `POST .../post`, `GET .../summary`), `cash-expenses` (incl. `POST .../post`), `cash-adjustments` (incl. `POST .../post`).

## Closes
Refs #293 (backend portion — frontend follow-up tracked in the same issue)

## Workspace
`sushigo-c` — `feature/293-cashadjustments-public-id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

