### PR TITLE
🔒 [#275][c] - Add units_of_measure.manage permission 🔒

### DIFF
--- a/code/api/app/Http/Requests/UnitsOfMeasure/CreateUnitOfMeasureRequest.php
+++ b/code/api/app/Http/Requests/UnitsOfMeasure/CreateUnitOfMeasureRequest.php
@@ -21,8 +21,7 @@ class CreateUnitOfMeasureRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        // Granular permission tracked in https://github.com/pakodiazdev/sushigo/issues/275
-        return true;
+        return $this->user()->can('units_of_measure.manage');
     }
 
     public function rules(): array

--- a/code/api/app/Http/Requests/UnitsOfMeasure/CreateUomConversionRequest.php
+++ b/code/api/app/Http/Requests/UnitsOfMeasure/CreateUomConversionRequest.php
@@ -21,8 +21,7 @@ class CreateUomConversionRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        // Granular permission tracked in https://github.com/pakodiazdev/sushigo/issues/275
-        return true;
+        return $this->user()->can('units_of_measure.manage');
     }
 
     public function rules(): array

--- a/code/api/app/Http/Requests/UnitsOfMeasure/UpdateUnitOfMeasureRequest.php
+++ b/code/api/app/Http/Requests/UnitsOfMeasure/UpdateUnitOfMeasureRequest.php
@@ -19,8 +19,7 @@ class UpdateUnitOfMeasureRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        // Granular permission tracked in https://github.com/pakodiazdev/sushigo/issues/275
-        return true;
+        return $this->user()->can('units_of_measure.manage');
     }
 
     public function rules(): array

--- a/code/api/database/seeders/Development/PermissionSeeder.php
+++ b/code/api/database/seeders/Development/PermissionSeeder.php
@@ -156,6 +156,9 @@ class PermissionSeeder extends LockedSeeder
             'inventory_locations.view' => ['label' => 'Ver ubicaciones de inventario',    'group' => self::GROUP_INVENTARIO],
             'inventory_locations.manage' => ['label' => 'Gestionar ubicaciones de inventario', 'group' => self::GROUP_INVENTARIO],
 
+            // Inventario — Unidades de medida
+            'units_of_measure.manage' => ['label' => 'Gestionar unidades de medida', 'group' => self::GROUP_INVENTARIO],
+
             // Inventario — Stock y movimientos
             'stock.view' => ['label' => 'Ver stock y movimientos',   'group' => self::GROUP_INVENTARIO],
             'stock.manage' => ['label' => 'Registrar movimientos de stock', 'group' => self::GROUP_INVENTARIO],
@@ -225,7 +228,7 @@ class PermissionSeeder extends LockedSeeder
                             ->orWhere('name', 'like', self::REPORTS_PATTERN)
                             ->orWhere('name', 'like', self::PAYROLL_PATTERN)
                             ->orWhere('name', 'like', 'audit-logs.%')
-                            ->orWhereIn('name', ['punctuality.manage', 'holidays.manage', 'settings.manage', 'overtime.manage', 'vacation-policy.manage']);
+                            ->orWhereIn('name', ['units_of_measure.manage', 'punctuality.manage', 'holidays.manage', 'settings.manage', 'overtime.manage', 'vacation-policy.manage']);
                     })
                     ->get()
             );
@@ -245,6 +248,7 @@ class PermissionSeeder extends LockedSeeder
                         $q->where('name', 'like', self::ITEMS_PATTERN)
                             ->orWhere('name', 'like', self::INVENTORY_LOCATIONS_PATTERN)
                             ->orWhere('name', 'like', self::STOCK_PATTERN)
+                            ->orWhere('name', 'units_of_measure.manage')
                             ->orWhereIn('name', self::SELF_SERVICE_REQUESTS_PERMISSIONS);
                     })
                     ->get()

--- a/code/api/database/seeders/Production/PermissionSeeder.php
+++ b/code/api/database/seeders/Production/PermissionSeeder.php
@@ -123,6 +123,9 @@ class PermissionSeeder extends LockedSeeder
             'inventory_locations.view',
             'inventory_locations.manage',
 
