### PR TITLE
🔨 [#293][c] - Migrate CashAdjustments frontend to public_id (ULID) 🔒

### DIFF
--- a/code/webapp/src/components/cash/__tests__/bank-account-form.test.tsx
+++ b/code/webapp/src/components/cash/__tests__/bank-account-form.test.tsx
@@ -77,7 +77,7 @@ describe('BankAccountForm', () => {
 
         it('renders edit account title when editing', () => {
             const account = {
-                id: 1,
+                id: '1',
                 branch_id: 1,
                 alias: 'Test Account',
                 bank_name: 'BBVA',
@@ -207,12 +207,12 @@ describe('BankAccountForm', () => {
     describe('reset on prop change', () => {
         it('updates form values when account prop changes', async () => {
             const account1 = {
-                id: 1, branch_id: 1, alias: 'First Account', bank_name: 'BBVA',
+                id: '1', branch_id: 1, alias: 'First Account', bank_name: 'BBVA',
                 account_number_masked: '1111', clabe_masked: '', is_active: true,
                 meta: {}, created_at: '', updated_at: '',
             }
             const account2 = {
-                id: 2, branch_id: 2, alias: 'Second Account', bank_name: 'SANTANDER',
+                id: '2', branch_id: 2, alias: 'Second Account', bank_name: 'SANTANDER',
                 account_number_masked: '2222', clabe_masked: '', is_active: false,
                 meta: {}, created_at: '', updated_at: '',
             }
@@ -230,7 +230,7 @@ describe('BankAccountForm', () => {
 
         it('resets to empty values when account becomes null', async () => {
             const account = {
-                id: 1, branch_id: 1, alias: 'Some Account', bank_name: 'BBVA',
+                id: '1', branch_id: 1, alias: 'Some Account', bank_name: 'BBVA',
                 account_number_masked: '1234', clabe_masked: '', is_active: true,
                 meta: {}, created_at: '', updated_at: '',
             }
@@ -249,7 +249,7 @@ describe('BankAccountForm', () => {
     describe('edit mode', () => {
         it('calls updateMutation when submitting in edit mode', async () => {
             const account = {
-                id: 1, branch_id: 1, alias: 'Test Account', bank_name: 'BBVA',
+                id: '1', branch_id: 1, alias: 'Test Account', bank_name: 'BBVA',
                 account_number_masked: '1234', clabe_masked: '', is_active: true,
                 meta: {}, created_at: '', updated_at: '',
             }
@@ -264,7 +264,7 @@ describe('BankAccountForm', () => {
 
             await waitFor(() => {
                 expect(mockUpdateMutation.mutateAsync).toHaveBeenCalledWith({
-                    id: 1,
+                    id: '1',
                     data: expect.objectContaining({ alias: 'Test Account' }),
                 })
             })

--- a/code/webapp/src/components/cash/__tests__/cash-register-form.test.tsx
+++ b/code/webapp/src/components/cash/__tests__/cash-register-form.test.tsx
@@ -79,7 +79,7 @@ describe('CashRegisterForm', () => {
 
         it('renders edit register title when editing', () => {
             const register = {
-                id: 1,
+                id: '1',
                 code: 'CAJA-001',
                 name: 'Main Register',
                 branch_id: 1,
@@ -159,12 +159,12 @@ describe('CashRegisterForm', () => {
     describe('reset on prop change', () => {
         it('updates form values when register prop changes', async () => {
             const register1 = {
-                id: 1, code: 'CAJA-001', name: 'Register A', branch_id: 1,
+                id: '1', code: 'CAJA-001', name: 'Register A', branch_id: 1,
                 operating_unit_id: null, type: CashRegisterType.ON_PREMISE,
                 is_active: true, meta: {}, created_at: '', updated_at: '',
             }
             const register2 = {
-                id: 2, code: 'CAJA-002', name: 'Register B', branch_id: 1,
+                id: '2', code: 'CAJA-002', name: 'Register B', branch_id: 1,
                 operating_unit_id: null, type: CashRegisterType.DELIVERY,
                 is_active: false, meta: {}, created_at: '', updated_at: '',
             }
@@ -182,7 +182,7 @@ describe('CashRegisterForm', () => {
 
         it('resets to empty values when register becomes null', async () => {
             const register = {
-                id: 1, code: 'CAJA-001', name: 'Register A', branch_id: 1,
+                id: '1', code: 'CAJA-001', name: 'Register A', branch_id: 1,
                 operating_unit_id: null, type: CashRegisterType.ON_PREMISE,
                 is_active: true, meta: {}, created_at: '', updated_at: '',
             }
@@ -201,7 +201,7 @@ describe('CashRegisterForm', () => {
     describe('edit mode', () => {
         it('calls updateMutation when submitting in edit mode', async () => {
             const register = {
-                id: 1, code: 'CAJA-001', name: 'Register A', branch_id: 1,
+                id: '1', code: 'CAJA-001', name: 'Register A', branch_id: 1,
                 operating_unit_id: null, type: CashRegisterType.ON_PREMISE,
                 is_active: true, meta: {}, created_at: '', updated_at: '',
             }
@@ -212,7 +212,7 @@ describe('CashRegisterForm', () => {
 
             await waitFor(() => {
                 expect(mockUpdateMutation.mutateAsync).toHaveBeenCalledWith({
-                    id: 1,
+                    id: '1',
                     data: expect.objectContaining({ name: 'Register A' }),
                 })
             })

--- a/code/webapp/src/components/cash/__tests__/cash-register-list.test.tsx
+++ b/code/webapp/src/components/cash/__tests__/cash-register-list.test.tsx
@@ -21,7 +21,7 @@ const mockCashRegistersData = {
     data: {
         data: [
             {
-                id: 1,
+                id: '1',
                 branch_id: 1,
                 operating_unit_id: 1,
                 code: 'CR001',
@@ -34,7 +34,7 @@ const mockCashRegistersData = {
                 updated_at: '2025-01-15T00:00:00+00:00',
             },
             {
-                id: 2,
+                id: '2',
                 branch_id: 1,
                 operating_unit_id: 1,
                 code: 'CR002',
@@ -151,7 +151,7 @@ describe('CashRegisterList', () => {
             data: {
                 data: [
                     {
-                        id: 3,
+                        id: '3',
                         branch_id: 1,
                         operating_unit_id: null,
                         code: 'CR003',

--- a/code/webapp/src/components/cash/__tests__/cash-terminal-form.test.tsx
+++ b/code/webapp/src/components/cash/__tests__/cash-terminal-form.test.tsx
@@ -77,7 +77,7 @@ describe('CashTerminalForm', () => {
 
         it('renders edit terminal title when editing', () => {
             const terminal = {
-                id: 1,
+                id: '1',
                 branch_id: 1,
                 name: 'Terminal 1',
                 provider: 'CLIP',
@@ -174,12 +174,12 @@ describe('CashTerminalForm', () => {
     describe('reset on prop change', () => {
         it('updates form values when terminal prop changes', async () => {
             const terminal1 = {
-                id: 1, branch_id: 1, name: 'Terminal A', provider: 'CLIP',
+                id: '1', branch_id: 1, name: 'Terminal A', provider: 'CLIP',
                 account_ref: 'REF-A', last_four: '1111', is_active: true,
                 meta: {}, created_at: '', updated_at: '',
             }
             const terminal2 = {
-                id: 2, branch_id: 2, name: 'Terminal B', provider: 'STRIPE',
+                id: '2', branch_id: 2, name: 'Terminal B', provider: 'STRIPE',
                 account_ref: 'REF-B', last_four: '2222', is_active: false,
                 meta: {}, created_at: '', updated_at: '',
             }
@@ -197,7 +197,7 @@ describe('CashTerminalForm', () => {
 
         it('resets to empty values when terminal becomes null', async () => {
             const terminal = {
-                id: 1, branch_id: 1, name: 'Terminal A', provider: 'CLIP',
+                id: '1', branch_id: 1, name: 'Terminal A', provider: 'CLIP',
                 account_ref: 'REF-A', last_four: '1111', is_active: true,
                 meta: {}, created_at: '', updated_at: '',
             }
@@ -216,7 +216,7 @@ describe('CashTerminalForm', () => {
     describe('edit mode', () => {
         it('calls updateMutation when submitting in edit mode', async () => {
             const terminal = {
-                id: 1, branch_id: 1, name: 'Terminal A', provider: 'CLIP',
+                id: '1', branch_id: 1, name: 'Terminal A', provider: 'CLIP',
                 account_ref: 'REF-001', last_four: '1234', is_active: true,
                 meta: {}, created_at: '', updated_at: '',
             }
@@ -231,7 +231,7 @@ describe('CashTerminalForm', () => {
 
             await waitFor(() => {
                 expect(mockUpdateMutation.mutateAsync).toHaveBeenCalledWith({
-                    id: 1,
+                    id: '1',
                     data: expect.objectContaining({ name: 'Terminal A' }),
                 })
             })

--- a/code/webapp/src/components/cash/__tests__/create-adjustment-dialog.test.tsx
+++ b/code/webapp/src/components/cash/__tests__/create-adjustment-dialog.test.tsx
@@ -178,6 +178,54 @@ describe('CreateAdjustmentDialog', () => {
         expect(updatedAmountInputs.length).toBe(initialAmountInputs.length + 1)
     })
 
+    it('shows the terminal selector and allows picking a terminal for CARD tender type', () => {
+        const { container } = render(
+            <CreateAdjustmentDialog
+                isOpen={true}
+                onClose={mockOnClose}
+                onSuccess={mockOnSuccess}
+                cashSessionId={'1'}
+            />,
+            { wrapper: createWrapper() },
+        )
+
+        const tenderTypeSelect = container.querySelectorAll('select')[2]!
+        fireEvent.change(tenderTypeSelect, { target: { value: 'CARD' } })
+
+        expect(screen.getByText('Terminal de Pago')).toBeDefined()
+
+        const terminalSelect = screen.getByText('Terminal de Pago')
+            .closest('div')!
+            .querySelector('select')!
+        fireEvent.change(terminalSelect, { target: { value: '1' } })
+
+        expect((terminalSelect as HTMLSelectElement).value).toBe('1')
+    })
+
+    it('shows the bank account selector and allows picking an account for TRANSFER tender type', () => {
+        const { container } = render(
+            <CreateAdjustmentDialog
+                isOpen={true}
+                onClose={mockOnClose}
+                onSuccess={mockOnSuccess}
+                cashSessionId={'1'}
+            />,
+            { wrapper: createWrapper() },
+        )
+
+        const tenderTypeSelect = container.querySelectorAll('select')[2]!
+        fireEvent.change(tenderTypeSelect, { target: { value: 'TRANSFER' } })
+
+        expect(screen.getByText('Cuenta Bancaria')).toBeDefined()
+
+        const bankAccountSelect = screen.getByText('Cuenta Bancaria')
+            .closest('div')!
+            .querySelector('select')!
+        fireEvent.change(bankAccountSelect, { target: { value: '1' } })
+
+        expect((bankAccountSelect as HTMLSelectElement).value).toBe('1')
+    })
+
     it('renders preselected session without session selector', () => {
         render(
             <CreateAdjustmentDialog

--- a/code/webapp/src/components/cash/__tests__/create-adjustment-dialog.test.tsx
+++ b/code/webapp/src/components/cash/__tests__/create-adjustment-dialog.test.tsx
@@ -11,7 +11,7 @@ vi.mock('@/services/cash-hooks', () => ({
     useCashSessions: vi.fn().mockReturnValue({
         data: {
             data: [
-                { id: 1, operating_date: '2025-01-15', cash_register: { name: 'Caja 1' } },
+                { id: '1', operating_date: '2025-01-15', cash_register: { name: 'Caja 1' } },
             ],
         },
         isLoading: false,
@@ -19,14 +19,14 @@ vi.mock('@/services/cash-hooks', () => ({
     useCashTerminals: vi.fn().mockReturnValue({
         data: {
             data: [
-                { id: 1, name: 'Terminal 1', is_active: true },
+                { id: '1', name: 'Terminal 1', is_active: true },
             ],
         },
     }),
     useBankAccounts: vi.fn().mockReturnValue({
         data: {
             data: [
-                { id: 1, name: 'Cuenta Principal', is_active: true },
+                { id: '1', name: 'Cuenta Principal', is_active: true },
             ],
         },
     }),
@@ -184,7 +184,7 @@ describe('CreateAdjustmentDialog', () => {
                 isOpen={true}
                 onClose={mockOnClose}
                 onSuccess={mockOnSuccess}
-                cashSessionId={1}
+                cashSessionId={'1'}
             />,
             { wrapper: createWrapper() },
         )
@@ -220,7 +220,7 @@ describe('CreateAdjustmentDialog', () => {
                 isOpen={true}
                 onClose={mockOnClose}
                 onSuccess={mockOnSuccess}
-                cashSessionId={1}
+                cashSessionId={'1'}
             />,
             { wrapper: createWrapper() },
         )

--- a/code/webapp/src/components/cash/__tests__/create-adjustment-dialog.test.tsx
+++ b/code/webapp/src/components/cash/__tests__/create-adjustment-dialog.test.tsx
@@ -19,14 +19,14 @@ vi.mock('@/services/cash-hooks', () => ({
     useCashTerminals: vi.fn().mockReturnValue({
         data: {
             data: [
-                { id: '1', name: 'Terminal 1', is_active: true },
+                { id: '1', name: 'Terminal 1', provider: 'Clip', is_active: true },
             ],
         },
     }),
     useBankAccounts: vi.fn().mockReturnValue({
         data: {
             data: [
-                { id: '1', name: 'Cuenta Principal', is_active: true },
+                { id: '1', alias: 'Cuenta Principal', bank_name: 'BBVA', is_active: true },
             ],
         },
     }),

--- a/code/webapp/src/components/cash/create-adjustment-dialog.tsx
+++ b/code/webapp/src/components/cash/create-adjustment-dialog.tsx
@@ -23,7 +23,7 @@ interface CreateAdjustmentDialogProps {
   isOpen: boolean
   onClose: () => void
   onSuccess?: () => void
-  cashSessionId?: number
+  cashSessionId?: string
 }
 
 export function CreateAdjustmentDialog({
@@ -33,7 +33,7 @@ export function CreateAdjustmentDialog({
   cashSessionId: preselectedSessionId,
 }: CreateAdjustmentDialogProps) {
   // Form state
-  const [cashSessionId, setCashSessionId] = useState<string>(preselectedSessionId?.toString() || '')
+  const [cashSessionId, setCashSessionId] = useState<string>(preselectedSessionId || '')
   const [type, setType] = useState<AdjustmentType>(AdjustmentType.EXTERNAL_IMPORT)
   const [direction, setDirection] = useState<Direction>(Direction.INFLOW)
   const [sourceSystem, setSourceSystem] = useState<string>('')
@@ -55,14 +55,14 @@ export function CreateAdjustmentDialog({
   // Set preselected session when dialog opens
   useEffect(() => {
     if (isOpen && preselectedSessionId) {
-      setCashSessionId(preselectedSessionId.toString())
+      setCashSessionId(preselectedSessionId)
     }
   }, [isOpen, preselectedSessionId])
 
   // Reset form when dialog closes
   useEffect(() => {
     if (!isOpen) {
-      setCashSessionId(preselectedSessionId?.toString() || '')
+      setCashSessionId(preselectedSessionId || '')
       setType(AdjustmentType.EXTERNAL_IMPORT)
       setDirection(Direction.INFLOW)
       setSourceSystem('')
@@ -118,7 +118,7 @@ export function CreateAdjustmentDialog({
 
     try {
       await createAdjustment.mutateAsync({
-        cash_session_id: parseInt(cashSessionId),
+        cash_session_id: cashSessionId,
         type,
         direction,
         source_system: sourceSystem || undefined,
@@ -157,7 +157,7 @@ export function CreateAdjustmentDialog({
             >
               <option value="">Selecciona una sesión abierta...</option>
               {sessions.map((session) => (
-                <option key={session.id} value={session.id.toString()}>
+                <option key={session.id} value={session.id}>
                   {session.cash_register?.name} - {session.operating_date}
                 </option>
               ))}
@@ -285,14 +285,14 @@ export function CreateAdjustmentDialog({
                   {line.tender_type === TenderType.CARD && (
                     <FormField label="Terminal de Pago" required>
                       <Select
-                        value={line.card_terminal_id?.toString() || ''}
+                        value={line.card_terminal_id || ''}
                         onChange={(e) =>
-                          handleLineChange(index, 'card_terminal_id', parseInt(e.target.value))
+                          handleLineChange(index, 'card_terminal_id', e.target.value || null)
                         }
                       >
                         <option value="">Selecciona una terminal...</option>
                         {terminals.map((terminal) => (
-                          <option key={terminal.id} value={terminal.id.toString()}>
+                          <option key={terminal.id} value={terminal.id}>
                             {terminal.name} ({terminal.provider})
                           </option>
                         ))}
@@ -304,14 +304,14 @@ export function CreateAdjustmentDialog({
                   {line.tender_type === TenderType.TRANSFER && (
                     <FormField label="Cuenta Bancaria" required>
                       <Select
-                        value={line.bank_account_id?.toString() || ''}
+                        value={line.bank_account_id || ''}
                         onChange={(e) =>
-                          handleLineChange(index, 'bank_account_id', parseInt(e.target.value))
+                          handleLineChange(index, 'bank_account_id', e.target.value || null)
                         }
                       >
                         <option value="">Selecciona una cuenta...</option>
                         {accounts.map((account) => (
-                          <option key={account.id} value={account.id.toString()}>
+                          <option key={account.id} value={account.id}>
                             {account.alias} - {account.bank_name}
                           </option>
                         ))}

--- a/code/webapp/src/components/cash/open-session-dialog.tsx
+++ b/code/webapp/src/components/cash/open-session-dialog.tsx
@@ -11,7 +11,7 @@ import { CashRegisterType, type CashSessionFormData } from '@/types/cash'
 interface OpenSessionDialogProps {
   isOpen: boolean
   onClose: () => void
-  onSuccess?: (sessionId: number) => void
+  onSuccess?: (sessionId: string) => void
   branchId?: number
 }
 
@@ -78,7 +78,7 @@ export function OpenSessionDialog({
 
     try {
       const payload: CashSessionFormData = {
-        cash_register_id: parseInt(cashRegisterId),
+        cash_register_id: cashRegisterId,
         operating_date: operatingDate,
       }
 

--- a/code/webapp/src/components/dashboard/Dashboard.tsx
+++ b/code/webapp/src/components/dashboard/Dashboard.tsx
@@ -136,7 +136,7 @@ function StatCard({ stat }: { stat: Stat }) {
     );
 }
 
-function SessionCard({ session, onRegisterAdjustment }: { session: CashSession; onRegisterAdjustment: (id: number) => void }) {
+function SessionCard({ session, onRegisterAdjustment }: { session: CashSession; onRegisterAdjustment: (id: string) => void }) {
     // Usar el current_balance que viene directamente de la sesión (calculado en el backend)
     const currentBalance = session.current_balance || session.opening_balance || '0.00';
 
@@ -145,7 +145,7 @@ function SessionCard({ session, onRegisterAdjustment }: { session: CashSession; 
             <div className="flex-1">
                 <div className="flex items-center gap-3 mb-2">
                     <h3 className="font-semibold">
-                        {session.cash_register?.name || `Caja #${session.cash_register_id}`}
+                        {session.cash_register?.name || 'Caja sin identificar'}
                     </h3>
                     <SessionStatusBadge status={session.status} />
                 </div>
@@ -200,7 +200,7 @@ export default function Dashboard() {
     const { currentBranch } = useAuthStore();
     const [isOpenSessionDialogOpen, setIsOpenSessionDialogOpen] = useState(false);
     const [isAdjustmentDialogOpen, setIsAdjustmentDialogOpen] = useState(false);
-    const [selectedSessionId, setSelectedSessionId] = useState<number | undefined>(undefined);
+    const [selectedSessionId, setSelectedSessionId] = useState<string | undefined>(undefined);
 
     const { data, isLoading, error } = useQuery({
         queryKey: ['dashboard'],
@@ -216,12 +216,12 @@ export default function Dashboard() {
         setIsOpenSessionDialogOpen(true);
     };
 
-    const handleSessionSuccess = (sessionId: number) => {
+    const handleSessionSuccess = (sessionId: string) => {
         console.log('Sesión creada:', sessionId);
         alert('¡Sesión de caja abierta exitosamente!');
     };
 
-    const handleCreateAdjustment = (sessionId?: number) => {
+    const handleCreateAdjustment = (sessionId?: string) => {
         setSelectedSessionId(sessionId);
         setIsAdjustmentDialogOpen(true);
     };

--- a/code/webapp/src/components/dashboard/__tests__/Dashboard.test.tsx
+++ b/code/webapp/src/components/dashboard/__tests__/Dashboard.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { SessionStatus } from '@/types/cash'
+import type { CashSession } from '@/types/cash'
+
+const mockNavigate = vi.fn()
+
+vi.mock('@tanstack/react-router', () => ({
+    useNavigate: () => mockNavigate,
+}))
+
+vi.mock('@/stores/auth.store', () => ({
+    useAuthStore: () => ({ currentBranch: { id: 1, name: 'Sucursal Test' } }),
+}))
+
+const mockSession: CashSession = {
+    id: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+    operating_date: '2026-07-24',
+    opening_balance: '500.00',
+    closing_balance: null,
+    status: SessionStatus.DRAFT,
+    opened_by: 1,
+    opened_at: '2026-07-24T08:00:00+00:00',
+    posted_by: null,
+    posted_at: null,
+    meta: null,
+    created_at: '2026-07-24T08:00:00+00:00',
+    updated_at: '2026-07-24T08:00:00+00:00',
+}
+
+vi.mock('@/services/cash-hooks', () => ({
+    useCashSessions: () => ({
+        data: { data: [mockSession] },
+        isLoading: false,
+    }),
+}))
+
+vi.mock('@/components/cash', () => ({
+    OpenSessionDialog: () => null,
+    CreateAdjustmentDialog: () => null,
+}))
+
+import Dashboard from '../Dashboard'
+
+const createWrapper = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    })
+    return ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+}
+
+afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+})
+
+describe('Dashboard', () => {
+    it('renders an open session card without a cash register name', async () => {
+        render(<Dashboard />, { wrapper: createWrapper() })
+
+        await waitFor(() => expect(screen.getByText('Caja sin identificar')).toBeDefined(), { timeout: 3000 })
+    }, 5000)
+
+    it('opens the adjustment dialog for a specific session when clicking "Registrar Ajuste" on a card', async () => {
+        render(<Dashboard />, { wrapper: createWrapper() })
+
+        await waitFor(() => expect(screen.getByText('Caja sin identificar')).toBeDefined(), { timeout: 3000 })
+
+        const registerAdjustmentButtons = screen.getAllByRole('button', { name: /registrar ajuste/i })
+        // The card-level button (not the quick-action one) is the last match
+        fireEvent.click(registerAdjustmentButtons[registerAdjustmentButtons.length - 1]!)
+
+        expect(screen.getAllByRole('button', { name: /registrar ajuste/i }).length).toBeGreaterThan(0)
+    }, 5000)
+})

--- a/code/webapp/src/components/test-open-session.tsx
+++ b/code/webapp/src/components/test-open-session.tsx
@@ -8,7 +8,7 @@ import { Plus } from 'lucide-react'
 export function TestOpenSessionPage() {
   const [isDialogOpen, setIsDialogOpen] = useState(false)
 
-  const handleSuccess = (sessionId: number) => {
+  const handleSuccess = (sessionId: string) => {
     console.log('Sesión creada con ID:', sessionId)
     alert(`¡Sesión abierta exitosamente! ID: ${sessionId}`)
   }

--- a/code/webapp/src/services/__tests__/cash-api.test.ts
+++ b/code/webapp/src/services/__tests__/cash-api.test.ts
@@ -69,7 +69,7 @@ describe('cashRegisterApi', () => {
             const mockResponse = { data: { status: 200, data: { id: 1 } } }
             vi.mocked(apiClient.get).mockResolvedValue(mockResponse)
 
-            const result = await cashRegisterApi.get(1)
+            const result = await cashRegisterApi.get('1')
 
             expect(apiClient.get).toHaveBeenCalledWith('/cash-registers/1')
             expect(result).toEqual(mockResponse)
@@ -95,7 +95,7 @@ describe('cashRegisterApi', () => {
             vi.mocked(apiClient.put).mockResolvedValue(mockResponse)
 
             const data = { name: 'Caja Principal' }
-            const result = await cashRegisterApi.update(1, data)
+            const result = await cashRegisterApi.update('1', data)
 
             expect(apiClient.put).toHaveBeenCalledWith('/cash-registers/1', data)
             expect(result).toEqual(mockResponse)
@@ -107,7 +107,7 @@ describe('cashRegisterApi', () => {
             const mockResponse = { data: { status: 200, message: 'Deleted' } }
             vi.mocked(apiClient.delete).mockResolvedValue(mockResponse)
 
-            const result = await cashRegisterApi.delete(1)
+            const result = await cashRegisterApi.delete('1')
 
             expect(apiClient.delete).toHaveBeenCalledWith('/cash-registers/1')
             expect(result).toEqual(mockResponse)
@@ -139,7 +139,7 @@ describe('cashTerminalApi', () => {
             const mockResponse = { data: { status: 200, data: { id: 1 } } }
             vi.mocked(apiClient.get).mockResolvedValue(mockResponse)
 
-            const result = await cashTerminalApi.get(1)
+            const result = await cashTerminalApi.get('1')
 
             expect(apiClient.get).toHaveBeenCalledWith('/cash-terminals/1')
             expect(result).toEqual(mockResponse)
@@ -172,7 +172,7 @@ describe('cashTerminalApi', () => {
             vi.mocked(apiClient.put).mockResolvedValue(mockResponse)
 
             const data = { name: 'Terminal Actualizada' }
-            const result = await cashTerminalApi.update(1, data)
+            const result = await cashTerminalApi.update('1', data)
 
             expect(apiClient.put).toHaveBeenCalledWith('/cash-terminals/1', data)
             expect(result).toEqual(mockResponse)
@@ -184,7 +184,7 @@ describe('cashTerminalApi', () => {
             const mockResponse = { data: { status: 200, message: 'Deleted' } }
             vi.mocked(apiClient.delete).mockResolvedValue(mockResponse)
 
-            const result = await cashTerminalApi.delete(1)
+            const result = await cashTerminalApi.delete('1')
 
             expect(apiClient.delete).toHaveBeenCalledWith('/cash-terminals/1')
             expect(result).toEqual(mockResponse)
@@ -216,7 +216,7 @@ describe('bankAccountApi', () => {
             const mockResponse = { data: { status: 200, data: { id: 1 } } }
             vi.mocked(apiClient.get).mockResolvedValue(mockResponse)
 
-            const result = await bankAccountApi.get(1)
+            const result = await bankAccountApi.get('1')
 
             expect(apiClient.get).toHaveBeenCalledWith('/bank-accounts/1')
             expect(result).toEqual(mockResponse)
@@ -249,7 +249,7 @@ describe('bankAccountApi', () => {
             vi.mocked(apiClient.put).mockResolvedValue(mockResponse)
 
             const data = { bank_name: 'Santander' }
-            const result = await bankAccountApi.update(1, data)
+            const result = await bankAccountApi.update('1', data)
 
             expect(apiClient.put).toHaveBeenCalledWith('/bank-accounts/1', data)
             expect(result).toEqual(mockResponse)
@@ -261,7 +261,7 @@ describe('bankAccountApi', () => {
             const mockResponse = { data: { status: 200, message: 'Deleted' } }
             vi.mocked(apiClient.delete).mockResolvedValue(mockResponse)
 
-            const result = await bankAccountApi.delete(1)
+            const result = await bankAccountApi.delete('1')
 
             expect(apiClient.delete).toHaveBeenCalledWith('/bank-accounts/1')
             expect(result).toEqual(mockResponse)
@@ -304,7 +304,7 @@ describe('cashSessionApi', () => {
             const mockResponse = { data: { status: 200, data: { id: 1 } } }
             vi.mocked(apiClient.get).mockResolvedValue(mockResponse)
 
-            const result = await cashSessionApi.get(1)
+            const result = await cashSessionApi.get('1')
 
             expect(apiClient.get).toHaveBeenCalledWith('/cash-sessions/1')
             expect(result).toEqual(mockResponse)
@@ -316,7 +316,7 @@ describe('cashSessionApi', () => {
             const mockResponse = { data: { status: 201, data: { id: 1 } } }
             vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
 
-            const data = { cash_register_id: 1, operating_date: '2026-04-18' } as CashSessionFormData
+            const data = { cash_register_id: '1', operating_date: '2026-04-18' } as CashSessionFormData
             const result = await cashSessionApi.create(data)
 
             expect(apiClient.post).toHaveBeenCalledWith('/cash-sessions', data)
@@ -330,7 +330,7 @@ describe('cashSessionApi', () => {
             vi.mocked(apiClient.put).mockResolvedValue(mockResponse)
 
             const data: Partial<CashSessionFormData> = { operating_date: '2026-04-19' }
-            const result = await cashSessionApi.update(1, data)
+            const result = await cashSessionApi.update('1', data)
 
             expect(apiClient.put).toHaveBeenCalledWith('/cash-sessions/1', data)
             expect(result).toEqual(mockResponse)
@@ -342,7 +342,7 @@ describe('cashSessionApi', () => {
             const mockResponse = { data: { status: 200, data: { id: 1, status: 'POSTED' } } }
             vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
 
-            const result = await cashSessionApi.post(1)
+            const result = await cashSessionApi.post('1')
 
             expect(apiClient.post).toHaveBeenCalledWith('/cash-sessions/1/post')
             expect(result).toEqual(mockResponse)
@@ -359,7 +359,7 @@ describe('cashSessionApi', () => {
             }
             vi.mocked(apiClient.get).mockResolvedValue(mockResponse)
 
-            const result = await cashSessionApi.getSummary(1)
+            const result = await cashSessionApi.getSummary('1')
 
             expect(apiClient.get).toHaveBeenCalledWith('/cash-sessions/1/summary')
             expect(result).toEqual(mockResponse)
@@ -391,7 +391,7 @@ describe('cashAdjustmentApi', () => {
             const mockResponse = { data: { status: 200, data: { id: 1 } } }
             vi.mocked(apiClient.get).mockResolvedValue(mockResponse)
 
-            const result = await cashAdjustmentApi.get(1)
+            const result = await cashAdjustmentApi.get('1')
 
             expect(apiClient.get).toHaveBeenCalledWith('/cash-adjustments/1')
             expect(result).toEqual(mockResponse)
@@ -404,7 +404,7 @@ describe('cashAdjustmentApi', () => {
             vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
 
             const data: CashAdjustmentFormData = {
-                cash_session_id: 1,
+                cash_session_id: '1',
                 type: 'CORRECTION' as AdjustmentType,
                 direction: 'INFLOW' as Direction,
                 notes: 'Corrección de caja',
@@ -422,7 +422,7 @@ describe('cashAdjustmentApi', () => {
             const mockResponse = { data: { status: 200, data: { id: 1, status: 'POSTED' } } }
             vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
 
-            const result = await cashAdjustmentApi.post(1)
+            const result = await cashAdjustmentApi.post('1')
 
             expect(apiClient.post).toHaveBeenCalledWith('/cash-adjustments/1/post')
             expect(result).toEqual(mockResponse)
@@ -434,7 +434,7 @@ describe('cashAdjustmentApi', () => {
             const mockResponse = { data: { status: 200, message: 'Deleted' } }
             vi.mocked(apiClient.delete).mockResolvedValue(mockResponse)
 
-            const result = await cashAdjustmentApi.delete(1)
+            const result = await cashAdjustmentApi.delete('1')
 
             expect(apiClient.delete).toHaveBeenCalledWith('/cash-adjustments/1')
             expect(result).toEqual(mockResponse)
@@ -466,7 +466,7 @@ describe('cashExpenseApi', () => {
             const mockResponse = { data: { status: 200, data: { id: 1 } } }
             vi.mocked(apiClient.get).mockResolvedValue(mockResponse)
 
-            const result = await cashExpenseApi.get(1)
+            const result = await cashExpenseApi.get('1')
 
             expect(apiClient.get).toHaveBeenCalledWith('/cash-expenses/1')
             expect(result).toEqual(mockResponse)
@@ -479,7 +479,7 @@ describe('cashExpenseApi', () => {
             vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
 
             const data: CashExpenseFormData = {
-                cash_session_id: 1,
+                cash_session_id: '1',
                 tender_type: 'CASH' as TenderType,
                 amount: '250.00',
                 category: 'SUPPLIES',
@@ -499,7 +499,7 @@ describe('cashExpenseApi', () => {
             vi.mocked(apiClient.put).mockResolvedValue(mockResponse)
 
             const data: Partial<CashExpenseFormData> = { category: 'CLEANING' }
-            const result = await cashExpenseApi.update(1, data)
+            const result = await cashExpenseApi.update('1', data)
 
             expect(apiClient.put).toHaveBeenCalledWith('/cash-expenses/1', data)
             expect(result).toEqual(mockResponse)
@@ -511,7 +511,7 @@ describe('cashExpenseApi', () => {
             const mockResponse = { data: { status: 200, data: { id: 1, status: 'POSTED' } } }
             vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
 
-            const result = await cashExpenseApi.post(1)
+            const result = await cashExpenseApi.post('1')
 
             expect(apiClient.post).toHaveBeenCalledWith('/cash-expenses/1/post')
             expect(result).toEqual(mockResponse)
@@ -523,7 +523,7 @@ describe('cashExpenseApi', () => {
             const mockResponse = { data: { status: 200, message: 'Deleted' } }
             vi.mocked(apiClient.delete).mockResolvedValue(mockResponse)
 
-            const result = await cashExpenseApi.delete(1)
+            const result = await cashExpenseApi.delete('1')
 
             expect(apiClient.delete).toHaveBeenCalledWith('/cash-expenses/1')
             expect(result).toEqual(mockResponse)

--- a/code/webapp/src/services/__tests__/cash-api.test.ts
+++ b/code/webapp/src/services/__tests__/cash-api.test.ts
@@ -66,7 +66,7 @@ describe('cashRegisterApi', () => {
 
     describe('get', () => {
         it('calls GET /cash-registers/:id', async () => {
-            const mockResponse = { data: { status: 200, data: { id: 1 } } }
+            const mockResponse = { data: { status: 200, data: { id: '1' } } }
             vi.mocked(apiClient.get).mockResolvedValue(mockResponse)
 
             const result = await cashRegisterApi.get('1')
@@ -78,7 +78,7 @@ describe('cashRegisterApi', () => {
 
     describe('create', () => {
         it('calls POST /cash-registers', async () => {
-            const mockResponse = { data: { status: 201, data: { id: 1 } } }
+            const mockResponse = { data: { status: 201, data: { id: '1' } } }
             vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
 
             const data = { name: 'Caja 1', code: 'CAJA01' } as CashRegisterFormData
@@ -91,7 +91,7 @@ describe('cashRegisterApi', () => {
 
     describe('update', () => {
         it('calls PUT /cash-registers/:id', async () => {
-            const mockResponse = { data: { status: 200, data: { id: 1 } } }
+            const mockResponse = { data: { status: 200, data: { id: '1' } } }
             vi.mocked(apiClient.put).mockResolvedValue(mockResponse)
 
             const data = { name: 'Caja Principal' }
@@ -136,7 +136,7 @@ describe('cashTerminalApi', () => {
 
     describe('get', () => {
         it('calls GET /cash-terminals/:id', async () => {
-            const mockResponse = { data: { status: 200, data: { id: 1 } } }
+            const mockResponse = { data: { status: 200, data: { id: '1' } } }
             vi.mocked(apiClient.get).mockResolvedValue(mockResponse)
 
             const result = await cashTerminalApi.get('1')
@@ -148,7 +148,7 @@ describe('cashTerminalApi', () => {
 
     describe('create', () => {
         it('calls POST /cash-terminals', async () => {
-            const mockResponse = { data: { status: 201, data: { id: 1 } } }
+            const mockResponse = { data: { status: 201, data: { id: '1' } } }
             vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
 
             const data: CashTerminalFormData = {
@@ -168,7 +168,7 @@ describe('cashTerminalApi', () => {
 
     describe('update', () => {
         it('calls PUT /cash-terminals/:id', async () => {
-            const mockResponse = { data: { status: 200, data: { id: 1 } } }
+            const mockResponse = { data: { status: 200, data: { id: '1' } } }
             vi.mocked(apiClient.put).mockResolvedValue(mockResponse)
 
             const data = { name: 'Terminal Actualizada' }
@@ -213,7 +213,7 @@ describe('bankAccountApi', () => {
 
     describe('get', () => {
         it('calls GET /bank-accounts/:id', async () => {
-            const mockResponse = { data: { status: 200, data: { id: 1 } } }
+            const mockResponse = { data: { status: 200, data: { id: '1' } } }
             vi.mocked(apiClient.get).mockResolvedValue(mockResponse)
 
             const result = await bankAccountApi.get('1')
@@ -225,7 +225,7 @@ describe('bankAccountApi', () => {
 
     describe('create', () => {
         it('calls POST /bank-accounts', async () => {
-            const mockResponse = { data: { status: 201, data: { id: 1 } } }
+            const mockResponse = { data: { status: 201, data: { id: '1' } } }
             vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
 
             const data: BankAccountFormData = {
@@ -245,7 +245,7 @@ describe('bankAccountApi', () => {
 
     describe('update', () => {
         it('calls PUT /bank-accounts/:id', async () => {
-            const mockResponse = { data: { status: 200, data: { id: 1 } } }
+            const mockResponse = { data: { status: 200, data: { id: '1' } } }
             vi.mocked(apiClient.put).mockResolvedValue(mockResponse)
 
             const data = { bank_name: 'Santander' }
@@ -301,7 +301,7 @@ describe('cashSessionApi', () => {
 
     describe('get', () => {
         it('calls GET /cash-sessions/:id', async () => {
-            const mockResponse = { data: { status: 200, data: { id: 1 } } }
+            const mockResponse = { data: { status: 200, data: { id: '1' } } }
             vi.mocked(apiClient.get).mockResolvedValue(mockResponse)
 
             const result = await cashSessionApi.get('1')
@@ -313,7 +313,7 @@ describe('cashSessionApi', () => {
 
     describe('create', () => {
         it('calls POST /cash-sessions', async () => {
-            const mockResponse = { data: { status: 201, data: { id: 1 } } }
+            const mockResponse = { data: { status: 201, data: { id: '1' } } }
             vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
 
             const data = { cash_register_id: '1', operating_date: '2026-04-18' } as CashSessionFormData
@@ -326,7 +326,7 @@ describe('cashSessionApi', () => {
 
     describe('update', () => {
         it('calls PUT /cash-sessions/:id', async () => {
-            const mockResponse = { data: { status: 200, data: { id: 1 } } }
+            const mockResponse = { data: { status: 200, data: { id: '1' } } }
             vi.mocked(apiClient.put).mockResolvedValue(mockResponse)
 
             const data: Partial<CashSessionFormData> = { operating_date: '2026-04-19' }
@@ -339,7 +339,7 @@ describe('cashSessionApi', () => {
 
     describe('post', () => {
         it('calls POST /cash-sessions/:id/post', async () => {
-            const mockResponse = { data: { status: 200, data: { id: 1, status: 'POSTED' } } }
+            const mockResponse = { data: { status: 200, data: { id: '1', status: 'POSTED' } } }
             vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
 
             const result = await cashSessionApi.post('1')
@@ -388,7 +388,7 @@ describe('cashAdjustmentApi', () => {
 
     describe('get', () => {
         it('calls GET /cash-adjustments/:id', async () => {
-            const mockResponse = { data: { status: 200, data: { id: 1 } } }
+            const mockResponse = { data: { status: 200, data: { id: '1' } } }
             vi.mocked(apiClient.get).mockResolvedValue(mockResponse)
 
             const result = await cashAdjustmentApi.get('1')
@@ -400,7 +400,7 @@ describe('cashAdjustmentApi', () => {
 
     describe('create', () => {
         it('calls POST /cash-adjustments', async () => {
-            const mockResponse = { data: { status: 201, data: { id: 1 } } }
+            const mockResponse = { data: { status: 201, data: { id: '1' } } }
             vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
 
             const data: CashAdjustmentFormData = {
@@ -419,7 +419,7 @@ describe('cashAdjustmentApi', () => {
 
     describe('post', () => {
         it('calls POST /cash-adjustments/:id/post', async () => {
-            const mockResponse = { data: { status: 200, data: { id: 1, status: 'POSTED' } } }
+            const mockResponse = { data: { status: 200, data: { id: '1', status: 'POSTED' } } }
             vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
 
             const result = await cashAdjustmentApi.post('1')
@@ -463,7 +463,7 @@ describe('cashExpenseApi', () => {
 
     describe('get', () => {
         it('calls GET /cash-expenses/:id', async () => {
-            const mockResponse = { data: { status: 200, data: { id: 1 } } }
+            const mockResponse = { data: { status: 200, data: { id: '1' } } }
             vi.mocked(apiClient.get).mockResolvedValue(mockResponse)
 
             const result = await cashExpenseApi.get('1')
@@ -475,7 +475,7 @@ describe('cashExpenseApi', () => {
 
     describe('create', () => {
         it('calls POST /cash-expenses', async () => {
-            const mockResponse = { data: { status: 201, data: { id: 1 } } }
+            const mockResponse = { data: { status: 201, data: { id: '1' } } }
             vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
 
             const data: CashExpenseFormData = {
@@ -495,7 +495,7 @@ describe('cashExpenseApi', () => {
 
     describe('update', () => {
         it('calls PUT /cash-expenses/:id', async () => {
-            const mockResponse = { data: { status: 200, data: { id: 1 } } }
+            const mockResponse = { data: { status: 200, data: { id: '1' } } }
             vi.mocked(apiClient.put).mockResolvedValue(mockResponse)
 
             const data: Partial<CashExpenseFormData> = { category: 'CLEANING' }
@@ -508,7 +508,7 @@ describe('cashExpenseApi', () => {
 
     describe('post', () => {
         it('calls POST /cash-expenses/:id/post', async () => {
-            const mockResponse = { data: { status: 200, data: { id: 1, status: 'POSTED' } } }
+            const mockResponse = { data: { status: 200, data: { id: '1', status: 'POSTED' } } }
             vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
 
             const result = await cashExpenseApi.post('1')

--- a/code/webapp/src/services/__tests__/cash-balance-service.test.ts
+++ b/code/webapp/src/services/__tests__/cash-balance-service.test.ts
@@ -23,8 +23,7 @@ afterEach(() => {
 
 function createSession(overrides: Partial<CashSession> = {}): CashSession {
     return {
-        id: 1,
-        cash_register_id: 1,
+        id: '1',
         operating_date: '2026-03-31',
         opening_balance: '1000.00',
         closing_balance: null,

--- a/code/webapp/src/services/__tests__/cash-hooks.test.ts
+++ b/code/webapp/src/services/__tests__/cash-hooks.test.ts
@@ -119,7 +119,7 @@ function makeWrapper() {
 }
 
 const mockListResponse = { data: { data: [], meta: {} } }
-const mockEntityResponse = { data: { data: { id: 1 } } }
+const mockEntityResponse = { data: { data: { id: '1' } } }
 
 // ── useCashRegisters ───────────────────────────────────────────────────────────
 
@@ -151,14 +151,14 @@ describe('useCashRegister', () => {
 
   it('fetches a single register by id', async () => {
     const { wrapper } = makeWrapper()
-    const { result } = renderHook(() => useCashRegister(5), { wrapper })
+    const { result } = renderHook(() => useCashRegister('5'), { wrapper })
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(cashRegisterApi.get).toHaveBeenCalledWith(5)
+    expect(cashRegisterApi.get).toHaveBeenCalledWith('5')
   })
 
   it('is disabled when id is 0', () => {
     const { wrapper } = makeWrapper()
-    const { result } = renderHook(() => useCashRegister(0), { wrapper })
+    const { result } = renderHook(() => useCashRegister(''), { wrapper })
     expect(result.current.fetchStatus).toBe('idle')
   })
 })
@@ -198,7 +198,7 @@ describe('useUpdateCashRegister', () => {
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => useUpdateCashRegister(), { wrapper })
     await act(async () => {
-      await result.current.mutateAsync({ id: 1, data: { name: 'Caja Updated' } })
+      await result.current.mutateAsync({ id: '1', data: { name: 'Caja Updated' } })
     })
     expect(mockShowSuccess).toHaveBeenCalled()
   })
@@ -208,7 +208,7 @@ describe('useUpdateCashRegister', () => {
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => useUpdateCashRegister(), { wrapper })
     await act(async () => {
-      try { await result.current.mutateAsync({ id: 1, data: { name: 'x' } }) }
+      try { await result.current.mutateAsync({ id: '1', data: { name: 'x' } }) }
       catch { /* expected */ }
     })
     expect(mockShowError).toHaveBeenCalled()
@@ -222,7 +222,7 @@ describe('useDeleteCashRegister', () => {
     vi.mocked(cashRegisterApi.delete).mockResolvedValueOnce(undefined as never)
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => useDeleteCashRegister(), { wrapper })
-    await act(async () => { await result.current.mutateAsync(1) })
+    await act(async () => { await result.current.mutateAsync('1') })
     expect(mockShowSuccess).toHaveBeenCalledWith(expect.stringContaining('eliminada'), expect.any(String))
   })
 
@@ -231,7 +231,7 @@ describe('useDeleteCashRegister', () => {
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => useDeleteCashRegister(), { wrapper })
     await act(async () => {
-      try { await result.current.mutateAsync(1) }
+      try { await result.current.mutateAsync('1') }
       catch { /* expected */ }
     })
     expect(mockShowError).toHaveBeenCalled()
@@ -257,14 +257,14 @@ describe('useCashTerminal', () => {
 
   it('fetches a single terminal by id', async () => {
     const { wrapper } = makeWrapper()
-    const { result } = renderHook(() => useCashTerminal(3), { wrapper })
+    const { result } = renderHook(() => useCashTerminal('3'), { wrapper })
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(cashTerminalApi.get).toHaveBeenCalledWith(3)
+    expect(cashTerminalApi.get).toHaveBeenCalledWith('3')
   })
 
   it('is disabled for id=0', () => {
     const { wrapper } = makeWrapper()
-    const { result } = renderHook(() => useCashTerminal(0), { wrapper })
+    const { result } = renderHook(() => useCashTerminal(''), { wrapper })
     expect(result.current.fetchStatus).toBe('idle')
   })
 })
@@ -299,7 +299,7 @@ describe('useUpdateCashTerminal', () => {
     vi.mocked(cashTerminalApi.update).mockResolvedValueOnce(mockEntityResponse as never)
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => useUpdateCashTerminal(), { wrapper })
-    await act(async () => { await result.current.mutateAsync({ id: 1, data: { name: 'T' } }) })
+    await act(async () => { await result.current.mutateAsync({ id: '1', data: { name: 'T' } }) })
     expect(mockShowSuccess).toHaveBeenCalled()
   })
 
@@ -308,7 +308,7 @@ describe('useUpdateCashTerminal', () => {
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => useUpdateCashTerminal(), { wrapper })
     await act(async () => {
-      try { await result.current.mutateAsync({ id: 1, data: {} }) }
+      try { await result.current.mutateAsync({ id: '1', data: {} }) }
       catch { /* expected */ }
     })
     expect(mockShowError).toHaveBeenCalled()
@@ -322,7 +322,7 @@ describe('useDeleteCashTerminal', () => {
     vi.mocked(cashTerminalApi.delete).mockResolvedValueOnce(undefined as never)
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => useDeleteCashTerminal(), { wrapper })
-    await act(async () => { await result.current.mutateAsync(2) })
+    await act(async () => { await result.current.mutateAsync('2') })
     expect(mockShowSuccess).toHaveBeenCalled()
   })
 
@@ -331,7 +331,7 @@ describe('useDeleteCashTerminal', () => {
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => useDeleteCashTerminal(), { wrapper })
     await act(async () => {
-      try { await result.current.mutateAsync(2) }
+      try { await result.current.mutateAsync('2') }
       catch { /* expected */ }
     })
     expect(mockShowError).toHaveBeenCalled()
@@ -357,13 +357,13 @@ describe('useBankAccount', () => {
 
   it('fetches by id', async () => {
     const { wrapper } = makeWrapper()
-    const { result } = renderHook(() => useBankAccount(7), { wrapper })
+    const { result } = renderHook(() => useBankAccount('7'), { wrapper })
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
   })
 
   it('is disabled for id=0', () => {
     const { wrapper } = makeWrapper()
-    const { result } = renderHook(() => useBankAccount(0), { wrapper })
+    const { result } = renderHook(() => useBankAccount(''), { wrapper })
     expect(result.current.fetchStatus).toBe('idle')
   })
 })
@@ -398,7 +398,7 @@ describe('useUpdateBankAccount', () => {
     vi.mocked(bankAccountApi.update).mockResolvedValueOnce(mockEntityResponse as never)
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => useUpdateBankAccount(), { wrapper })
-    await act(async () => { await result.current.mutateAsync({ id: 1, data: { alias: 'Updated' } }) })
+    await act(async () => { await result.current.mutateAsync({ id: '1', data: { alias: 'Updated' } }) })
     expect(mockShowSuccess).toHaveBeenCalled()
   })
 
@@ -407,7 +407,7 @@ describe('useUpdateBankAccount', () => {
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => useUpdateBankAccount(), { wrapper })
     await act(async () => {
-      try { await result.current.mutateAsync({ id: 1, data: {} }) }
+      try { await result.current.mutateAsync({ id: '1', data: {} }) }
       catch { /* expected */ }
     })
     expect(mockShowError).toHaveBeenCalled()
@@ -421,7 +421,7 @@ describe('useDeleteBankAccount', () => {
     vi.mocked(bankAccountApi.delete).mockResolvedValueOnce(undefined as never)
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => useDeleteBankAccount(), { wrapper })
-    await act(async () => { await result.current.mutateAsync(1) })
+    await act(async () => { await result.current.mutateAsync('1') })
     expect(mockShowSuccess).toHaveBeenCalled()
   })
 
@@ -430,7 +430,7 @@ describe('useDeleteBankAccount', () => {
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => useDeleteBankAccount(), { wrapper })
     await act(async () => {
-      try { await result.current.mutateAsync(1) }
+      try { await result.current.mutateAsync('1') }
       catch { /* expected */ }
     })
     expect(mockShowError).toHaveBeenCalled()
@@ -456,13 +456,13 @@ describe('useCashSession', () => {
 
   it('fetches a single session', async () => {
     const { wrapper } = makeWrapper()
-    const { result } = renderHook(() => useCashSession(10), { wrapper })
+    const { result } = renderHook(() => useCashSession('10'), { wrapper })
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
   })
 
   it('is disabled for id=0', () => {
     const { wrapper } = makeWrapper()
-    const { result } = renderHook(() => useCashSession(0), { wrapper })
+    const { result } = renderHook(() => useCashSession(''), { wrapper })
     expect(result.current.fetchStatus).toBe('idle')
   })
 })
@@ -473,14 +473,14 @@ describe('useCashSessionSummary', () => {
 
   it('fetches session summary', async () => {
     const { wrapper } = makeWrapper()
-    const { result } = renderHook(() => useCashSessionSummary(10), { wrapper })
+    const { result } = renderHook(() => useCashSessionSummary('10'), { wrapper })
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(cashSessionApi.getSummary).toHaveBeenCalledWith(10)
+    expect(cashSessionApi.getSummary).toHaveBeenCalledWith('10')
   })
 
   it('is disabled for id=0', () => {
     const { wrapper } = makeWrapper()
-    const { result } = renderHook(() => useCashSessionSummary(0), { wrapper })
+    const { result } = renderHook(() => useCashSessionSummary(''), { wrapper })
     expect(result.current.fetchStatus).toBe('idle')
   })
 })
@@ -493,7 +493,7 @@ describe('useCreateCashSession', () => {
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => useCreateCashSession(), { wrapper })
     await act(async () => {
-      await result.current.mutateAsync({ cash_register_id: 1, operating_date: '2026-03-31', opening_balance: '1000' })
+      await result.current.mutateAsync({ cash_register_id: '1', operating_date: '2026-03-31', opening_balance: '1000' })
     })
     expect(mockShowSuccess).toHaveBeenCalledWith(expect.stringContaining('abierta'), expect.any(String))
   })
@@ -503,7 +503,7 @@ describe('useCreateCashSession', () => {
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => useCreateCashSession(), { wrapper })
     await act(async () => {
-      try { await result.current.mutateAsync({ cash_register_id: 1, operating_date: '2026-03-31', opening_balance: '1000' }) }
+      try { await result.current.mutateAsync({ cash_register_id: '1', operating_date: '2026-03-31', opening_balance: '1000' }) }
       catch { /* expected */ }
     })
     expect(mockShowError).toHaveBeenCalled()
@@ -517,7 +517,7 @@ describe('useUpdateCashSession', () => {
     vi.mocked(cashSessionApi.update).mockResolvedValueOnce(mockEntityResponse as never)
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => useUpdateCashSession(), { wrapper })
-    await act(async () => { await result.current.mutateAsync({ id: 1, data: { opening_balance: '500' } }) })
+    await act(async () => { await result.current.mutateAsync({ id: '1', data: { opening_balance: '500' } }) })
     expect(mockShowSuccess).toHaveBeenCalled()
   })
 
@@ -526,7 +526,7 @@ describe('useUpdateCashSession', () => {
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => useUpdateCashSession(), { wrapper })
     await act(async () => {
-      try { await result.current.mutateAsync({ id: 1, data: {} }) }
+      try { await result.current.mutateAsync({ id: '1', data: {} }) }
       catch { /* expected */ }
     })
     expect(mockShowError).toHaveBeenCalled()
@@ -540,7 +540,7 @@ describe('usePostCashSession', () => {
     vi.mocked(cashSessionApi.post).mockResolvedValueOnce(mockEntityResponse as never)
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => usePostCashSession(), { wrapper })
-    await act(async () => { await result.current.mutateAsync(5) })
+    await act(async () => { await result.current.mutateAsync('5') })
     expect(mockShowSuccess).toHaveBeenCalledWith(expect.stringContaining('cerrada'), expect.any(String))
   })
 
@@ -549,7 +549,7 @@ describe('usePostCashSession', () => {
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => usePostCashSession(), { wrapper })
     await act(async () => {
-      try { await result.current.mutateAsync(5) }
+      try { await result.current.mutateAsync('5') }
       catch { /* expected */ }
     })
     expect(mockShowError).toHaveBeenCalled()
@@ -575,13 +575,13 @@ describe('useCashAdjustment', () => {
 
   it('fetches single adjustment', async () => {
     const { wrapper } = makeWrapper()
-    const { result } = renderHook(() => useCashAdjustment(3), { wrapper })
+    const { result } = renderHook(() => useCashAdjustment('3'), { wrapper })
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
   })
 
   it('is disabled for id=0', () => {
     const { wrapper } = makeWrapper()
-    const { result } = renderHook(() => useCashAdjustment(0), { wrapper })
+    const { result } = renderHook(() => useCashAdjustment(''), { wrapper })
     expect(result.current.fetchStatus).toBe('idle')
   })
 })
@@ -590,23 +590,23 @@ describe('useCreateCashAdjustment', () => {
   afterEach(() => { vi.clearAllMocks() })
 
   it('shows success toast on create', async () => {
-    const mockResponse = { data: { data: { id: 1, cash_session_id: 10 } } }
+    const mockResponse = { data: { data: { id: '1', cash_session: { id: '10' } } } }
     vi.mocked(cashAdjustmentApi.create).mockResolvedValueOnce(mockResponse as never)
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => useCreateCashAdjustment(), { wrapper })
     await act(async () => {
-      await result.current.mutateAsync({ cash_session_id: 10, type: AdjustmentType.CORRECTION, direction: Direction.INFLOW, lines: [] })
+      await result.current.mutateAsync({ cash_session_id: '10', type: AdjustmentType.CORRECTION, direction: Direction.INFLOW, lines: [] })
     })
     expect(mockShowSuccess).toHaveBeenCalled()
   })
 
   it('shows success toast when cash_session_id is null', async () => {
-    const mockResponse = { data: { data: { id: 1, cash_session_id: null } } }
+    const mockResponse = { data: { data: { id: '1', cash_session: null } } }
     vi.mocked(cashAdjustmentApi.create).mockResolvedValueOnce(mockResponse as never)
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => useCreateCashAdjustment(), { wrapper })
     await act(async () => {
-      await result.current.mutateAsync({ cash_session_id: 0, type: AdjustmentType.CORRECTION, direction: Direction.INFLOW, lines: [] })
+      await result.current.mutateAsync({ cash_session_id: '10', type: AdjustmentType.CORRECTION, direction: Direction.INFLOW, lines: [] })
     })
     expect(mockShowSuccess).toHaveBeenCalled()
   })
@@ -616,7 +616,7 @@ describe('useCreateCashAdjustment', () => {
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => useCreateCashAdjustment(), { wrapper })
     await act(async () => {
-      try { await result.current.mutateAsync({ cash_session_id: 1, type: AdjustmentType.CORRECTION, direction: Direction.INFLOW, lines: [] }) }
+      try { await result.current.mutateAsync({ cash_session_id: '1', type: AdjustmentType.CORRECTION, direction: Direction.INFLOW, lines: [] }) }
       catch { /* expected */ }
     })
     expect(mockShowError).toHaveBeenCalled()
@@ -630,7 +630,7 @@ describe('usePostCashAdjustment', () => {
     vi.mocked(cashAdjustmentApi.post).mockResolvedValueOnce(mockEntityResponse as never)
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => usePostCashAdjustment(), { wrapper })
-    await act(async () => { await result.current.mutateAsync(2) })
+    await act(async () => { await result.current.mutateAsync('2') })
     expect(mockShowSuccess).toHaveBeenCalledWith(expect.stringContaining('confirmado'), expect.any(String))
   })
 
@@ -639,7 +639,7 @@ describe('usePostCashAdjustment', () => {
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => usePostCashAdjustment(), { wrapper })
     await act(async () => {
-      try { await result.current.mutateAsync(2) }
+      try { await result.current.mutateAsync('2') }
       catch { /* expected */ }
     })
     expect(mockShowError).toHaveBeenCalled()
@@ -653,7 +653,7 @@ describe('useDeleteCashAdjustment', () => {
     vi.mocked(cashAdjustmentApi.delete).mockResolvedValueOnce(undefined as never)
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => useDeleteCashAdjustment(), { wrapper })
-    await act(async () => { await result.current.mutateAsync(3) })
+    await act(async () => { await result.current.mutateAsync('3') })
     expect(mockShowSuccess).toHaveBeenCalled()
   })
 
@@ -662,7 +662,7 @@ describe('useDeleteCashAdjustment', () => {
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => useDeleteCashAdjustment(), { wrapper })
     await act(async () => {
-      try { await result.current.mutateAsync(3) }
+      try { await result.current.mutateAsync('3') }
       catch { /* expected */ }
     })
     expect(mockShowError).toHaveBeenCalled()
@@ -688,13 +688,13 @@ describe('useCashExpense', () => {
 
   it('fetches single expense', async () => {
     const { wrapper } = makeWrapper()
-    const { result } = renderHook(() => useCashExpense(4), { wrapper })
+    const { result } = renderHook(() => useCashExpense('4'), { wrapper })
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
   })
 
   it('is disabled for id=0', () => {
     const { wrapper } = makeWrapper()
-    const { result } = renderHook(() => useCashExpense(0), { wrapper })
+    const { result } = renderHook(() => useCashExpense(''), { wrapper })
     expect(result.current.fetchStatus).toBe('idle')
   })
 })
@@ -707,7 +707,7 @@ describe('useCreateCashExpense', () => {
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => useCreateCashExpense(), { wrapper })
     await act(async () => {
-      await result.current.mutateAsync({ cash_session_id: 1, tender_type: TenderType.CASH, amount: '50', category: 'Supplies', vendor: 'Vendor X', incurred_at: '2026-01-01' })
+      await result.current.mutateAsync({ cash_session_id: '1', tender_type: TenderType.CASH, amount: '50', category: 'Supplies', vendor: 'Vendor X', incurred_at: '2026-01-01' })
     })
     expect(mockShowSuccess).toHaveBeenCalledWith(expect.stringContaining('registrado'), expect.any(String))
   })
@@ -717,7 +717,7 @@ describe('useCreateCashExpense', () => {
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => useCreateCashExpense(), { wrapper })
     await act(async () => {
-      try { await result.current.mutateAsync({ cash_session_id: 1, tender_type: TenderType.CASH, amount: '50', category: 'Supplies', vendor: 'Vendor X', incurred_at: '2026-01-01' }) }
+      try { await result.current.mutateAsync({ cash_session_id: '1', tender_type: TenderType.CASH, amount: '50', category: 'Supplies', vendor: 'Vendor X', incurred_at: '2026-01-01' }) }
       catch { /* expected */ }
     })
     expect(mockShowError).toHaveBeenCalled()
@@ -731,7 +731,7 @@ describe('useUpdateCashExpense', () => {
     vi.mocked(cashExpenseApi.update).mockResolvedValueOnce(mockEntityResponse as never)
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => useUpdateCashExpense(), { wrapper })
-    await act(async () => { await result.current.mutateAsync({ id: 1, data: { amount: '60' } }) })
+    await act(async () => { await result.current.mutateAsync({ id: '1', data: { amount: '60' } }) })
     expect(mockShowSuccess).toHaveBeenCalled()
   })
 
@@ -740,7 +740,7 @@ describe('useUpdateCashExpense', () => {
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => useUpdateCashExpense(), { wrapper })
     await act(async () => {
-      try { await result.current.mutateAsync({ id: 1, data: {} }) }
+      try { await result.current.mutateAsync({ id: '1', data: {} }) }
       catch { /* expected */ }
     })
     expect(mockShowError).toHaveBeenCalled()
@@ -754,7 +754,7 @@ describe('usePostCashExpense', () => {
     vi.mocked(cashExpenseApi.post).mockResolvedValueOnce(mockEntityResponse as never)
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => usePostCashExpense(), { wrapper })
-    await act(async () => { await result.current.mutateAsync(6) })
+    await act(async () => { await result.current.mutateAsync('6') })
     expect(mockShowSuccess).toHaveBeenCalledWith(expect.stringContaining('confirmado'), expect.any(String))
   })
 
@@ -763,7 +763,7 @@ describe('usePostCashExpense', () => {
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => usePostCashExpense(), { wrapper })
     await act(async () => {
-      try { await result.current.mutateAsync(6) }
+      try { await result.current.mutateAsync('6') }
       catch { /* expected */ }
     })
     expect(mockShowError).toHaveBeenCalled()
@@ -777,7 +777,7 @@ describe('useDeleteCashExpense', () => {
     vi.mocked(cashExpenseApi.delete).mockResolvedValueOnce(undefined as never)
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => useDeleteCashExpense(), { wrapper })
-    await act(async () => { await result.current.mutateAsync(7) })
+    await act(async () => { await result.current.mutateAsync('7') })
     expect(mockShowSuccess).toHaveBeenCalledWith(expect.stringContaining('eliminado'), expect.any(String))
   })
 
@@ -786,7 +786,7 @@ describe('useDeleteCashExpense', () => {
     const { wrapper } = makeWrapper()
     const { result } = renderHook(() => useDeleteCashExpense(), { wrapper })
     await act(async () => {
-      try { await result.current.mutateAsync(7) }
+      try { await result.current.mutateAsync('7') }
       catch { /* expected */ }
     })
     expect(mockShowError).toHaveBeenCalled()

--- a/code/webapp/src/services/__tests__/cash-hooks.test.ts
+++ b/code/webapp/src/services/__tests__/cash-hooks.test.ts
@@ -600,7 +600,7 @@ describe('useCreateCashAdjustment', () => {
     expect(mockShowSuccess).toHaveBeenCalled()
   })
 
-  it('shows success toast when cash_session_id is null', async () => {
+  it('shows success toast when cash_session relation is null', async () => {
     const mockResponse = { data: { data: { id: '1', cash_session: null } } }
     vi.mocked(cashAdjustmentApi.create).mockResolvedValueOnce(mockResponse as never)
     const { wrapper } = makeWrapper()

--- a/code/webapp/src/services/cash-api.ts
+++ b/code/webapp/src/services/cash-api.ts
@@ -34,16 +34,16 @@ export const cashRegisterApi = {
   list: (params?: CashRegisterFilters) =>
     api.get<PaginatedResponse<CashRegister>>('/cash-registers', { params }),
 
-  get: (id: number) =>
+  get: (id: string) =>
     api.get<EntityResponse<CashRegister>>(`/cash-registers/${id}`),
 
   create: (data: CashRegisterFormData) =>
     api.post<EntityResponse<CashRegister>>('/cash-registers', data),
 
-  update: (id: number, data: Partial<CashRegisterFormData>) =>
+  update: (id: string, data: Partial<CashRegisterFormData>) =>
     api.put<EntityResponse<CashRegister>>(`/cash-registers/${id}`, data),
 
-  delete: (id: number) =>
+  delete: (id: string) =>
     api.delete<MessageResponse>(`/cash-registers/${id}`),
 }
 
@@ -55,16 +55,16 @@ export const cashTerminalApi = {
   list: (params?: CashTerminalFilters) =>
     api.get<PaginatedResponse<CashTerminal>>('/cash-terminals', { params }),
 
-  get: (id: number) =>
+  get: (id: string) =>
     api.get<EntityResponse<CashTerminal>>(`/cash-terminals/${id}`),
 
   create: (data: CashTerminalFormData) =>
     api.post<EntityResponse<CashTerminal>>('/cash-terminals', data),
 
-  update: (id: number, data: Partial<CashTerminalFormData>) =>
+  update: (id: string, data: Partial<CashTerminalFormData>) =>
     api.put<EntityResponse<CashTerminal>>(`/cash-terminals/${id}`, data),
 
-  delete: (id: number) =>
+  delete: (id: string) =>
     api.delete<MessageResponse>(`/cash-terminals/${id}`),
 }
 
@@ -76,16 +76,16 @@ export const bankAccountApi = {
   list: (params?: BankAccountFilters) =>
     api.get<PaginatedResponse<BankAccount>>('/bank-accounts', { params }),
 
-  get: (id: number) =>
+  get: (id: string) =>
     api.get<EntityResponse<BankAccount>>(`/bank-accounts/${id}`),
 
   create: (data: BankAccountFormData) =>
     api.post<EntityResponse<BankAccount>>('/bank-accounts', data),
 
-  update: (id: number, data: Partial<BankAccountFormData>) =>
+  update: (id: string, data: Partial<BankAccountFormData>) =>
     api.put<EntityResponse<BankAccount>>(`/bank-accounts/${id}`, data),
 
-  delete: (id: number) =>
+  delete: (id: string) =>
     api.delete<MessageResponse>(`/bank-accounts/${id}`),
 }
 
@@ -97,19 +97,19 @@ export const cashSessionApi = {
   list: (params?: CashSessionFilters) =>
     api.get<PaginatedResponse<CashSession>>('/cash-sessions', { params }),
 
-  get: (id: number) =>
+  get: (id: string) =>
     api.get<EntityResponse<CashSession>>(`/cash-sessions/${id}`),
 
   create: (data: CashSessionFormData) =>
     api.post<EntityResponse<CashSession>>('/cash-sessions', data),
 
-  update: (id: number, data: Partial<CashSessionFormData>) =>
+  update: (id: string, data: Partial<CashSessionFormData>) =>
     api.put<EntityResponse<CashSession>>(`/cash-sessions/${id}`, data),
 
-  post: (id: number) =>
+  post: (id: string) =>
     api.post<EntityResponse<CashSession>>(`/cash-sessions/${id}/post`),
 
-  getSummary: (id: number) =>
+  getSummary: (id: string) =>
     api.get<EntityResponse<SessionSummary>>(`/cash-sessions/${id}/summary`),
 }
 
@@ -121,16 +121,16 @@ export const cashAdjustmentApi = {
   list: (params?: CashAdjustmentFilters) =>
     api.get<PaginatedResponse<CashAdjustment>>('/cash-adjustments', { params }),
 
-  get: (id: number) =>
+  get: (id: string) =>
     api.get<EntityResponse<CashAdjustment>>(`/cash-adjustments/${id}`),
 
   create: (data: CashAdjustmentFormData) =>
     api.post<EntityResponse<CashAdjustment>>('/cash-adjustments', data),
 
-  post: (id: number) =>
+  post: (id: string) =>
     api.post<EntityResponse<CashAdjustment>>(`/cash-adjustments/${id}/post`),
 
-  delete: (id: number) =>
+  delete: (id: string) =>
     api.delete<MessageResponse>(`/cash-adjustments/${id}`),
 }
 
@@ -142,18 +142,18 @@ export const cashExpenseApi = {
   list: (params?: CashExpenseFilters) =>
     api.get<PaginatedResponse<CashExpense>>('/cash-expenses', { params }),
 
-  get: (id: number) =>
+  get: (id: string) =>
     api.get<EntityResponse<CashExpense>>(`/cash-expenses/${id}`),
 
   create: (data: CashExpenseFormData) =>
     api.post<EntityResponse<CashExpense>>('/cash-expenses', data),
 
-  update: (id: number, data: Partial<CashExpenseFormData>) =>
+  update: (id: string, data: Partial<CashExpenseFormData>) =>
     api.put<EntityResponse<CashExpense>>(`/cash-expenses/${id}`, data),
 
-  post: (id: number) =>
+  post: (id: string) =>
     api.post<EntityResponse<CashExpense>>(`/cash-expenses/${id}/post`),
 
-  delete: (id: number) =>
+  delete: (id: string) =>
     api.delete<MessageResponse>(`/cash-expenses/${id}`),
 }

--- a/code/webapp/src/services/cash-hooks.ts
+++ b/code/webapp/src/services/cash-hooks.ts
@@ -38,7 +38,7 @@ export function useCashRegisters(filters?: CashRegisterFilters) {
   })
 }
 
-export function useCashRegister(id: number) {
+export function useCashRegister(id: string) {
   return useQuery({
     queryKey: ['cash-registers', id],
     queryFn: async () => {
@@ -70,7 +70,7 @@ export function useUpdateCashRegister() {
   const { showSuccess, showError } = useToast()
 
   return useMutation({
-    mutationFn: ({ id, data }: { id: number; data: Partial<CashRegisterFormData> }) =>
+    mutationFn: ({ id, data }: { id: string; data: Partial<CashRegisterFormData> }) =>
       cashRegisterApi.update(id, data),
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: ['cash-registers'] })
@@ -88,7 +88,7 @@ export function useDeleteCashRegister() {
   const { showSuccess, showError } = useToast()
 
   return useMutation({
-    mutationFn: (id: number) => cashRegisterApi.delete(id),
+    mutationFn: (id: string) => cashRegisterApi.delete(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['cash-registers'] })
       showSuccess('La caja registradora ha sido eliminada exitosamente.', 'Caja eliminada')
@@ -113,7 +113,7 @@ export function useCashTerminals(filters?: CashTerminalFilters) {
   })
 }
 
-export function useCashTerminal(id: number) {
+export function useCashTerminal(id: string) {
   return useQuery({
     queryKey: ['cash-terminals', id],
     queryFn: async () => {
@@ -145,7 +145,7 @@ export function useUpdateCashTerminal() {
   const { showSuccess, showError } = useToast()
 
   return useMutation({
-    mutationFn: ({ id, data }: { id: number; data: Partial<CashTerminalFormData> }) =>
+    mutationFn: ({ id, data }: { id: string; data: Partial<CashTerminalFormData> }) =>
       cashTerminalApi.update(id, data),
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: ['cash-terminals'] })
@@ -163,7 +163,7 @@ export function useDeleteCashTerminal() {
   const { showSuccess, showError } = useToast()
 
   return useMutation({
-    mutationFn: (id: number) => cashTerminalApi.delete(id),
+    mutationFn: (id: string) => cashTerminalApi.delete(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['cash-terminals'] })
       showSuccess('La terminal de pago ha sido eliminada exitosamente.', 'Terminal eliminada')
@@ -188,7 +188,7 @@ export function useBankAccounts(filters?: BankAccountFilters) {
   })
 }
 
-export function useBankAccount(id: number) {
+export function useBankAccount(id: string) {
   return useQuery({
     queryKey: ['bank-accounts', id],
     queryFn: async () => {
@@ -220,7 +220,7 @@ export function useUpdateBankAccount() {
   const { showSuccess, showError } = useToast()
 
   return useMutation({
-    mutationFn: ({ id, data }: { id: number; data: Partial<BankAccountFormData> }) =>
+    mutationFn: ({ id, data }: { id: string; data: Partial<BankAccountFormData> }) =>
       bankAccountApi.update(id, data),
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: ['bank-accounts'] })
@@ -238,7 +238,7 @@ export function useDeleteBankAccount() {
   const { showSuccess, showError } = useToast()
 
   return useMutation({
-    mutationFn: (id: number) => bankAccountApi.delete(id),
+    mutationFn: (id: string) => bankAccountApi.delete(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['bank-accounts'] })
       showSuccess('La cuenta bancaria ha sido eliminada exitosamente.', 'Cuenta eliminada')
@@ -263,7 +263,7 @@ export function useCashSessions(filters?: CashSessionFilters) {
   })
 }
 
-export function useCashSession(id: number) {
+export function useCashSession(id: string) {
   return useQuery({
     queryKey: ['cash-sessions', id],
     queryFn: async () => {
@@ -274,7 +274,7 @@ export function useCashSession(id: number) {
   })
 }
 
-export function useCashSessionSummary(id: number) {
+export function useCashSessionSummary(id: string) {
   return useQuery({
     queryKey: ['cash-sessions', id, 'summary'],
     queryFn: async () => {
@@ -306,7 +306,7 @@ export function useUpdateCashSession() {
   const { showSuccess, showError } = useToast()
 
   return useMutation({
-    mutationFn: ({ id, data }: { id: number; data: Partial<CashSessionFormData> }) =>
+    mutationFn: ({ id, data }: { id: string; data: Partial<CashSessionFormData> }) =>
       cashSessionApi.update(id, data),
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: ['cash-sessions'] })
@@ -324,7 +324,7 @@ export function usePostCashSession() {
   const { showSuccess, showError } = useToast()
 
   return useMutation({
-    mutationFn: (id: number) => cashSessionApi.post(id),
+    mutationFn: (id: string) => cashSessionApi.post(id),
     onSuccess: (_, id) => {
       queryClient.invalidateQueries({ queryKey: ['cash-sessions'] })
       queryClient.invalidateQueries({ queryKey: ['cash-sessions', id] })
@@ -350,7 +350,7 @@ export function useCashAdjustments(filters?: CashAdjustmentFilters) {
   })
 }
 
-export function useCashAdjustment(id: number) {
+export function useCashAdjustment(id: string) {
   return useQuery({
     queryKey: ['cash-adjustments', id],
     queryFn: async () => {
@@ -372,7 +372,7 @@ export function useCreateCashAdjustment() {
       queryClient.invalidateQueries({ queryKey: ['cash-sessions'] })
 
       // Invalidar el summary de la sesión específica para que se recalcule el saldo
-      const sessionId = response.data.data.cash_session_id
+      const sessionId = response.data.data.cash_session?.id
       if (sessionId) {
         queryClient.invalidateQueries({ queryKey: ['cash-sessions', sessionId, 'summary'] })
       }
@@ -390,7 +390,7 @@ export function usePostCashAdjustment() {
   const { showSuccess, showError } = useToast()
 
   return useMutation({
-    mutationFn: (id: number) => cashAdjustmentApi.post(id),
+    mutationFn: (id: string) => cashAdjustmentApi.post(id),
     onSuccess: (_, id) => {
       queryClient.invalidateQueries({ queryKey: ['cash-adjustments'] })
       queryClient.invalidateQueries({ queryKey: ['cash-adjustments', id] })
@@ -408,7 +408,7 @@ export function useDeleteCashAdjustment() {
   const { showSuccess, showError } = useToast()
 
   return useMutation({
-    mutationFn: (id: number) => cashAdjustmentApi.delete(id),
+    mutationFn: (id: string) => cashAdjustmentApi.delete(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['cash-adjustments'] })
       queryClient.invalidateQueries({ queryKey: ['cash-sessions'] })
@@ -439,7 +439,7 @@ export function useCashExpenses(filters?: CashExpenseFilters) {
   })
 }
 
-export function useCashExpense(id: number) {
+export function useCashExpense(id: string) {
   return useQuery({
     queryKey: ['cash-expenses', id],
     queryFn: async () => {
@@ -472,7 +472,7 @@ export function useUpdateCashExpense() {
   const { showSuccess, showError } = useToast()
 
   return useMutation({
-    mutationFn: ({ id, data }: { id: number; data: Partial<CashExpenseFormData> }) =>
+    mutationFn: ({ id, data }: { id: string; data: Partial<CashExpenseFormData> }) =>
       cashExpenseApi.update(id, data),
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: ['cash-expenses'] })
@@ -491,7 +491,7 @@ export function usePostCashExpense() {
   const { showSuccess, showError } = useToast()
 
   return useMutation({
-    mutationFn: (id: number) => cashExpenseApi.post(id),
+    mutationFn: (id: string) => cashExpenseApi.post(id),
     onSuccess: (_, id) => {
       queryClient.invalidateQueries({ queryKey: ['cash-expenses'] })
       queryClient.invalidateQueries({ queryKey: ['cash-expenses', id] })
@@ -509,7 +509,7 @@ export function useDeleteCashExpense() {
   const { showSuccess, showError } = useToast()
 
   return useMutation({
-    mutationFn: (id: number) => cashExpenseApi.delete(id),
+    mutationFn: (id: string) => cashExpenseApi.delete(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['cash-expenses'] })
       queryClient.invalidateQueries({ queryKey: ['cash-sessions'] })

--- a/code/webapp/src/types/cash.ts
+++ b/code/webapp/src/types/cash.ts
@@ -36,7 +36,7 @@ export enum TenderType {
 // ============================================================================
 
 export interface CashRegister {
-  id: number
+  id: string
   branch_id: number
   operating_unit_id: number | null
   code: string
@@ -53,7 +53,7 @@ export interface CashRegister {
 }
 
 export interface CashTerminal {
-  id: number
+  id: string
   branch_id: number
   name: string
   provider: string
@@ -68,7 +68,7 @@ export interface CashTerminal {
 }
 
 export interface BankAccount {
-  id: number
+  id: string
   branch_id: number
   alias: string
   bank_name: string
@@ -83,8 +83,9 @@ export interface BankAccount {
 }
 
 export interface CashSession {
-  id: number
-  cash_register_id: number
+  id: string
+  // cash_register_id is hidden by the backend (App\Models\CashSession::$hidden)
+  // since it's the internal numeric FK — use the cash_register relation's id instead.
   operating_date: string
   opening_balance: string
   closing_balance: string | null
@@ -106,8 +107,9 @@ export interface CashSession {
 }
 
 export interface CashAdjustment {
-  id: number
-  cash_session_id: number
+  id: string
+  // cash_session_id is hidden by the backend (App\Models\CashAdjustment::$hidden)
+  // — use the cash_session relation's id instead.
   source_system: string | null
   type: AdjustmentType
   direction: Direction
@@ -125,12 +127,12 @@ export interface CashAdjustment {
 
 export interface CashAdjustmentLine {
   id: number
-  cash_adjustment_id: number
+  // cash_adjustment_id/card_terminal_id/bank_account_id are hidden by the
+  // backend (App\Models\CashAdjustmentLine::$hidden) — use the
+  // card_terminal/bank_account relations' ids instead.
   tender_type: TenderType
   amount: string
   currency: string
-  card_terminal_id: number | null
-  bank_account_id: number | null
   reference: string | null
   meta: Record<string, unknown> | null
   created_at: string
@@ -142,16 +144,16 @@ export interface CashAdjustmentLine {
 }
 
 export interface CashExpense {
-  id: number
-  cash_session_id: number
+  id: string
+  // cash_session_id/card_terminal_id/bank_account_id are hidden by the
+  // backend (App\Models\CashExpense::$hidden) — use the cash_session/
+  // card_terminal/bank_account relations' ids instead.
   tender_type: TenderType
   amount: string
   category: string
   vendor: string
   reference: string | null
   notes: string | null
-  card_terminal_id: number | null
-  bank_account_id: number | null
   incurred_at: string
   created_by: number
   posted_by: number | null
@@ -274,14 +276,14 @@ export interface BankAccountFormData {
 }
 
 export interface CashSessionFormData {
-  cash_register_id: number
+  cash_register_id: string
   operating_date: string
   opening_balance?: string
   meta?: Record<string, unknown>
 }
 
 export interface CashAdjustmentFormData {
-  cash_session_id: number
+  cash_session_id: string
   source_system?: string
   type: AdjustmentType
   direction: Direction
@@ -294,22 +296,22 @@ export interface CashAdjustmentLineFormData {
   tender_type: TenderType
   amount: string
   currency?: string
-  card_terminal_id?: number | null
-  bank_account_id?: number | null
+  card_terminal_id?: string | null
+  bank_account_id?: string | null
   reference?: string
   meta?: Record<string, unknown>
 }
 
 export interface CashExpenseFormData {
-  cash_session_id: number
+  cash_session_id: string
   tender_type: TenderType
   amount: string
   category: string
   vendor: string
   reference?: string
   notes?: string
-  card_terminal_id?: number | null
-  bank_account_id?: number | null
+  card_terminal_id?: string | null
+  bank_account_id?: string | null
   incurred_at: string
   meta?: Record<string, unknown>
 }
@@ -345,7 +347,7 @@ export interface BankAccountFilters {
 }
 
 export interface CashSessionFilters {
-  cash_register_id?: number
+  cash_register_id?: string
   operating_date?: string
   status?: SessionStatus
   date_from?: string
@@ -355,7 +357,7 @@ export interface CashSessionFilters {
 }
 
 export interface CashAdjustmentFilters {
-  cash_session_id?: number
+  cash_session_id?: string
   type?: AdjustmentType
   direction?: Direction
   posted?: boolean
@@ -364,7 +366,7 @@ export interface CashAdjustmentFilters {
 }
 
 export interface CashExpenseFilters {
-  cash_session_id?: number
+  cash_session_id?: string
   category?: string
   tender_type?: TenderType
   incurred_from?: string


### PR DESCRIPTION
## Summary
Closes #293
Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/299

Frontend follow-up to #293's backend work (PR #294), which exposed `public_id` (ULID) instead of numeric `id` for the 6 CashAdjustments resources (CashRegister, CashTerminal, BankAccount, CashSession, CashExpense, CashAdjustment).

- Changed `id: number` → `id: string` across `types/cash.ts`, `services/cash-api.ts`, `services/cash-hooks.ts` for all 6 resources
- Removed `cash_register_id`/`cash_session_id`/`card_terminal_id`/`bank_account_id` flat FK fields from the response types — the backend hides these columns (`$hidden`) since PR #294; consumers now read the nested relation's `id` instead (e.g. `session.cash_register?.id`)
- **Fixed a live bug**: `open-session-dialog.tsx` and `create-adjustment-dialog.tsx` were still doing `parseInt(cashRegisterId)` / `parseInt(cashSessionId)` on what the backend has sent as a ULID since #294 merged — every session-open and adjustment-create from the UI was sending garbage (`NaN`/truncated) FK values
- **Fixed a second live bug**: `useCreateCashAdjustment`'s cache-invalidation read `response.data.data.cash_session_id`, a field the backend has hidden since #294 — the surgical per-session summary invalidation silently never fired (fell back to the broader `['cash-sessions']` invalidation, so it wasn't user-visible, but the intended optimization was dead code)
- Updated test fixtures across `cash-api.test.ts`, `cash-hooks.test.ts`, `cash-balance-service.test.ts`, and the CashAdjustments component tests to use string ids

## Test plan
- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 errors (2 pre-existing unrelated warnings)
- [x] Full webapp test suite: 239 files, 3405 tests passing
- [x] Verified end-to-end against the live dev-lab API (see Manual Testing) — request/response shapes match the new types exactly

## Manual Testing
Chrome extension wasn't available for this session, so this was verified via direct API calls replaying the exact payloads the fixed components now send, against the running dev-lab backend (workspace `sushigo-c`, `http://localhost:8003`):
1. `GET /api/v1/cash-registers` → confirms `id` is a ULID string
2. `POST /api/v1/cash-sessions` with `cash_register_id: "<ULID>"` (the exact payload `open-session-dialog.tsx` now sends) → 201, response has no `cash_register_id` field, only nested `cash_register: { id: "<ULID>", ... }`
3. `POST /api/v1/cash-adjustments` with `cash_session_id: "<ULID>"` and a CASH line (the exact payload `create-adjustment-dialog.tsx` now sends) → 201, response's `cash_session.id` is what `useCreateCashAdjustment` now reads for cache invalidation
4. `GET /api/v1/cash-sessions?cash_register_id=<ULID>` → list filter accepts the ULID correctly
5. `GET /api/v1/cash-sessions/<ULID>` and `POST /api/v1/cash-sessions/<ULID>/post` → Show/Post work with the ULID in the URL

For a reviewer with browser access: open Dashboard → "Abrir Sesión" → select a register → submit; then "Registrar Ajuste" on the new session → submit a CASH line. Before this PR both of these would have silently sent a broken FK to the backend.

## Workspace
`sushigo-c` — `refactor/293-cashadjustments-frontend-public-id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)