### PR TITLE
📚 [#293][c] - Log frontend/review session in task time tracking 📊

### DIFF
--- a/doc/tasks/2026-07/293-cashadjustments-public-id.md
+++ b/doc/tasks/2026-07/293-cashadjustments-public-id.md
@@ -42,14 +42,15 @@ Como desarrollador, dando seguimiento a #291, necesito que los 6 tipos de recurs
 ### 📊 Estimates
 - **Optimistic:** `2h`
 - **Pessimistic:** `4h` (6 models × migration/trait/routes/controllers/requests/tests, plus discovering the List-controller-has-no-auth-at-all finding mid-audit)
-- **Tracked:** `5.6h` (backend only, PR #294 merged; frontend pass not yet started)
+- **Tracked:** `7.9h` (5.6h backend, PR #294 merged; +2h17m frontend + review pass, PR #299)
 
 ### 📅 Sessions
 ```json
 [
   { "date": "2026-07-23", "start": "22:00", "end": "24:00" },
   { "date": "2026-07-24", "start": "00:00", "end": "00:31" },
-  { "date": "2026-07-24", "start": "07:30", "end": "10:35" }
+  { "date": "2026-07-24", "start": "07:30", "end": "10:35" },
+  { "date": "2026-07-24", "start": "14:26", "end": "16:43" }
 ]
 ```
 


### PR DESCRIPTION
## Summary
Closes #293
Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/300

Small follow-up to #299 (already merged) — logs the frontend/review-pass work session that happened after that PR was opened, so the task's time tracking stays accurate.

- Added the 2026-07-24 14:26–16:43 session (frontend migration, PR review follow-up, sonar-review coverage pass) to `doc/tasks/2026-07/293-cashadjustments-public-id.md`
- Updated `Tracked` total to 7.9h (5.6h backend + 2h17m frontend)
- Mirrored the same sessions JSON to the GitHub issue #293 body (already applied directly via `gh issue edit`, included here for the record)

## Test plan
Docs-only change (task tracking markdown) — no code touched, no tests applicable.

## Manual Testing
N/A — non-functional documentation update.

## Workspace
`sushigo-c` — `chore/293-log-frontend-session`

🤖 Generated with [Claude Code](https://claude.com/claude-code)