### PR TITLE
🐛 [#296][e] - Stop hardcoding shared mydb_test in phpunit.xml 🗄️

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -65,6 +65,7 @@ jobs:
         if: steps.changes.outputs.api == 'true'
         env:
           DB_HOST: 127.0.0.1
+          DB_DATABASE: mydb_test
         run: php artisan test --coverage --coverage-clover=coverage.xml
 
       - name: Upload coverage report

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,8 @@ make cypress WORKSPACE=sushigo-a            # interactive UI (pick a spec)
 > **Rule:** When working in dev-lab, never prefix test or artisan commands with `docker exec dev_container`.
 > The dev-lab stack does NOT use `dev_container` — that container belongs to the standalone Docker mode below.
 
+> **Test database:** each dev-lab workspace has its own isolated PHPUnit test database (`sushigo_ws_<letter>_test`), configured via `code/api/.env.testing` (Laravel loads this instead of `.env` when `APP_ENV=testing`). This is separate from the standalone Docker mode's single shared `mydb_test` described under "API Tests" below. Don't share a test database across workspaces — concurrent `RefreshDatabase` schema setup across workspaces causes `SQLSTATE[40P01]` deadlocks.
+
 ---
 
 ### Docker Development (standalone container mode)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ make cypress WORKSPACE=sushigo-a            # interactive UI (pick a spec)
 > **Rule:** When working in dev-lab, never prefix test or artisan commands with `docker exec dev_container`.
 > The dev-lab stack does NOT use `dev_container` — that container belongs to the standalone Docker mode below.
 
-> **Test database:** each dev-lab workspace has its own isolated PHPUnit test database (`sushigo_ws_<letter>_test`), configured via `code/api/.env.testing` (Laravel loads this instead of `.env` when `APP_ENV=testing`). This is separate from the standalone Docker mode's single shared `mydb_test` described under "API Tests" below. Don't share a test database across workspaces — concurrent `RefreshDatabase` schema setup across workspaces causes `SQLSTATE[40P01]` deadlocks.
+> **Test database:** each dev-lab workspace has its own isolated PHPUnit test database (`sushigo_ws_<letter>_test`), configured via `code/api/.env.testing` (Laravel loads this instead of `.env` when `APP_ENV=testing`). `phpunit.xml` does **not** hardcode `DB_DATABASE` — outside dev-lab (standalone Docker mode, CI) it must be supplied explicitly (`DB_DATABASE=mydb_test`, see "Docker Development" below), otherwise tests silently fall back to `.env`'s dev database. Don't share a test database across workspaces — concurrent `RefreshDatabase` schema setup across workspaces causes `SQLSTATE[40P01]` deadlocks.
 
 ---
 
@@ -78,10 +78,12 @@ This monorepo runs inside `dev_container`. Each sub-project maps to a path insid
 docker compose up --build
 
 # Run API tests
-docker exec -it dev_container bash -c "cd /app/code/api && php artisan test"
+# DB_DATABASE=mydb_test is required — phpunit.xml no longer hardcodes it (see below),
+# so without this override tests would run against the dev database (mydb) instead.
+docker exec -it dev_container bash -c "cd /app/code/api && DB_DATABASE=mydb_test php artisan test"
 
 # Run specific test
-docker exec -it dev_container bash -c "cd /app/code/api && php artisan test --filter=WageHistoryTest"
+docker exec -it dev_container bash -c "cd /app/code/api && DB_DATABASE=mydb_test php artisan test --filter=WageHistoryTest"
 
 # Run database seeders
 docker exec -it dev_container bash -c "cd /app/code/api && php artisan db:seed"
@@ -579,10 +581,10 @@ Full convention reference: `doc/conventions/testing/testing-strategy.md`
 
 ### API Tests
 
-Tests use PostgreSQL (`mydb_test` database). Each test runs in a transaction that rolls back:
+Tests use PostgreSQL (`mydb_test` database, passed explicitly via `DB_DATABASE=mydb_test` — `phpunit.xml` does not hardcode it). Each test runs in a transaction that rolls back:
 
 ```bash
-docker exec -it dev_container php artisan test --testsuite=Feature
+docker exec -it dev_container bash -c "cd /app/code/api && DB_DATABASE=mydb_test php artisan test --testsuite=Feature"
 ```
 
 ### Test Users

--- a/code/api/.gitignore
+++ b/code/api/.gitignore
@@ -3,6 +3,7 @@
 .env
 .env.backup
 .env.production
+.env.testing
 .phpactor.json
 .phpunit.result.cache
 /.fleet

--- a/code/api/phpunit.xml
+++ b/code/api/phpunit.xml
@@ -27,7 +27,6 @@
         <env name="DB_CONNECTION" value="pgsql"/>
         <env name="DB_HOST" value="127.0.0.1"/>
         <env name="DB_PORT" value="5432"/>
-        <env name="DB_DATABASE" value="mydb_test"/>
         <env name="DB_USERNAME" value="admin"/>
         <env name="DB_PASSWORD" value="admin"/>
         <env name="MAIL_MAILER" value="array"/>

--- a/code/api/phpunit.xml
+++ b/code/api/phpunit.xml
@@ -27,6 +27,15 @@
         <env name="DB_CONNECTION" value="pgsql"/>
         <env name="DB_HOST" value="127.0.0.1"/>
         <env name="DB_PORT" value="5432"/>
+        <!--
+            DB_DATABASE is intentionally NOT set here. It must be supplied by the
+            environment running the tests:
+              - dev-lab: each workspace's code/api/.env.testing (DB_DATABASE=sushigo_ws_<letter>_test)
+              - CI: DB_DATABASE=mydb_test set as a step env var (see .github/workflows/api-tests.yml)
+              - standalone Docker mode: pass DB_DATABASE=mydb_test explicitly (see CLAUDE.md)
+            A hardcoded value here would force every dev-lab workspace onto the same
+            shared test database, causing SQLSTATE[40P01] deadlocks under concurrent runs.
+        -->
         <env name="DB_USERNAME" value="admin"/>
         <env name="DB_PASSWORD" value="admin"/>
         <env name="MAIL_MAILER" value="array"/>


### PR DESCRIPTION
## Summary
Closes #296

- Removed the hardcoded `<env name="DB_DATABASE" value="mydb_test"/>` from `code/api/phpunit.xml`, which was forcing every dev-lab workspace's test suite onto the literal same shared database regardless of which workspace ran it
- Added `.env.testing` to `code/api/.gitignore` (workspace-generated, never committed, same treatment as `.env`)
- Documented the per-workspace test DB isolation in `CLAUDE.md`

## Why

Every dev-lab workspace clone carries the same `phpunit.xml`. Since PHPUnit sets its `<env>` values before Laravel boots, `DB_DATABASE=mydb_test` overrode any per-workspace `.env.testing`, so all workspaces' test suites pointed at one shared database. This caused real `SQLSTATE[40P01]` deadlocks when two workspaces ran `php artisan test` concurrently — hit repeatedly during parallel work on issue #268.

Companion fix in `sushigo-dev-lab`: pakodiazdev/sushigo-dev-lab#56 — generates a per-workspace `code/api/.env.testing` with `DB_DATABASE=sushigo_ws_<letter>_test`. Laravel auto-loads `.env.testing` instead of `.env` when `APP_ENV=testing`, so once that file exists, this phpunit.xml change lets the workspace-specific value take effect.

## Test plan
- [x] Full suite passes locally (1344 tests, 0 failures) using a workspace-specific `.env.testing`
- [x] Verified live: created `sushigo_ws_e_test` in this workspace, ran the suite while workspace `sushigo-c` concurrently ran its own suite against the old shared `mydb_test` — no collision, `sushigo_ws_e_test` shows the fully migrated schema

## Manual Testing

1. In a dev-lab workspace, create `code/api/.env.testing` as a copy of `.env` with `DB_DATABASE` changed to a workspace-specific name (e.g. `sushigo_ws_e_test`).
2. Create that database: `psql -h 127.0.0.1 -U admin -d postgres -c "CREATE DATABASE sushigo_ws_e_test;"`
3. Run `cd code/api && php artisan test` — confirm it connects to `sushigo_ws_e_test` (check `psql -d sushigo_ws_e_test -c '\dt'` shows migrated tables), not `mydb_test`.
4. Run the suite in two workspaces at the same time — confirm no `SQLSTATE[40P01]` deadlocks.

## Workspace
`sushigo-e` — `fix/296-per-workspace-test-db`

🤖 Generated with [Claude Code](https://claude.com/claude-code)