### PR TITLE
🔒 [#323][a] - Use crypto.randomUUID for toast id generation 🔒

### DIFF
--- a/code/webapp/src/components/ui/toast-provider.tsx
+++ b/code/webapp/src/components/ui/toast-provider.tsx
@@ -6,6 +6,16 @@ interface ToastWithId extends Omit<ToastProps, 'onClose'> {
   id: string
 }
 
+let toastFallbackCounter = 0
+
+function generateToastId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  toastFallbackCounter += 1
+  return `toast-${Date.now()}-${toastFallbackCounter}`
+}
+
 export function ToastProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<ToastWithId[]>([])
 
@@ -14,7 +24,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   }, [])
 
   const showToast = useCallback((toast: Omit<ToastProps, 'id' | 'onClose'>) => {
-    const id = Math.random().toString(36).substring(2, 9)
+    const id = generateToastId()
     setToasts((prev) => [...prev, { ...toast, id }])
   }, [])
 

--- a/doc/sprints/sprint-001-attendance-payroll-quality.md
+++ b/doc/sprints/sprint-001-attendance-payroll-quality.md
@@ -117,11 +117,11 @@ Lower-value maintainability cleanups are interleaved into the same rounds as hig
 
 | Status | Issue | Title | Value | Opt. | Pess. | Tracked | PR / Commit | Notes |
 |---|---:|---|---|---:|---:|---:|---|---|
-| ⏳ | #323 | [Security] PRNGs should not be used in security contexts | Critical | 0.5h | 1h | — | — | Do first — Security, not just style |
-| 🚧 | #322 | [Reliability] Mouse events should have corresponding keyboard events | Critical | 1h | 2h | 0.2h | PR #333 | Real a11y/interaction bug. Fixed, SonarCloud + Copilot review passed, awaiting merge |
-| ⏳ | #325 | Overlay del diálogo "Registrar entrada" no cubre toda la pantalla | High | 0.5h | 1.5h | — | — | Quick real bug fix. **Land before starting #328** — both touch `AttendanceTimeDialog.tsx` |
-| ⏳ | #329 | Auto-calculate current week for payroll close + Sunday 19:00 gate | High | 3h | 6h | — | — | Prevents closing a wrong/partial payroll period |
-| ⏳ | #327 | Add "Ausentes" stat card, move absent employees out of main grid | High | 2h | 4h | — | — | Frontend-only |
+| ✅ | #323 | [Security] PRNGs should not be used in security contexts | Critical | 0.5h | 1h | 0.6h | PR #332 | Fixed — `Math.random()` → `crypto.randomUUID()`, plus guarded `generateToastId()` fallback for insecure contexts (Copilot review). Commits squashed to 1. Reviewed, merge pending |
+| ✅ | #322 | [Reliability] Mouse events should have corresponding keyboard events | Critical | 1h | 2h | 0.2h | PR #333 | Real a11y/interaction bug. Fixed, SonarCloud + Copilot review passed, merged |
+| 🚧 | #325 | Overlay del diálogo "Registrar entrada" no cubre toda la pantalla | High | 0.5h | 1.5h | — | PR #334 | Quick real bug fix. **Land before starting #328** — both touch `AttendanceTimeDialog.tsx` |
+| 🚧 | #329 | Auto-calculate current week for payroll close + Sunday 19:00 gate | High | 3h | 6h | — | — | Prevents closing a wrong/partial payroll period |
+| 🚧 | #327 | Add "Ausentes" stat card, move absent employees out of main grid | High | 2h | 4h | — | — | Frontend-only |
 | ⏳ | #276 | Integrate a real WhatsApp provider in WhatsAppService | Medium | 2h | 4h | — | — | Backend-only, zero overlap with anything |
 | ⏳ | #309 | [Maintainability] JSX list components should not use array indexes as key | Medium | 1h | 2h | — | — | Real rendering-bug risk on list reorder, not just style |
 | ⏳ | #321 | [Maintainability] Heading elements should have accessible content | Medium | 0.5h | 1h | — | — | a11y |
@@ -260,11 +260,11 @@ Update the comparison as each round finishes — do not wait until sprint closur
 
 | Status | Issue | Result Summary | Pull Request | Merge Commit | Tracked | Evidence Notes |
 |---|---:|---|---:|---|---:|---|
-| ⏳ | #323 | Not started | — | — | — | — |
-| 🚧 | #322 | Backdrop `<div onClick>` → native `<button>` in confirm-dialog.tsx, BranchSwitcher.tsx, Sidebar.tsx (reused `dialog-frame.tsx` idiom) | PR #333 | — | 0.2h | SonarCloud + Copilot review passed; existing Vitest suites (60 tests) pass unmodified; awaiting merge |
-| ⏳ | #325 | Not started | — | — | — | — |
-| ⏳ | #329 | Not started | — | — | — | — |
-| ⏳ | #327 | Not started | — | — | — | — |
+| ✅ | #323 | `Math.random()` → `crypto.randomUUID()` in `toast-provider.tsx`, guarded `generateToastId()` fallback (Date.now() + counter, no `Math.random()`) for insecure contexts/older browsers per Copilot review | PR #332 | — | 0.6h | ESLint + TypeScript pass, 0 errors; no Vitest/Cypress needed (internal id-gen, no behavior change); commits squashed to 1; reviewed, merge pending |
+| ✅ | #322 | Backdrop `<div onClick>` → native `<button>` in confirm-dialog.tsx, BranchSwitcher.tsx, Sidebar.tsx (reused `dialog-frame.tsx` idiom) | PR #333 | 621868b | 0.2h | SonarCloud + Copilot review passed; existing Vitest suites (60 tests) pass unmodified; merged |
+| 🚧 | #325 | In progress — PR #334 open | PR #334 | — | — | — |
+| 🚧 | #329 | In progress | — | — | — | — |
+| 🚧 | #327 | In progress | — | — | — | — |
 | ⏳ | #328 | Not started | — | — | — | — |
 | ⏳ | #276 | Not started | — | — | — | — |
 | ⏳ | #324 | Not started | — | — | — | — |

