### PR TITLE
🐛 [#322][b] - Add keyboard support to clickable backdrop overlays ⌨️

### DIFF
--- a/code/webapp/src/components/auth/BranchSwitcher.tsx
+++ b/code/webapp/src/components/auth/BranchSwitcher.tsx
@@ -48,9 +48,11 @@ export function BranchSwitcher() {
 
             {isOpen && (
                 <>
-                    <div
-                        className="fixed inset-0 z-30"
+                    <button
+                        type="button"
+                        className="fixed inset-0 z-30 cursor-default appearance-none border-none bg-transparent p-0"
                         onClick={() => setIsOpen(false)}
+                        aria-label="Cerrar selector de sucursal"
                     />
                     <div className="absolute bottom-full left-0 right-0 mb-2 z-40 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 py-2 max-h-64 overflow-y-auto">
                         {availableBranches.map((branch) => (

--- a/code/webapp/src/components/layout/Sidebar.tsx
+++ b/code/webapp/src/components/layout/Sidebar.tsx
@@ -269,9 +269,11 @@ export default function Sidebar() {
         <>
             {/* Mobile Overlay */}
             {isMobileOpen && (
-                <div
-                    className="fixed inset-0 bg-black/50 z-40 lg:hidden"
+                <button
+                    type="button"
+                    className="fixed inset-0 bg-black/50 z-40 lg:hidden cursor-default appearance-none border-none p-0"
                     onClick={closeMobileSidebar}
+                    aria-label="Cerrar menú"
                 />
             )}
 

--- a/code/webapp/src/components/ui/confirm-dialog.tsx
+++ b/code/webapp/src/components/ui/confirm-dialog.tsx
@@ -136,9 +136,12 @@ export function ConfirmDialog({
   const content = (
     <div className={`${portalTarget ? 'absolute' : 'fixed'} inset-0 z-[60] flex items-center justify-center`}>
       {/* Backdrop */}
-      <div
-        className={`absolute inset-0 bg-black/50 ${backdropAnimation}`}
-        onClick={() => !isLoading && onClose()}
+      <button
+        type="button"
+        className={`absolute inset-0 bg-black/50 ${backdropAnimation} cursor-default appearance-none border-none p-0`}
+        onClick={onClose}
+        disabled={isLoading}
+        aria-label="Cerrar diálogo"
       />
 
       {/* Dialog */}

--- a/doc/sprints/sprint-001-attendance-payroll-quality.md
+++ b/doc/sprints/sprint-001-attendance-payroll-quality.md
@@ -118,7 +118,7 @@ Lower-value maintainability cleanups are interleaved into the same rounds as hig
 | Status | Issue | Title | Value | Opt. | Pess. | Tracked | PR / Commit | Notes |
 |---|---:|---|---|---:|---:|---:|---|---|
 | ⏳ | #323 | [Security] PRNGs should not be used in security contexts | Critical | 0.5h | 1h | — | — | Do first — Security, not just style |
-| ⏳ | #322 | [Reliability] Mouse events should have corresponding keyboard events | Critical | 1h | 2h | — | — | Real a11y/interaction bug |
+| 🚧 | #322 | [Reliability] Mouse events should have corresponding keyboard events | Critical | 1h | 2h | 0.2h | PR #333 | Real a11y/interaction bug. Fixed, SonarCloud + Copilot review passed, awaiting merge |
 | ⏳ | #325 | Overlay del diálogo "Registrar entrada" no cubre toda la pantalla | High | 0.5h | 1.5h | — | — | Quick real bug fix. **Land before starting #328** — both touch `AttendanceTimeDialog.tsx` |
 | ⏳ | #329 | Auto-calculate current week for payroll close + Sunday 19:00 gate | High | 3h | 6h | — | — | Prevents closing a wrong/partial payroll period |
 | ⏳ | #327 | Add "Ausentes" stat card, move absent employees out of main grid | High | 2h | 4h | — | — | Frontend-only |
@@ -261,7 +261,7 @@ Update the comparison as each round finishes — do not wait until sprint closur
 | Status | Issue | Result Summary | Pull Request | Merge Commit | Tracked | Evidence Notes |
 |---|---:|---|---:|---|---:|---|
 | ⏳ | #323 | Not started | — | — | — | — |
-| ⏳ | #322 | Not started | — | — | — | — |
+| 🚧 | #322 | Backdrop `<div onClick>` → native `<button>` in confirm-dialog.tsx, BranchSwitcher.tsx, Sidebar.tsx (reused `dialog-frame.tsx` idiom) | PR #333 | — | 0.2h | SonarCloud + Copilot review passed; existing Vitest suites (60 tests) pass unmodified; awaiting merge |
 | ⏳ | #325 | Not started | — | — | — | — |
 | ⏳ | #329 | Not started | — | — | — | — |
 | ⏳ | #327 | Not started | — | — | — | — |

--- a/doc/tasks/2026-07/322-keyboard-events-clickable-overlays.md
+++ b/doc/tasks/2026-07/322-keyboard-events-clickable-overlays.md
@@ -1,0 +1,73 @@
+# 🐛 Task #322: Mouse events should have corresponding keyboard events (typescript:S1082)
+
+## 📖 Story
+
+**English:**
+As a developer, I need clickable backdrop overlays to also support keyboard interaction, so that SonarCloud's reliability gate stays clean and keyboard-only users can dismiss dialogs/dropdowns/sidebars.
+
+**Español:**
+Como desarrollador, necesito que los overlays de fondo clicables también soporten interacción por teclado, para que el gate de confiabilidad de SonarCloud se mantenga limpio y los usuarios que navegan solo con teclado puedan cerrar diálogos/dropdowns/sidebars.
+
+---
+
+## 🔍 SonarCloud Finding
+
+| Rule | Category | Severity | File | Line |
+|---|---|---|---|---|
+| `typescript:S1082` | Reliability | MINOR | `src/components/ui/confirm-dialog.tsx` | 139 |
+| `typescript:S1082` | Reliability | MINOR | `src/components/auth/BranchSwitcher.tsx` | 51 |
+| `typescript:S1082` | Reliability | MINOR | `src/components/layout/Sidebar.tsx` | 272 |
+
+**Message:** Visible, non-interactive elements (`<div>`) with an `onClick` handler have no corresponding keyboard event handler.
+
+Overlaps with the S6848 maintainability finding for the same elements — fixed together per file.
+
+## ✅ Technical Tasks
+
+- [x] 🔍 Confirmed all 3 locations are invisible/semi-transparent "backdrop" overlays used to close a dialog/dropdown/sidebar on outside click
+- [x] 🔍 Found an existing native-`<button>` idiom already used for this exact pattern in `src/components/employees/dialog-frame.tsx` (and reused in `ExtraDayNegotiationDialog.tsx`, `OvertimeDecisionDialog.tsx`, `RegisterLeaveDialog.tsx`, `extra-day-section.tsx`) — gets keyboard support for free, no visual change
+- [x] 🔨 Replace the backdrop `<div onClick>` with `<button type="button" aria-label="..." className="... cursor-default appearance-none border-none p-0">` in `confirm-dialog.tsx`
+- [x] 🔨 Same replacement in `BranchSwitcher.tsx`
+- [x] 🔨 Same replacement in `Sidebar.tsx`
+- [x] 🔍 Verified no test selects these backdrops by tag name (`BranchSwitcher.test.tsx` selects by `.fixed.inset-0` class only, which still matches after the tag change)
+
+## 🎯 Acceptance Criteria
+
+- [x] All 3 flagged locations no longer trigger `typescript:S1082`
+- [x] No visual/behavioral regression — backdrop still closes the dialog/dropdown/sidebar on click
+- [x] Existing tests pass unmodified
+- [x] Lint + typecheck clean
+
+## 🚫 Explicitly Out of Scope
+
+- `src/components/ui/slide-panel.tsx:178` has the same underlying pattern but was **not** one of the 3 SonarCloud-flagged locations for this issue — left untouched, per explicit decision to stay scoped to the reported findings.
+
+---
+
+## 🔗 References
+
+- SonarCloud project: https://sonarcloud.io/project/issues?id=pakodiazdev_sushigo-webapp&rules=typescript:S1082
+- GitHub Issue: [#322](https://github.com/pakodiazdev/sushigo/issues/322)
+
+---
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `0.5h` · **Pessimistic:** `1.5h` · **Tracked:** `12m`
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-07-26", "start": "19:07", "end": "19:19" }
+]
+```
+
+## 📊 Retrospective
+- **Actual total:** 12m (12m)
+- **vs optimistic:** −18m
+- **vs pessimistic:** −1h18m
+
+**Justification:**
+
+The fix was a mechanical, well-scoped change: three near-identical backdrop `<div onClick>` elements converted to `<button>`, reusing an idiom already established elsewhere in the codebase (`dialog-frame.tsx`). No new behavior, no ambiguity in the approach, and existing tests already covered the affected components (confirmed passing without modification), so there was no back-and-forth or rework.


### PR DESCRIPTION
## Summary
Closes #322
Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/333

- 🐛 Fix SonarCloud `typescript:S1082` (Reliability, MINOR) — 3 backdrop `<div onClick>` overlays had no corresponding keyboard event
- ⌨️ Replaced each backdrop `<div>` with a native `<button type="button">` styled identically, which gets keyboard (Enter/Space) support for free — no visual or behavioral change
- 🔍 Reused the existing button-backdrop idiom already established in `src/components/employees/dialog-frame.tsx` for consistency instead of introducing a new pattern

## Test plan
- [x] Vitest: `npx vitest run src/components/ui/__tests__/confirm-dialog.test.tsx src/components/auth/__tests__/BranchSwitcher.test.tsx` — 22 passed (includes existing backdrop-click-to-close test)
- [x] Vitest: `npx vitest run src/components/layout/__tests__/Sidebar.test.tsx src/contexts/__tests__/SidebarContext.test.tsx` — 38 passed
- [x] Linters: ESLint ✅ · TypeScript ✅

## Manual Testing
1. Open the app, log in as `admin@sushigo.com`
2. Trigger any confirm dialog (e.g. delete an item) — click the dimmed backdrop area outside the dialog panel → dialog closes
3. Click the "Sucursal Actual" branch switcher in the sidebar footer to open the dropdown, then click anywhere outside it → dropdown closes
4. On a narrow/mobile viewport, open the sidebar via the hamburger menu, then click the dark overlay area → sidebar closes
5. All three should behave exactly as before (no visual change) — the fix only adds keyboard accessibility to the same overlay elements

## Workspace
`sushigo-b` — `fix/322-keyboard-events-overlays`

🤖 Generated with [Claude Code](https://claude.com/claude-code)