### PR TITLE
🔒 [#295][c] - Add authorization and branch-scoping to CashAdjustments List endpoints 🔒

### DIFF
--- a/code/api/app/Http/Controllers/CashAdjustments/BankAccounts/ListBankAccountsController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/BankAccounts/ListBankAccountsController.php
@@ -2,10 +2,12 @@
 
 namespace App\Http\Controllers\CashAdjustments\BankAccounts;
 
+use App\Http\Controllers\Concerns\ScopesToUserBranches;
 use App\Http\Controllers\Controller;
 use App\Models\BankAccount;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Get(
@@ -25,9 +27,14 @@ use Illuminate\Http\Request;
  */
 class ListBankAccountsController extends Controller
 {
+    use ScopesToUserBranches;
+
     public function __invoke(Request $request): JsonResponse
     {
-        $query = BankAccount::with('branch');
+        Gate::authorize('viewAny', BankAccount::class);
+
+        $query = BankAccount::with('branch')
+            ->whereIn('branch_id', $this->userBranchIds($request));
 
         if ($request->has('branch_id')) {
             $query->byBranch($request->input('branch_id'));

--- a/code/api/app/Http/Controllers/CashAdjustments/CashAdjustments/ListCashAdjustmentsController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashAdjustments/ListCashAdjustmentsController.php
@@ -3,11 +3,14 @@
 namespace App\Http\Controllers\CashAdjustments\CashAdjustments;
 
 use App\Http\Controllers\Concerns\ResolvesPublicIdFilters;
+use App\Http\Controllers\Concerns\ScopesToUserBranches;
 use App\Http\Controllers\Controller;
 use App\Models\CashAdjustment;
 use App\Models\CashSession;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Get(
@@ -30,10 +33,15 @@ use Illuminate\Http\Request;
 class ListCashAdjustmentsController extends Controller
 {
     use ResolvesPublicIdFilters;
+    use ScopesToUserBranches;
 
     public function __invoke(Request $request): JsonResponse
     {
-        $query = CashAdjustment::with(['cashSession.cashRegister', 'lines', 'postedBy']);
+        Gate::authorize('viewAny', CashAdjustment::class);
+
+        $branchIds = $this->userBranchIds($request);
+        $query = CashAdjustment::with(['cashSession.cashRegister', 'lines', 'postedBy'])
+            ->whereHas('cashSession.cashRegister', fn (Builder $q) => $q->whereIn('branch_id', $branchIds));
 
         if ($request->has('cash_session_id')) {
             $query->where(

--- a/code/api/app/Http/Controllers/CashAdjustments/CashExpenses/ListCashExpensesController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashExpenses/ListCashExpensesController.php
@@ -3,11 +3,14 @@
 namespace App\Http\Controllers\CashAdjustments\CashExpenses;
 
 use App\Http\Controllers\Concerns\ResolvesPublicIdFilters;
+use App\Http\Controllers\Concerns\ScopesToUserBranches;
 use App\Http\Controllers\Controller;
 use App\Models\CashExpense;
 use App\Models\CashSession;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Get(
@@ -31,16 +34,23 @@ use Illuminate\Http\Request;
 class ListCashExpensesController extends Controller
 {
     use ResolvesPublicIdFilters;
+    use ScopesToUserBranches;
 
     public function __invoke(Request $request): JsonResponse
     {
+        Gate::authorize('viewAny', CashExpense::class);
+
+        $branchIds = $this->userBranchIds($request);
         $query = CashExpense::with([
             'cashSession.cashRegister',
             'cardTerminal',
             'bankAccount',
             'createdBy',
             'postedBy',
-        ]);
+        ])->whereHas(
+            'cashSession.cashRegister',
+            fn (Builder $q) => $q->whereIn('branch_id', $branchIds)
+        );
 
         if ($request->has('cash_session_id')) {
             $query->where(

--- a/code/api/app/Http/Controllers/CashAdjustments/CashRegisters/ListCashRegistersController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashRegisters/ListCashRegistersController.php
@@ -2,10 +2,12 @@
 
 namespace App\Http\Controllers\CashAdjustments\CashRegisters;
 
+use App\Http\Controllers\Concerns\ScopesToUserBranches;
 use App\Http\Controllers\Controller;
 use App\Models\CashRegister;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Get(
@@ -28,9 +30,14 @@ use Illuminate\Http\Request;
  */
 class ListCashRegistersController extends Controller
 {
+    use ScopesToUserBranches;
+
     public function __invoke(Request $request): JsonResponse
     {
-        $query = CashRegister::with(['branch', 'operatingUnit']);
+        Gate::authorize('viewAny', CashRegister::class);
+
+        $query = CashRegister::with(['branch', 'operatingUnit'])
+            ->whereIn('branch_id', $this->userBranchIds($request));
 
         // Filter by branch
         if ($request->has('branch_id')) {

--- a/code/api/app/Http/Controllers/CashAdjustments/CashSessions/ListCashSessionsController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashSessions/ListCashSessionsController.php
@@ -3,11 +3,14 @@
 namespace App\Http\Controllers\CashAdjustments\CashSessions;
 
 use App\Http\Controllers\Concerns\ResolvesPublicIdFilters;
+use App\Http\Controllers\Concerns\ScopesToUserBranches;
 use App\Http\Controllers\Controller;
 use App\Models\CashRegister;
 use App\Models\CashSession;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Get(
@@ -30,10 +33,15 @@ use Illuminate\Http\Request;
 class ListCashSessionsController extends Controller
 {
     use ResolvesPublicIdFilters;
+    use ScopesToUserBranches;
 
     public function __invoke(Request $request): JsonResponse
     {
-        $query = CashSession::with(['cashRegister.branch']);
+        Gate::authorize('viewAny', CashSession::class);
+
+        $branchIds = $this->userBranchIds($request);
+        $query = CashSession::with(['cashRegister.branch'])
+            ->whereHas('cashRegister', fn (Builder $q) => $q->whereIn('branch_id', $branchIds));
 
         if ($request->has('cash_register_id')) {
             $query->where(

--- a/code/api/app/Http/Controllers/CashAdjustments/CashTerminals/ListCashTerminalsController.php
+++ b/code/api/app/Http/Controllers/CashAdjustments/CashTerminals/ListCashTerminalsController.php
@@ -2,10 +2,12 @@
 
 namespace App\Http\Controllers\CashAdjustments\CashTerminals;
 
+use App\Http\Controllers\Concerns\ScopesToUserBranches;
 use App\Http\Controllers\Controller;
 use App\Models\CashTerminal;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * @OA\Get(
@@ -26,9 +28,14 @@ use Illuminate\Http\Request;
  */
 class ListCashTerminalsController extends Controller
 {
+    use ScopesToUserBranches;
+
     public function __invoke(Request $request): JsonResponse
     {
-        $query = CashTerminal::with('branch');
+        Gate::authorize('viewAny', CashTerminal::class);
+
+        $query = CashTerminal::with('branch')
+            ->whereIn('branch_id', $this->userBranchIds($request));
 
         if ($request->has('branch_id')) {
             $query->byBranch($request->input('branch_id'));

--- a/code/api/app/Http/Controllers/Concerns/ScopesToUserBranches.php
+++ b/code/api/app/Http/Controllers/Concerns/ScopesToUserBranches.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers\Concerns;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+
+/**
+ * Scopes a List query to the requesting user's active branch assignments
+ * (see #295 — List endpoints previously returned every branch's records,
+ * unlike Show/Update/Delete/Post which already scope via ChecksBranchAccess).
+ */
+trait ScopesToUserBranches
+{
+    /**
+     * @return Collection<int, int>
+     */
+    protected function userBranchIds(Request $request): Collection
+    {
+        return $request->user()->operatingUnits()
+            ->wherePivot('is_active', true)
+            ->pluck('branch_id');
+    }
+}

--- a/code/api/tests/Feature/CashAdjustments/BankAccounts/BankAccountAuthorizationTest.php
+++ b/code/api/tests/Feature/CashAdjustments/BankAccounts/BankAccountAuthorizationTest.php
@@ -31,6 +31,34 @@ class BankAccountAuthorizationTest extends TestCase
     }
 
     #[Test]
+    public function list_rejects_a_user_without_the_permission(): void
+    {
+        $branch = Branch::factory()->create();
+        BankAccount::factory()->for($branch)->create();
+        $this->actingAsUserWithBranchAccess($branch, 'some.other.permission');
+
+        $response = $this->getJson('/api/v1/bank-accounts');
+
+        $response->assertStatus(403);
+    }
+
+    #[Test]
+    public function list_only_returns_accounts_within_the_users_branch(): void
+    {
+        $branchA = Branch::factory()->create();
+        $branchB = Branch::factory()->create();
+        $accountA = BankAccount::factory()->for($branchA)->create();
+        BankAccount::factory()->for($branchB)->create();
+        $this->actingAsUserWithBranchAccess($branchA, 'bank_accounts.view');
+
+        $response = $this->getJson('/api/v1/bank-accounts');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $accountA->public_id);
+    }
+
+    #[Test]
     public function show_rejects_a_user_without_branch_access(): void
     {
         $branch = Branch::factory()->create();

--- a/code/api/tests/Feature/CashAdjustments/CashAdjustments/CashAdjustmentAuthorizationTest.php
+++ b/code/api/tests/Feature/CashAdjustments/CashAdjustments/CashAdjustmentAuthorizationTest.php
@@ -7,9 +7,7 @@ use App\Models\CashAdjustment;
 use App\Models\CashAdjustmentLine;
 use App\Models\CashRegister;
 use App\Models\CashSession;
-use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Laravel\Passport\Passport;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Feature\CashAdjustments\Concerns\SetsUpBranchAccess;
 use Tests\TestCase;
@@ -89,13 +87,41 @@ class CashAdjustmentAuthorizationTest extends TestCase
             CashSession::factory()->for(CashRegister::factory()->for($branch)->create(), 'cashRegister')->draft(),
             'cashSession'
         )->draft()->create();
-        Passport::actingAs(User::factory()->create());
+        $this->actingAsUserWithBranchAccess($branch, 'cash_adjustments.view');
 
         $response = $this->getJson('/api/v1/cash-adjustments?cash_session_id='.$adjustment->cashSession->public_id);
 
         $response->assertStatus(200)
             ->assertJsonCount(1, 'data')
             ->assertJsonPath('data.0.id', $adjustment->public_id);
+    }
+
+    #[Test]
+    public function list_rejects_a_user_without_the_permission(): void
+    {
+        $branch = Branch::factory()->create();
+        $this->adjustmentForBranch($branch);
+        $this->actingAsUserWithBranchAccess($branch, 'some.other.permission');
+
+        $response = $this->getJson('/api/v1/cash-adjustments');
+
+        $response->assertStatus(403);
+    }
+
+    #[Test]
+    public function list_only_returns_adjustments_within_the_users_branch(): void
+    {
+        $branchA = Branch::factory()->create();
+        $branchB = Branch::factory()->create();
+        $adjustmentA = $this->adjustmentForBranch($branchA);
+        $this->adjustmentForBranch($branchB);
+        $this->actingAsUserWithBranchAccess($branchA, 'cash_adjustments.view');
+
+        $response = $this->getJson('/api/v1/cash-adjustments');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $adjustmentA->public_id);
     }
 
     #[Test]

--- a/code/api/tests/Feature/CashAdjustments/CashExpenses/CashExpenseAuthorizationTest.php
+++ b/code/api/tests/Feature/CashAdjustments/CashExpenses/CashExpenseAuthorizationTest.php
@@ -7,9 +7,7 @@ use App\Models\CashExpense;
 use App\Models\CashRegister;
 use App\Models\CashSession;
 use App\Models\CashTerminal;
-use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Laravel\Passport\Passport;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Feature\CashAdjustments\Concerns\SetsUpBranchAccess;
 use Tests\TestCase;
@@ -75,13 +73,41 @@ class CashExpenseAuthorizationTest extends TestCase
             CashSession::factory()->for(CashRegister::factory()->for($branch)->create(), 'cashRegister')->draft(),
             'cashSession'
         )->cash()->draft()->create();
-        Passport::actingAs(User::factory()->create());
+        $this->actingAsUserWithBranchAccess($branch, 'cash_expenses.view');
 
         $response = $this->getJson('/api/v1/cash-expenses?cash_session_id='.$expense->cashSession->public_id);
 
         $response->assertStatus(200)
             ->assertJsonCount(1, 'data')
             ->assertJsonPath('data.0.id', $expense->public_id);
+    }
+
+    #[Test]
+    public function list_rejects_a_user_without_the_permission(): void
+    {
+        $branch = Branch::factory()->create();
+        $this->expenseForBranch($branch);
+        $this->actingAsUserWithBranchAccess($branch, 'some.other.permission');
+
+        $response = $this->getJson('/api/v1/cash-expenses');
+
+        $response->assertStatus(403);
+    }
+
+    #[Test]
+    public function list_only_returns_expenses_within_the_users_branch(): void
+    {
+        $branchA = Branch::factory()->create();
+        $branchB = Branch::factory()->create();
+        $expenseA = $this->expenseForBranch($branchA);
+        $this->expenseForBranch($branchB);
+        $this->actingAsUserWithBranchAccess($branchA, 'cash_expenses.view');
+
+        $response = $this->getJson('/api/v1/cash-expenses');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $expenseA->public_id);
     }
 
     #[Test]

--- a/code/api/tests/Feature/CashAdjustments/CashRegisters/CashRegisterAuthorizationTest.php
+++ b/code/api/tests/Feature/CashAdjustments/CashRegisters/CashRegisterAuthorizationTest.php
@@ -73,6 +73,48 @@ class CashRegisterAuthorizationTest extends TestCase
     }
 
     #[Test]
+    public function list_rejects_a_user_without_the_permission(): void
+    {
+        $branch = Branch::factory()->create();
+        CashRegister::factory()->for($branch)->create();
+        $this->actingAsUserWithBranchAccess($branch, 'some.other.permission');
+
+        $response = $this->getJson('/api/v1/cash-registers');
+
+        $response->assertStatus(403);
+    }
+
+    #[Test]
+    public function list_only_returns_registers_within_the_users_branch(): void
+    {
+        $branchA = Branch::factory()->create();
+        $branchB = Branch::factory()->create();
+        $registerA = CashRegister::factory()->for($branchA)->create();
+        CashRegister::factory()->for($branchB)->create();
+        $this->actingAsUserWithBranchAccess($branchA, 'cash_registers.view');
+
+        $response = $this->getJson('/api/v1/cash-registers');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $registerA->public_id);
+    }
+
+    #[Test]
+    public function list_excludes_a_branch_id_filter_the_user_cannot_access(): void
+    {
+        $branchA = Branch::factory()->create();
+        $branchB = Branch::factory()->create();
+        CashRegister::factory()->for($branchA)->create();
+        CashRegister::factory()->for($branchB)->create();
+        $this->actingAsUserWithBranchAccess($branchA, 'cash_registers.view');
+
+        $response = $this->getJson('/api/v1/cash-registers?branch_id='.$branchB->id);
+
+        $response->assertStatus(200)->assertJsonCount(0, 'data');
+    }
+
+    #[Test]
     public function show_rejects_a_user_without_branch_access(): void
     {
         $branch = Branch::factory()->create();

--- a/code/api/tests/Feature/CashAdjustments/CashSessions/CashSessionAuthorizationTest.php
+++ b/code/api/tests/Feature/CashAdjustments/CashSessions/CashSessionAuthorizationTest.php
@@ -5,9 +5,7 @@ namespace Tests\Feature\CashAdjustments\CashSessions;
 use App\Models\Branch;
 use App\Models\CashRegister;
 use App\Models\CashSession;
-use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Laravel\Passport\Passport;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Feature\CashAdjustments\Concerns\SetsUpBranchAccess;
 use Tests\TestCase;
@@ -72,13 +70,56 @@ class CashSessionAuthorizationTest extends TestCase
         $otherRegister = CashRegister::factory()->for($branch)->create();
         $session = CashSession::factory()->for($register, 'cashRegister')->draft()->create();
         CashSession::factory()->for($otherRegister, 'cashRegister')->draft()->create();
-        Passport::actingAs(User::factory()->create());
+        $this->actingAsUserWithBranchAccess($branch, 'cash_sessions.view');
 
         $response = $this->getJson('/api/v1/cash-sessions?cash_register_id='.$register->public_id);
 
         $response->assertStatus(200)
             ->assertJsonCount(1, 'data')
             ->assertJsonPath('data.0.id', $session->public_id);
+    }
+
+    #[Test]
+    public function list_rejects_a_user_without_the_permission(): void
+    {
+        $branch = Branch::factory()->create();
+        $this->sessionForBranch($branch);
+        $this->actingAsUserWithBranchAccess($branch, 'some.other.permission');
+
+        $response = $this->getJson('/api/v1/cash-sessions');
+
+        $response->assertStatus(403);
+    }
+
+    #[Test]
+    public function list_only_returns_sessions_within_the_users_branch(): void
+    {
+        $branchA = Branch::factory()->create();
+        $branchB = Branch::factory()->create();
+        $sessionA = $this->sessionForBranch($branchA);
+        $this->sessionForBranch($branchB);
+        $this->actingAsUserWithBranchAccess($branchA, 'cash_sessions.view');
+
+        $response = $this->getJson('/api/v1/cash-sessions');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $sessionA->public_id);
+    }
+
+    #[Test]
+    public function list_excludes_a_cash_register_id_filter_from_a_branch_the_user_cannot_access(): void
+    {
+        $branchA = Branch::factory()->create();
+        $branchB = Branch::factory()->create();
+        $this->sessionForBranch($branchA);
+        $registerB = CashRegister::factory()->for($branchB)->create();
+        CashSession::factory()->for($registerB, 'cashRegister')->draft()->create();
+        $this->actingAsUserWithBranchAccess($branchA, 'cash_sessions.view');
+
+        $response = $this->getJson('/api/v1/cash-sessions?cash_register_id='.$registerB->public_id);
+
+        $response->assertStatus(200)->assertJsonCount(0, 'data');
     }
 
     #[Test]

--- a/code/api/tests/Feature/CashAdjustments/CashTerminals/CashTerminalAuthorizationTest.php
+++ b/code/api/tests/Feature/CashAdjustments/CashTerminals/CashTerminalAuthorizationTest.php
@@ -31,6 +31,34 @@ class CashTerminalAuthorizationTest extends TestCase
     }
 
     #[Test]
+    public function list_rejects_a_user_without_the_permission(): void
+    {
+        $branch = Branch::factory()->create();
+        CashTerminal::factory()->for($branch)->create();
+        $this->actingAsUserWithBranchAccess($branch, 'some.other.permission');
+
+        $response = $this->getJson('/api/v1/cash-terminals');
+
+        $response->assertStatus(403);
+    }
+
+    #[Test]
+    public function list_only_returns_terminals_within_the_users_branch(): void
+    {
+        $branchA = Branch::factory()->create();
+        $branchB = Branch::factory()->create();
+        $terminalA = CashTerminal::factory()->for($branchA)->create();
+        CashTerminal::factory()->for($branchB)->create();
+        $this->actingAsUserWithBranchAccess($branchA, 'cash_terminals.view');
+
+        $response = $this->getJson('/api/v1/cash-terminals');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $terminalA->public_id);
+    }
+
+    #[Test]
     public function show_rejects_a_user_without_branch_access(): void
     {
         $branch = Branch::factory()->create();

--- a/doc/tasks/2026-07/295-cashadjustments-list-authorization.md
+++ b/doc/tasks/2026-07/295-cashadjustments-list-authorization.md
@@ -22,23 +22,23 @@ Discovered during the #291/#293 audit, deliberately deferred until those PRs set
 
 ## ✅ Technical Tasks
 
-- [ ] 🔒 Add `Gate::authorize('viewAny', Model::class)` to all 6 `List*Controller` classes
-- [ ] 🔒 Scope each `List` query to the requesting user's assigned branches via `$user->operatingUnits()->wherePivot('is_active', true)->pluck('branch_id')`:
+- [x] 🔒 Add `Gate::authorize('viewAny', Model::class)` to all 6 `List*Controller` classes
+- [x] 🔒 Scope each `List` query to the requesting user's assigned branches via `$user->operatingUnits()->wherePivot('is_active', true)->pluck('branch_id')` — extracted into a shared `ScopesToUserBranches` concern:
   - `CashRegister`, `CashTerminal`, `BankAccount`: direct `branch_id` column — `whereIn`
   - `CashSession`: via `cashRegister.branch_id` — `whereHas`
   - `CashExpense`, `CashAdjustment`: via `cashSession.cashRegister.branch_id` — nested `whereHas`
-- [ ] 🔒 An explicit `branch_id` filter the user doesn't have access to is silently excluded via the same scoping (no separate 403) — consistent with how list endpoints avoid leaking existence via error codes
-- [ ] ✅ Feature tests per domain: a user assigned to branch A doesn't see branch B's records in `List`, even without an explicit `branch_id` filter; a user without the `.view` permission gets `403`
-- [ ] 🧪 Full PHPUnit suite green, Pint clean
+- [x] 🔒 An explicit `branch_id` filter the user doesn't have access to is silently excluded via the same scoping (no separate 403) — consistent with how list endpoints avoid leaking existence via error codes
+- [x] ✅ Feature tests per domain: a user assigned to branch A doesn't see branch B's records in `List`, even without an explicit `branch_id` filter; a user without the `.view` permission gets `403`
+- [x] 🧪 Full PHPUnit suite green (1140/1140), Pint clean (13 files)
 
 ---
 
 ## 🎯 Acceptance Criteria
 
-- [ ] All 6 `List` endpoints reject users lacking the corresponding `.view` permission with `403`
-- [ ] All 6 `List` endpoints only return records within the requesting user's assigned branch(es), with or without an explicit `branch_id` filter
-- [ ] No behavior change for users who already have proper branch access and permission
-- [ ] No behavior change to `Create`/`Show`/`Update`/`Delete`/`Post` (untouched)
+- [x] All 6 `List` endpoints reject users lacking the corresponding `.view` permission with `403`
+- [x] All 6 `List` endpoints only return records within the requesting user's assigned branch(es), with or without an explicit `branch_id` filter
+- [x] No behavior change for users who already have proper branch access and permission
+- [x] No behavior change to `Create`/`Show`/`Update`/`Delete`/`Post` (untouched)
 
 ---
 
@@ -47,14 +47,23 @@ Discovered during the #291/#293 audit, deliberately deferred until those PRs set
 ### 📊 Estimates
 - **Optimistic:** `1h` (mechanical repeat of the #291 branch-scoping pattern across 6 controllers)
 - **Pessimistic:** `2h` (6 domains × query scoping + tests, plus verifying existing List tests still pass)
-- **Tracked:** _in progress_
+- **Tracked:** `0.5h`
 
 ### 📅 Sessions
 ```json
 [
-  { "date": "2026-07-24", "start": "17:00", "end": "?" }
+  { "date": "2026-07-24", "start": "17:00", "end": "17:33" }
 ]
 ```
+
+## 📊 Retrospective
+- **Actual total:** 33m
+- **vs optimistic:** −27m under
+- **vs pessimistic:** −1h 27m under
+
+**Justification:**
+
+Landed well under the optimistic estimate. The #291 audit had already surfaced the exact scoping pattern needed (`ChecksBranchAccess`/`operatingUnits()`), so this was a mechanical repeat across 6 controllers with no new investigation required. Extracted the branch-id resolution into a small `ScopesToUserBranches` concern (mirroring the existing `ResolvesPublicIdFilters` trait already used in these same controllers) to avoid repeating the same 4-line query snippet six times — consistent with this project's strong anti-duplication stance (#282/#289). Three existing `list_filters_by_*_public_id` tests authenticated as a fully unpermissioned user (`Passport::actingAs(User::factory()->create())`), which would have broken once authorization was enforced — updated them to use the existing `actingAsUserWithBranchAccess` helper instead of writing a new one. Full suite (1140 tests) and Pint stayed green throughout.
 
 ---
 

--- a/doc/tasks/2026-07/295-cashadjustments-list-authorization.md
+++ b/doc/tasks/2026-07/295-cashadjustments-list-authorization.md
@@ -1,0 +1,65 @@
+# 🐛 Task #295: CashAdjustments List endpoints have no authorization or branch-scoping
+
+## 📖 Story
+
+**English:**
+As a developer, I need to add resource-level authorization and branch-scoping to the CashAdjustments domain's `List*Controller` classes, so that only users with the `.view` permission can list cash registers/terminals/bank accounts/sessions/expenses/adjustments, and each user only sees records within their assigned branch(es) — matching the protection already applied to Show/Update/Delete/Post by #291.
+
+**Español:**
+Como desarrollador, necesito agregar autorización a nivel de recurso y filtrado por sucursal a los controladores `List*` del dominio CashAdjustments, para que solo los usuarios con el permiso `.view` puedan listar cajas/terminales/cuentas bancarias/sesiones/gastos/ajustes, y cada usuario solo vea registros de su(s) sucursal(es) asignada(s) — igualando la protección ya aplicada a Show/Update/Delete/Post en #291.
+
+---
+
+## 🔍 Root cause
+
+All 6 `List*Controller` classes (`ListCashRegistersController`, `ListCashTerminalsController`, `ListBankAccountsController`, `ListCashSessionsController`, `ListCashExpensesController`, `ListCashAdjustmentsController`) call **zero** authorization checks — not even `viewAny()`, which every policy already defines. Routes only apply `auth:api` (login check). Any authenticated user, regardless of role/permission, can list every record across all branches.
+
+`branch_id` exists as an optional query filter on 3 of the 6 endpoints, but nothing stops a user from omitting it (seeing every branch) or passing a `branch_id` they have no access to.
+
+Discovered during the #291/#293 audit, deliberately deferred until those PRs settled (see PR #294 discussion).
+
+---
+
+## ✅ Technical Tasks
+
+- [ ] 🔒 Add `Gate::authorize('viewAny', Model::class)` to all 6 `List*Controller` classes
+- [ ] 🔒 Scope each `List` query to the requesting user's assigned branches via `$user->operatingUnits()->wherePivot('is_active', true)->pluck('branch_id')`:
+  - `CashRegister`, `CashTerminal`, `BankAccount`: direct `branch_id` column — `whereIn`
+  - `CashSession`: via `cashRegister.branch_id` — `whereHas`
+  - `CashExpense`, `CashAdjustment`: via `cashSession.cashRegister.branch_id` — nested `whereHas`
+- [ ] 🔒 An explicit `branch_id` filter the user doesn't have access to is silently excluded via the same scoping (no separate 403) — consistent with how list endpoints avoid leaking existence via error codes
+- [ ] ✅ Feature tests per domain: a user assigned to branch A doesn't see branch B's records in `List`, even without an explicit `branch_id` filter; a user without the `.view` permission gets `403`
+- [ ] 🧪 Full PHPUnit suite green, Pint clean
+
+---
+
+## 🎯 Acceptance Criteria
+
+- [ ] All 6 `List` endpoints reject users lacking the corresponding `.view` permission with `403`
+- [ ] All 6 `List` endpoints only return records within the requesting user's assigned branch(es), with or without an explicit `branch_id` filter
+- [ ] No behavior change for users who already have proper branch access and permission
+- [ ] No behavior change to `Create`/`Show`/`Update`/`Delete`/`Post` (untouched)
+
+---
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `1h` (mechanical repeat of the #291 branch-scoping pattern across 6 controllers)
+- **Pessimistic:** `2h` (6 domains × query scoping + tests, plus verifying existing List tests still pass)
+- **Tracked:** _in progress_
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-07-24", "start": "17:00", "end": "?" }
+]
+```
+
+---
+
+## 🔗 References
+
+- GitHub issue: [#295](https://github.com/pakodiazdev/sushigo/issues/295)
+- Discovered during #293's audit (public_id migration) — see PR #294 discussion
+- Reuses `App\Policies\Concerns\ChecksBranchAccess` pattern from #291


### PR DESCRIPTION
## Summary
Closes #295
Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/301

- 🔒 Added `Gate::authorize('viewAny', Model::class)` to all 6 CashAdjustments `List*Controller` classes (CashRegister, CashTerminal, BankAccount, CashSession, CashExpense, CashAdjustment) — previously any authenticated user could list every record with no permission check
- 🔒 Added a `ScopesToUserBranches` concern (mirrors `ResolvesPublicIdFilters`, already used in these same controllers) that scopes each `List` query to the requesting user's active operating-unit branches
- 🔒 CashRegister/CashTerminal/BankAccount scope directly on `branch_id`; CashSession scopes via `cashRegister.branch_id`; CashExpense/CashAdjustment scope via `cashSession.cashRegister.branch_id`
- 🔒 An explicit `branch_id`/`cash_register_id` filter for a branch the user can't access is silently excluded via the same scoping (empty result), not a separate 403 — consistent with how list endpoints avoid leaking existence via error codes
- 🧪 Updated 3 existing `list_filters_by_*_public_id` tests that authenticated as a fully unpermissioned user — now use the existing `actingAsUserWithBranchAccess` helper
- 🧪 Added `list_rejects_a_user_without_the_permission` and `list_only_returns_*_within_the_users_branch` coverage per domain, plus filter-exclusion tests for CashRegister/CashSession

## Test plan
- [x] PHPUnit: `php artisan test --filter=AuthorizationTest` — 67 passed (132 assertions)
- [x] PHPUnit: full Feature suite — 1140 passed (3614 assertions), 0 regressions
- [x] Linters: Pint clean (13 files)

## Manual Testing
1. Log in as a user assigned to Branch A with `cash_registers.view` permission (e.g. `admin@sushigo.com`)
2. Create a second branch and a cash register under it via the API/seeder (or use a second seeded branch if available)
3. `GET /api/v1/cash-registers` — response should only include Branch A's registers, never Branch B's
4. `GET /api/v1/cash-registers?branch_id=<branch-b-id>` — response should return an empty `data` array (not a 403)
5. Repeat with a user who lacks `cash_registers.view` entirely — `GET /api/v1/cash-registers` should return `403`
6. Same pattern applies to `/cash-terminals`, `/bank-accounts`, `/cash-sessions`, `/cash-expenses`, `/cash-adjustments`

## Workspace
`sushigo-c` — `fix/295-cashadjustments-list-authorization`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