--- a/doc/tasks/2026-07/323-secure-toast-id-generator.md
+++ b/doc/tasks/2026-07/323-secure-toast-id-generator.md
@@ -1,0 +1,66 @@
+# 🔒 Task #323: Replace insecure PRNG used for toast ids in sushigo-webapp
+
+## 📖 Story
+
+**English:**
+As a developer, I need to review the SonarCloud Security finding for `typescript:S2245` in `sushigo-webapp`, so the project's security review status stays clean and any real risk is addressed or consciously accepted with justification.
+
+**Español:**
+Como desarrollador, necesito revisar el hallazgo de seguridad reportado por SonarCloud para `sushigo-webapp`, para que el estado de revisión de seguridad del proyecto se mantenga limpio y cualquier riesgo real sea resuelto o aceptado conscientemente con justificación.
+
+---
+
+## 🔍 SonarCloud Finding
+
+| Rule | Category | Severity | File | Line |
+|---|---|---|---|---|
+| `typescript:S2245` | Security | MAJOR | `src/components/ui/toast-provider.tsx` | 17 |
+
+**Message:** "Make sure that using this pseudorandom number generator (Math.random()) is safe here."
+
+## ✅ Technical Tasks
+
+- [x] 🔍 Inspect `toast-provider.tsx:17` — confirmed the `id` from `Math.random().toString(36).substring(2, 9)` is only used as a React list key and as the token passed to `removeToast()` to dismiss a specific toast; not a token, session id, or secret
+- [x] 🔧 Replace `Math.random().toString(36).substring(2, 9)` with `crypto.randomUUID()` — cheap, no behavior change, removes the finding at the source
+- [x] 🛡️ Add guarded `generateToastId()` fallback (Date.now() + counter, no `Math.random()`) for environments where `crypto.randomUUID` is unavailable, per Copilot review comment on PR #332
+- [ ] 🔍 Confirm SonarCloud's PR analysis shows the `typescript:S2245` occurrence resolved (this is a Vulnerability Issue, not a Security Hotspot — no manual "mark reviewed" step is needed, it clears automatically once the fixed line is re-scanned on the PR)
+
+## 🎯 Acceptance Criteria
+
+- [x] The finding at `toast-provider.tsx:17` is resolved via code fix (no behavioral change to toast display/removal)
+- [ ] SonarCloud's PR analysis shows 0 occurrences of `typescript:S2245` for sushigo-webapp
+
+## 🚫 Explicitly Out of Scope
+
+- No new Vitest test added: `showToast`'s id generation is an internal implementation detail (React list key / dismiss token), not user-facing behavior; existing toast display/removal behavior is unaffected by swapping the id generator.
+
+---
+
+## 🔗 References
+
+- SonarCloud project: https://sonarcloud.io/project/issues?id=pakodiazdev_sushigo-webapp&rules=typescript:S2245
+- Rule: `typescript:S2245`
+
+---
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `0.25h` · **Pessimistic:** `1h` · **Tracked:** `34m`
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-07-26", "start": "19:08", "end": "19:16" },
+  { "date": "2026-07-26", "start": "19:40", "end": "20:06" }
+]
+```
+
+## 📊 Retrospective
+- **Actual total:** 34m (8m + 26m)
+- **vs optimistic:** +19m
+- **vs pessimistic:** −26m
+
+**Justification:**
+
+Session 1 was a single-line RNG swap (`Math.random()` → `crypto.randomUUID()`) in a component whose id is only used as a React list key / dismiss token, so inspection and implementation were immediate with no ambiguity. Session 2 addressed a Copilot review comment: `crypto.randomUUID()` can be unavailable in insecure contexts or older browsers, so a guarded `generateToastId()` fallback (Date.now() + counter, not `Math.random()`, to keep SonarCloud's `S2245` resolved) was added, plus a rebase onto an updated `main`. The overrun past the optimistic estimate reflects that second round of review-driven work, which wasn't part of the original scope.


### PR DESCRIPTION
## Summary
Closes #323
Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/332

- 🔒 Replace `Math.random().toString(36).substring(2, 9)` with `crypto.randomUUID()` in `toast-provider.tsx` to clear SonarCloud `typescript:S2245`
- 🔍 Confirmed the toast `id` is only used as a React list key / dismiss token — not a security-sensitive value — so a straight code fix was preferred over manually marking the finding "Safe" in SonarCloud
- 📝 No behavior change to toast display/removal

## Test plan
- [x] Lint: `npm run lint` — 0 errors (2 pre-existing unrelated warnings)
- [x] Typecheck: `npm run typecheck` — 0 errors
- [ ] SonarCloud PR analysis: confirm `typescript:S2245` occurrence resolved for sushigo-webapp

## Manual Testing
1. Run the webapp (`npm run dev`)
2. Trigger any toast (e.g. submit a form successfully or with an error)
3. Confirm the toast appears and auto-dismisses / can be dismissed manually, same as before — the only change is the internal id generator

## Workspace
`sushigo-a` — `fix/323-secure-toast-id-generator`

🤖 Generated with [Claude Code](https://claude.com/claude-code)