+            // Inventario — Unidades de medida
+            'units_of_measure.manage',
+
             // Inventario — Stock y movimientos
             'stock.view',
             'stock.manage',
@@ -176,7 +179,7 @@ class PermissionSeeder extends LockedSeeder
                             ->orWhere('name', 'like', 'inventory_locations.%')
                             ->orWhere('name', 'like', 'stock.%')
                             ->orWhere('name', 'like', 'audit-logs.%')
-                            ->orWhereIn('name', ['punctuality.manage', 'holidays.manage', 'payroll.preview', 'payroll.close', 'payroll.reopen', 'payroll.reclose', 'overtime.manage', 'vacation-policy.manage']);
+                            ->orWhereIn('name', ['units_of_measure.manage', 'punctuality.manage', 'holidays.manage', 'payroll.preview', 'payroll.close', 'payroll.reopen', 'payroll.reclose', 'overtime.manage', 'vacation-policy.manage']);
                     })
                     ->get()
             );
@@ -193,6 +196,7 @@ class PermissionSeeder extends LockedSeeder
                         $q->where('name', 'like', 'items.%')
                             ->orWhere('name', 'like', 'inventory_locations.%')
                             ->orWhere('name', 'like', 'stock.%')
+                            ->orWhere('name', 'units_of_measure.manage')
                             ->orWhereIn('name', self::SELF_SERVICE_REQUESTS_PERMISSIONS);
                     })
                     ->get()

--- a/code/api/database/seeders/Testing/CoreTestSeeder.php
+++ b/code/api/database/seeders/Testing/CoreTestSeeder.php
@@ -93,6 +93,7 @@ class CoreTestSeeder extends Seeder
         'items.delete',
         'inventory_locations.view',
         'inventory_locations.manage',
+        'units_of_measure.manage',
         'stock.view',
         'stock.manage',
         'attendances.view',
