### PR TITLE
📚 [#330][a] - Adopt formal sprint documentation process 📅

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ SushiGo is the operations platform for a single restaurant tenant inside the Com
     - [Database](#database)
     - [Local setup](#local-setup)
   - [Architecture \& domain documentation](#architecture--domain-documentation)
+  - [Sprints](#sprints)
   - [Development tips](#development-tips)
   - [License](#license)
 
@@ -247,6 +248,15 @@ Uses the workspace's own `docker-compose.e2e.yml` with a Cypress container.
 - [Task #004 — Auth + Zustand migration](doc/tasks/2025-11/004-authentication-frontend-zustand.md)
 
 These documents capture the target inventory domain (operating units, stock movements, Hashids exposure) and should guide upcoming modules.
+
+## Sprints
+
+Development is organized into documented sprints — see [`doc/conventions/sprints.md`](doc/conventions/sprints.md) for the full convention and [`doc/sprints/`](doc/sprints/) for every sprint document (goal, scope, execution rounds, conflict analysis, and results).
+
+| Sprint | Title | Status | Started | Completed | Target | Document |
+|---|---|---|---|---|---|---|
+| 000 | Introduction | Completed | 2026-07-26 | 2026-07-26 | — | [sprint-000-introduction.md](doc/sprints/sprint-000-introduction.md) |
+| 001 | Attendance, Payroll & Quality | In Progress | 2026-07-26 | — | 2026-08-09 | [sprint-001-attendance-payroll-quality.md](doc/sprints/sprint-001-attendance-payroll-quality.md) |
 
 ## Development tips
 

--- a/doc/conventions/sprints.md
+++ b/doc/conventions/sprints.md
@@ -1,0 +1,846 @@
+# Sprint Documentation Convention
+
+> **Location:** `doc/conventions/sprints.md`  
+> **Applies to:** all SushiGo sprint documents  
+> **Source of truth:** the repository  
+> **Operational platform:** GitHub Projects, Issues, Pull Requests, and Actions
+
+---
+
+## 1. Purpose
+
+Sprint documents preserve the permanent engineering history of SushiGo.
+
+GitHub is used to operate the work:
+
+- backlog management;
+- Issue discussion and assignment;
+- Pull Request review;
+- checks and automation;
+- project-board visualization.
+
+The repository preserves the evidence:
+
+- sprint purpose and context;
+- selected scope;
+- value ranking;
+- execution rounds;
+- dependencies;
+- file-conflict analysis;
+- estimates and actual time;
+- technical and product decisions;
+- delivered value;
+- quality results;
+- lessons learned.
+
+> **GitHub is the operational workspace. The repository is the permanent engineering record.**
+
+A sprint document must remain understandable even if SushiGo is migrated to another project-management platform.
+
+External links may be included, but the document must also preserve the relevant Issue numbers, titles, summaries, estimates, decisions, results, and evidence.
+
+---
+
+## 2. Directory Structure
+
+Sprint documentation lives under:
+
+```text
+doc/
+├── conventions/
+│   └── sprints.md
+└── sprints/
+    ├── README.md
+    ├── sprint-000-introduction.md
+    ├── sprint-001-attendance-payroll-quality.md
+    ├── sprint-002-<delivered-value>.md
+    └── planned/
+        └── sprint-003-<expected-value>.md
+```
+
+### `doc/sprints/`
+
+This directory contains:
+
+- the current sprint;
+- every completed sprint;
+- `sprint-000-introduction.md`;
+- the sprint index in `README.md`.
+
+The sprint with the **highest sequential number directly inside `doc/sprints/`** is the current sprint.
+
+Every lower-numbered sprint directly inside `doc/sprints/` is completed.
+
+There must never be more than one current sprint.
+
+### `doc/sprints/planned/`
+
+This directory contains future sprints that have been identified but have not started.
+
+It may normally be empty.
+
+A planned sprint should be created only when enough discovered work exists to define another coherent increment of business or engineering value.
+
+When a planned sprint starts, its document is moved to `doc/sprints/` without changing its filename:
+
+```bash
+git mv   doc/sprints/planned/sprint-003-purchase-traceability.md   doc/sprints/sprint-003-purchase-traceability.md
+```
+
+After this move:
+
+- the promoted sprint becomes current;
+- the previous highest-numbered sprint becomes completed.
+
+---
+
+## 3. File Naming Convention
+
+Sprint files follow this format:
+
+```text
+sprint-NNN-short-value-title.md
+```
+
+Examples:
+
+```text
+sprint-000-introduction.md
+sprint-001-attendance-payroll-quality.md
+sprint-002-inventory-reliability.md
+sprint-003-purchase-traceability.md
+```
+
+### Naming rules
+
+1. The `sprint-` prefix is mandatory.
+2. `NNN` is a sequential number with **exactly three digits** (`000`–`999`), giving the project a capacity of 999 sprints — a two-digit scheme (`00`–`99`) would cap out at 99.
+3. Sprint numbers are never reused.
+4. Filenames use lowercase `kebab-case`.
+5. The title summarizes the principal business or engineering value sought by the sprint.
+6. The title does not need to list every Issue, module, or technical change.
+7. Dates, statuses, estimates, and tracked time must not appear in the filename.
+8. The filename must remain unchanged throughout the sprint lifecycle.
+9. A sprint file may move only from `planned/` to `doc/sprints/`.
+10. Completed sprint files must not be renamed or moved.
+11. `sprint-000-introduction.md` documents the transition to sprint-based development. It does not represent the beginning of the SushiGo product.
+
+### Valid examples
+
+```text
+sprint-004-stock-reliability.md
+sprint-005-payroll-period-integrity.md
+sprint-006-component-consistency.md
+```
+
+### Invalid examples
+
+```text
+Sprint001.md
+sprint_001_attendance.md
+completed-sprint-001-attendance.md
+sprint-1-misc.md
+sprint-01-attendance.md
+sprint-002-2026-07-26-attendance.md
+sprint-003-fix-issues-325-and-328.md
+```
+
+---
+
+## 4. Sprint Lifecycle
+
+The normal lifecycle is:
+
+```text
+Planned
+   ↓
+In Progress
+   ↓
+Completed
+```
+
+The sprint location determines its lifecycle role:
+
+| Location | Meaning |
+|---|---|
+| `doc/sprints/planned/` | Planned but not started |
+| Highest-numbered sprint in `doc/sprints/` | Current / In Progress |
+| Lower-numbered sprints in `doc/sprints/` | Completed |
+
+### Lifecycle rules
+
+- A planned sprint number must be greater than the current sprint number.
+- A planned sprint does not start until it is moved to `doc/sprints/`.
+- The current sprint remains current until the next sprint is promoted.
+- A sprint may finish implementation before its evidence, metrics, and lessons are fully consolidated.
+- A sprint is formally completed when its closure checklist is complete and the next sprint becomes current.
+- Completed sprint documents are historical records and should be treated as immutable.
+- Completed documents may be changed only to fix typos, broken links, missing evidence, or factual errors.
+- Historical work must not be removed merely to make the sprint appear cleaner.
+- A cancelled planned sprint must remain documented, must include its cancellation reason, and its number must not be reused.
+
+---
+
+## 5. Work Item Status Markers
+
+Every Issue or task listed in a sprint must use exactly one status marker.
+
+| Marker | Status | Meaning |
+|---|---|---|
+| ⏳ | Pending | Approved for the sprint but not started |
+| 🚧 | In Progress | Implementation, review, or validation has started |
+| ✅ | Completed | Acceptance criteria were met and evidence was recorded |
+| ⚠️ | Deprecated | The work or approach was superseded and should no longer be used |
+| ❌ | Cancelled | Explicitly removed or no longer required |
+
+### Status rules
+
+- Every listed work item must have one marker.
+- `⚠️ Deprecated` and `❌ Cancelled` entries must remain in the document.
+- A deprecated item must identify its replacement or superseding decision.
+- A cancelled item must include its reason.
+- A blocked item remains `⏳ Pending` and records its blocker in `Dependencies` or `Notes`.
+- Status markers must be updated as work advances.
+- Emoji markers support readability and evidence tracking; they do not replace GitHub Issue state or acceptance criteria.
+
+Example:
+
+```markdown
+| Status | Issue | Title | Notes |
+|---|---:|---|---|
+| ✅ | #325 | Fix attendance dialog overlay | Delivered in PR #341 |
+| 🚧 | #328 | Correct recorded attendance event | Frontend review pending |
+| ⏳ | #306 | Add explicit button types | Starts after #328 |
+| ⚠️ | #318 | Track TODO tags manually | Superseded by automated rule |
+| ❌ | #85 | Flutter mobile bootstrap | Removed from this sprint |
+```
+
+---
+
+## 6. Required Sprint Metadata
+
+Every sprint document begins with YAML front matter.
+
+```yaml
+---
+sprint: "001"
+title: Attendance, Payroll & Quality
+status: In Progress
+
+created: 2026-07-25
+started: 2026-07-26
+completed:
+last_updated: 2026-07-26
+
+base_branch: main
+base_commit: 079a316
+scope_issues: 26
+
+github_project:
+github_milestone:
+
+previous: sprint-000-introduction.md
+next:
+---
+```
+
+### Allowed sprint status values
+
+```text
+Planned
+In Progress
+Completed
+Cancelled
+```
+
+`Deprecated` is a work-item state, not a sprint lifecycle state.
+
+### Date definitions
+
+| Field | Meaning |
+|---|---|
+| `created` | Date when the sprint was designed or documented |
+| `started` | Date when execution actually began |
+| `completed` | Date when the sprint was formally closed |
+| `last_updated` | Date of the latest material document update |
+
+### Metadata rules
+
+- Dates use ISO 8601: `YYYY-MM-DD`.
+- Lifecycle dates belong inside the document, never in the filename.
+- `sprint` must be quoted (`sprint: "001"`, not `sprint: 001`) — some YAML 1.1 parsers treat an unquoted leading-zero value as an octal/number literal and silently drop the padding, breaking the stable 3-digit ID.
+- `base_commit` records the repository state used during planning.
+- `scope_issues` records the number of Issues initially selected.
+- `started` remains empty while the sprint is planned.
+- `completed` remains empty until formal closure.
+- `previous` points to the preceding sprint filename.
+- `next` is filled only when the next sprint is known.
+- GitHub fields may remain empty when no corresponding resource exists.
+
+---
+
+## 7. Time and Duration Rules
+
+Calendar duration and engineering effort are different measurements.
+
+A sprint may remain open for several calendar days while accumulating fewer effective work hours.
+
+Both must be documented.
+
+### Sprint timeline
+
+```markdown
+## Sprint Timeline
+
+| Metric | Value |
+|---|---:|
+| Created | 2026-07-25 |
+| Started | 2026-07-26 |
+| Completed | 2026-08-12 |
+| Calendar duration | 18 days |
+| Active workdays | 9 days |
+```
+
+### Consolidated effort
+
+```markdown
+## Consolidated Time Tracking
+
+| Category | Estimated | Tracked | Variance |
+|---|---:|---:|---:|
+| Planning and issue scoping | 4h | 4.5h | +0.5h |
+| Implementation | 38h | 39h | +1h |
+| Code review and validation | 4h | 3h | -1h |
+| Documentation | 2h | 2h | 0h |
+| Rework and corrections | 3h | 1.5h | -1.5h |
+| **Total** | **51h** | **50h** | **-1h** |
+```
+
+### Time-tracking rules
+
+- Original estimates must not be overwritten.
+- Revised estimates must be recorded separately with their reason.
+- Tracked time should come from the sessions recorded in each GitHub Issue.
+- Sprint totals must equal the sum of their underlying Issue totals.
+- Implementation time should be separated from planning, review, validation, documentation, and rework when those values are available.
+- Estimate variance must be calculated per round and for the complete sprint.
+- Negative variance means execution beat the estimate.
+- Positive variance means execution exceeded the estimate.
+
+---
+
+## 8. Standard Sprint Document Structure
+
+Every sprint document must use the following section order.
+
+Mandatory headings must remain stable to improve navigation, migration, automation, and AI retrieval.
+
+A section may state `Not applicable`, but it must not be silently removed.
+
+**Exception:** `sprint-000-introduction.md` does not follow this structure — per Naming Rule 11, it documents the transition to sprint-based development using a narrative format instead, since it predates the process it introduces.
+
+The template below is shown inside a fenced block so its own `#`/`##` headings do not become part of this convention document's heading hierarchy. It uses four backticks so the nested three-backtick examples inside it (Sprint Goal, Route B, Estimate Tracking, Closure Checklist) render correctly without closing the outer fence early.
+
+---
+
+````markdown
+# Sprint NNN — Sprint Title
+
+> One or two sentences describing the principal increment of value expected from the sprint.
+
+## 1. Executive Summary
+
+Summarize:
+
+- the sprint goal;
+- the principal business or engineering value;
+- the number and type of Issues included;
+- the planned execution strategy;
+- the expected outcome.
+
+This section must be understandable without reading the full document.
+
+## 2. Context
+
+Explain why the sprint exists.
+
+Include relevant information such as:
+
+- current product or operational needs;
+- technical debt or quality conditions;
+- previous work already completed;
+- repository branch and base commit;
+- constraints discovered during Issue analysis;
+- why the selected work belongs in the same sprint.
+
+## 3. Sprint Goal
+
+State one primary goal.
+
+```markdown
+**Sprint Goal:** Improve attendance and payroll reliability while reducing
+high-risk frontend quality debt without creating file conflicts between agents.
+```
+
+A sprint may contain several Issues, but it must communicate one coherent increment of value.
+
+## 4. Sprint Timeline
+
+| Metric | Value |
+|---|---:|
+| Created | YYYY-MM-DD |
+| Started | YYYY-MM-DD |
+| Completed | — |
+| Calendar duration | — |
+| Active workdays | — |
+
+## 5. Scope
+
+### 5.1 Included
+
+List the business areas, features, defects, quality improvements, and technical work included.
+
+### 5.2 Excluded
+
+Record work intentionally left outside the sprint.
+
+### 5.3 Scope Changes
+
+Record all additions, removals, deprecations, and cancellations made after sprint start.
+
+| Date | Status | Item | Change | Reason |
+|---|---|---|---|---|
+| YYYY-MM-DD | ❌ | #000 | Removed from sprint | Reason |
+| YYYY-MM-DD | ⚠️ | Previous approach | Superseded | Replacement |
+
+Items must never disappear from sprint history without an entry here.
+
+## 6. Value Ranking
+
+Classify work by value and urgency before defining execution order.
+
+| Tier | Issues | Rationale |
+|---|---|---|
+| **Critical** | #000 | Security, data integrity, or production correctness |
+| **High** | #000, #000 | Direct product or operational value |
+| **Medium** | #000 | Functional risk, accessibility, or developer productivity |
+| **Low** | #000 | Maintainability or non-urgent cleanup |
+| **Deferred** | #000 | Valid work intentionally assigned the lowest priority |
+
+### Ordering principle
+
+> **Value first, parallelism second.**
+
+High-value work is scheduled as early as possible.
+
+Lower-value work may be included as conflict-free filler when agent capacity is available, but filler must never displace critical or high-value work.
+
+## 7. Route A — Execution Rounds
+
+Organize Issues into rounds that are conflict-free by default.
+
+A round represents work that may be executed in parallel when enough agents or workspaces are available.
+
+### Round 1 — Round Objective
+
+| Status | Issue | Title | Value | Opt. | Pess. | Tracked | PR / Commit | Notes |
+|---|---:|---|---|---:|---:|---:|---|---|
+| ⏳ | #000 | Issue title | Critical | 1h | 2h | — | — | Priority or conflict note |
+| ⏳ | #000 | Issue title | High | 2h | 4h | — | — | Independent work |
+| ⏳ | #000 | Issue title | Low | 0.5h | 1h | — | — | Conflict-free filler |
+|  |  | **Round total** |  | **3.5h** | **7h** | **—** |  |  |
+
+Repeat the same structure for every round.
+
+### Round rules
+
+- Issues in the same round must not modify the same files unless explicitly coordinated.
+- Round order represents the recommended default execution order.
+- Rounds are not hard dependencies unless Route B identifies a dependency.
+- When agent capacity is limited, highest-value Issues start first.
+- Filler work starts only when higher-value work is already assigned or blocked.
+- Every Issue row must retain its title, value, estimates, status, evidence, and relevant notes.
+
+## 8. Route B — Sequential Dependencies
+
+Record product-level, technical, and file-level ordering constraints.
+
+```text
+#000 (Round 1) → #000 (Round 2)
+Reason: both modify the same component; the smaller fix must land first.
+
+#000 (Round 2) → #000 and #000 (Round 3)
+Reason: the first Issue changes a shared contract required by later work.
+```
+
+For every dependency, identify:
+
+- predecessor;
+- successor;
+- dependency type;
+- why the order matters;
+- evidence that the predecessor is complete.
+
+If no product-level dependency exists, state that explicitly.
+
+## 9. Conflict Risk Map
+
+List files touched by two or more sprint Issues.
+
+| Shared file | Issues touching it | Planned rounds | Risk / Coordination |
+|---|---|---|---|
+| `path/to/file.tsx` | #000, #000 | 1, 2 | Must land sequentially |
+| `path/to/service.php` | #000, #000, #000 | 1, 3, 4 | High-conflict node |
+
+### Conflict methodology
+
+Explain how affected files were identified, for example:
+
+- GitHub Issue affected locations;
+- SonarCloud findings;
+- repository audit;
+- code search;
+- confirmed files from Issue scoping;
+- generated dependency graph.
+
+Two Issues conflict when they modify the same file or when one changes a contract consumed by the other.
+
+## 10. Estimate Tracking by Round
+
+| Round | Issue count | Opt. total | Pess. total | Tracked total | vs Opt. | vs Pess. |
+|---|---:|---:|---:|---:|---:|---:|
+| Round 1 | 0 | 0h | 0h | — | — | — |
+| Round 2 | 0 | 0h | 0h | — | — | — |
+| **Grand total** | **0** | **0h** | **0h** | **—** | **—** | **—** |
+
+Calculations:
+
+```text
+vs Opt.  = Tracked total - Optimistic total
+vs Pess. = Tracked total - Pessimistic total
+```
+
+Update the comparison as each round finishes.
+
+Do not wait until sprint closure, because a slow round may be hidden by faster work elsewhere.
+
+## 11. Consolidated Time Tracking
+
+| Category | Estimated | Tracked | Variance |
+|---|---:|---:|---:|
+| Planning and issue scoping | — | — | — |
+| Implementation | — | — | — |
+| Code review and validation | — | — | — |
+| Documentation | — | — | — |
+| Rework and corrections | — | — | — |
+| **Total** | **—** | **—** | **—** |
+
+## 12. Notes on Estimate Confidence
+
+Explain the origin and confidence of the estimates.
+
+Possible sources include:
+
+- Issue body estimates;
+- prior implementation history;
+- affected-file count;
+- complexity analysis;
+- agent-generated rough sizing;
+- direct technical scoping.
+
+Clearly distinguish technically scoped estimates from preliminary planning estimates.
+
+## 13. Execution Evidence
+
+Record the relation between Sprint, Issues, Pull Requests, and commits.
+
+| Status | Issue | Result Summary | Pull Request | Merge Commit | Tracked | Evidence Notes |
+|---|---:|---|---:|---|---:|---|
+| ✅ | #000 | Delivered result | #000 | `abcdef1` | 2.5h | Acceptance criteria passed |
+| ❌ | #000 | Removed from scope | — | — | 0h | Cancellation reason |
+| ⚠️ | #000 | Replaced by #000 | #000 | `abcdef2` | 1h | Superseding approach |
+
+Do not record only a link.
+
+Include enough identifiers and text to reconstruct the history after a platform migration.
+
+## 14. Quality Results
+
+Record relevant before-and-after evidence.
+
+| Metric | Before | Target | After | Result |
+|---|---:|---:|---:|---|
+| Tests passing | — | 100% | — | ⏳ |
+| Coverage | — | — | — | ⏳ |
+| SonarCloud Issues | — | — | — | ⏳ |
+| Technical debt | — | — | — | ⏳ |
+| Bugs fixed | 0 | — | — | ⏳ |
+| Security findings | — | 0 new | — | ⏳ |
+
+Possible evidence includes:
+
+- automated tests;
+- SonarCloud Quality Gate;
+- coverage;
+- static analysis;
+- manual acceptance validation;
+- screenshots;
+- release or deployment verification;
+- production observation.
+
+## 15. Results
+
+### 15.1 Delivered Value
+
+Describe what changed for the restaurant, users, maintainers, or future development.
+
+### 15.2 Planned vs. Actual
+
+Summarize:
+
+- planned Issue count;
+- completed Issue count;
+- deprecated or cancelled work;
+- estimated and tracked time;
+- scope changes;
+- deviations from the original execution route.
+
+### 15.3 Known Limitations
+
+Record incomplete behavior, accepted debt, deferred risks, and follow-up work.
+
+Do not leave limitations documented only in closed GitHub Issues.
+
+## 16. Lessons Learned
+
+Record conclusions that should affect future sprints.
+
+Examples:
+
+- estimation accuracy;
+- agent coordination;
+- workspace capacity;
+- conflict-analysis accuracy;
+- testing gaps;
+- architecture discoveries;
+- changes needed in conventions or templates.
+
+Lessons must be specific enough to change future behavior.
+
+## 17. Follow-up Work
+
+Record newly discovered work without silently expanding the current sprint.
+
+| Status | Proposed Issue | Title | Reason | Candidate Sprint |
+|---|---:|---|---|---|
+| ⏳ | #000 | Follow-up title | Discovered during #000 | Next sprint |
+| ⚠️ | — | Superseded idea | Replaced by another approach | None |
+
+Follow-up work belongs in the backlog or in a future document under `planned/`.
+
+## 18. Sprint Closure Checklist
+
+```markdown
+- [ ] All included work items have a final status marker.
+- [ ] Completed items include Pull Request or commit evidence.
+- [ ] Deprecated items identify their replacement.
+- [ ] Cancelled items include a reason.
+- [ ] Scope changes are recorded.
+- [ ] Tracked time was synchronized from Issue sessions.
+- [ ] Round totals and sprint totals were recalculated.
+- [ ] Estimate variance was calculated.
+- [ ] Consolidated effort was completed.
+- [ ] Dependencies reflect actual execution.
+- [ ] Conflict notes reflect actual execution.
+- [ ] Tests and relevant quality metrics were recorded.
+- [ ] Delivered value and known limitations were documented.
+- [ ] Follow-up work was created or recorded.
+- [ ] Lessons learned were captured.
+- [ ] Metadata dates and status were updated.
+- [ ] The next sprint was promoted or created when applicable.
+```
+````
+
+A sprint must not be considered closed until this checklist is complete.
+
+---
+
+## 9. Multi-Agent Editing Rules
+
+SushiGo may be implemented by several AI agents in parallel.
+
+Sprint documentation must therefore minimize shared-file conflicts and preserve stable ownership.
+
+### Ownership
+
+- The project owner or a designated coordination agent owns sprint structure, value ranking, round definitions, dependencies, conflict maps, and aggregate totals.
+- Implementation agents may update only the row, evidence, status, and tracked time associated with their assigned Issue.
+- Implementation agents must not reorder rounds, change priorities, or rewrite unrelated sections.
+- Aggregate totals should be recalculated by the coordination agent at round boundaries and sprint closure.
+
+### Safe updates by implementation agents
+
+An implementation agent may update:
+
+- its Issue status marker;
+- tracked time;
+- Pull Request;
+- merge commit;
+- concise result summary;
+- evidence notes.
+
+It must not modify:
+
+- another agent's Issue row;
+- value ranking;
+- dependency ordering;
+- unrelated conflict-map entries;
+- completed sprint documents.
+
+### Preservation rules
+
+- Never delete a historical row.
+- Never renumber a sprint.
+- Never reuse a cancelled or skipped sprint number.
+- Never rewrite completed history to match the latest architecture.
+- Record corrections explicitly when the original history was materially wrong.
+- Prefer small, scoped documentation commits during an active sprint.
+- Avoid broad formatting rewrites while multiple agents are working.
+
+---
+
+## 10. Minimal Sprint Template
+
+Use this template when creating a new sprint document.
+
+```markdown
+---
+sprint: "NNN"
+title: Sprint Value Title
+status: Planned
+
+created: YYYY-MM-DD
+started:
+completed:
+last_updated: YYYY-MM-DD
+
+base_branch: main
+base_commit:
+scope_issues: 0
+
+github_project:
+github_milestone:
+
+previous:
+next:
+---
+
+# Sprint NNN — Sprint Value Title
+
+> Brief description of the expected increment of value.
+
+## 1. Executive Summary
+
+## 2. Context
+
+## 3. Sprint Goal
+
+**Sprint Goal:** ...
+
+## 4. Sprint Timeline
+
+| Metric | Value |
+|---|---:|
+| Created | YYYY-MM-DD |
+| Started | — |
+| Completed | — |
+| Calendar duration | — |
+| Active workdays | — |
+
+## 5. Scope
+
+### 5.1 Included
+
+### 5.2 Excluded
+
+### 5.3 Scope Changes
+
+| Date | Status | Item | Change | Reason |
+|---|---|---|---|---|
+
+## 6. Value Ranking
+
+| Tier | Issues | Rationale |
+|---|---|---|
+
+## 7. Route A — Execution Rounds
+
+### Round 1 — Objective
+
+| Status | Issue | Title | Value | Opt. | Pess. | Tracked | PR / Commit | Notes |
+|---|---:|---|---|---:|---:|---:|---|---|
+| ⏳ | #000 | Title | High | 0h | 0h | — | — | — |
+|  |  | **Round total** |  | **0h** | **0h** | **—** |  |  |
+
+## 8. Route B — Sequential Dependencies
+
+## 9. Conflict Risk Map
+
+| Shared file | Issues touching it | Planned rounds | Risk / Coordination |
+|---|---|---|---|
+
+## 10. Estimate Tracking by Round
+
+| Round | Issue count | Opt. total | Pess. total | Tracked total | vs Opt. | vs Pess. |
+|---|---:|---:|---:|---:|---:|---:|
+| **Grand total** | **0** | **0h** | **0h** | **—** | **—** | **—** |
+
+## 11. Consolidated Time Tracking
+
+| Category | Estimated | Tracked | Variance |
+|---|---:|---:|---:|
+| Planning and issue scoping | — | — | — |
+| Implementation | — | — | — |
+| Code review and validation | — | — | — |
+| Documentation | — | — | — |
+| Rework and corrections | — | — | — |
+| **Total** | **—** | **—** | **—** |
+
+## 12. Notes on Estimate Confidence
+
+## 13. Execution Evidence
+
+| Status | Issue | Result Summary | Pull Request | Merge Commit | Tracked | Evidence Notes |
+|---|---:|---|---:|---|---:|---|
+
+## 14. Quality Results
+
+| Metric | Before | Target | After | Result |
+|---|---:|---:|---:|---|
+
+## 15. Results
+
+### 15.1 Delivered Value
+
+### 15.2 Planned vs. Actual
+
+### 15.3 Known Limitations
+
+## 16. Lessons Learned
+
+## 17. Follow-up Work
+
+| Status | Proposed Issue | Title | Reason | Candidate Sprint |
+|---|---:|---|---|---|
+
+## 18. Sprint Closure Checklist
+
+- [ ] All work items have a final status.
+- [ ] Evidence and tracked time are complete.
+- [ ] Estimates and totals were recalculated.
+- [ ] Consolidated effort was completed.
+- [ ] Quality results were recorded.
+- [ ] Scope changes and limitations were documented.
+- [ ] Follow-up work and lessons learned were captured.
+- [ ] Metadata was updated.
+```

--- a/doc/sprints/README.md
+++ b/doc/sprints/README.md
@@ -1,0 +1,12 @@
+# Sprint Index
+
+Index of every SushiGo sprint document. See `doc/conventions/sprints.md` for the full convention.
+
+| Sprint | Title | Status | Document |
+|---|---|---|---|
+| 000 | Introduction | Completed | [sprint-000-introduction.md](sprint-000-introduction.md) |
+| 001 | Attendance, Payroll & Quality | In Progress (current) | [sprint-001-attendance-payroll-quality.md](sprint-001-attendance-payroll-quality.md) |
+
+Planned sprints not yet started live under [`planned/`](planned/) and are not listed here until promoted.
+
+Update this table whenever a sprint document is added, promoted from `planned/`, or completed.

--- a/doc/sprints/sprint-000-introduction.md
+++ b/doc/sprints/sprint-000-introduction.md
@@ -1,0 +1,158 @@
+---
+sprint: "000"
+title: Introduction
+status: Completed
+
+created: 2026-07-26
+started: 2026-07-26
+completed: 2026-07-26
+last_updated: 2026-07-26
+
+base_branch: main
+base_commit: 079a316
+scope_issues: 0
+
+github_project:
+github_milestone:
+
+previous:
+next: sprint-001-attendance-payroll-quality.md
+---
+
+# Introduction
+
+## Purpose
+
+This document explains the evolution of SushiGo's development process and why the project transitions to a structured, iteration-based workflow from this point forward.
+
+It is **not** the beginning of the project.
+
+Instead, it marks the beginning of a formal engineering process that will be used for all future development.
+
+---
+
+# Project Vision
+
+SushiGo was conceived from the beginning as a real software product intended to support the daily operation of SushiGo Restaurant.
+
+At the same time, the project has always served as a public portfolio demonstrating software engineering practices, architecture decisions and product evolution.
+
+The product vision has remained constant since day one.
+
+Only the development process evolved.
+
+---
+
+# Initial Development
+
+Development started as a personal spare-time project.
+
+There was no fixed schedule, no dedicated team and no predefined iteration length.
+
+Features were implemented whenever time was available, making traditional sprint planning impractical.
+
+During this stage, prioritization was mostly dynamic and driven by immediate business value.
+
+The objective was simple:
+
+- Build a usable product.
+- Validate ideas quickly.
+- Continuously improve the system.
+
+---
+
+# AI Experimentation
+
+The project also became an opportunity to experiment with AI-assisted software development.
+
+Initially, this exploration focused on GitHub Copilot and the emerging "vibe coding" workflow that was becoming popular.
+
+The goal was never to let AI replace engineering.
+
+Instead, the objective was to understand how AI could accelerate software development while maintaining production-quality standards.
+
+As the project evolved, additional AI tools and eventually multi-agent workflows became part of the development process.
+
+---
+
+# Lessons Learned
+
+One of the most important conclusions reached during the project was that AI dramatically changes **who implements the code**, but it does not fundamentally change software engineering itself.
+
+Large software systems still require:
+
+- Domain understanding
+- Architecture
+- Planning
+- Documentation
+- Business rules
+- Code reviews
+- Technical decisions
+- Risk analysis
+- Quality assurance
+
+The implementation work became increasingly delegated to AI agents, while engineering responsibilities remained under human supervision.
+
+This project intentionally preserves traditional software engineering practices because they continue to be essential for building maintainable software.
+
+---
+
+# Why Introduce Structured Iterations?
+
+As SushiGo continued growing, several factors made informal development increasingly difficult:
+
+- The number of GitHub Issues increased.
+- Technical debt began to be tracked through SonarCloud.
+- Multiple AI agents started working simultaneously.
+- File conflicts became more frequent.
+- Time estimation became useful.
+- Progress needed to be measurable.
+- Architectural decisions required better traceability.
+
+At this stage, organic development no longer scaled efficiently.
+
+A structured engineering process became necessary.
+
+---
+
+# Development Process
+
+From this point forward, SushiGo will be developed using documented iterations.
+
+Each iteration contains:
+
+- Objectives
+- Prioritized backlog
+- Business value
+- Technical dependencies
+- File conflict analysis
+- Parallel execution strategy
+- Time estimates
+- Review results
+- Lessons learned
+
+The objective is not bureaucracy.
+
+The objective is to preserve the engineering context of the project so that both humans and AI agents can understand not only **what** was built, but also **why** every technical decision was made.
+
+---
+
+# Development Philosophy
+
+This repository follows a simple principle:
+
+> AI changed who writes the code, not how software engineering should be practiced.
+
+AI is treated as an implementation accelerator rather than a replacement for engineering.
+
+Architecture, planning, documentation and technical leadership remain central to the development process.
+
+---
+
+# What Comes Next
+
+Starting with the next document, SushiGo development will be organized into versioned iterations.
+
+Each iteration will represent a complete engineering cycle including planning, implementation, review and measurable results.
+
+This document serves as the transition point between the project's organic development phase and its structured engineering process.

--- a/doc/sprints/sprint-001-attendance-payroll-quality.md
+++ b/doc/sprints/sprint-001-attendance-payroll-quality.md
@@ -1,0 +1,329 @@
+---
+sprint: "001"
+title: Attendance, Payroll & Quality
+status: In Progress
+
+created: 2026-07-25
+started: 2026-07-26
+completed:
+last_updated: 2026-07-26
+
+base_branch: main
+base_commit: 079a316
+scope_issues: 26
+
+github_project: SushiGo Admin (#7)
+github_milestone:
+
+previous: sprint-000-introduction.md
+next:
+---
+
+# Sprint 001 — Attendance, Payroll & Quality
+
+> Close a real attendance-editing gap, tighten payroll-close integrity, and clear the highest-value frontend quality/security debt — all 26 currently open Issues, ordered by value and scheduled so multiple agents can work in parallel without touching the same file.
+
+## 1. Executive Summary
+
+This sprint absorbs every Issue open on `pakodiazdev/sushigo` at the time of planning (26 total): 4 hand-authored feature/bug Issues from this week (#325, #327, #328, #329), 2 older hand-authored Issues (#276, #324), 1 large deferred Issue (#85, mobile bootstrap), and 19 SonarCloud code-quality Issues (#305–#323).
+
+The work was ordered by **value first, parallelism second**: Security and Reliability bugs go first, then user-requested attendance/payroll product features, then real-risk quality issues (accidental form submits, list-reorder rendering bugs, accessibility gaps), then pure maintainability cleanup, with the large deferred mobile bootstrap kept explicitly last despite having zero file conflicts with anything else.
+
+A file-level conflict analysis (parsed directly from each SonarCloud Issue's "Affected locations," plus a code audit for the 7 hand-authored Issues) produced **6 execution rounds** — every Issue inside the same round shares zero files with every other Issue in that round, so a round's Issues can all be worked simultaneously, one agent per Issue, with no merge-conflict risk between them.
+
+Expected outcome: a real attendance-correction capability shipped, payroll-close periods can no longer be closed early or as a partial week, the two highest-connected quality debt nodes (#305, #306) cleared, and the sprint's own estimate-vs-tracked comparison populated so future sprints can calibrate estimates against real data.
+
+## 2. Context
+
+The previous planning document (an unversioned `sushigo-dev-lab/plan/roadmap.md`, tracking the same backlog before it existed as a formal sprint) established the value ranking and round structure below through direct repository analysis, not topic guessing. That document lived in the dev-lab orchestration repo, outside version control (`plan/.gitignore` excluded everything under it), so no history of past planning was preserved. This sprint moves that planning permanently into `sushigo`, under the process introduced in `sprint-000-introduction.md`, so it accumulates real history from this point forward.
+
+Relevant discoveries folded into scope during planning:
+
+- Issue #326 (an earlier attempt at the attendance-editing feature) was closed as superseded once a code audit against `origin/main` showed #83 already shipped the role/date authorization layer (`AttendancePolicy`, `useAttendancePermissions`) — #328 in this sprint is the corrected, narrower scope: allow *correcting* an already-recorded value, which no existing endpoint permits today.
+- #325 and #328 both modify `AttendanceTimeDialog.tsx` — sequenced across Round 1 → Round 2 specifically because of this.
+- #305 and #306 are the two most-connected nodes in the conflict graph (48 and 18 affected files respectively); nearly every SonarCloud Issue scheduled in Round 3 or later is downstream of one of them clearing a shared file.
+
+Base state: `main` @ `079a316`, 26 open Issues, zero Issues yet linked to a GitHub Project or labeled with a sprint/iteration.
+
+## 3. Sprint Goal
+
+**Sprint Goal:** Improve attendance and payroll reliability while reducing high-risk frontend quality debt without creating file conflicts between agents.
+
+## 4. Sprint Timeline
+
+| Metric | Value |
+|---|---:|
+| Created | 2026-07-25 |
+| Started | 2026-07-26 |
+| Completed | — |
+| Target completion (deadline) | 2026-08-09 |
+| Calendar duration (planned) | 14 days |
+| Active workdays | — |
+
+### How the deadline was set
+
+The target date is **not** the raw sum of every Issue's Pessimistic estimate (that grand total is 85.5h and assumes fully serial execution — see §10). It is the project's existing GitHub Project iteration cadence: the "Iteration" field on **SushiGo Admin** (#7) already has three completed iterations (`Iteration`, `Iteration 2`, `Iteration 3`, all 2025-11 → 2025-12) at a **14-day duration**. Sprint 1 reuses that cadence rather than inventing a new one.
+
+Sanity check against effort: assuming enough parallel agents that a round's duration is bounded by its *slowest single Issue* rather than the sum of all Issues in it, the critical path across all 6 rounds (excluding #85, explicitly deprioritized filler that must not gate the sprint) is:
+
+```text
+Round 1 (#329, 6h max)  →  Round 2 (#328, 7h)  →  Round 3 (2h)  →  Round 4 (#305, 8h)  →  Round 5 (#308, 5h)  →  Round 6 (#311, 2h)
+Pessimistic critical path ≈ 30h  ·  Optimistic critical path ≈ 17h
+```
+
+30h of pessimistic critical-path effort over a 14-day window is ≈2.1h/day of active agent-supervised work — comfortably inside the window, so 2026-08-09 is a realistic, non-aggressive deadline rather than a stretch target.
+
+## 5. Scope
+
+### 5.1 Included
+
+All 26 currently open Issues on `pakodiazdev/sushigo`:
+
+- **Attendance & payroll product work:** #325, #327, #328, #329
+- **Backend feature:** #276
+- **Developer tooling:** #324
+- **SonarCloud code quality (Maintainability/Reliability/Security):** #305, #306, #307, #308, #309, #310, #311, #312, #313, #314, #315, #316, #317, #318, #319, #320, #321, #322, #323
+- **Deferred, included only because it has zero file conflicts with the rest:** #85
+
+### 5.2 Excluded
+
+Nothing was intentionally left out of this sprint — it absorbs the full open backlog at planning time. Any Issue opened after `base_commit` (`079a316`) is out of scope until explicitly added via §5.3.
+
+### 5.3 Scope Changes
+
+| Date | Status | Item | Change | Reason |
+|---|---|---|---|---|
+| 2026-07-26 | ✅ | — | Sprint created from `sushigo-dev-lab/plan/roadmap.md` | Converting ad hoc planning into the formal sprint process (`sprint-000-introduction.md`) |
+
+## 6. Value Ranking
+
+| Tier | Issues | Rationale |
+|---|---|---|
+| **Critical** | #323 (Security), #322 (Reliability bug) | Real security/correctness bugs, not style — always go first regardless of file conflicts |
+| **High** | #325, #329, #328, #327 | User-requested product work: a real UX bug (#325) and three attendance/payroll features that close operational gaps (mistaken time corrections, payroll period integrity, cleaner working screen) |
+| **Medium** | #276, #306, #309, #310, #320, #321, #324 | Real functional/accessibility risk (WhatsApp silently not sending, accidental form submits, list-reorder rendering bugs, a11y gaps) or clear productivity value (#324), but lower urgency than the above |
+| **Low** | #305, #307, #308, #311–#319 (remaining Maintainability code smells) | Pure code-quality cleanup, no user-facing behavior change |
+| **Deferred** | #85 | Large (8–14h), separate Flutter repo, strategically deferred already — kept last on purpose despite having zero file conflicts with anything |
+
+### Ordering principle
+
+> **Value first, parallelism second.**
+
+Lower-value maintainability cleanups are interleaved into the same rounds as high-value work whenever they don't conflict on a file, so spare agent capacity is never idle. An Issue only lands later than its value would suggest when it genuinely collides (same file) with something higher-value already scheduled earlier.
+
+## 7. Route A — Execution Rounds
+
+### Round 1 — Critical + High value, plus zero-conflict filler (14 Issues)
+
+| Status | Issue | Title | Value | Opt. | Pess. | Tracked | PR / Commit | Notes |
+|---|---:|---|---|---:|---:|---:|---|---|
+| ⏳ | #323 | [Security] PRNGs should not be used in security contexts | Critical | 0.5h | 1h | — | — | Do first — Security, not just style |
+| ⏳ | #322 | [Reliability] Mouse events should have corresponding keyboard events | Critical | 1h | 2h | — | — | Real a11y/interaction bug |
+| ⏳ | #325 | Overlay del diálogo "Registrar entrada" no cubre toda la pantalla | High | 0.5h | 1.5h | — | — | Quick real bug fix. **Land before starting #328** — both touch `AttendanceTimeDialog.tsx` |
+| ⏳ | #329 | Auto-calculate current week for payroll close + Sunday 19:00 gate | High | 3h | 6h | — | — | Prevents closing a wrong/partial payroll period |
+| ⏳ | #327 | Add "Ausentes" stat card, move absent employees out of main grid | High | 2h | 4h | — | — | Frontend-only |
+| ⏳ | #276 | Integrate a real WhatsApp provider in WhatsAppService | Medium | 2h | 4h | — | — | Backend-only, zero overlap with anything |
+| ⏳ | #309 | [Maintainability] JSX list components should not use array indexes as key | Medium | 1h | 2h | — | — | Real rendering-bug risk on list reorder, not just style |
+| ⏳ | #321 | [Maintainability] Heading elements should have accessible content | Medium | 0.5h | 1h | — | — | a11y |
+| ⏳ | #314 | [Maintainability] Unused React typed props should be removed | Low (filler) | 1h | 2h | — | — | Conflict-free, fills spare capacity |
+| ⏳ | #315 | [Maintainability] Functions should not be nested too deeply | Low (filler) | 0.5h | 1h | — | — | Conflict-free, fills spare capacity |
+| ⏳ | #316 | [Maintainability] Jump statements should not be redundant | Low (filler) | 0.5h | 1h | — | — | Conflict-free, fills spare capacity |
+| ⏳ | #317 | [Maintainability] "catch" clauses should do more than rethrow | Low (filler) | 0.5h | 1h | — | — | Conflict-free, fills spare capacity |
+| ⏳ | #319 | [Maintainability] Type constituents of unions/intersections redundant | Low (filler) | 0.5h | 1h | — | — | Conflict-free, fills spare capacity |
+| ⏳ | #85 | Mobile App — Project Bootstrap (Flutter) | Deferred | 8h | 14h | — | — | Zero conflicts, but **must not** be prioritized over the 13 Issues above — background work for a spare agent only |
+|  |  | **Round 1 total** |  | **21.5h** | **41.5h** | **—** |  |  |
+
+**If only 5 workspaces are available:** run #323, #322, #325, #329, #327 first — the entire Critical+High tier unblocked today. Cycle #276, #309, #321, then filler, in as workspaces free up.
+
+### Round 2 — 5 Issues
+
+| Status | Issue | Title | Value | Opt. | Pess. | Tracked | PR / Commit | Notes |
+|---|---:|---|---|---:|---:|---:|---|---|
+| ⏳ | #328 | Allow correcting an already-recorded attendance event | High | 4h | 7h | — | — | Unblocked once #325 merges — same file (`AttendanceTimeDialog.tsx`) |
+| ⏳ | #306 | [Maintainability] `<button>` elements should have an explicit "type" attribute | Medium | 3h | 5h | — | — | 18 files — prevents accidental form-submit bugs |
+| ⏳ | #307 | [Maintainability] Number static methods preferred over global equivalents | Low (filler) | 2h | 3h | — | — | Conflict-free with this round |
+| ⏳ | #312 | [Maintainability] React Context Provider values should have stable identities | Low (filler) | 1h | 2h | — | — | Conflict-free with this round |
+| ⏳ | #318 | [Maintainability] Track uses of "TODO" tags | Low (filler) | 0.5h | 1h | — | — | Conflict-free with this round |
+|  |  | **Round 2 total** |  | **10.5h** | **18h** | **—** |  |  |
+
+### Round 3 — 3 Issues
+
+| Status | Issue | Title | Value | Opt. | Pess. | Tracked | PR / Commit | Notes |
+|---|---:|---|---|---:|---:|---:|---|---|
+| ⏳ | #310 | [Maintainability] Non-interactive DOM elements should not have an interactive handler | Medium | 1h | 2h | — | — | a11y — conflicted with #306 via `Sidebar.tsx`/`DevDebugger.tsx`, now clear |
+| ⏳ | #320 | [Maintainability] Label elements should have a text label and an associated control | Medium | 0.5h | 1h | — | — | a11y — conflicted with #306 via `data-grid.tsx`, now clear |
+| ⏳ | #313 | [Maintainability] Exceptions should not be ignored | Low (filler) | 1h | 2h | — | — | Conflict-free with this round |
+|  |  | **Round 3 total** |  | **2.5h** | **5h** | **—** |  |  |
+
+### Round 4 — 2 Issues
+
+| Status | Issue | Title | Value | Opt. | Pess. | Tracked | PR / Commit | Notes |
+|---|---:|---|---|---:|---:|---:|---|---|
+| ⏳ | #324 | Add a dev-only Components catalog page | Medium | 3h | 6h | — | — | Conflicted with #322/#306/#310 via `Sidebar.tsx` in earlier rounds, now clear |
+| ⏳ | #305 | [Maintainability] React props should be read-only | Low | 5h | 8h | — | — | 48 files, the single most-connected Issue in the graph |
+|  |  | **Round 4 total** |  | **8h** | **14h** | **—** |  |  |
+
+### Round 5 — 1 Issue
+
+| Status | Issue | Title | Value | Opt. | Pess. | Tracked | PR / Commit | Notes |
+|---|---:|---|---|---:|---:|---:|---|---|
+| ⏳ | #308 | [Maintainability] Ternary operators should not be nested | Low | 3h | 5h | — | — | Conflicts with #305 and several Round 1–3 Issues via `data-grid.tsx`, `confirm-dialog.tsx`, `Dashboard.tsx` |
+|  |  | **Round 5 total** |  | **3h** | **5h** | **—** |  |  |
+
+### Round 6 — 1 Issue
+
+| Status | Issue | Title | Value | Opt. | Pess. | Tracked | PR / Commit | Notes |
+|---|---:|---|---|---:|---:|---:|---|---|
+| ⏳ | #311 | [Maintainability] Cognitive Complexity of functions should not be too high | Low | 1h | 2h | — | — | Last — conflicts with `DevDebugger.tsx`/`product-wizard.tsx`/`stock-out-form.tsx` touched across earlier rounds |
+|  |  | **Round 6 total** |  | **1h** | **2h** | **—** |  |  |
+
+### Round rules
+
+- Issues in the same round must not modify the same files unless explicitly coordinated.
+- Round order represents the recommended default execution order, not a hard dependency, except where §8 identifies a real one.
+- When agent capacity is limited, highest-value Issues start first; filler starts only once higher-value work is already assigned or blocked.
+
+## 8. Route B — Sequential Dependencies
+
+```text
+#325 (Round 1, ~1h)  →  #328 (Round 2, ~4-7h)
+   Both touch AttendanceTimeDialog.tsx — land #325's one-line fix first
+   so #328 isn't rebasing around it mid-flight.
+
+#306 (Round 2)  →  unblocks #310, #320 (Round 3)  →  unblocks #324, #305 (Round 4)  →  unblocks #308 (Round 5)  →  unblocks #311 (Round 6)
+   This chain is why the SonarCloud tail stretches to 6 rounds: #305/#306 are the two
+   highest-connected nodes in the conflict graph, and nearly everything downstream of
+   them touches a file one of them also touches.
+```
+
+No product-level dependency chains exist in this sprint (unlike the previous roadmap's now-closed Payroll/Overtime/Vacation chains) — every ordering constraint above is file-conflict driven, not business-logic driven.
+
+## 9. Conflict Risk Map
+
+| Shared file | Issues touching it | Planned rounds | Risk / Coordination |
+|---|---|---|---|
+| `src/components/ui/data-grid.tsx` | #305, #306, #308, #309, #320 | 4, 2, 5, 1, 3 | High-conflict node — never schedule two of these together |
+| `src/components/dashboard/Dashboard.tsx` | #305, #308, #309, #318 | 4, 5, 1, 2 | — |
+| `src/components/cash/create-adjustment-dialog.tsx` | #305, #307, #309, #313 | 4, 2, 1, 3 | — |
+| `src/components/inventory/product-wizard.tsx` | #305, #308, #309, #311 | 4, 5, 1, 6 | — |
+| `src/components/dev/DevDebugger.tsx` | #305, #306, #310, #311 | 4, 2, 3, 6 | — |
+| `src/components/layout/Sidebar.tsx` | #306, #310, #322, #324 | 2, 3, 1, 4 | Touched by 4 Issues — verify before mixing rounds |
+| `src/components/ui/confirm-dialog.tsx` | #308, #310, #322 | 5, 3, 1 | — |
+| `src/components/auth/BranchSwitcher.tsx` | #306, #310, #322 | 2, 3, 1 | — |
+| `src/components/ui/toast-provider.tsx` | #305, #312, #323 | 4, 2, 1 | — |
+| `src/components/inventory/stock-out-form.tsx` | #305, #308, #311 | 4, 5, 6 | — |
+| `src/components/employees/employee-edit-create-form.tsx` | #305, #308, #315 | 4, 5, 1 | — |
+| `src/components/attendance/AttendanceTimeDialog.tsx` | #325, #328 | 1, 2 | See §8 |
+| `src/stores/auth.store.ts` | #313, #317 | 3, 1 | — |
+| `src/hooks/use-employees-search.ts` | #308, #319 | 5, 1 | — |
+
+(Remaining 2-way overlaps — `toast.tsx`, `dropdown-menu.tsx`, `search-input.tsx`, `logo.tsx`, `slide-panel.tsx`, `SidebarContext.tsx`, `ThemeContext.tsx`, `wage-history-card.tsx`, `register-wage-form.tsx`, `open-session-dialog.tsx`, `variant-details.tsx`, `employee-detail-view.tsx`, `stock-dashboard.tsx` — all between #305 and one other Issue already placed in a different round above.)
+
+### Conflict methodology
+
+- SonarCloud Issues (#305–#323): files parsed directly from each Issue's "Affected locations" section.
+- Hand-authored Issues (#276, #324, #325, #327, #328, #329, #85): files confirmed via direct code audit against `origin/main` during scoping.
+- Two Issues conflict when they modify the same file. Rounds are a graph-coloring of that conflict graph: no two Issues in the same round share a file.
+
+## 10. Estimate Tracking by Round
+
+| Round | Issue count | Opt. total | Pess. total | Tracked total | vs Opt. | vs Pess. |
+|---|---:|---:|---:|---:|---:|---:|
+| Round 1 | 14 | 21.5h | 41.5h | — | — | — |
+| Round 2 | 5 | 10.5h | 18h | — | — | — |
+| Round 3 | 3 | 2.5h | 5h | — | — | — |
+| Round 4 | 2 | 8h | 14h | — | — | — |
+| Round 5 | 1 | 3h | 5h | — | — | — |
+| Round 6 | 1 | 1h | 2h | — | — | — |
+| **Grand total** | **26** | **46.5h** | **85.5h** | **—** | **—** | **—** |
+
+Update the comparison as each round finishes — do not wait until sprint closure, because a slow round may be hidden by faster work elsewhere.
+
+## 11. Consolidated Time Tracking
+
+| Category | Estimated | Tracked | Variance |
+|---|---:|---:|---:|
+| Planning and issue scoping | ~6h (this sprint's own setup: research, issue creation/correction, conflict analysis, sprint-doc conversion) | — | — |
+| Implementation | 46.5h–85.5h (see §10) | — | — |
+| Code review and validation | — | — | — |
+| Documentation | — | — | — |
+| Rework and corrections | — | — | — |
+| **Total** | **—** | **—** | **—** |
+
+## 12. Notes on Estimate Confidence
+
+- #325, #327, #328, #329, #276, #324, #85 Opt./Pess. values come from their own GitHub Issue bodies (`## ⏱️ Time` → Estimates).
+- All SonarCloud Issue Opt./Pess. values are **rough T-shirt sizing from affected-file count**, not from the Issue body — those Issues carry no Time section today. Treat them as planning-only; update with real Estimates on each Issue once someone actually scopes it, and update the corresponding row above to match before that round starts.
+- The sprint deadline (§4) is derived from the GitHub Project's existing 14-day iteration cadence, cross-checked against — not derived from — the raw estimate totals. See §4 for the calculation.
+
+## 13. Execution Evidence
+
+| Status | Issue | Result Summary | Pull Request | Merge Commit | Tracked | Evidence Notes |
+|---|---:|---|---:|---|---:|---|
+| ⏳ | #323 | Not started | — | — | — | — |
+| ⏳ | #322 | Not started | — | — | — | — |
+| ⏳ | #325 | Not started | — | — | — | — |
+| ⏳ | #329 | Not started | — | — | — | — |
+| ⏳ | #327 | Not started | — | — | — | — |
+| ⏳ | #328 | Not started | — | — | — | — |
+| ⏳ | #276 | Not started | — | — | — | — |
+| ⏳ | #324 | Not started | — | — | — | — |
+| ⏳ | #305–#321 (17 remaining SonarCloud Issues) | Not started | — | — | — | — |
+| ⏳ | #85 | Not started | — | — | — | — |
+
+This table should be expanded to one row per Issue as work starts — collapsed here at sprint creation time since nothing has begun.
+
+## 14. Quality Results
+
+| Metric | Before | Target | After | Result |
+|---|---:|---:|---:|---|
+| Tests passing | — | 100% | — | ⏳ |
+| Coverage | — | maintain or improve | — | ⏳ |
+| SonarCloud Issues (open) | 19 | 0 | — | ⏳ |
+| Technical debt | — | — | — | ⏳ |
+| Bugs fixed | 0 | 2 (#322, #325) | — | ⏳ |
+| Security findings | 1 open (#323) | 0 new, 1 resolved | — | ⏳ |
+
+## 15. Results
+
+### 15.1 Delivered Value
+
+Not applicable — sprint just started, no results yet.
+
+### 15.2 Planned vs. Actual
+
+Not applicable — sprint just started, no results yet.
+
+### 15.3 Known Limitations
+
+Not applicable — sprint just started, no results yet.
+
+## 16. Lessons Learned
+
+Not applicable — sprint just started, no lessons yet. First candidate lesson to validate at closure: whether the 14-day/critical-path deadline in §4 held, and whether the SonarCloud Opt./Pess. T-shirt sizing (§12) was anywhere close to real Tracked time.
+
+## 17. Follow-up Work
+
+| Status | Proposed Issue | Title | Reason | Candidate Sprint |
+|---|---:|---|---|---|
+| ⏳ | — | Retrofit real Estimates onto #305–#323 per `doc/conventions/tasks.md` | Current values are rough sizing, not technically scoped | Sprint 001 (before each Issue's round starts) |
+
+## 18. Sprint Closure Checklist
+
+- [ ] All included work items have a final status marker.
+- [ ] Completed items include Pull Request or commit evidence.
+- [ ] Deprecated items identify their replacement.
+- [ ] Cancelled items include a reason.
+- [ ] Scope changes are recorded.
+- [ ] Tracked time was synchronized from Issue sessions.
+- [ ] Round totals and sprint totals were recalculated.
+- [ ] Estimate variance was calculated.
+- [ ] Consolidated effort was completed.
+- [ ] Dependencies reflect actual execution.
+- [ ] Conflict notes reflect actual execution.
+- [ ] Tests and relevant quality metrics were recorded.
+- [ ] Delivered value and known limitations were documented.
+- [ ] Follow-up work was created or recorded.
+- [ ] Lessons learned were captured.
+- [ ] Metadata dates and status were updated.
+- [ ] The next sprint was promoted or created when applicable.


### PR DESCRIPTION
## Summary
Closes #330
Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/331

- 📅 Added `doc/conventions/sprints.md` with 3-digit sprint numbering (`sprint-NNN`, up to 999 sprints instead of 99)
- 🗂️ Renamed `doc/sprints/00-introduction.md` → `doc/sprints/sprint-000-introduction.md`, adding the required YAML front matter
- 📝 Added `doc/sprints/sprint-001-attendance-payroll-quality.md`, converting the prior unversioned `sushigo-dev-lab/plan/roadmap.md` into the standard 18-section sprint format — covers all 26 currently open Issues with value ranking, 6 file-conflict-free execution rounds, a conflict risk map, and an estimate-tracking table (Opt./Pess./Tracked) to compare against real time at closure
- 📆 Sprint 1 deadline (2026-08-09) is derived from the GitHub Project's existing 14-day iteration cadence, cross-checked against the critical-path effort estimate (~17–30h across 6 sequential rounds)

## Test plan
- [ ] `doc/conventions/sprints.md` has no remaining 2-digit sprint references outside the intentional "invalid example"
- [ ] `sprint-001-attendance-payroll-quality.md` follows every section of the template in order

## Manual Testing
Documentation-only change — no app behavior affected.
1. Open `doc/conventions/sprints.md` and confirm every example uses `sprint-NNN-...` (3 digits)
2. Open `doc/sprints/sprint-001-attendance-payroll-quality.md` and confirm it has YAML front matter, all 18 sections, and the 6 round tables sum to the totals in §10

## Workspace
`sushigo-a` — `docs/330-adopt-sprint-documentation`

🤖 Generated with Claude Code