### PR TITLE
🐛 [#303][c] - Add missing permission definitions to Dev/Prod seeders 🐛

### DIFF
--- a/code/api/database/seeders/Development/PermissionSeeder.php
+++ b/code/api/database/seeders/Development/PermissionSeeder.php
@@ -26,6 +26,8 @@ class PermissionSeeder extends LockedSeeder
 
     private const PAYROLL_PATTERN = 'payroll.%';
 
+    private const ATTENDANCES_PATTERN = 'attendances.%';
+
     /**
      * Self-service Solicitudes access — every employee can view/create/cancel
      * their own requests, including self-service vacation requests (via the
@@ -163,6 +165,10 @@ class PermissionSeeder extends LockedSeeder
             'stock.view' => ['label' => 'Ver stock y movimientos',   'group' => self::GROUP_INVENTARIO],
             'stock.manage' => ['label' => 'Registrar movimientos de stock', 'group' => self::GROUP_INVENTARIO],
 
+            // Asistencia — registro
+            'attendances.view' => ['label' => 'Ver asistencias', 'group' => 'Asistencia'],
+            'attendances.create' => ['label' => 'Registrar asistencia', 'group' => 'Asistencia'],
+
             // Asistencia — configuración
             'punctuality.manage' => ['label' => 'Gestionar rangos de puntualidad', 'group' => 'Asistencia'],
             'holidays.manage' => ['label' => 'Gestionar días festivos', 'group' => 'Asistencia'],
@@ -227,6 +233,7 @@ class PermissionSeeder extends LockedSeeder
                             ->orWhere('name', 'like', self::STOCK_PATTERN)
                             ->orWhere('name', 'like', self::REPORTS_PATTERN)
                             ->orWhere('name', 'like', self::PAYROLL_PATTERN)
+                            ->orWhere('name', 'like', self::ATTENDANCES_PATTERN)
                             ->orWhere('name', 'like', 'audit-logs.%')
                             ->orWhereIn('name', ['units_of_measure.manage', 'punctuality.manage', 'holidays.manage', 'settings.manage', 'overtime.manage', 'vacation-policy.manage']);
                     })
@@ -274,6 +281,7 @@ class PermissionSeeder extends LockedSeeder
                             ->orWhere('name', 'like', self::LEAVES_PATTERN)
                             ->orWhere('name', 'like', self::EMPLOYEE_REQUESTS_PATTERN)
                             ->orWhere('name', 'like', self::REPORTS_PATTERN)
+                            ->orWhere('name', 'like', self::ATTENDANCES_PATTERN)
                             ->orWhereIn('name', ['payroll.preview', 'payroll.close']);
                     })
                     ->get()

--- a/code/api/database/seeders/Production/PermissionSeeder.php
+++ b/code/api/database/seeders/Production/PermissionSeeder.php
@@ -98,6 +98,10 @@ class PermissionSeeder extends LockedSeeder
             'attendances.view',
             'attendances.create',
 
+            // Reportes
+            'reports.today',
+            'reports.weekly-summary',
+
             // Asistencia — configuración
             'punctuality.manage',
             'holidays.manage',
@@ -157,7 +161,8 @@ class PermissionSeeder extends LockedSeeder
                             ->orWhere('name', 'like', 'employees.%')
                             ->orWhere('name', 'like', 'leaves.%')
                             ->orWhere('name', 'like', 'employee-requests.%')
-                            ->orWhere('name', 'like', 'attendances.%');
+                            ->orWhere('name', 'like', 'attendances.%')
+                            ->orWhere('name', 'like', 'reports.%');
                     })
                     ->get()
             );
@@ -175,6 +180,7 @@ class PermissionSeeder extends LockedSeeder
                             ->orWhere('name', 'like', 'vacation-requests.%')
                             ->orWhere('name', 'like', 'employee-requests.%')
                             ->orWhere('name', 'like', 'attendances.%')
+                            ->orWhere('name', 'like', 'reports.%')
                             ->orWhere('name', 'like', 'items.%')
                             ->orWhere('name', 'like', 'inventory_locations.%')
                             ->orWhere('name', 'like', 'stock.%')

--- a/doc/tasks/2026-07/303-permission-seeder-audit.md
+++ b/doc/tasks/2026-07/303-permission-seeder-audit.md
@@ -1,0 +1,69 @@
+# 🐛 Task #303: Missing permission definitions in Development/Production seeders
+
+## 📖 Story
+
+**English:**
+As a developer, I need every permission string actually checked in code (route middleware, `authorize()` methods, `hasPermissionTo()`) to exist in every environment's permission seeder, so that a permission enforced in the app is never silently unreachable — not even for `admin` — because the seeder for that environment never defined it.
+
+**Español:**
+Como desarrollador, necesito que cada permiso que realmente se valida en el código (middleware de rutas, métodos `authorize()`, `hasPermissionTo()`) exista en el seeder de permisos de cada entorno, para que un permiso exigido por la aplicación nunca sea inalcanzable en silencio — ni siquiera para `admin` — porque el seeder de ese entorno nunca lo definió.
+
+---
+
+## 🔍 Root cause
+
+Audited every permission string checked in code against `Development/PermissionSeeder`, `Production/PermissionSeeder`, and `Testing/CoreTestSeeder`. Found two gaps:
+
+- **`attendances.view` / `attendances.create`** — enforced via `permission:attendances.create` middleware on `/negotiated-extra-days` (`routes/api/attendance.php`). Present in `Production` and `Testing`, but entirely absent from `Development` (no definition, no role assignment). In dev-lab, nobody — including `admin`/`manager` — could ever pass this check.
+- **`reports.today` / `reports.weekly-summary`** — `reports.weekly-summary` enforced via `WeeklySummaryRequest::authorize()`. Present in `Development` and `Testing`, but entirely absent from `Production`. In production, nobody — including `admin` — could pass this check.
+
+(`reports.today`'s own `TodayReportRequest::authorize()` currently `return true` unconditionally, so it's unenforced everywhere — seeded-but-unused, not a blocking bug, no action needed.)
+
+---
+
+## ✅ Technical Tasks
+
+- [x] 🔐 Add `attendances.view` / `attendances.create` definitions to `Development/PermissionSeeder`, assigned to `admin` and `manager` (matching `attendances.%` in `Production`/`Testing`)
+- [x] 🔐 Add `reports.today` / `reports.weekly-summary` definitions to `Production/PermissionSeeder`, assigned to `admin` and `manager` (matching `reports.%` in `Development`/`Testing`)
+- [x] 🧪 Static verification: diffed every used permission string against all three seeders — zero gaps remaining
+- [x] 🧪 Pint clean
+
+---
+
+## 🎯 Acceptance Criteria
+
+- [x] Every permission string enforced in code exists in all three seeders (Development, Production, Testing)
+- [x] `admin` and `manager` roles get `attendances.*` in Development and `reports.*` in Production, matching the pattern already established elsewhere
+- [x] No behavior change to permissions/roles not covered by this audit
+
+---
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `0.5h` (mechanical audit + two small seeder edits)
+- **Pessimistic:** `1h`
+- **Tracked:** `0.3h`
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-07-24", "start": "20:23", "end": "20:40" }
+]
+```
+
+## 📊 Retrospective
+- **Actual total:** ~17m
+- **vs optimistic:** −13m under
+- **vs pessimistic:** −43m under
+
+**Justification:**
+
+Landed under the optimistic estimate. The audit itself was mechanical (grep every `permission:`/`->can(`/`hasPermissionTo(` usage, diff against each seeder's permission list), and both fixes were small, well-precedented edits (copying the exact pattern already used for the same permission group in the sibling seeder). No test suite changes were needed since these seeders aren't exercised by PHPUnit (Testing uses `CoreTestSeeder`, which already had both permission groups defined correctly).
+
+---
+
+## 🔗 References
+
+- GitHub issue: [#303](https://github.com/pakodiazdev/sushigo/issues/303)
+- Surfaced while auditing permission coverage after #275


### PR DESCRIPTION
## Summary
Closes #303
Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/304

- 🔐 Add `attendances.view` / `attendances.create` to `Development/PermissionSeeder`, assigned to `admin` and `manager` — matches the `attendances.%` grant already in `Production`/`Testing`. Without this, dev-lab had zero users (not even `admin`) able to pass `permission:attendances.create` on `/negotiated-extra-days`, since the permission row never existed in that environment.
- 🔐 Add `reports.today` / `reports.weekly-summary` to `Production/PermissionSeeder`, assigned to `admin` and `manager` — matches the `reports.%` grant already in `Development`/`Testing`. Same problem in reverse: production had zero users able to pass `WeeklySummaryRequest::authorize()`.
- 🧪 Audited every permission string actually checked in code (`permission:` route middleware, `->can('...')`, `hasPermissionTo('...')`) against all three seeders — these were the only two gaps found.

## Test plan
- [x] Static audit: diffed every permission string used in code against `Development`, `Production`, and `Testing` seeders — zero gaps remaining after this change
- [x] Linters: Pint ✅
- [x] `php -l` on both modified seeder files — no syntax errors
- N/A — these `LockedSeeder` classes aren't exercised by PHPUnit (Testing uses `CoreTestSeeder`, which already had both permission groups correctly defined, so the existing 1384-test suite is unaffected)

## Manual Testing
1. On a **fresh dev-lab seed** (`php artisan db:seed`), log in as `admin@sushigo.com` and call `POST /api/v1/negotiated-extra-days` (or whichever endpoint sits behind `permission:attendances.create`) → should no longer 403
2. On a **fresh production seed**, log in as an `admin` and call `GET /api/v1/reports/weekly-summary` → should no longer 403
3. Confirm roles that shouldn't have these permissions (e.g. `cook`) still get `403`

## Workspace
`sushigo-c` — `fix/303-permission-seeder-audit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)