@@ -129,8 +130,8 @@ class CoreTestSeeder extends Seeder
     /** role name => permission name prefixes or exact names */
     private const ROLE_PERMISSIONS = [
         'super-admin' => '*',  // all permissions
-        'admin' => ['users.', 'employees.', 'leaves.', 'vacation-requests.', 'vacation-policy.', 'employee-requests.', 'items.', 'inventory_locations.', 'stock.', 'attendances.', 'punctuality.', 'reports.', 'holidays.', 'payroll.', 'overtime.', 'audit-logs.'],
-        'inventory-manager' => ['items.', 'inventory_locations.', 'stock.', ...self::SELF_SERVICE_REQUESTS],
+        'admin' => ['users.', 'employees.', 'leaves.', 'vacation-requests.', 'vacation-policy.', 'employee-requests.', 'items.', 'inventory_locations.', 'stock.', 'attendances.', 'punctuality.', 'reports.', 'holidays.', 'payroll.', 'overtime.', 'audit-logs.', '=units_of_measure.manage'],
+        'inventory-manager' => ['items.', 'inventory_locations.', 'stock.', '=units_of_measure.manage', ...self::SELF_SERVICE_REQUESTS],
         'manager' => [...self::BASIC_USER_VIEW, 'employees.', 'leaves.', 'employee-requests.', 'attendances.', 'reports.', '=payroll.preview', '=payroll.close'],
         'cook' => [...self::BASIC_USER_VIEW, ...self::SELF_SERVICE_REQUESTS],
         'kitchen-assistant' => [...self::BASIC_USER_VIEW, ...self::SELF_SERVICE_REQUESTS],

--- a/code/api/routes/api/units-of-measure.php
+++ b/code/api/routes/api/units-of-measure.php
@@ -16,7 +16,7 @@ Route::prefix('units-of-measure')->group(function () {
     Route::get('/', ListUnitsOfMeasureController::class)->name('units-of-measure.list');
     Route::get(RouteParams::ID, ShowUnitOfMeasureController::class)->name('units-of-measure.show');
 
-    Route::middleware('auth:api')->group(function () {
+    Route::middleware(['auth:api', 'permission:units_of_measure.manage'])->group(function () {
         Route::post('/', CreateUnitOfMeasureController::class)->name('units-of-measure.create');
         Route::put(RouteParams::ID, UpdateUnitOfMeasureController::class)->name('units-of-measure.update');
         Route::delete(RouteParams::ID, DeleteUnitOfMeasureController::class)->name('units-of-measure.delete');
@@ -27,7 +27,7 @@ Route::prefix('units-of-measure')->group(function () {
 Route::prefix('uom-conversions')->group(function () {
     Route::get('/', ListUomConversionsController::class)->name('uom-conversions.list');
 
-    Route::middleware('auth:api')->group(function () {
+    Route::middleware(['auth:api', 'permission:units_of_measure.manage'])->group(function () {
         Route::post('/', CreateUomConversionController::class)->name('uom-conversions.create');
         Route::delete(RouteParams::ID, DeleteUomConversionController::class)->name('uom-conversions.delete');
     });

--- a/code/api/tests/Feature/Inventory/UnitOfMeasurePermissionsTest.php
+++ b/code/api/tests/Feature/Inventory/UnitOfMeasurePermissionsTest.php
@@ -1,0 +1,279 @@
+<?php
+
+namespace Tests\Feature\Inventory;
+
+use App\Models\Employee;
+use App\Models\UnitOfMeasure;
+use App\Models\UomConversion;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * Verifies that units-of-measure and uom-conversions write routes enforce
+ * the units_of_measure.manage permission — list/show stay public.
+ *
+ * - inventory-manager → full write access
+ * - admin             → full write access (inherits the permission)
+ * - cook              → 403 on all write endpoints
+ * - unauthenticated   → 401 on all write endpoints (public reads still 200)
+ */
+class UnitOfMeasurePermissionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $inventoryManager;
+
+    private User $admin;
+
+    private User $cook;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Permission::create(['name' => 'units_of_measure.manage', 'guard_name' => 'api']);
+
+        foreach (Employee::POSITION_ROLES as $roleName) {
+            Role::firstOrCreate(['name' => $roleName, 'guard_name' => 'api']);
+        }
+
+        $inventoryManagerRole = Role::firstOrCreate(['name' => 'inventory-manager', 'guard_name' => 'api']);
+        $inventoryManagerRole->givePermissionTo('units_of_measure.manage');
+
+        $adminRole = Role::firstOrCreate(['name' => 'admin', 'guard_name' => 'api']);
+        $adminRole->givePermissionTo('units_of_measure.manage');
+
+        $this->inventoryManager = User::factory()->create();
+        $this->inventoryManager->assignRole('inventory-manager');
+
+        $this->admin = User::factory()->create();
+        $this->admin->assignRole('admin');
+
+        $this->cook = User::factory()->create();
+        $this->cook->assignRole('cook');
+    }
+
+    // -------------------------------------------------------------------------
+    // Public reads — untouched by this permission
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function anyone_can_list_units_of_measure(): void
+    {
+        $this->getJson('/api/v1/units-of-measure')->assertStatus(200);
+    }
+
+    #[Test]
+    public function anyone_can_list_uom_conversions(): void
+    {
+        $this->getJson('/api/v1/uom-conversions')->assertStatus(200);
+    }
+
+    // -------------------------------------------------------------------------
+    // Units of Measure — inventory-manager / admin can write
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function inventory_manager_can_create_unit_of_measure(): void
+    {
+        Passport::actingAs($this->inventoryManager);
+
+        $this->postJson('/api/v1/units-of-measure', [
+            'code' => 'LT',
+            'name' => 'Litro',
+            'symbol' => 'l',
+        ])->assertStatus(201);
+    }
+
+    #[Test]
+    public function admin_can_create_unit_of_measure(): void
+    {
+        Passport::actingAs($this->admin);
+
+        $this->postJson('/api/v1/units-of-measure', [
+            'code' => 'ML',
+            'name' => 'Mililitro',
+            'symbol' => 'ml',
+        ])->assertStatus(201);
+    }
+
+    #[Test]
+    public function inventory_manager_can_update_unit_of_measure(): void
+    {
+        Passport::actingAs($this->inventoryManager);
+
+        $uom = UnitOfMeasure::create([
+            'code' => 'PZ',
+            'name' => 'Pieza',
+            'symbol' => 'pz',
+        ]);
+
+        $this->putJson("/api/v1/units-of-measure/{$uom->id}", [
+            'name' => 'Pieza actualizada',
+        ])->assertStatus(200);
+    }
+
+    #[Test]
+    public function inventory_manager_can_delete_unit_of_measure(): void
+    {
+        Passport::actingAs($this->inventoryManager);
+
+        $uom = UnitOfMeasure::create([
+            'code' => 'CJ',
+            'name' => 'Caja',
+            'symbol' => 'cj',
+        ]);
+
+        $this->deleteJson("/api/v1/units-of-measure/{$uom->id}")->assertStatus(200);
+    }
+
+    // -------------------------------------------------------------------------
+    // Units of Measure — cook forbidden
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function cook_cannot_create_unit_of_measure(): void
+    {
+        Passport::actingAs($this->cook);
+
+        $this->postJson('/api/v1/units-of-measure', [
+            'code' => 'XX',
+            'name' => 'Unauthorized',
+            'symbol' => 'xx',
+        ])->assertStatus(403);
+    }
+
+    #[Test]
+    public function cook_cannot_update_unit_of_measure(): void
+    {
+        Passport::actingAs($this->cook);
+
+        $uom = UnitOfMeasure::create([
+            'code' => 'KG',
+            'name' => 'Kilogramo',
+            'symbol' => 'kg',
+        ]);
+
+        $this->putJson("/api/v1/units-of-measure/{$uom->id}", [
+            'name' => 'Should not update',
+        ])->assertStatus(403);
+    }
+
+    #[Test]
+    public function cook_cannot_delete_unit_of_measure(): void
+    {
+        Passport::actingAs($this->cook);
+
+        $uom = UnitOfMeasure::create([
+            'code' => 'GR',
+            'name' => 'Gramo',
+            'symbol' => 'g',
+        ]);
+
+        $this->deleteJson("/api/v1/units-of-measure/{$uom->id}")->assertStatus(403);
+    }
+
+    // -------------------------------------------------------------------------
+    // UOM Conversions — inventory-manager can write, cook forbidden
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function inventory_manager_can_create_uom_conversion(): void
+    {
+        Passport::actingAs($this->inventoryManager);
+
+        $from = UnitOfMeasure::create(['code' => 'KG', 'name' => 'Kilogramo', 'symbol' => 'kg']);
+        $to = UnitOfMeasure::create(['code' => 'GR', 'name' => 'Gramo', 'symbol' => 'g']);
+
+        $this->postJson('/api/v1/uom-conversions', [
+            'from_uom_id' => $from->id,
+            'to_uom_id' => $to->id,
+            'factor' => 1000,
+        ])->assertStatus(201);
+    }
+
+    #[Test]
+    public function inventory_manager_can_delete_uom_conversion(): void
+    {
+        Passport::actingAs($this->inventoryManager);
+
+        $from = UnitOfMeasure::create(['code' => 'KG', 'name' => 'Kilogramo', 'symbol' => 'kg']);
+        $to = UnitOfMeasure::create(['code' => 'GR', 'name' => 'Gramo', 'symbol' => 'g']);
+
+        $createResponse = $this->postJson('/api/v1/uom-conversions', [
+            'from_uom_id' => $from->id,
+            'to_uom_id' => $to->id,
+            'factor' => 1000,
+        ]);
+
+        $createResponse->assertStatus(201);
+        $conversionId = $createResponse->json('data.id');
+        $this->assertNotNull($conversionId);
+
+        $this->deleteJson("/api/v1/uom-conversions/{$conversionId}")->assertStatus(200);
+    }
+
+    #[Test]
+    public function cook_cannot_create_uom_conversion(): void
+    {
+        Passport::actingAs($this->cook);
+
+        $from = UnitOfMeasure::create(['code' => 'KG', 'name' => 'Kilogramo', 'symbol' => 'kg']);
+        $to = UnitOfMeasure::create(['code' => 'GR', 'name' => 'Gramo', 'symbol' => 'g']);
+
+        $this->postJson('/api/v1/uom-conversions', [
+            'from_uom_id' => $from->id,
+            'to_uom_id' => $to->id,
+            'factor' => 1000,
+        ])->assertStatus(403);
+    }
+
+    #[Test]
+    public function cook_cannot_delete_uom_conversion(): void
+    {
+        Passport::actingAs($this->cook);
+
+        $from = UnitOfMeasure::create(['code' => 'KG', 'name' => 'Kilogramo', 'symbol' => 'kg']);
+        $to = UnitOfMeasure::create(['code' => 'GR', 'name' => 'Gramo', 'symbol' => 'g']);
+
+        $conversion = UomConversion::create([
+            'from_uom_id' => $from->id,
+            'to_uom_id' => $to->id,
+            'factor' => 1000,
+        ]);
+
+        $this->deleteJson("/api/v1/uom-conversions/{$conversion->id}")->assertStatus(403);
+    }
+
+    // -------------------------------------------------------------------------
+    // Unauthenticated
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function unauthenticated_cannot_create_unit_of_measure(): void
+    {
+        $this->postJson('/api/v1/units-of-measure', [
+            'code' => 'YY',
+            'name' => 'Unauthenticated',
+            'symbol' => 'yy',
+        ])->assertStatus(401);
+    }
+
+    #[Test]
+    public function unauthenticated_cannot_create_uom_conversion(): void
+    {
+        $from = UnitOfMeasure::create(['code' => 'KG', 'name' => 'Kilogramo', 'symbol' => 'kg']);
+        $to = UnitOfMeasure::create(['code' => 'GR', 'name' => 'Gramo', 'symbol' => 'g']);
+
+        $this->postJson('/api/v1/uom-conversions', [
+            'from_uom_id' => $from->id,
+            'to_uom_id' => $to->id,
+            'factor' => 1000,
+        ])->assertStatus(401);
+    }
+}

--- a/doc/tasks/2026-07/275-units-of-measure-permissions.md
+++ b/doc/tasks/2026-07/275-units-of-measure-permissions.md
@@ -1,0 +1,68 @@
+# 🔐 Task #275: Define granular permissions for Units of Measure management
+
+## 📖 Story
+
+**English:**
+As a developer, I need to add permission-based authorization to the `units-of-measure` (create/update/delete) and `uom-conversions` (create/delete) write endpoints, so that only users with a dedicated permission can manage them — matching the protection already applied to the rest of the Inventory module (`items.*`, `inventory_locations.*`, `stock.*`).
+
+**Español:**
+Como desarrollador, necesito agregar autorización basada en permisos a los endpoints de escritura de `units-of-measure` (crear/editar/eliminar) y `uom-conversions` (crear/eliminar), para que solo los usuarios con un permiso dedicado puedan gestionarlos — igualando la protección ya aplicada al resto del módulo de Inventario (`items.*`, `inventory_locations.*`, `stock.*`).
+
+---
+
+## 🔍 Root cause
+
+`units-of-measure` and `uom-conversions` write endpoints are gated only by `auth:api` — any authenticated user can manage them. The `authorize()` methods on `CreateUnitOfMeasureRequest`, `UpdateUnitOfMeasureRequest`, and `CreateUomConversionRequest` were left as `return true` with a TODO during task #268 (SonarCloud `php:S1135` cleanup), since adding real enforcement required a product decision (permission name, which roles get it) out of scope for a mechanical TODO pass.
+
+---
+
+## ✅ Technical Tasks
+
+- [x] 🔐 Add `units_of_measure.manage` permission definition to `Development/PermissionSeeder`, `Production/PermissionSeeder`, and `Testing/CoreTestSeeder`
+- [x] 🔐 Assign it to `admin` and `inventory-manager` roles, matching the existing `inventory_locations.manage` pattern (read endpoints stay public)
+- [x] 🔐 Add `permission:units_of_measure.manage` middleware to the write routes in `routes/api/units-of-measure.php` (create/update/delete for UOM, create/delete for conversions)
+- [x] 🔐 Update `CreateUnitOfMeasureRequest::authorize()`, `UpdateUnitOfMeasureRequest::authorize()`, `CreateUomConversionRequest::authorize()` to call `$this->user()->can('units_of_measure.manage')`
+- [x] 🧹 Remove the `// Granular permission tracked in #275` TODO comments once wired up
+- [x] ✅ Feature tests: `admin`/`inventory-manager` can create/update/delete; unpermissioned user gets `403`; unauthenticated gets `401`
+- [x] 🧪 Full PHPUnit suite green, Pint clean
+
+---
+
+## 🎯 Acceptance Criteria
+
+- [x] All UOM/conversion write endpoints reject users lacking `units_of_measure.manage` with `403`
+- [x] `admin` and `inventory-manager` roles retain full write access
+- [x] No behavior change to the public read endpoints (`list`/`show`)
+
+---
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `0.5h` (mechanical repeat of the `inventory_locations.manage` pattern)
+- **Pessimistic:** `1.5h` (first Feature test file for this module — no existing UOM test coverage to extend)
+- **Tracked:** `1h`
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-07-24", "start": "18:17", "end": "19:17" }
+]
+```
+
+## 📊 Retrospective
+- **Actual total:** 1h
+- **vs optimistic:** +30m over
+- **vs pessimistic:** on target
+
+**Justification:**
+
+Landed at the pessimistic estimate. The permission-wiring itself (seeders, route middleware, `authorize()` methods) was a mechanical repeat of the `inventory_locations.manage` pattern, as expected. The extra time went into `UnitOfMeasurePermissionsTest` — this is the first Feature test file for the Units of Measure module, so there was no existing suite to extend and every fixture (users, roles, UOM records, conversions) had to be built from scratch, mirroring `InventoryPermissionsTest`.
+
+---
+
+## 🔗 References
+
+- GitHub issue: [#275](https://github.com/pakodiazdev/sushigo/issues/275)
+- Parent: #268
+- Reuses `inventory_locations.manage` pattern


### PR DESCRIPTION
## Summary
Closes #275
Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/302

- 🔐 Add `units_of_measure.manage` permission (Development/Production/Testing seeders), assigned to `admin` and `inventory-manager`
- 🔐 Add `permission:units_of_measure.manage` middleware to `units-of-measure` (create/update/delete) and `uom-conversions` (create/delete) write routes — public reads (`list`/`show`) unaffected
- 🔐 Wire `CreateUnitOfMeasureRequest`, `UpdateUnitOfMeasureRequest`, `CreateUomConversionRequest` `authorize()` to check the permission, removing the TODOs left from #268
- ✅ New `UnitOfMeasurePermissionsTest` — first Feature test file for this module

## Test plan
- [x] PHPUnit: `php artisan test --filter=UnitOfMeasurePermissionsTest` (15/15 passing)
- [x] Full suite: `php artisan test` (1384/1384 passing)
- [x] Linters: Pint ✅ (no ESLint/TypeScript changes — backend only)

## Manual Testing
1. As `admin@sushigo.com` or `inventory@sushigo.com`, `POST /api/v1/units-of-measure` with a valid payload → `201`
2. As a user without `units_of_measure.manage` (e.g. `manager@sushigo.com`), attempt the same `POST` → `403`
3. `GET /api/v1/units-of-measure` (no auth needed) → still `200` for any caller, confirming public reads are untouched
4. Repeat steps 1–3 against `POST /api/v1/uom-conversions` and `DELETE /api/v1/units-of-measure/{id}` / `DELETE /api/v1/uom-conversions/{id}`

## Workspace
`sushigo-c` — `fix/275-units-of-measure-permissions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)