### PR TITLE
✨ [#327][e] - Add Ausentes stat card and hide vacationing employees from grid ✨

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Development is organized into documented sprints — see [`doc/conventions/sprin
 | Sprint | Title | Status | Started | Completed | Target | Document |
 |---|---|---|---|---|---|---|
 | 000 | Introduction | Completed | 2026-07-26 | 2026-07-26 | — | [sprint-000-introduction.md](doc/sprints/sprint-000-introduction.md) |
-| 001 | Attendance, Payroll & Quality | In Progress | 2026-07-26 | — | 2026-08-09 | [sprint-001-attendance-payroll-quality.md](doc/sprints/sprint-001-attendance-payroll-quality.md) |
+| 001 | Attendance, Payroll & Quality | In Progress | 2026-07-26 | 19.2% | 2026-08-09 | [sprint-001-attendance-payroll-quality.md](doc/sprints/sprint-001-attendance-payroll-quality.md) |
 
 ## Development tips
 

--- a/code/api/app/Console/Commands/TestReset.php
+++ b/code/api/app/Console/Commands/TestReset.php
@@ -7,6 +7,7 @@ use Database\Seeders\Fakes\FakeEmployeesSeeder;
 use Database\Seeders\OvertimeLftTierSeeder;
 use Database\Seeders\PunctualityBonusGroupSeeder;
 use Database\Seeders\PunctualityRangeSeeder;
+use Database\Seeders\Testing\AttendanceAbsentStatCardSeeder;
 use Database\Seeders\Testing\AttendanceTestSeeder;
 use Database\Seeders\Testing\AttendanceTodayLeaveSeeder;
 use Database\Seeders\Testing\CloseDayHappyPathSeeder;
@@ -50,6 +51,10 @@ class TestReset extends Command
         'attendance-today-leave' => [
             AttendanceTestSeeder::class,
             AttendanceTodayLeaveSeeder::class,
+        ],
+        'attendance-absent-stat-card' => [
+            AttendanceTestSeeder::class,
+            AttendanceAbsentStatCardSeeder::class,
         ],
         'close-day-happy' => [
             AttendanceTestSeeder::class,

--- a/code/api/database/seeders/Testing/AttendanceAbsentStatCardSeeder.php
+++ b/code/api/database/seeders/Testing/AttendanceAbsentStatCardSeeder.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Database\Seeders\Testing;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+/**
+ * "Ausentes" stat card seeder — one employee per bucket for the
+ * attendance-absent-stat-card Cypress spec:
+ *   EMP-001 Mendoza, Carlos   → no attendance record (pending)
+ *   EMP-002 García, María     → checked in, no check-out (checkedIn)
+ *   EMP-003 López, Pedro      → day_status VACATION (absent, hidden from grid)
+ *   EMP-004 Ramírez, Ana      → day_status ABSENCE (absent, stays in grid — "Justificar falta")
+ *   EMP-005 Sánchez, Roberto  → day_status DAY_OFF (absent, hidden from grid)
+ *
+ * Employees must already exist (AttendanceTestSeeder ran first).
+ */
+class AttendanceAbsentStatCardSeeder extends Seeder
+{
+    private const TEST_DATE = '2026-04-09';
+
+    private const CHECK_IN_UTC = '2026-04-09 19:00:00';
+
+    public function run(): void
+    {
+        $now = now();
+
+        $employeeIdMap = DB::table('employees')
+            ->whereIn('code', ['EMP-002', 'EMP-003', 'EMP-004', 'EMP-005'])
+            ->pluck('id', 'code')
+            ->toArray();
+
+        DB::table('attendances')->insert([
+            $this->buildRow($employeeIdMap['EMP-002'], self::CHECK_IN_UTC, 'WORKED', $now),
+            $this->buildRow($employeeIdMap['EMP-003'], null, 'VACATION', $now),
+            $this->buildRow($employeeIdMap['EMP-004'], null, 'ABSENCE', $now),
+            $this->buildRow($employeeIdMap['EMP-005'], null, 'DAY_OFF', $now),
+        ]);
+    }
+
+    private function buildRow(int $employeeId, ?string $checkIn, string $dayStatus, mixed $now): array
+    {
+        return [
+            'employee_id' => $employeeId,
+            'date' => self::TEST_DATE,
+            'check_in' => $checkIn,
+            'check_out' => null,
+            'lunch_start' => null,
+            'lunch_end' => null,
+            'entry_late_seconds' => 0,
+            'lunch_late_seconds' => 0,
+            'net_worked_minutes' => null,
+            'overtime_minutes' => 0,
+            'overtime_authorized' => false,
+            'overtime_authorized_by' => null,
+            'overtime_authorized_at' => null,
+            'day_status' => $dayStatus,
+            'confirmed_by' => null,
+            'meta' => null,
+            'public_id' => (string) Str::ulid(),
+            'created_at' => $now,
+            'updated_at' => $now,
+        ];
+    }
+}

--- a/code/webapp/cypress/e2e/attendance-absent-stat-card.cy.ts
+++ b/code/webapp/cypress/e2e/attendance-absent-stat-card.cy.ts
@@ -1,0 +1,166 @@
+/**
+ * Attendance Today — "Ausentes" Stat Card, Tab Filters & Smart Default — E2E happy-path tests
+ *
+ * Covers issue #327: a dedicated "Ausentes" stat card that removes employees
+ * with a scheduled or marked absence from the main working grid, every stat
+ * card acting as a clickable tab that filters the grid, a smart default tab
+ * on page load (Pendientes, or En trabajo if nobody is pending), and the
+ * active tab persisting in the URL (?tab=) across reloads.
+ *
+ * Test date: 2026-04-09 (Thursday, a work day for all seeded employees)
+ *
+ * Employees used (seeded by AttendanceAbsentStatCardSeeder):
+ *   EMP-001  Mendoza, Carlos   → no attendance record (pending)      — bucket: pending
+ *   EMP-002  García, María     → checked in, no check-out            — bucket: checkedIn
+ *   EMP-003  López, Pedro      → day_status VACATION                 — bucket: absent (hidden outside Ausentes/Total)
+ *   EMP-004  Ramírez, Ana      → day_status ABSENCE ("Marcar falta") — bucket: absent (hidden outside Ausentes/Total, even though "Justificar falta" lives on this card)
+ *   EMP-005  Sánchez, Roberto  → day_status DAY_OFF (scheduled rest) — bucket: absent (hidden outside Ausentes/Total)
+ *
+ * Since EMP-001 is pending, the page is expected to land on the "Pendientes"
+ * tab by default.
+ *
+ * Para correr solo este archivo:
+ *   make cypress-spec SPEC=attendance-absent-stat-card
+ */
+
+import users from "../fixtures/users.json";
+
+const { email: adminEmail, password: adminPassword } = users.admin;
+
+// ── Suite setup ──────────────────────────────────────────────────────────────
+
+before(() => {
+  cy.task("test:reset", "attendance-absent-stat-card", { timeout: 60_000 });
+});
+
+// Test time: 14:30 CDMX on 2026-04-09, after check-ins are recorded
+const TEST_TIME_ISO = "2026-04-09T14:30:00-06:00";
+const TEST_TIME_UTC = new Date("2026-04-09T20:30:00Z");
+
+beforeEach(() => {
+  cy.intercept({ url: /\/api\/v1\// }, (req) => {
+    req.headers["X-Test-Time"] = TEST_TIME_ISO;
+    req.continue();
+  }).as("apiWithTestTime");
+
+  cy.loginByApi(adminEmail, adminPassword);
+  cy.visitWithAuth("/attendance");
+  cy.url().should("include", "/attendance", { timeout: 10_000 });
+  // Wait for a stable page element before checking for the dev debugger —
+  // calling closeDevDebugger() immediately after navigation can no-op if the
+  // overlay mounts slightly later, leaving it to cover the UI mid-test.
+  cy.get("[data-testid='stat-total']", { timeout: 10_000 }).should("be.visible");
+  cy.closeDevDebugger();
+
+  cy.clock(TEST_TIME_UTC.getTime(), ["Date"]);
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+type StatTab = "total" | "pending" | "checked-in" | "done" | "absent";
+
+/** Clicks a stat card by its data-testid (they're buttons acting as tabs). */
+function clickTab(tab: StatTab) {
+  cy.get(`[data-testid='stat-${tab}']`, { timeout: 10_000 }).click({ force: true });
+}
+
+// ── Stat card ────────────────────────────────────────────────────────────────
+
+describe("Ausentes stat card", () => {
+  it("shows a 5th 'Ausentes' card counting VACATION, ABSENCE and DAY_OFF employees", () => {
+    cy.get("[data-testid='stat-absent']", { timeout: 10_000 })
+      .find("p")
+      .first()
+      .should("have.text", "3");
+  });
+
+  it("lays out 5 stat cards evenly (no orphan cell)", () => {
+    cy.get("[data-testid='stat-absent']", { timeout: 10_000 }).closest("div.grid").should("have.class", "grid-cols-3");
+    cy.get("[data-testid='stat-absent']").closest("div.grid").should("have.class", "sm:grid-cols-5");
+  });
+});
+
+// ── Smart default tab ──────────────────────────────────────────────────────────
+
+describe("Default tab on page load", () => {
+  it("lands on 'Pendientes' since there is a pending employee (Mendoza)", () => {
+    cy.get("[data-testid='stat-pending']", { timeout: 10_000 }).should("have.attr", "aria-pressed", "true");
+    cy.contains("Mendoza", { timeout: 10_000 }).should("be.visible");
+    cy.contains("García").should("not.exist");
+    cy.contains("Ramírez").should("not.exist");
+  });
+});
+
+// ── Tab filter behavior ────────────────────────────────────────────────────────
+
+describe("Stat cards as tabs", () => {
+  it("clicking 'Ausentes' reveals López, Sánchez and Ramírez (with 'Justificar falta'), and hides Mendoza/García", () => {
+    clickTab("absent");
+
+    cy.contains("López", { timeout: 10_000 }).should("be.visible");
+    cy.contains("Sánchez").should("be.visible");
+    cy.contains("p", "Ramírez, Ana").closest("div.rounded-xl").within(() => {
+      cy.contains("Falta").should("be.visible");
+      cy.get("[data-testid='btn-justify-absence']").should("be.visible");
+    });
+    cy.contains("Mendoza").should("not.exist");
+    cy.contains("García").should("not.exist");
+  });
+
+  it("clicking 'Total empleados' shows literally everyone, including López and Sánchez", () => {
+    clickTab("total");
+
+    cy.contains("Mendoza", { timeout: 10_000 }).should("be.visible");
+    cy.contains("García").should("be.visible");
+    cy.contains("López").should("be.visible");
+    cy.contains("Ramírez").should("be.visible");
+    cy.contains("Sánchez").should("be.visible");
+  });
+
+  it("clicking the active tab again toggles off, returning to the broad default view (VACATION/DAY_OFF hidden, ABSENCE stays)", () => {
+    // Wait for the smart default to actually resolve to "Pendientes" before
+    // toggling it off — otherwise this click can race the default-filter
+    // effect and simply set "Pendientes" instead of clearing it.
+    cy.get("[data-testid='stat-pending']", { timeout: 10_000 }).should("have.attr", "aria-pressed", "true");
+    clickTab("pending");
+
+    cy.contains("Mendoza", { timeout: 10_000 }).should("be.visible");
+    cy.contains("García").should("be.visible");
+    cy.contains("Ramírez").should("be.visible");
+    cy.contains("López").should("not.exist");
+    cy.contains("Sánchez").should("not.exist");
+  });
+
+  it("clicking 'En trabajo' shows only García", () => {
+    clickTab("checked-in");
+
+    cy.contains("García", { timeout: 10_000 }).should("be.visible");
+    cy.contains("Mendoza").should("not.exist");
+    cy.contains("Ramírez").should("not.exist");
+  });
+});
+
+// ── URL persistence ─────────────────────────────────────────────────────────────
+
+describe("Selected tab persists in the URL", () => {
+  it("reflects the smart default tab in the URL on load", () => {
+    cy.url({ timeout: 10_000 }).should("include", "tab=pending");
+  });
+
+  it("updates the URL when a different tab is clicked", () => {
+    clickTab("done");
+    cy.url().should("include", "tab=done");
+  });
+
+  it("restores the tab from the URL after a page reload", () => {
+    clickTab("absent");
+    cy.url().should("include", "tab=absent");
+
+    cy.reload();
+    cy.clock(TEST_TIME_UTC.getTime(), ["Date"]);
+
+    cy.url({ timeout: 10_000 }).should("include", "tab=absent");
+    cy.get("[data-testid='stat-absent']", { timeout: 10_000 }).should("have.attr", "aria-pressed", "true");
+    cy.contains("López", { timeout: 10_000 }).should("be.visible");
+  });
+});

--- a/code/webapp/cypress/e2e/attendance-audit-log.cy.ts
+++ b/code/webapp/cypress/e2e/attendance-audit-log.cy.ts
@@ -48,6 +48,11 @@ describe('Attendance audit log viewer', () => {
     cy.closeDevDebugger()
 
     cy.clock(TEST_TIME_UTC.getTime(), ['Date'])
+
+    // This spec isn't about the stat-card tabs — reveal every employee
+    // regardless of bucket (issue #327 made the default view land on a
+    // single bucket tab, e.g. "Pendientes").
+    cy.get("[data-testid='stat-total']", { timeout: 10_000 }).click({ force: true })
   })
 
   it('shows the reasoned check-in in the record audit history', () => {

--- a/code/webapp/cypress/e2e/attendance-checkin.cy.ts
+++ b/code/webapp/cypress/e2e/attendance-checkin.cy.ts
@@ -63,6 +63,11 @@ beforeEach(() => {
 
   // Mock Date AFTER page loads to avoid interfering with auth initialization
   cy.clock(TEST_TIME_UTC.getTime(), ["Date"]);
+
+  // This spec isn't about the stat-card tabs — reveal every employee
+  // regardless of bucket (issue #327 made the default view land on a
+  // single bucket tab, e.g. "Pendientes").
+  cy.get("[data-testid='stat-total']", { timeout: 10_000 }).click({ force: true });
 });
 
 // ── Helpers ─────────────────────────────────────────────────────────────────

--- a/code/webapp/cypress/e2e/attendance-close-day-overtime.cy.ts
+++ b/code/webapp/cypress/e2e/attendance-close-day-overtime.cy.ts
@@ -50,6 +50,11 @@ function setupBeforeEach() {
   cy.url().should("include", "/attendance", { timeout: 10_000 });
   cy.closeDevDebugger();
   cy.clock(TEST_TIME_UTC.getTime(), ["Date"]);
+
+  // This spec isn't about the stat-card tabs — reveal every employee
+  // regardless of bucket (issue #327 made the default view land on a
+  // single bucket tab, e.g. "Pendientes").
+  cy.get("[data-testid='stat-total']", { timeout: 10_000 }).click({ force: true });
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────────

--- a/code/webapp/cypress/e2e/attendance-close-day.cy.ts
+++ b/code/webapp/cypress/e2e/attendance-close-day.cy.ts
@@ -64,6 +64,11 @@ function setupBeforeEach(seederGroup: string) {
   cy.url().should("include", "/attendance", { timeout: 10_000 });
   cy.closeDevDebugger();
   cy.clock(TEST_TIME_UTC.getTime(), ["Date"]);
+
+  // This spec isn't about the stat-card tabs — reveal every employee
+  // regardless of bucket (issue #327 made the default view land on a
+  // single bucket tab, e.g. "Pendientes").
+  cy.get("[data-testid='stat-total']", { timeout: 10_000 }).click({ force: true });
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────────

--- a/code/webapp/cypress/e2e/attendance-day-status.cy.ts
+++ b/code/webapp/cypress/e2e/attendance-day-status.cy.ts
@@ -46,12 +46,20 @@ beforeEach(() => {
   cy.closeDevDebugger();
 
   cy.clock(TEST_TIME_UTC.getTime(), ["Date"]);
+
+  // This spec isn't about the stat-card tabs — reveal every employee
+  // regardless of bucket (issue #327 made the default view land on a
+  // single bucket tab, e.g. "Pendientes").
+  cy.get("[data-testid='stat-total']", { timeout: 10_000 }).click({ force: true });
 });
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 /**
- * Clicks "Marcar falta" for the given employee and confirms the dialog.
+ * Clicks "Marcar falta" for the given employee, confirms the dialog, then
+ * declines the follow-up "¿Deseas justificar la falta ahora?" prompt so the
+ * flow ends the same way it did before that prompt existed (falta marked,
+ * not yet justified).
  */
 function markFalta(lastName: string, firstName: string) {
   cy.intercept("GET", "**/attendances/today*").as("refetchAttendance");
@@ -67,6 +75,10 @@ function markFalta(lastName: string, firstName: string) {
   cy.contains("button", "Confirmar falta").click({ force: true });
 
   cy.wait("@refetchAttendance", { timeout: 10_000 });
+
+  // Decline the immediate justify-now prompt
+  cy.contains("¿Deseas justificar la falta ahora?", { timeout: 10_000 }).should("be.visible");
+  cy.contains("button", "Ahora no").click({ force: true });
 }
 
 /**
@@ -126,6 +138,42 @@ describe("Day Status — Justificar Falta", () => {
     getCard("García", "María").within(() => {
       cy.contains("Ausencia", { timeout: 10_000 }).should("be.visible");
       cy.contains("Falta").should("not.exist");
+    });
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════════
+// 3. Justificar la falta de inmediato — desde el prompt que sigue a "Confirmar falta"
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe("Day Status — Justificar de inmediato", () => {
+  it("abre el diálogo de registrar ausencia al elegir 'Justificar ahora'", () => {
+    cy.intercept("GET", "**/attendances/today*").as("refetchAttendance");
+    cy.intercept("GET", "**/leave-types*").as("leaveTypesLoad");
+    cy.intercept("POST", "**/leaves").as("registerLeave");
+
+    cy.contains("p", "López, Pedro")
+      .closest("div.rounded-xl")
+      .find("[data-testid='btn-mark-falta']")
+      .scrollIntoView()
+      .click({ force: true });
+
+    cy.contains("¿Confirmar falta?").should("be.visible");
+    cy.contains("button", "Confirmar falta").click({ force: true });
+    cy.wait("@refetchAttendance", { timeout: 10_000 });
+
+    cy.contains("¿Deseas justificar la falta ahora?", { timeout: 10_000 }).should("be.visible");
+    cy.contains("button", "Justificar ahora").click({ force: true });
+
+    cy.contains("h3", "Registrar ausencia", { timeout: 6_000 }).should("be.visible");
+    cy.wait("@leaveTypesLoad");
+    cy.get("dialog select").first().select("Incapacidad médica");
+    cy.get("dialog").contains("button", "Registrar ausencia").click({ force: true });
+
+    cy.wait("@registerLeave").its("response.statusCode").should("eq", 201);
+
+    getCard("López", "Pedro").within(() => {
+      cy.contains("Ausencia", { timeout: 10_000 }).should("be.visible");
     });
   });
 });

--- a/code/webapp/cypress/e2e/attendance-extra-day-express.cy.ts
+++ b/code/webapp/cypress/e2e/attendance-extra-day-express.cy.ts
@@ -56,6 +56,11 @@ beforeEach(() => {
 
   // Mock Date after page loads
   cy.clock(TEST_TIME_UTC.getTime(), ["Date"]);
+
+  // This spec isn't about the stat-card tabs — reveal every employee
+  // regardless of bucket (issue #327 made the default view land on a
+  // single bucket tab, e.g. "Pendientes").
+  cy.get("[data-testid='stat-total']", { timeout: 10_000 }).click({ force: true });
 });
 
 // ── Helpers ─────────────────────────────────────────────────────────────────

--- a/code/webapp/cypress/e2e/attendance-lunch-return.cy.ts
+++ b/code/webapp/cypress/e2e/attendance-lunch-return.cy.ts
@@ -55,6 +55,11 @@ beforeEach(() => {
 
   // Mock Date AFTER page loads to avoid interfering with auth initialization
   cy.clock(TEST_TIME_UTC.getTime(), ["Date"]);
+
+  // This spec isn't about the stat-card tabs — reveal every employee
+  // regardless of bucket (issue #327 made the default view land on a
+  // single bucket tab, e.g. "Pendientes").
+  cy.get("[data-testid='stat-total']", { timeout: 10_000 }).click({ force: true });
 });
 
 // ── Helpers ─────────────────────────────────────────────────────────────────

--- a/code/webapp/cypress/e2e/attendance-lunch-start.cy.ts
+++ b/code/webapp/cypress/e2e/attendance-lunch-start.cy.ts
@@ -55,6 +55,11 @@ beforeEach(() => {
   // Mock Date for dialogs — the dialogs use Date.now() for default time
   // but formatTime() uses new Date(iso) which cy.clock breaks
   cy.clock(TEST_TIME_UTC.getTime(), ["Date"]);
+
+  // This spec isn't about the stat-card tabs — reveal every employee
+  // regardless of bucket (issue #327 made the default view land on a
+  // single bucket tab, e.g. "Pendientes").
+  cy.get("[data-testid='stat-total']", { timeout: 10_000 }).click({ force: true });
 });
 
 // ── Helpers ─────────────────────────────────────────────────────────────────

--- a/code/webapp/cypress/e2e/attendance-overtime-decision.cy.ts
+++ b/code/webapp/cypress/e2e/attendance-overtime-decision.cy.ts
@@ -56,6 +56,11 @@ beforeEach(() => {
   cy.closeDevDebugger();
 
   cy.clock(TEST_TIME_UTC.getTime(), ["Date"]);
+
+  // This spec isn't about the stat-card tabs — reveal every employee
+  // regardless of bucket (issue #327 made the default view land on a
+  // single bucket tab, e.g. "Pendientes").
+  cy.get("[data-testid='stat-total']", { timeout: 10_000 }).click({ force: true });
 });
 
 // ── Helpers ──────────────────────────────────────────────────────────────────

--- a/code/webapp/cypress/e2e/attendance-register-leave.cy.ts
+++ b/code/webapp/cypress/e2e/attendance-register-leave.cy.ts
@@ -43,6 +43,11 @@ beforeEach(() => {
   cy.closeDevDebugger()
 
   cy.clock(TEST_TIME_UTC.getTime(), ['Date'])
+
+  // This spec isn't about the stat-card tabs — reveal every employee
+  // regardless of bucket (issue #327 made the default view land on a
+  // single bucket tab, e.g. "Pendientes").
+  cy.get("[data-testid='stat-total']", { timeout: 10_000 }).click({ force: true })
 })
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -100,6 +105,10 @@ function registerMedicalAbsence(firstName: string, lastName: string) {
   cy.url().should('include', '/attendance', { timeout: 10_000 })
   cy.closeDevDebugger()
   cy.wait('@refetchAttendance', { timeout: 10_000 })
+
+  // Fresh visit re-resolves the smart default tab — reveal every employee
+  // regardless of bucket so the card under test is visible (issue #327).
+  cy.get("[data-testid='stat-total']", { timeout: 10_000 }).click({ force: true })
 }
 
 // ══════════════════════════════════════════════════════════════════════════════
@@ -149,6 +158,10 @@ describe('Register Leave — cancel closes dialog without changes', () => {
     cy.visitWithAuth('/attendance')
     cy.url().should('include', '/attendance', { timeout: 10_000 })
     cy.closeDevDebugger()
+
+    // Fresh visit re-resolves the smart default tab — reveal every employee
+    // regardless of bucket so the card under test is visible (issue #327).
+    cy.get("[data-testid='stat-total']", { timeout: 10_000 }).click({ force: true })
 
     getCard('García', 'María').within(() => {
       cy.contains('Sin registro').should('be.visible')

--- a/code/webapp/cypress/e2e/attendance-today-leave-context.cy.ts
+++ b/code/webapp/cypress/e2e/attendance-today-leave-context.cy.ts
@@ -42,6 +42,11 @@ beforeEach(() => {
   cy.closeDevDebugger()
 
   cy.clock(TEST_TIME_UTC.getTime(), ['Date'])
+
+  // This spec isn't about the stat-card tabs — reveal every employee
+  // regardless of bucket (issue #327 made the default view land on a
+  // single bucket tab, e.g. "Pendientes").
+  cy.get("[data-testid='stat-total']", { timeout: 10_000 }).click({ force: true })
 })
 
 // ── Helpers ──────────────────────────────────────────────────────────────────

--- a/code/webapp/src/components/attendance/AttendanceStates.tsx
+++ b/code/webapp/src/components/attendance/AttendanceStates.tsx
@@ -1,4 +1,5 @@
-import { Users, XCircle, AlertTriangle } from 'lucide-react'
+import { Users, XCircle, AlertTriangle, FilterX } from 'lucide-react'
+import { Button } from '@/components/ui/button'
 
 // ── Empty State ────────────────────────────────────────────────────────────────
 
@@ -10,6 +11,28 @@ export function EmptyState() {
             <p className="text-sm text-muted-foreground">
                 No hay empleados activos registrados en esta sucursal.
             </p>
+        </div>
+    )
+}
+
+// ── No Matches For Filter State ───────────────────────────────────────────────
+
+interface NoMatchesForFilterStateProps {
+    onShowAll: () => void
+}
+
+/** Shown when a stat-card filter (e.g. "Ausentes") narrows the grid to zero rows, even though employees exist. */
+export function NoMatchesForFilterState({ onShowAll }: Readonly<NoMatchesForFilterStateProps>) {
+    return (
+        <div className="flex flex-col items-center justify-center py-24 text-center gap-3">
+            <FilterX className="h-10 w-10 text-muted-foreground" />
+            <p className="text-lg font-medium text-foreground">Sin resultados para este filtro</p>
+            <p className="text-sm text-muted-foreground">
+                Ningún empleado coincide con la vista seleccionada.
+            </p>
+            <Button size="sm" variant="neutral" onClick={onShowAll}>
+                Ver todos
+            </Button>
         </div>
     )
 }

--- a/code/webapp/src/components/attendance/AttendanceSummaryBar.tsx
+++ b/code/webapp/src/components/attendance/AttendanceSummaryBar.tsx
@@ -1,4 +1,4 @@
-import { Clock, CheckCircle2, XCircle, AlertTriangle, Users } from 'lucide-react'
+import { Clock, CheckCircle2, XCircle, AlertTriangle, Users, UserX } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 // ── Types ──────────────────────────────────────────────────────────────────────
@@ -8,8 +8,12 @@ export interface AttendanceSummary {
     pending: number
     checkedIn: number
     done: number
+    absent: number
     withOvertime: number
 }
+
+/** Which stat tab is filtering the main grid — `null` means no tab is active (default view). */
+export type AttendanceFilter = 'total' | 'pending' | 'checkedIn' | 'done' | 'absent'
 
 // ── Sub-components ─────────────────────────────────────────────────────────────
 
@@ -18,17 +22,30 @@ interface SummaryStatProps {
     value: number
     icon: React.ReactNode
     colorClass: string
+    active?: boolean
+    onClick?: () => void
+    testId?: string
 }
 
-export function SummaryStat({ label, value, icon, colorClass }: Readonly<SummaryStatProps>) {
+export function SummaryStat({ label, value, icon, colorClass, active = false, onClick, testId }: Readonly<SummaryStatProps>) {
     return (
-        <div className="flex items-center gap-3 px-4 py-3 rounded-xl border bg-card">
+        <button
+            type="button"
+            data-testid={testId}
+            onClick={onClick}
+            aria-pressed={active}
+            className={cn(
+                'flex items-center gap-3 px-4 py-3 rounded-xl border bg-card text-left transition-colors',
+                'hover:bg-muted/50',
+                active && 'ring-2 ring-primary bg-muted/50'
+            )}
+        >
             <div className={cn('shrink-0', colorClass)}>{icon}</div>
             <div>
                 <p className={cn('text-2xl font-bold leading-none', colorClass)}>{value}</p>
                 <p className="text-xs text-muted-foreground mt-0.5">{label}</p>
             </div>
-        </div>
+        </button>
     )
 }
 
@@ -40,7 +57,7 @@ export function OvertimeWarning({ count }: Readonly<OvertimeWarningProps>) {
     if (count === 0) return null
 
     return (
-        <div className="col-span-2 sm:col-span-4">
+        <div className="col-span-3 sm:col-span-5">
             <div className="flex items-center gap-2 px-4 py-2 rounded-lg bg-yellow-50 dark:bg-yellow-950/30 border border-yellow-200 dark:border-yellow-800">
                 <AlertTriangle className="h-4 w-4 text-yellow-600 dark:text-yellow-400 shrink-0" />
                 <p className="text-sm text-yellow-800 dark:text-yellow-300">
@@ -57,34 +74,57 @@ export function OvertimeWarning({ count }: Readonly<OvertimeWarningProps>) {
 
 export interface AttendanceSummaryBarProps {
     summary: AttendanceSummary
+    activeFilter?: AttendanceFilter | null
+    onFilterChange?: (filter: AttendanceFilter) => void
 }
 
-export function AttendanceSummaryBar({ summary }: Readonly<AttendanceSummaryBarProps>) {
+export function AttendanceSummaryBar({ summary, activeFilter = null, onFilterChange }: Readonly<AttendanceSummaryBarProps>) {
     return (
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <div className="grid grid-cols-3 sm:grid-cols-5 gap-3">
             <SummaryStat
                 label="Total empleados"
                 value={summary.total}
                 icon={<Users className="h-4 w-4" />}
                 colorClass="text-foreground"
+                active={activeFilter === 'total'}
+                onClick={() => onFilterChange?.('total')}
+                testId="stat-total"
             />
             <SummaryStat
                 label="Pendientes"
                 value={summary.pending}
                 icon={<XCircle className="h-4 w-4" />}
                 colorClass="text-muted-foreground"
+                active={activeFilter === 'pending'}
+                onClick={() => onFilterChange?.('pending')}
+                testId="stat-pending"
             />
             <SummaryStat
                 label="En trabajo"
                 value={summary.checkedIn}
                 icon={<Clock className="h-4 w-4" />}
                 colorClass="text-blue-600 dark:text-blue-400"
+                active={activeFilter === 'checkedIn'}
+                onClick={() => onFilterChange?.('checkedIn')}
+                testId="stat-checked-in"
             />
             <SummaryStat
                 label="Completados"
                 value={summary.done}
                 icon={<CheckCircle2 className="h-4 w-4" />}
                 colorClass="text-green-600 dark:text-green-400"
+                active={activeFilter === 'done'}
+                onClick={() => onFilterChange?.('done')}
+                testId="stat-done"
+            />
+            <SummaryStat
+                label="Ausentes"
+                value={summary.absent}
+                icon={<UserX className="h-4 w-4" />}
+                colorClass="text-red-600 dark:text-red-400"
+                active={activeFilter === 'absent'}
+                onClick={() => onFilterChange?.('absent')}
+                testId="stat-absent"
             />
             <OvertimeWarning count={summary.withOvertime} />
         </div>

--- a/code/webapp/src/components/attendance/EmployeeAttendanceCard.tsx
+++ b/code/webapp/src/components/attendance/EmployeeAttendanceCard.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import {
     UtensilsCrossed,
     AlertTriangle,
@@ -20,7 +19,7 @@ import { Button } from '@/components/ui/button'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { cn } from '@/lib/utils'
 import { formatLastFirst } from '@/lib/format'
-import { getAttendancePhase, formatTime, formatSeconds, parseIsoToUtcMs } from '@/types/attendance'
+import { formatTime, formatSeconds, parseIsoToUtcMs } from '@/types/attendance'
 import type {
     TodayAttendanceRow,
     AttendancePhase,
@@ -29,6 +28,7 @@ import type {
 } from '@/types/attendance'
 import { getPhaseCardClass } from './attendance-helpers'
 import { RegisterLeaveDialog } from './RegisterLeaveDialog'
+import { useEmployeeAttendanceCard } from './use-employee-attendance-card'
 
 // ── Sub-components ─────────────────────────────────────────────────────���───────
 
@@ -246,6 +246,11 @@ export interface EmployeeAttendanceCardProps {
     onMarkDayStatus: (employee: TodayAttendanceEmployee, status: 'ABSENCE') => void
     onWeeklySummary?: (employee: TodayAttendanceEmployee) => void
     onViewAudit?: (employee: TodayAttendanceEmployee, attendanceId: string) => void
+    /** Called once the mark-falta flow concludes (justified now or declined), so the
+     *  parent can play an exit animation before the card leaves the current tab. */
+    onFaltaFlowComplete?: (employeeId: string) => void
+    /** True while the card is playing its exit animation before leaving the grid. */
+    isExiting?: boolean
     canEdit?: boolean
 }
 
@@ -259,16 +264,29 @@ export function EmployeeAttendanceCard({
     onMarkDayStatus,
     onWeeklySummary,
     onViewAudit,
+    onFaltaFlowComplete,
+    isExiting = false,
     canEdit = true,
 }: Readonly<EmployeeAttendanceCardProps>) {
-    const phase = getAttendancePhase(row.attendance)
     const att = row.attendance
     const leave = row.today_leave
-    const [confirmFaltaOpen, setConfirmFaltaOpen] = useState(false)
-    const [showJustifyDialog, setShowJustifyDialog] = useState(false)
-
-    const isScheduledRestDay = row.schedule?.is_day_off === true
-    const isFullDayLeave = leave?.time_mode === 'OPEN_ENDED'
+    const {
+        phase,
+        isScheduledRestDay,
+        isFullDayLeave,
+        displayedActionsPhase,
+        actionsFadingOut,
+        confirmFaltaOpen,
+        openConfirmFalta,
+        closeConfirmFalta,
+        confirmFalta,
+        askJustifyOpen,
+        declineJustifyNow,
+        acceptJustifyNow,
+        showJustifyDialog,
+        openJustifyDialog,
+        closeJustifyDialog,
+    } = useEmployeeAttendanceCard(row, onMarkDayStatus, onFaltaFlowComplete)
 
     function renderPendingActions() {
         if (isFullDayLeave) {
@@ -298,7 +316,7 @@ export function EmployeeAttendanceCard({
                         variant="outline-danger"
                         className="w-full"
                         data-testid="btn-mark-falta"
-                        onClick={() => setConfirmFaltaOpen(true)}
+                        onClick={openConfirmFalta}
                     >
                         <UserX className="h-3.5 w-3.5 mr-1.5" />
                         Marcar falta
@@ -312,7 +330,8 @@ export function EmployeeAttendanceCard({
         <div
             className={cn(
                 'rounded-xl border bg-card p-4 flex flex-col gap-3 transition-colors',
-                getPhaseCardClass(phase)
+                getPhaseCardClass(phase),
+                isExiting && 'animate-card-exit pointer-events-none'
             )}
         >
             {/* Header: Name + Phase Badge + Weekly Summary */}
@@ -390,22 +409,22 @@ export function EmployeeAttendanceCard({
             )}
 
             {/* Actions for pending employees */}
-            {canEdit && phase === 'pending' && (
-                <div className="flex flex-col gap-1.5 mt-auto">
+            {canEdit && displayedActionsPhase === 'pending' && (
+                <div className={cn('flex flex-col gap-1.5 mt-auto', actionsFadingOut && 'animate-fade-out pointer-events-none')}>
                     {renderPendingActions()}
                 </div>
             )}
 
             {/* Justify an already-marked falta — registers a direct leave for today,
                 which overwrites the ABSENCE attendance record with the chosen type. */}
-            {canEdit && phase === 'absence' && (
-                <div className="flex flex-col gap-1.5 mt-auto">
+            {canEdit && displayedActionsPhase === 'absence' && (
+                <div className={cn('flex flex-col gap-1.5 mt-auto', !actionsFadingOut && 'animate-fade-in')}>
                     <Button
                         size="sm"
                         variant="outline"
                         className="w-full"
                         data-testid="btn-justify-absence"
-                        onClick={() => setShowJustifyDialog(true)}
+                        onClick={openJustifyDialog}
                     >
                         <CalendarX className="h-3.5 w-3.5 mr-1.5" />
                         Justificar falta
@@ -416,11 +435,8 @@ export function EmployeeAttendanceCard({
             {/* Confirm-falta dialog */}
             <ConfirmDialog
                 isOpen={confirmFaltaOpen}
-                onClose={() => setConfirmFaltaOpen(false)}
-                onConfirm={() => {
-                    setConfirmFaltaOpen(false)
-                    onMarkDayStatus(row.employee, 'ABSENCE')
-                }}
+                onClose={closeConfirmFalta}
+                onConfirm={confirmFalta}
                 title="¿Confirmar falta?"
                 description={`${formatLastFirst(row.employee.user)} no tiene registro de entrada. ¿Confirmar que faltó hoy?`}
                 confirmLabel="Confirmar falta"
@@ -428,11 +444,24 @@ export function EmployeeAttendanceCard({
                 container="viewport"
             />
 
+            {/* Ask whether to justify the falta right away */}
+            <ConfirmDialog
+                isOpen={askJustifyOpen}
+                onClose={declineJustifyNow}
+                onConfirm={acceptJustifyNow}
+                title="¿Deseas justificar la falta ahora?"
+                description="Puedes registrar el motivo de la ausencia ahora, o hacerlo después desde la pestaña Ausentes."
+                confirmLabel="Justificar ahora"
+                cancelLabel="Ahora no"
+                variant="info"
+                container="viewport"
+            />
+
             {/* Justify-falta dialog — direct leave registration (not a request) */}
             <RegisterLeaveDialog
                 isOpen={showJustifyDialog}
                 employee={row.employee}
-                onClose={() => setShowJustifyDialog(false)}
+                onClose={closeJustifyDialog}
             />
 
             {/* Lunch-start action — only for checked-in employees */}

--- a/code/webapp/src/components/attendance/RegisterLeaveDialog.tsx
+++ b/code/webapp/src/components/attendance/RegisterLeaveDialog.tsx
@@ -1,21 +1,12 @@
 import { Loader2, X } from 'lucide-react'
 import { createPortal } from 'react-dom'
-import { useEffect, useRef, useState } from 'react'
+import { useRef } from 'react'
 import { Button } from '@/components/ui/button'
 import { FormField, Select, Textarea } from '@/components/ui/form-fields'
 import { formatLastFirst } from '@/lib/format'
+import { useDialogTransition } from '@/components/ui/use-dialog-transition'
 import { useRegisterLeaveDialog } from './use-register-leave-dialog'
 import type { TodayAttendanceEmployee } from '@/types/attendance'
-
-function getAnimationClass(
-  state: 'enter' | 'exit' | null,
-  enterClass: string,
-  exitClass: string,
-): string {
-  if (state === 'enter') return enterClass
-  if (state === 'exit') return exitClass
-  return ''
-}
 
 // ── Props ───────────────────────────────────────────────────────────────────────
 
@@ -32,8 +23,6 @@ export function RegisterLeaveDialog({
   employee,
   onClose,
 }: Readonly<RegisterLeaveDialogProps>) {
-  const [visible, setVisible] = useState(false)
-  const [animating, setAnimating] = useState<'enter' | 'exit' | null>(null)
   const dialogRef = useRef<HTMLDialogElement>(null)
 
   const {
@@ -52,37 +41,12 @@ export function RegisterLeaveDialog({
 
   const { register, formState: { errors } } = form
 
-  // Animation
-  useEffect(() => {
-    if (isOpen) {
-      setVisible(true)
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => setAnimating('enter'))
-      })
-    } else if (visible) {
-      setAnimating('exit')
-      const timer = setTimeout(() => {
-        setVisible(false)
-        setAnimating(null)
-        handleClose()
-      }, 200)
-      return () => clearTimeout(timer)
-    }
-  }, [isOpen, visible, handleClose])
-
-  // Escape key
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && isOpen && !isPending) onClose()
-    }
-    document.addEventListener('keydown', onKey)
-    return () => document.removeEventListener('keydown', onKey)
-  }, [isOpen, isPending, onClose])
+  const { visible, backdropCls: backdropAnim, panelCls: panelAnim } = useDialogTransition(isOpen, {
+    onEscape: () => { if (!isPending) onClose() },
+    onExitComplete: handleClose,
+  })
 
   if (!visible) return null
-
-  const backdropAnim = getAnimationClass(animating, 'animate-dialog-backdrop-in', 'animate-dialog-backdrop-out')
-  const panelAnim = getAnimationClass(animating, 'animate-dialog-in', 'animate-dialog-out')
 
   const employeeName = formatLastFirst(employee?.user)
 

--- a/code/webapp/src/components/attendance/__tests__/AttendanceStates.test.tsx
+++ b/code/webapp/src/components/attendance/__tests__/AttendanceStates.test.tsx
@@ -1,12 +1,13 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, afterEach } from 'vitest'
-import { render, cleanup } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup, fireEvent } from '@testing-library/react'
 import {
     EmptyState,
     ErrorState,
     NoBranchState,
+    NoMatchesForFilterState,
     SkeletonGrid,
 } from '../AttendanceStates'
 
@@ -68,6 +69,26 @@ describe('NoBranchState', () => {
         const { container } = render(<NoBranchState />)
 
         expect(container.innerHTML).toContain('text-yellow-500')
+    })
+})
+
+// ── NoMatchesForFilterState Tests ─────────────────────────────────────────────
+
+describe('NoMatchesForFilterState', () => {
+    it('renders the no-results message', () => {
+        const { getByText } = render(<NoMatchesForFilterState onShowAll={() => {}} />)
+
+        expect(getByText('Sin resultados para este filtro')).toBeDefined()
+        expect(getByText('Ningún empleado coincide con la vista seleccionada.')).toBeDefined()
+    })
+
+    it('calls onShowAll when the "Ver todos" button is clicked', () => {
+        const onShowAll = vi.fn()
+        const { getByText } = render(<NoMatchesForFilterState onShowAll={onShowAll} />)
+
+        fireEvent.click(getByText('Ver todos'))
+
+        expect(onShowAll).toHaveBeenCalledTimes(1)
     })
 })
 

--- a/code/webapp/src/components/attendance/__tests__/AttendanceSummaryBar.test.tsx
+++ b/code/webapp/src/components/attendance/__tests__/AttendanceSummaryBar.test.tsx
@@ -1,15 +1,15 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, afterEach } from 'vitest'
-import { render, cleanup } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup, fireEvent } from '@testing-library/react'
 import { Users } from 'lucide-react'
 import {
     AttendanceSummaryBar,
     SummaryStat,
     OvertimeWarning,
 } from '../AttendanceSummaryBar'
-import type { AttendanceSummary } from '../AttendanceSummaryBar'
+import type { AttendanceSummary, AttendanceFilter } from '../AttendanceSummaryBar'
 
 afterEach(() => {
     cleanup()
@@ -56,6 +56,36 @@ describe('SummaryStat', () => {
         )
         expect(getByText('0')).toBeDefined()
     })
+
+    it('calls onClick when clicked', () => {
+        const onClick = vi.fn()
+        const { getByRole } = render(
+            <SummaryStat
+                label="Pendientes"
+                value={5}
+                icon={<Users className="h-4 w-4" />}
+                colorClass="text-yellow-600"
+                onClick={onClick}
+            />
+        )
+
+        fireEvent.click(getByRole('button'))
+        expect(onClick).toHaveBeenCalledOnce()
+    })
+
+    it('reflects active state via aria-pressed', () => {
+        const { getByRole } = render(
+            <SummaryStat
+                label="Pendientes"
+                value={5}
+                icon={<Users className="h-4 w-4" />}
+                colorClass="text-yellow-600"
+                active
+            />
+        )
+
+        expect(getByRole('button').getAttribute('aria-pressed')).toBe('true')
+    })
 })
 
 // ── OvertimeWarning Tests ──────────────────────────────────────────────────────
@@ -96,6 +126,7 @@ describe('AttendanceSummaryBar', () => {
         pending: 3,
         checkedIn: 4,
         done: 2,
+        absent: 1,
         withOvertime: 1,
     }
 
@@ -125,6 +156,54 @@ describe('AttendanceSummaryBar', () => {
 
         expect(getByText('Completados')).toBeDefined()
         expect(getByText('2')).toBeDefined()
+    })
+
+    it('renders absent count', () => {
+        const { getByText } = render(<AttendanceSummaryBar summary={defaultSummary} />)
+
+        const label = getByText('Ausentes')
+        expect(label).toBeDefined()
+        const value = label.parentElement?.querySelector('p')
+        expect(value?.textContent).toBe('1')
+    })
+
+    it('applies grid-cols-3 sm:grid-cols-5 so 5 cards fit evenly', () => {
+        const { container } = render(<AttendanceSummaryBar summary={defaultSummary} />)
+
+        const grid = container.firstChild as HTMLElement
+        expect(grid?.className).toContain('grid-cols-3')
+        expect(grid?.className).toContain('sm:grid-cols-5')
+    })
+
+    it.each<[string, AttendanceFilter]>([
+        ['Total empleados', 'total'],
+        ['Pendientes', 'pending'],
+        ['En trabajo', 'checkedIn'],
+        ['Completados', 'done'],
+        ['Ausentes', 'absent'],
+    ])('clicking "%s" calls onFilterChange with "%s"', (label, filter) => {
+        const onFilterChange = vi.fn()
+        const { getByText } = render(
+            <AttendanceSummaryBar summary={defaultSummary} onFilterChange={onFilterChange} />
+        )
+
+        fireEvent.click(getByText(label))
+        expect(onFilterChange).toHaveBeenCalledWith(filter)
+    })
+
+    it('marks the active tab as pressed and the rest as not pressed', () => {
+        const { getByText } = render(
+            <AttendanceSummaryBar summary={defaultSummary} activeFilter="absent" />
+        )
+
+        expect(getByText('Ausentes').closest('button')?.getAttribute('aria-pressed')).toBe('true')
+        expect(getByText('Pendientes').closest('button')?.getAttribute('aria-pressed')).toBe('false')
+    })
+
+    it('has no active tab when activeFilter is not provided', () => {
+        const { getByText } = render(<AttendanceSummaryBar summary={defaultSummary} />)
+
+        expect(getByText('Total empleados').closest('button')?.getAttribute('aria-pressed')).toBe('false')
     })
 
     it('renders overtime warning when employees have overtime', () => {
@@ -157,12 +236,13 @@ describe('AttendanceSummaryBar', () => {
             pending: 0,
             checkedIn: 0,
             done: 0,
+            absent: 0,
             withOvertime: 0,
         }
         const { getAllByText } = render(<AttendanceSummaryBar summary={zeroSummary} />)
 
         // All zero values should be rendered
         const zeros = getAllByText('0')
-        expect(zeros.length).toBeGreaterThanOrEqual(4)
+        expect(zeros.length).toBeGreaterThanOrEqual(5)
     })
 })

--- a/code/webapp/src/components/attendance/__tests__/EmployeeAttendanceCard.test.tsx
+++ b/code/webapp/src/components/attendance/__tests__/EmployeeAttendanceCard.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { render, cleanup, fireEvent } from '@testing-library/react'
+import { render, cleanup, fireEvent, act } from '@testing-library/react'
 import type { TodayAttendanceEmployee } from '@/types/attendance'
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
@@ -29,6 +29,7 @@ import type { TodayAttendanceRow, TodayAttendanceData, TodayScheduleDay, TodayLe
 afterEach(() => {
     cleanup()
     mockRegisterLeaveDialog.mockClear()
+    vi.useRealTimers()
 })
 
 // ── Fixtures ───────────────────────────────────────────────────────────────────
@@ -381,6 +382,102 @@ describe('EmployeeAttendanceCard', () => {
         expect(onMarkDayStatus).not.toHaveBeenCalled()
     })
 
+    it('asks whether to justify the falta right after confirming it', () => {
+        const { getByTestId, getByText } = render(<EmployeeAttendanceCard {...defaultProps} />)
+
+        fireEvent.click(getByTestId('btn-mark-falta'))
+        fireEvent.click(getByText('Confirmar falta'))
+
+        expect(getByText('¿Deseas justificar la falta ahora?')).toBeDefined()
+    })
+
+    it('opens RegisterLeaveDialog when choosing to justify the falta right away', () => {
+        const { getByTestId, getByText } = render(<EmployeeAttendanceCard {...defaultProps} />)
+
+        fireEvent.click(getByTestId('btn-mark-falta'))
+        fireEvent.click(getByText('Confirmar falta'))
+        fireEvent.click(getByText('Justificar ahora'))
+
+        expect(mockRegisterLeaveDialog).toHaveBeenLastCalledWith(
+            expect.objectContaining({ isOpen: true, employee: mockRow.employee })
+        )
+    })
+
+    it('calls onFaltaFlowComplete when declining to justify the falta right away', () => {
+        const onFaltaFlowComplete = vi.fn()
+        const { getByTestId, getByText } = render(
+            <EmployeeAttendanceCard {...defaultProps} onFaltaFlowComplete={onFaltaFlowComplete} />
+        )
+
+        fireEvent.click(getByTestId('btn-mark-falta'))
+        fireEvent.click(getByText('Confirmar falta'))
+        fireEvent.click(getByText('Ahora no'))
+
+        expect(onFaltaFlowComplete).toHaveBeenCalledWith(mockRow.employee.id)
+    })
+
+    it('calls onFaltaFlowComplete when RegisterLeaveDialog closes', () => {
+        const onFaltaFlowComplete = vi.fn()
+        const { getByTestId, getByText } = render(
+            <EmployeeAttendanceCard {...defaultProps} onFaltaFlowComplete={onFaltaFlowComplete} />
+        )
+
+        fireEvent.click(getByTestId('btn-mark-falta'))
+        fireEvent.click(getByText('Confirmar falta'))
+        fireEvent.click(getByText('Justificar ahora'))
+
+        const calls = mockRegisterLeaveDialog.mock.calls
+        const lastCall = calls[calls.length - 1]
+        if (!lastCall) throw new Error('RegisterLeaveDialog was not called')
+        lastCall[0].onClose()
+
+        expect(onFaltaFlowComplete).toHaveBeenCalledWith(mockRow.employee.id)
+    })
+
+    it('crossfades: pending actions fade out and "Justificar falta" fades in when the row turns ABSENCE', () => {
+        vi.useFakeTimers()
+
+        const { getByTestId, queryByTestId, rerender } = render(
+            <EmployeeAttendanceCard {...defaultProps} row={mockRow} />
+        )
+
+        expect(getByTestId('btn-mark-falta')).toBeDefined()
+
+        const absenceRow: TodayAttendanceRow = {
+            employee: mockRow.employee,
+            attendance: makeAttendance({ id: '01HZATTEND000010', check_in: null, day_status: 'ABSENCE' }),
+            schedule: null,
+            today_leave: null,
+        }
+        rerender(<EmployeeAttendanceCard {...defaultProps} row={absenceRow} />)
+
+        // Still showing the old pending buttons, now fading out — not yet swapped
+        const fadingOutContainer = getByTestId('btn-mark-falta').parentElement as HTMLElement
+        expect(fadingOutContainer.className).toContain('animate-fade-out')
+        expect(queryByTestId('btn-justify-absence')).toBeNull()
+
+        act(() => {
+            vi.advanceTimersByTime(200)
+        })
+
+        // Swapped to the justify button, fading in
+        expect(queryByTestId('btn-mark-falta')).toBeNull()
+        const fadedInContainer = getByTestId('btn-justify-absence').parentElement as HTMLElement
+        expect(fadedInContainer.className).toContain('animate-fade-in')
+    })
+
+    it('does not crossfade for a direct initial ABSENCE render (no prior pending state)', () => {
+        const absenceRow: TodayAttendanceRow = {
+            employee: mockRow.employee,
+            attendance: makeAttendance({ id: '01HZATTEND000011', check_in: null, day_status: 'ABSENCE' }),
+            schedule: null,
+            today_leave: null,
+        }
+        const { getByTestId } = render(<EmployeeAttendanceCard {...defaultProps} row={absenceRow} />)
+
+        expect(getByTestId('btn-justify-absence')).toBeDefined()
+    })
+
     it('renders "Justificar falta" button when day_status is ABSENCE', () => {
         const absenceRow: TodayAttendanceRow = {
             employee: mockRow.employee,
@@ -606,6 +703,19 @@ describe('EmployeeAttendanceCard', () => {
             <EmployeeAttendanceCard {...defaultProps} row={pendingRow} canEdit={false} />
         )
         expect(getByText(/pendiente autorización/)).toBeDefined()
+    })
+
+    it('applies the exit animation class when isExiting is true', () => {
+        const { container } = render(<EmployeeAttendanceCard {...defaultProps} isExiting />)
+        const root = container.firstChild as HTMLElement
+        expect(root.className).toContain('animate-card-exit')
+        expect(root.className).toContain('pointer-events-none')
+    })
+
+    it('does not apply the exit animation class by default', () => {
+        const { container } = render(<EmployeeAttendanceCard {...defaultProps} />)
+        const root = container.firstChild as HTMLElement
+        expect(root.className).not.toContain('animate-card-exit')
     })
 })
 

--- a/code/webapp/src/components/attendance/index.ts
+++ b/code/webapp/src/components/attendance/index.ts
@@ -28,9 +28,9 @@ export type { OvertimeDecisionDialogProps } from './OvertimeDecisionDialog'
 export { getPhaseCardClass } from './attendance-helpers'
 
 export { AttendanceSummaryBar, SummaryStat, OvertimeWarning } from './AttendanceSummaryBar'
-export type { AttendanceSummaryBarProps, AttendanceSummary } from './AttendanceSummaryBar'
+export type { AttendanceSummaryBarProps, AttendanceSummary, AttendanceFilter } from './AttendanceSummaryBar'
 
-export { EmptyState, ErrorState, NoBranchState, SkeletonGrid } from './AttendanceStates'
+export { EmptyState, ErrorState, NoBranchState, NoMatchesForFilterState, SkeletonGrid } from './AttendanceStates'
 
 // Pay Period Status Badge
 export { PayPeriodStatusBadge } from './PayPeriodStatusBadge'

--- a/code/webapp/src/components/attendance/use-employee-attendance-card.ts
+++ b/code/webapp/src/components/attendance/use-employee-attendance-card.ts
@@ -1,0 +1,103 @@
+import { useState, useEffect, useRef } from 'react'
+import { getAttendancePhase } from '@/types/attendance'
+import type { AttendancePhase, TodayAttendanceEmployee, TodayAttendanceRow } from '@/types/attendance'
+
+export interface EmployeeAttendanceCardState {
+  phase: AttendancePhase
+  isScheduledRestDay: boolean
+  isFullDayLeave: boolean
+  // Crossfade of the pending (Registrar entrada/Marcar falta) vs. "Justificar
+  // falta" actions — which phase's actions are currently rendered, and
+  // whether they're mid fade-out (see displayedActionsPhase in the effect below).
+  displayedActionsPhase: AttendancePhase
+  actionsFadingOut: boolean
+  // Confirm-falta dialog
+  confirmFaltaOpen: boolean
+  openConfirmFalta: () => void
+  closeConfirmFalta: () => void
+  confirmFalta: () => void
+  // Ask-justify-now dialog
+  askJustifyOpen: boolean
+  declineJustifyNow: () => void
+  acceptJustifyNow: () => void
+  // Justify (RegisterLeaveDialog)
+  showJustifyDialog: boolean
+  openJustifyDialog: () => void
+  closeJustifyDialog: () => void
+}
+
+/**
+ * Owns all state and phase-transition logic for a single EmployeeAttendanceCard:
+ * the mark-falta → ask-justify-now? → justify-dialog flow, and the crossfade
+ * between the pending actions and the "Justificar falta" button.
+ */
+export function useEmployeeAttendanceCard(
+  row: TodayAttendanceRow,
+  onMarkDayStatus: (employee: TodayAttendanceEmployee, status: 'ABSENCE') => void,
+  onFaltaFlowComplete?: (employeeId: string) => void,
+): EmployeeAttendanceCardState {
+  const phase = getAttendancePhase(row.attendance)
+  const isScheduledRestDay = row.schedule?.is_day_off === true
+  const isFullDayLeave = row.today_leave?.time_mode === 'OPEN_ENDED'
+
+  const [confirmFaltaOpen, setConfirmFaltaOpen] = useState(false)
+  const [askJustifyOpen, setAskJustifyOpen] = useState(false)
+  const [showJustifyDialog, setShowJustifyDialog] = useState(false)
+
+  const [displayedActionsPhase, setDisplayedActionsPhase] = useState(phase)
+  const [actionsFadingOut, setActionsFadingOut] = useState(false)
+  const actionsFadeTimer = useRef<ReturnType<typeof setTimeout>>(undefined)
+
+  useEffect(() => {
+    if (phase === displayedActionsPhase) return
+
+    const isPendingAbsenceSwap =
+      (displayedActionsPhase === 'pending' && phase === 'absence') ||
+      (displayedActionsPhase === 'absence' && phase === 'pending')
+
+    if (!isPendingAbsenceSwap) {
+      setDisplayedActionsPhase(phase)
+      setActionsFadingOut(false)
+      return
+    }
+
+    setActionsFadingOut(true)
+    actionsFadeTimer.current = setTimeout(() => {
+      setDisplayedActionsPhase(phase)
+      setActionsFadingOut(false)
+    }, 200)
+
+    return () => clearTimeout(actionsFadeTimer.current)
+  }, [phase, displayedActionsPhase])
+
+  return {
+    phase,
+    isScheduledRestDay,
+    isFullDayLeave,
+    displayedActionsPhase,
+    actionsFadingOut,
+    confirmFaltaOpen,
+    openConfirmFalta: () => setConfirmFaltaOpen(true),
+    closeConfirmFalta: () => setConfirmFaltaOpen(false),
+    confirmFalta: () => {
+      setConfirmFaltaOpen(false)
+      onMarkDayStatus(row.employee, 'ABSENCE')
+      setAskJustifyOpen(true)
+    },
+    askJustifyOpen,
+    declineJustifyNow: () => {
+      setAskJustifyOpen(false)
+      onFaltaFlowComplete?.(row.employee.id)
+    },
+    acceptJustifyNow: () => {
+      setAskJustifyOpen(false)
+      setShowJustifyDialog(true)
+    },
+    showJustifyDialog,
+    openJustifyDialog: () => setShowJustifyDialog(true),
+    closeJustifyDialog: () => {
+      setShowJustifyDialog(false)
+      onFaltaFlowComplete?.(row.employee.id)
+    },
+  }
+}

--- a/code/webapp/src/components/ui/__tests__/use-dialog-transition.test.ts
+++ b/code/webapp/src/components/ui/__tests__/use-dialog-transition.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { renderHook, act, cleanup } from '@testing-library/react'
+import { useDialogTransition } from '@/components/ui/use-dialog-transition'
+
+vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+  setTimeout(() => cb(0), 0)
+  return 0
+})
+
+describe('useDialogTransition', () => {
+  afterEach(() => {
+    cleanup()
+    document.body.style.overflow = ''
+  })
+
+  it('starts with visible false when isOpen is false', () => {
+    const { result } = renderHook(() => useDialogTransition(false))
+
+    expect(result.current.visible).toBe(false)
+    expect(result.current.backdropCls).toBe('')
+    expect(result.current.panelCls).toBe('')
+  })
+
+  it('sets visible true and applies enter classes when isOpen becomes true', async () => {
+    vi.useFakeTimers()
+    const { result, rerender } = renderHook(
+      ({ isOpen }) => useDialogTransition(isOpen),
+      { initialProps: { isOpen: false } },
+    )
+
+    rerender({ isOpen: true })
+    expect(result.current.visible).toBe(true)
+
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync()
+      await vi.runOnlyPendingTimersAsync()
+    })
+
+    expect(result.current.backdropCls).toBe('animate-dialog-backdrop-in')
+    expect(result.current.panelCls).toBe('animate-dialog-in')
+    vi.useRealTimers()
+  })
+
+  it('does not lock body scroll by default', () => {
+    renderHook(() => useDialogTransition(true))
+    expect(document.body.style.overflow).toBe('')
+  })
+
+  it('locks and unlocks body scroll when lockScroll is true', () => {
+    const { rerender, unmount } = renderHook(
+      ({ isOpen }) => useDialogTransition(isOpen, { lockScroll: true }),
+      { initialProps: { isOpen: true } },
+    )
+
+    expect(document.body.style.overflow).toBe('hidden')
+
+    rerender({ isOpen: false })
+    expect(document.body.style.overflow).toBe('unset')
+
+    unmount()
+  })
+
+  it('calls onEscape when Escape is pressed while open', () => {
+    const onEscape = vi.fn()
+    renderHook(() => useDialogTransition(true, { onEscape }))
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    })
+
+    expect(onEscape).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call onEscape when closed', () => {
+    const onEscape = vi.fn()
+    renderHook(() => useDialogTransition(false, { onEscape }))
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    })
+
+    expect(onEscape).not.toHaveBeenCalled()
+  })
+
+  it('animates out then calls onExitComplete after the exit duration', () => {
+    vi.useFakeTimers()
+    const onExitComplete = vi.fn()
+    const { result, rerender } = renderHook(
+      ({ isOpen }) => useDialogTransition(isOpen, { onExitComplete }),
+      { initialProps: { isOpen: true } },
+    )
+
+    rerender({ isOpen: false })
+
+    expect(result.current.backdropCls).toBe('animate-dialog-backdrop-out')
+    expect(result.current.panelCls).toBe('animate-dialog-out')
+    expect(onExitComplete).not.toHaveBeenCalled()
+
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+
+    expect(result.current.visible).toBe(false)
+    expect(result.current.backdropCls).toBe('')
+    expect(onExitComplete).toHaveBeenCalledTimes(1)
+
+    vi.useRealTimers()
+  })
+})

--- a/code/webapp/src/components/ui/confirm-dialog.tsx
+++ b/code/webapp/src/components/ui/confirm-dialog.tsx
@@ -1,8 +1,9 @@
-import { useContext, useEffect, useRef, useState } from 'react'
+import { useContext, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { Button, type ButtonProps } from '@/components/ui/button'
 import { Loader2, AlertTriangle, Info } from 'lucide-react'
 import { SlidePanelOverlayContext } from '@/components/ui/slide-panel-context'
+import { useDialogTransition } from '@/components/ui/use-dialog-transition'
 
 export interface ConfirmDialogProps {
   isOpen: boolean
@@ -59,70 +60,18 @@ export function ConfirmDialog({
   confirmDisabled = false,
   container,
 }: ConfirmDialogProps) {
-  const [visible, setVisible] = useState(false)
-  const [animating, setAnimating] = useState<'enter' | 'exit' | null>(null)
   const dialogRef = useRef<HTMLDivElement>(null)
   const slidePanelOverlay = useContext(SlidePanelOverlayContext)
 
-  useEffect(() => {
-    if (isOpen) {
-      setVisible(true)
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => setAnimating('enter'))
-      })
-    } else if (visible) {
-      setAnimating('exit')
-      const timer = setTimeout(() => {
-        setVisible(false)
-        setAnimating(null)
-      }, 200)
-      return () => clearTimeout(timer)
-    }
-  }, [isOpen, visible])
-
-  // Close on Escape
-  useEffect(() => {
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && isOpen && !isLoading) {
-        onClose()
-      }
-    }
-    document.addEventListener('keydown', handleEscape)
-    return () => document.removeEventListener('keydown', handleEscape)
-  }, [isOpen, isLoading, onClose])
-
-  // Prevent body scroll only in viewport mode
-  useEffect(() => {
-    if (container === 'viewport' && isOpen) {
-      document.body.style.overflow = 'hidden'
-    } else if (container === 'viewport') {
-      document.body.style.overflow = 'unset'
-    }
-    return () => {
-      if (container === 'viewport') {
-        document.body.style.overflow = 'unset'
-      }
-    }
-  }, [isOpen, container])
+  const { visible, backdropCls: backdropAnimation, panelCls: panelAnimation } = useDialogTransition(isOpen, {
+    onEscape: () => { if (!isLoading) onClose() },
+    lockScroll: container === 'viewport',
+  })
 
   if (!visible) return null
 
   const styles = variantStyles[variant]
   const Icon = styles.icon
-
-  const backdropAnimation =
-    animating === 'enter'
-      ? 'animate-dialog-backdrop-in'
-      : animating === 'exit'
-        ? 'animate-dialog-backdrop-out'
-        : ''
-
-  const panelAnimation =
-    animating === 'enter'
-      ? 'animate-dialog-in'
-      : animating === 'exit'
-        ? 'animate-dialog-out'
-        : ''
 
   // Determine portal target:
   // - 'viewport': portal to document.body (covers full window)

--- a/code/webapp/src/components/ui/use-dialog-transition.ts
+++ b/code/webapp/src/components/ui/use-dialog-transition.ts
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react'
+
+export type DialogAnimationPhase = 'enter' | 'exit' | null
+
+export function animCls(animating: DialogAnimationPhase, enterVal: string, exitVal: string): string {
+  if (animating === 'enter') return enterVal
+  if (animating === 'exit') return exitVal
+  return ''
+}
+
+export interface UseDialogTransitionOptions {
+  /** Called when Escape is pressed while the dialog is open. Omit to disable Escape handling. */
+  onEscape?: () => void
+  /** Called once the exit animation finishes and the dialog has fully unmounted. */
+  onExitComplete?: () => void
+  /** Lock body scroll while the dialog is open (default false — only needed for full-viewport dialogs). */
+  lockScroll?: boolean
+  /** Exit animation duration in ms, must match the CSS keyframe duration. */
+  exitDurationMs?: number
+}
+
+/**
+ * Shared enter/exit transition state machine for centered/portal dialogs
+ * (fade + scale via `animate-dialog-*` classes in index.css).
+ */
+export function useDialogTransition(isOpen: boolean, options: UseDialogTransitionOptions = {}) {
+  const { onEscape, onExitComplete, lockScroll = false, exitDurationMs = 200 } = options
+  const [visible, setVisible] = useState(false)
+  const [animating, setAnimating] = useState<DialogAnimationPhase>(null)
+
+  useEffect(() => {
+    if (isOpen) {
+      setVisible(true)
+      if (lockScroll) document.body.style.overflow = 'hidden'
+      requestAnimationFrame(() => requestAnimationFrame(() => setAnimating('enter')))
+    } else if (visible) {
+      setAnimating('exit')
+      if (lockScroll) document.body.style.overflow = 'unset'
+      const timer = setTimeout(() => {
+        setVisible(false)
+        setAnimating(null)
+        onExitComplete?.()
+      }, exitDurationMs)
+      return () => clearTimeout(timer)
+    }
+  }, [isOpen, visible, lockScroll, exitDurationMs, onExitComplete])
+
+  useEffect(() => {
+    if (!lockScroll) return
+    return () => { document.body.style.overflow = 'unset' }
+  }, [lockScroll])
+
+  useEffect(() => {
+    if (!onEscape) return
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && isOpen) onEscape()
+    }
+    document.addEventListener('keydown', handleEscape)
+    return () => document.removeEventListener('keydown', handleEscape)
+  }, [isOpen, onEscape])
+
+  const backdropCls = animCls(animating, 'animate-dialog-backdrop-in', 'animate-dialog-backdrop-out')
+  const panelCls = animCls(animating, 'animate-dialog-in', 'animate-dialog-out')
+
+  return { visible, backdropCls, panelCls }
+}

--- a/code/webapp/src/index.css
+++ b/code/webapp/src/index.css
@@ -186,6 +186,21 @@
     animation: fade-in 0.3s ease-out;
 }
 
+@keyframes fade-out {
+    from {
+        opacity: 1;
+        transform: translateY(0);
+    }
+    to {
+        opacity: 0;
+        transform: translateY(-6px);
+    }
+}
+
+.animate-fade-out {
+    animation: fade-out 0.2s ease-in forwards;
+}
+
 /* ── ConfirmDialog Animations ───────────────────────────────────── */
 @keyframes dialog-backdrop-in {
     from { opacity: 0; }
@@ -284,4 +299,19 @@
     to {
         opacity: 0;
     }
+}
+
+/* ── EmployeeAttendanceCard exit animation (e.g. after marking falta) ───── */
+@keyframes card-exit {
+    from {
+        opacity: 1;
+        transform: translateX(0) scale(1);
+    }
+    to {
+        opacity: 0;
+        transform: translateX(24px) scale(0.96);
+    }
+}
+.animate-card-exit {
+    animation: card-exit 0.35s ease-in forwards;
 }

--- a/code/webapp/src/pages/attendance/-use-today-attendance-page.ts
+++ b/code/webapp/src/pages/attendance/-use-today-attendance-page.ts
@@ -1,13 +1,13 @@
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback, useEffect, useRef, useMemo } from 'react'
 import { useAuthStore } from '@/stores/auth.store'
 import { useDailyAttendance, useCheckIn, useLunchStart, useLunchReturn, useCheckOut, useOvertimeDecision, useBulkOvertimeDecision, useMarkDayStatus } from '@/services/attendance-hooks'
 import { useExtraDayExpress } from '@/components/attendance/use-extra-day-express'
-import { getAttendancePhase } from '@/types/attendance'
+import { getAttendancePhase, isAbsentRow, isHiddenFromGrid } from '@/types/attendance'
 import { todayDateCdmx } from '@/lib/datetime'
 import { timeToIsoWithOffset } from '@/lib/timezone'
 import { useBusinessDate } from '@/stores/clock.store'
 import type { TodayAttendanceRow, AttendancePhase, TodayAttendanceEmployee, OvertimeDecisionPayload, OvertimePendingEntry, OvertimeValuationMethod } from '@/types/attendance'
-import type { AttendanceSummary } from '@/components/attendance'
+import type { AttendanceSummary, AttendanceFilter } from '@/components/attendance'
 
 // Re-export from shared utilities for backwards compatibility
 export { currentTimeLabel } from '@/lib/datetime'
@@ -17,20 +17,70 @@ export interface PendingAttendanceData {
   attendanceId: string
 }
 
+type AttendanceBucket = 'pending' | 'checkedIn' | 'done' | 'absent'
+
+/** Which stat bucket a row belongs to (exported for testing) */
+export function attendanceBucket(row: TodayAttendanceRow): AttendanceBucket {
+  if (isAbsentRow(row)) return 'absent'
+  const phase = getAttendancePhase(row.attendance)
+  if (phase === 'pending') return 'pending'
+  if (phase === 'done') return 'done'
+  return 'checkedIn'
+}
+
 /** Computes attendance summary from rows (exported for testing) */
 export function computeSummary(rows: TodayAttendanceRow[]): AttendanceSummary {
-  let pending = 0, checkedIn = 0, done = 0, withOvertime = 0
+  let pending = 0, checkedIn = 0, done = 0, absent = 0, withOvertime = 0
 
   for (const row of rows) {
-    const phase = getAttendancePhase(row.attendance)
-    if (phase === 'pending') pending++
-    else if (phase === 'done' || phase === 'on-leave' || phase === 'day-off' || phase === 'absence') done++
-    else checkedIn++
+    const bucket = attendanceBucket(row)
+    if (bucket === 'pending') pending++
+    else if (bucket === 'checkedIn') checkedIn++
+    else if (bucket === 'done') done++
+    else absent++
 
     if ((row.attendance?.overtime_minutes ?? 0) > 0) withOvertime++
   }
 
-  return { total: rows.length, pending, checkedIn, done, withOvertime }
+  return { total: rows.length, pending, checkedIn, done, absent, withOvertime }
+}
+
+/**
+ * Whether a single row belongs in the grid for the given tab filter.
+ * `null` (no tab selected) is the default view: everything except rows that never
+ * need action (VACATION, scheduled rest days) — ABSENCE/LEAVE stay visible by
+ * default since their cards expose actions/info the manager still needs (see
+ * isHiddenFromGrid). Selecting "Total" or "Ausentes" overrides that default to
+ * reveal the rows hidden from the default view.
+ */
+function matchesGridFilter(row: TodayAttendanceRow, filter: AttendanceFilter | null): boolean {
+  if (filter === 'total') return true
+  if (filter === 'absent') return isAbsentRow(row)
+  if (filter === null) return !isHiddenFromGrid(row)
+  return !isHiddenFromGrid(row) && attendanceBucket(row) === filter
+}
+
+/** Rows to render in the main grid for the given tab filter (exported for testing). */
+export function filterRowsForGrid(rows: TodayAttendanceRow[], filter: AttendanceFilter | null): TodayAttendanceRow[] {
+  return rows.filter((row) => matchesGridFilter(row, filter))
+}
+
+/**
+ * Smart default tab applied once the page's first data load resolves and no
+ * tab was already chosen (e.g. from the URL). Cascades through the buckets in
+ * priority order — Pendientes, then En trabajo, then Completados, then
+ * Ausentes — landing on the first one that actually has anyone in it, so the
+ * manager never lands on an empty single-bucket tab (e.g. once everyone has
+ * checked out, or on a day where every employee is on vacation). Falls back
+ * to `null` (the default full view) only when there are no employees at all.
+ * Exported for testing.
+ */
+export function resolveDefaultFilter(summary: AttendanceSummary): AttendanceFilter | null {
+  if (summary.pending > 0) return 'pending'
+  if (summary.checkedIn > 0) return 'checkedIn'
+  if (summary.done > 0) return 'done'
+  if (summary.absent > 0) return 'absent'
+  return null
 }
 
 /**
@@ -79,6 +129,7 @@ export function timeToIso(hhmm: string, date?: string): string {
 export interface UseTodayAttendancePageResult {
   // Data
   rows: TodayAttendanceRow[]
+  visibleRows: TodayAttendanceRow[]
   summary: AttendanceSummary
   isLoading: boolean
   isError: boolean
@@ -86,6 +137,14 @@ export interface UseTodayAttendancePageResult {
   hasBranch: boolean
   branchId: number | null
   getPhase: (row: TodayAttendanceRow) => AttendancePhase
+  // Stat tab filter
+  selectedFilter: AttendanceFilter | null
+  toggleFilter: (filter: AttendanceFilter) => void
+  // Keeps a card rendered through the mark-falta → justify-now? → (dialog) flow,
+  // then plays an exit animation once the flow concludes
+  isCardExiting: (employeeId: string) => boolean
+  pinEmployeeCard: (employeeId: string) => void
+  onFaltaFlowComplete: (employeeId: string) => void
   // Date selection
   selectedDate: string
   setSelectedDate: (date: string) => void
@@ -137,7 +196,7 @@ export interface UseTodayAttendancePageResult {
   confirmExtraDay: (payload: { agreed_daily_wage: number; prima_percent: number; notes: string }) => void
 }
 
-export function useTodayAttendancePage(): UseTodayAttendancePageResult {
+export function useTodayAttendancePage(initialFilter: AttendanceFilter | null = null): UseTodayAttendancePageResult {
   const currentBranch = useAuthStore(s => s.currentBranch)
   const branchId = currentBranch?.id ?? null
 
@@ -160,6 +219,125 @@ export function useTodayAttendancePage(): UseTodayAttendancePageResult {
   const extraDayMutation = useExtraDayExpress()
 
   const summary = computeSummary(data)
+
+  // ── Stat tab filter ───────────────────────────────────────────────────────────
+  const [selectedFilter, setSelectedFilter] = useState<AttendanceFilter | null>(initialFilter)
+  const hasAppliedDefaultFilter = useRef(initialFilter !== null)
+
+  // Apply the smart default (Pendientes, or En trabajo if nothing is pending)
+  // once the first load resolves, unless a tab was already chosen (e.g. from
+  // the URL). Runs at most once — later loading states (refetches, date
+  // changes) never override a filter the user or the URL already picked.
+  useEffect(() => {
+    if (hasAppliedDefaultFilter.current || isLoading) return
+    hasAppliedDefaultFilter.current = true
+    setSelectedFilter(resolveDefaultFilter(summary))
+  }, [isLoading, summary])
+
+  const toggleFilter = useCallback((filter: AttendanceFilter) => {
+    // A manual click always wins over the smart default — even one that
+    // arrives before the initial load resolves (the default-filter effect
+    // below checks this same ref and skips applying its value if so).
+    hasAppliedDefaultFilter.current = true
+    setSelectedFilter((current) => (current === filter ? null : filter))
+  }, [])
+
+  // ── Keep a card rendered through the mark-falta → justify-now? → (dialog) flow ──
+  // 'pinned'  — the underlying row no longer matches the active tab, but a dialog
+  //             flow on this exact card is still in progress; render normally,
+  //             fully interactive, so the flow isn't yanked out from under the user.
+  // 'exiting' — the flow just concluded; play the exit animation, then remove.
+  const [cardOverrides, setCardOverrides] = useState<Map<string, 'pinned' | 'exiting'>>(new Map())
+  const exitTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
+
+  useEffect(() => {
+    const timers = exitTimers.current
+    return () => {
+      timers.forEach((timer) => clearTimeout(timer))
+    }
+  }, [])
+
+  const pinEmployeeCard = useCallback((employeeId: string) => {
+    setCardOverrides((current) => {
+      if (current.get(employeeId) === 'pinned') return current
+      const next = new Map(current)
+      next.set(employeeId, 'pinned')
+      return next
+    })
+  }, [])
+
+  // The mark-falta flow always ends with the row in the 'absent' bucket,
+  // regardless of which choice the manager makes:
+  //  - Decline / no leave registered → day_status stays ABSENCE.
+  //  - Justify with a full-day (non-SCHEDULED) leave → RegisterDirectLeaveAction
+  //    overwrites the existing Attendance record's day_status to LEAVE.
+  //  - Justify with a partial (SCHEDULED) leave → shouldCreateAttendanceRecords()
+  //    is false, so RegisterDirectLeaveAction skips touching Attendance entirely
+  //    and day_status is left as ABSENCE (see RegisterDirectLeaveAction.php).
+  // Either way day_status ends up ABSENCE or LEAVE, so isAbsentRow is true and
+  // isHiddenFromGrid is false — today_leave.time_mode never overrides this,
+  // since isAbsentRow checks getAttendancePhase(row.attendance) first and only
+  // falls back to today_leave for rows with NO attendance record at all.
+  // This is computed from `filter` alone — deliberately NOT from `data` —
+  // because `data` can still reflect the pre-mutation row when the flow
+  // concludes quickly (useMarkDayStatus only invalidates/refetches on
+  // success, and the manager can dismiss the justify-now prompt before that
+  // refetch lands). Deciding from `data` in that window used the stale
+  // (still-pending) bucket and produced the wrong answer once the real data
+  // arrived a moment later.
+  function matchesFilterAfterFalta(filter: AttendanceFilter | null): boolean {
+    return filter === null || filter === 'total' || filter === 'absent'
+  }
+
+  // Ends the pin started by pinEmployeeCard once the mark-falta → justify-now?
+  // flow concludes. If the row's final status still belongs in the active tab
+  // (e.g. ABSENCE stays visible on the default view), it never actually needs
+  // to leave the grid — clear the pin immediately instead of playing the
+  // fade/slide-out animation, which would otherwise make the card vanish and
+  // then abruptly pop back in.
+  const startExitAnimation = useCallback((employeeId: string) => {
+    if (matchesFilterAfterFalta(selectedFilter)) {
+      const existingTimer = exitTimers.current.get(employeeId)
+      if (existingTimer) {
+        clearTimeout(existingTimer)
+        exitTimers.current.delete(employeeId)
+      }
+      setCardOverrides((current) => {
+        if (!current.has(employeeId)) return current
+        const next = new Map(current)
+        next.delete(employeeId)
+        return next
+      })
+      return
+    }
+
+    setCardOverrides((current) => {
+      const next = new Map(current)
+      next.set(employeeId, 'exiting')
+      return next
+    })
+
+    const existingTimer = exitTimers.current.get(employeeId)
+    if (existingTimer) clearTimeout(existingTimer)
+
+    const timer = setTimeout(() => {
+      setCardOverrides((current) => {
+        if (!current.has(employeeId)) return current
+        const next = new Map(current)
+        next.delete(employeeId)
+        return next
+      })
+      exitTimers.current.delete(employeeId)
+    }, 350)
+    exitTimers.current.set(employeeId, timer)
+  }, [selectedFilter])
+
+  // Pinned/exiting rows are kept in their natural `data` position (not appended
+  // at the end) so the card doesn't visibly jump while its dialog flow plays out.
+  const visibleRows = useMemo(() => {
+    if (cardOverrides.size === 0) return filterRowsForGrid(data, selectedFilter)
+    return data.filter((row) => cardOverrides.has(row.employee.id) || matchesGridFilter(row, selectedFilter))
+  }, [data, selectedFilter, cardOverrides])
 
   // ── Extra day express state (declared first — openCheckIn depends on it) ──────
   const [extraDayRow, setExtraDayRow] = useState<TodayAttendanceRow | null>(null)
@@ -380,6 +558,7 @@ export function useTodayAttendancePage(): UseTodayAttendancePageResult {
 
   return {
     rows: data,
+    visibleRows,
     summary,
     isLoading,
     isError,
@@ -387,6 +566,11 @@ export function useTodayAttendancePage(): UseTodayAttendancePageResult {
     hasBranch: !!branchId,
     branchId,
     getPhase: (row) => getAttendancePhase(row.attendance),
+    selectedFilter,
+    toggleFilter,
+    isCardExiting: (employeeId) => cardOverrides.get(employeeId) === 'exiting',
+    pinEmployeeCard,
+    onFaltaFlowComplete: startExitAnimation,
     selectedDate,
     setSelectedDate,
     // Check-in

--- a/code/webapp/src/pages/attendance/__tests__/use-today-attendance-page.test.ts
+++ b/code/webapp/src/pages/attendance/__tests__/use-today-attendance-page.test.ts
@@ -6,6 +6,9 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import {
   useTodayAttendancePage,
   computeSummary,
+  attendanceBucket,
+  filterRowsForGrid,
+  resolveDefaultFilter,
   currentTimeLabel,
   timeToIso,
   todayCdmxDate,
@@ -115,6 +118,7 @@ describe('computeSummary', () => {
       pending: 0,
       checkedIn: 0,
       done: 0,
+      absent: 0,
       withOvertime: 0,
     })
   })
@@ -204,6 +208,192 @@ describe('computeSummary', () => {
     ]
     const result = computeSummary(rows)
     expect(result.checkedIn).toBe(1)
+  })
+
+  it('counts ABSENCE, VACATION and LEAVE day_status as absent — not done', () => {
+    const rows = [
+      makeRow({ attendance: { id: 'att-1', day_status: 'ABSENCE' } as TodayAttendanceRow['attendance'] }),
+      makeRow({
+        employee: { id: 'emp-002', code: 'EMP-002', user: { first_name: 'Ana', last_name: 'López' }, roles: [], daily_wage: null },
+        attendance: { id: 'att-2', day_status: 'VACATION' } as TodayAttendanceRow['attendance'],
+      }),
+      makeRow({
+        employee: { id: 'emp-003', code: 'EMP-003', user: { first_name: 'Beto', last_name: 'Ruiz' }, roles: [], daily_wage: null },
+        attendance: { id: 'att-3', day_status: 'LEAVE' } as TodayAttendanceRow['attendance'],
+      }),
+    ]
+    const result = computeSummary(rows)
+    expect(result.absent).toBe(3)
+    expect(result.done).toBe(0)
+    expect(result.pending).toBe(0)
+    expect(result.checkedIn).toBe(0)
+  })
+
+  it('counts a full-day OPEN_ENDED today_leave as absent, even without an attendance record', () => {
+    const rows = [
+      makeRow({
+        today_leave: {
+          id: 'leave-1',
+          time_mode: 'OPEN_ENDED',
+          calculation_mode: 'FIXED_PERCENTAGE',
+          is_paid: true,
+          starts_at: null,
+          ends_at: null,
+          note: null,
+        },
+      }),
+    ]
+    const result = computeSummary(rows)
+    expect(result.absent).toBe(1)
+    expect(result.pending).toBe(0)
+  })
+
+  it('does not count a partial SCHEDULED today_leave as absent — stays pending/checkedIn', () => {
+    const rows = [
+      makeRow({
+        today_leave: {
+          id: 'leave-1',
+          time_mode: 'SCHEDULED',
+          calculation_mode: 'PROPORTIONAL_HOURS',
+          is_paid: true,
+          starts_at: '2026-04-01T19:00:00Z',
+          ends_at: '2026-04-01T22:00:00Z',
+          note: null,
+        },
+      }),
+    ]
+    const result = computeSummary(rows)
+    expect(result.absent).toBe(0)
+    expect(result.pending).toBe(1)
+  })
+
+  it('counts DAY_OFF (scheduled rest day) as absent, not done', () => {
+    const rows = [
+      makeRow({ attendance: { id: 'att-1', day_status: 'DAY_OFF' } as TodayAttendanceRow['attendance'] }),
+    ]
+    const result = computeSummary(rows)
+    expect(result.absent).toBe(1)
+    expect(result.done).toBe(0)
+  })
+})
+
+// ══════════════════════════════════════════════════════════════════════════════
+// attendanceBucket
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('attendanceBucket', () => {
+  it('returns "pending" for a row with no attendance', () => {
+    expect(attendanceBucket(makeRow())).toBe('pending')
+  })
+
+  it('returns "checkedIn" for checked-in/at-lunch/returned rows', () => {
+    const checkedIn = makeRow({ attendance: { id: 'a', check_in: '2026-04-01T13:00:00Z' } as TodayAttendanceRow['attendance'] })
+    const atLunch = makeRow({ attendance: { id: 'a', check_in: '2026-04-01T13:00:00Z', lunch_start: '2026-04-01T14:00:00Z' } as TodayAttendanceRow['attendance'] })
+    expect(attendanceBucket(checkedIn)).toBe('checkedIn')
+    expect(attendanceBucket(atLunch)).toBe('checkedIn')
+  })
+
+  it('returns "done" for a checked-out row', () => {
+    const row = makeRow({ attendance: { id: 'a', check_in: '2026-04-01T13:00:00Z', check_out: '2026-04-01T22:00:00Z' } as TodayAttendanceRow['attendance'] })
+    expect(attendanceBucket(row)).toBe('done')
+  })
+
+  it.each(['ABSENCE', 'VACATION', 'LEAVE', 'DAY_OFF'])('returns "absent" for day_status %s', (day_status) => {
+    const row = makeRow({ attendance: { id: 'a', day_status } as TodayAttendanceRow['attendance'] })
+    expect(attendanceBucket(row)).toBe('absent')
+  })
+})
+
+// ══════════════════════════════════════════════════════════════════════════════
+// filterRowsForGrid
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('filterRowsForGrid', () => {
+  function rowsFixture() {
+    return [
+      makeRow({ employee: { id: 'e1', code: 'E1', user: { first_name: 'A', last_name: 'A' }, roles: [], daily_wage: null } }), // pending
+      makeRow({
+        employee: { id: 'e2', code: 'E2', user: { first_name: 'B', last_name: 'B' }, roles: [], daily_wage: null },
+        attendance: { id: 'a2', check_in: '2026-04-01T13:00:00Z' } as TodayAttendanceRow['attendance'],
+      }), // checkedIn
+      makeRow({
+        employee: { id: 'e3', code: 'E3', user: { first_name: 'C', last_name: 'C' }, roles: [], daily_wage: null },
+        attendance: { id: 'a3', check_in: '2026-04-01T13:00:00Z', check_out: '2026-04-01T22:00:00Z' } as TodayAttendanceRow['attendance'],
+      }), // done
+      makeRow({
+        employee: { id: 'e4', code: 'E4', user: { first_name: 'D', last_name: 'D' }, roles: [], daily_wage: null },
+        attendance: { id: 'a4', day_status: 'ABSENCE' } as TodayAttendanceRow['attendance'],
+      }), // absent — stays visible by default
+      makeRow({
+        employee: { id: 'e5', code: 'E5', user: { first_name: 'E', last_name: 'E' }, roles: [], daily_wage: null },
+        attendance: { id: 'a5', day_status: 'VACATION' } as TodayAttendanceRow['attendance'],
+      }), // absent — hidden by default
+      makeRow({
+        employee: { id: 'e6', code: 'E6', user: { first_name: 'F', last_name: 'F' }, roles: [], daily_wage: null },
+        attendance: { id: 'a6', day_status: 'DAY_OFF' } as TodayAttendanceRow['attendance'],
+      }), // absent — hidden by default
+    ]
+  }
+
+  it('with null filter, shows everyone except VACATION/DAY_OFF (default view)', () => {
+    const visible = filterRowsForGrid(rowsFixture(), null)
+    expect(visible.map((r) => r.employee.code)).toEqual(['E1', 'E2', 'E3', 'E4'])
+  })
+
+  it('with "total" filter, shows literally everyone including VACATION/DAY_OFF', () => {
+    const visible = filterRowsForGrid(rowsFixture(), 'total')
+    expect(visible).toHaveLength(6)
+  })
+
+  it('with "absent" filter, shows only ABSENCE/VACATION/DAY_OFF rows', () => {
+    const visible = filterRowsForGrid(rowsFixture(), 'absent')
+    expect(visible.map((r) => r.employee.code)).toEqual(['E4', 'E5', 'E6'])
+  })
+
+  it('with "pending" filter, shows only the pending row', () => {
+    const visible = filterRowsForGrid(rowsFixture(), 'pending')
+    expect(visible.map((r) => r.employee.code)).toEqual(['E1'])
+  })
+
+  it('with "checkedIn" filter, shows only the checked-in row', () => {
+    const visible = filterRowsForGrid(rowsFixture(), 'checkedIn')
+    expect(visible.map((r) => r.employee.code)).toEqual(['E2'])
+  })
+
+  it('with "done" filter, shows only the done row', () => {
+    const visible = filterRowsForGrid(rowsFixture(), 'done')
+    expect(visible.map((r) => r.employee.code)).toEqual(['E3'])
+  })
+})
+
+// ══════════════════════════════════════════════════════════════════════════════
+// resolveDefaultFilter
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('resolveDefaultFilter', () => {
+  it('returns "pending" when there is at least one pending employee', () => {
+    const summary = { total: 3, pending: 2, checkedIn: 1, done: 0, absent: 0, withOvertime: 0 }
+    expect(resolveDefaultFilter(summary)).toBe('pending')
+  })
+
+  it('returns "checkedIn" when there are no pending employees', () => {
+    const summary = { total: 3, pending: 0, checkedIn: 1, done: 2, absent: 0, withOvertime: 0 }
+    expect(resolveDefaultFilter(summary)).toBe('checkedIn')
+  })
+
+  it('returns "done" when nobody is pending or checked in, but someone has finished', () => {
+    const summary = { total: 2, pending: 0, checkedIn: 0, done: 1, absent: 1, withOvertime: 0 }
+    expect(resolveDefaultFilter(summary)).toBe('done')
+  })
+
+  it('returns "absent" when everyone is absent and no other bucket has anyone', () => {
+    const summary = { total: 1, pending: 0, checkedIn: 0, done: 0, absent: 1, withOvertime: 0 }
+    expect(resolveDefaultFilter(summary)).toBe('absent')
+  })
+
+  it('returns null when there are no employees at all, instead of landing on an empty bucket tab', () => {
+    const summary = { total: 0, pending: 0, checkedIn: 0, done: 0, absent: 0, withOvertime: 0 }
+    expect(resolveDefaultFilter(summary)).toBeNull()
   })
 })
 
@@ -683,6 +873,7 @@ describe('useTodayAttendancePage', () => {
         pending: 1,
         checkedIn: 0,
         done: 0,
+        absent: 0,
         withOvertime: 0,
       })
     })
@@ -700,6 +891,237 @@ describe('useTodayAttendancePage', () => {
         attendance: { id: 'att-1', check_in: '2026-04-01T13:00:00Z' } as TodayAttendanceRow['attendance'],
       })
       expect(result.current.getPhase(checkedInRow)).toBe('checked-in')
+    })
+  })
+
+  // ── Tab filter (smart default + URL initial value) ────────────────────────────
+
+  describe('tab filter', () => {
+    it('defaults to "pending" once loaded when there is a pending employee', async () => {
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+      await waitFor(() => expect(result.current.selectedFilter).toBe('pending'))
+    })
+
+    it('defaults to "checkedIn" once loaded when nobody is pending', async () => {
+      vi.mocked(attendanceApi.daily).mockResolvedValue({
+        data: {
+          data: [
+            makeRow({
+              attendance: { id: 'att-1', check_in: '2026-04-01T13:00:00Z' } as TodayAttendanceRow['attendance'],
+            }),
+          ],
+        },
+      } as never)
+
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+      await waitFor(() => expect(result.current.selectedFilter).toBe('checkedIn'))
+    })
+
+    it('keeps an explicit initialFilter (e.g. from the URL) instead of applying the smart default', async () => {
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage('done'), { wrapper })
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+      // Give the smart-default effect a tick to (not) fire
+      await waitFor(() => expect(result.current.selectedFilter).toBe('done'))
+    })
+
+    it('a manual toggleFilter call before the initial load resolves is not later overwritten by the smart default', async () => {
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      // Click a tab immediately, while the initial fetch is still in flight
+      expect(result.current.isLoading).toBe(true)
+      act(() => result.current.toggleFilter('checkedIn'))
+      expect(result.current.selectedFilter).toBe('checkedIn')
+
+      // Once the load resolves, the smart default (which would pick "pending"
+      // for this fixture) must NOT clobber the manual selection
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+      expect(result.current.selectedFilter).toBe('checkedIn')
+    })
+
+    it('toggleFilter clicking the active tab again clears the filter back to null', async () => {
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      await waitFor(() => expect(result.current.selectedFilter).toBe('pending'))
+
+      act(() => result.current.toggleFilter('pending'))
+      expect(result.current.selectedFilter).toBeNull()
+    })
+  })
+
+  // ── Pin + exit animation (e.g. after marking falta) ───────────────────────────
+
+  describe('pin + exit animation', () => {
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    function mockPendingPlusAbsent() {
+      vi.mocked(attendanceApi.daily).mockResolvedValue({
+        data: {
+          data: [
+            makeRow(), // EMP-001, pending — resolves the default filter to "pending"
+            makeRow({
+              employee: { id: 'emp-002', code: 'EMP-002', user: { first_name: 'Ana', last_name: 'López' }, roles: [], daily_wage: null },
+              attendance: { id: 'att-2', day_status: 'ABSENCE' } as TodayAttendanceRow['attendance'],
+            }),
+          ],
+        },
+      } as never)
+    }
+
+    it('pinEmployeeCard keeps a row rendered even once it no longer matches the active filter, with no exit animation yet', async () => {
+      mockPendingPlusAbsent()
+
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      await waitFor(() => expect(result.current.selectedFilter).toBe('pending'))
+
+      // Under the "pending" filter, EMP-002 (absent) is normally hidden
+      expect(result.current.visibleRows.map((r) => r.employee.id)).toEqual(['emp-001'])
+
+      act(() => result.current.pinEmployeeCard('emp-002'))
+
+      // Pinned — stays rendered, but not yet playing the exit animation
+      expect(result.current.visibleRows.map((r) => r.employee.id)).toEqual(['emp-001', 'emp-002'])
+      expect(result.current.isCardExiting('emp-002')).toBe(false)
+    })
+
+    it('onFaltaFlowComplete plays the exit animation, then removes the row after it finishes', async () => {
+      mockPendingPlusAbsent()
+
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      await waitFor(() => expect(result.current.selectedFilter).toBe('pending'))
+
+      act(() => result.current.pinEmployeeCard('emp-002'))
+      expect(result.current.isCardExiting('emp-002')).toBe(false)
+
+      vi.useFakeTimers()
+      act(() => result.current.onFaltaFlowComplete('emp-002'))
+
+      // Still rendered — now playing the exit animation
+      expect(result.current.visibleRows.map((r) => r.employee.id)).toEqual(['emp-001', 'emp-002'])
+      expect(result.current.isCardExiting('emp-002')).toBe(true)
+
+      act(() => vi.advanceTimersByTime(350))
+
+      expect(result.current.visibleRows.map((r) => r.employee.id)).toEqual(['emp-001'])
+      expect(result.current.isCardExiting('emp-002')).toBe(false)
+    })
+
+    it('onFaltaFlowComplete plays the exit animation even when `data` has not refetched yet (still shows the row as pending)', async () => {
+      // Both rows still pending in `data` — simulating the window between
+      // "Confirmar falta" (which fires the mutation and pins the card) and
+      // the mutation's onSuccess refetch actually landing. The decision to
+      // animate must not be based on this stale snapshot.
+      vi.mocked(attendanceApi.daily).mockResolvedValue({
+        data: {
+          data: [
+            makeRow(), // emp-001, pending
+            makeRow({
+              employee: { id: 'emp-002', code: 'EMP-002', user: { first_name: 'Ana', last_name: 'López' }, roles: [], daily_wage: null },
+            }), // emp-002, still pending in `data` — refetch hasn't landed
+          ],
+        },
+      } as never)
+
+      const { wrapper, queryClient } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      await waitFor(() => expect(result.current.selectedFilter).toBe('pending'))
+
+      act(() => result.current.pinEmployeeCard('emp-002'))
+
+      vi.useFakeTimers()
+      act(() => result.current.onFaltaFlowComplete('emp-002'))
+
+      // Must still play the exit animation — the flow guarantees emp-002 ends
+      // up ABSENCE (bucket 'absent'), which doesn't match the "pending" tab,
+      // even though `data` here hasn't caught up yet.
+      expect(result.current.isCardExiting('emp-002')).toBe(true)
+
+      // The mutation's refetch lands mid-animation, now reflecting ABSENCE —
+      // same as useMarkDayStatus's onSuccess invalidateQueries in production.
+      vi.mocked(attendanceApi.daily).mockResolvedValue({
+        data: {
+          data: [
+            makeRow(),
+            makeRow({
+              employee: { id: 'emp-002', code: 'EMP-002', user: { first_name: 'Ana', last_name: 'López' }, roles: [], daily_wage: null },
+              attendance: { id: 'att-2', day_status: 'ABSENCE' } as TodayAttendanceRow['attendance'],
+            }),
+          ],
+        },
+      } as never)
+      await act(async () => {
+        await queryClient.invalidateQueries({ queryKey: ['attendances', 'daily'] })
+      })
+
+      act(() => vi.advanceTimersByTime(350))
+      expect(result.current.visibleRows.map((r) => r.employee.id)).toEqual(['emp-001'])
+    })
+
+    it('onFaltaFlowComplete clears the pin immediately, with no exit animation, when the row still matches the active filter', async () => {
+      mockPendingPlusAbsent()
+
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      // "Total" reveals everyone, so the ABSENCE row (emp-002) already matches
+      // the active filter before and after the flow — it never needs to leave.
+      await waitFor(() => expect(result.current.selectedFilter).toBe('pending'))
+      act(() => result.current.toggleFilter('total'))
+
+      act(() => result.current.pinEmployeeCard('emp-002'))
+      expect(result.current.visibleRows.map((r) => r.employee.id)).toEqual(['emp-001', 'emp-002'])
+
+      act(() => result.current.onFaltaFlowComplete('emp-002'))
+
+      // Pin cleared immediately — no 'exiting' state, no animation, row stays put
+      expect(result.current.isCardExiting('emp-002')).toBe(false)
+      expect(result.current.visibleRows.map((r) => r.employee.id)).toEqual(['emp-001', 'emp-002'])
+    })
+
+    it('keeps a pinned/exiting row in its original grid position instead of moving it to the end', async () => {
+      vi.mocked(attendanceApi.daily).mockResolvedValue({
+        data: {
+          data: [
+            makeRow(), // emp-001, pending
+            makeRow({
+              employee: { id: 'emp-002', code: 'EMP-002', user: { first_name: 'Ana', last_name: 'López' }, roles: [], daily_wage: null },
+              attendance: { id: 'att-2', day_status: 'ABSENCE' } as TodayAttendanceRow['attendance'],
+            }), // emp-002, absent — sits BETWEEN two pending rows
+            makeRow({
+              employee: { id: 'emp-003', code: 'EMP-003', user: { first_name: 'Beto', last_name: 'Ruiz' }, roles: [], daily_wage: null },
+            }), // emp-003, pending
+          ],
+        },
+      } as never)
+
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      await waitFor(() => expect(result.current.selectedFilter).toBe('pending'))
+      expect(result.current.visibleRows.map((r) => r.employee.id)).toEqual(['emp-001', 'emp-003'])
+
+      act(() => result.current.pinEmployeeCard('emp-002'))
+
+      // emp-002 reappears in its original slot (between emp-001 and emp-003),
+      // not appended after emp-003
+      expect(result.current.visibleRows.map((r) => r.employee.id)).toEqual(['emp-001', 'emp-002', 'emp-003'])
     })
   })
 

--- a/code/webapp/src/pages/attendance/index.tsx
+++ b/code/webapp/src/pages/attendance/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, useSearch } from '@tanstack/react-router'
 import { requirePermission } from '@/lib/route-guards'
 import { RefreshCw, DoorClosed } from 'lucide-react'
 import { PageContainer } from '@/components/ui/page-container'
@@ -13,6 +13,7 @@ import {
   EmptyState,
   ErrorState,
   NoBranchState,
+  NoMatchesForFilterState,
   OvertimeDecisionDialog,
   SkeletonGrid,
   useCloseDayPanel,
@@ -30,7 +31,18 @@ import { todayDateCdmx } from '@/lib/datetime'
 import { useBusinessDate } from '@/stores/clock.store'
 import { formatFirstLast, formatLastFirst } from '@/lib/format'
 import type { PendingAttendanceData } from './-use-today-attendance-page'
+import type { AttendanceFilter } from '@/components/attendance'
 import type { TodayAttendanceEmployee, OvertimePendingEntry, OvertimeValuationMethod } from '@/types/attendance'
+
+const ATTENDANCE_FILTERS: readonly AttendanceFilter[] = ['total', 'pending', 'checkedIn', 'done', 'absent']
+
+function isAttendanceFilter(value: unknown): value is AttendanceFilter {
+  return typeof value === 'string' && (ATTENDANCE_FILTERS as readonly string[]).includes(value)
+}
+
+interface AttendanceSearch {
+  tab?: AttendanceFilter
+}
 
 // ── Module-level helpers (keep complexity out of the component) ───────────────
 
@@ -105,17 +117,29 @@ function resolveOvertimeDialog({
 export const Route = createFileRoute('/attendance/')({
   beforeLoad: requirePermission('employees.view'),
   component: AttendancePage,
+  validateSearch: (search: Record<string, unknown>): AttendanceSearch => ({
+    tab: isAttendanceFilter(search.tab) ? search.tab : undefined,
+  }),
 })
 
 export function AttendancePage() {
+  const search = useSearch({ from: '/attendance/' })
+  const navigate = Route.useNavigate()
+
   const {
     rows,
+    visibleRows,
     summary,
     isLoading,
     isError,
     branchName,
     hasBranch,
     branchId,
+    selectedFilter,
+    toggleFilter,
+    isCardExiting,
+    pinEmployeeCard,
+    onFaltaFlowComplete,
     selectedDate,
     setSelectedDate,
     // Check-in
@@ -162,7 +186,7 @@ export function AttendancePage() {
     isRegisteringExtraDay,
     closeExtraDay,
     confirmExtraDay,
-  } = useTodayAttendancePage()
+  } = useTodayAttendancePage(search.tab ?? null)
 
   const maxTime = useApplicationTimeLabel()
   const closeDayPanel = useCloseDayPanel(rows, branchId, maxTime)
@@ -172,6 +196,15 @@ export function AttendancePage() {
   const { canEdit, requiresReason } = useAttendancePermissions(selectedDate)
   const weeklySummary = useWeeklySummaryDialog()
   const [auditRecord, setAuditRecord] = useState<{ employeeName: string; attendanceId: string } | null>(null)
+
+  // Mirror the active tab into the URL (?tab=) so a page refresh keeps the
+  // same filter — including the smart default the hook resolves on first load.
+  useEffect(() => {
+    navigate({
+      search: (prev) => ({ ...prev, tab: selectedFilter ?? undefined }),
+      replace: true,
+    })
+  }, [selectedFilter, navigate])
 
   // Feed bulk overtime decisions from the close-day panel into the queue
   const { overtimePending, clearOvertimePending } = closeDayPanel
@@ -241,25 +274,34 @@ export function AttendancePage() {
         }
       />
 
-      <AttendanceSummaryBar summary={summary} />
+      <AttendanceSummaryBar summary={summary} activeFilter={selectedFilter} onFilterChange={toggleFilter} />
 
       {(() => {
         if (isError) return <ErrorState />
         if (isLoading && rows.length === 0) return <SkeletonGrid />
         if (rows.length === 0) return <EmptyState />
+        if (visibleRows.length === 0) return <NoMatchesForFilterState onShowAll={() => toggleFilter('total')} />
         return (
           <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-            {rows.map((row) => (
+            {visibleRows.map((row) => (
               <EmployeeAttendanceCard
                 key={row.employee.id}
                 row={row}
                 canEdit={canEdit}
+                isExiting={isCardExiting(row.employee.id)}
+                onFaltaFlowComplete={onFaltaFlowComplete}
                 onCheckIn={openCheckIn}
                 onLunchStart={openLunchStart}
                 onLunchReturn={openLunchReturn}
                 onCheckOut={openCheckOut}
                 onOvertimeDecision={openOvertimeDecision}
-                onMarkDayStatus={markDayStatus}
+                onMarkDayStatus={(employee, status) => {
+                  // Keep this card rendered through the justify-now? flow —
+                  // its bucket is about to change and would otherwise vanish
+                  // from the current tab mid-flow (see onFaltaFlowComplete).
+                  pinEmployeeCard(employee.id)
+                  markDayStatus(employee, status)
+                }}
                 onWeeklySummary={can('reports.weekly-summary')
                   ? (emp) => weeklySummary.open(emp.id, formatLastFirst(emp.user))
                   : undefined}

--- a/code/webapp/src/types/__tests__/attendance.test.ts
+++ b/code/webapp/src/types/__tests__/attendance.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect } from 'vitest'
 import {
     getAttendancePhase,
+    isAbsentRow,
+    isHiddenFromGrid,
     formatSeconds,
     formatTime,
 } from '@/types/attendance'
-import type { TodayAttendanceData } from '@/types/attendance'
+import type { TodayAttendanceData, TodayAttendanceRow } from '@/types/attendance'
 
 describe('getAttendancePhase', () => {
     it('returns "pending" when attendance is null', () => {
@@ -163,6 +165,223 @@ describe('getAttendancePhase', () => {
             requires_overtime_decision: false,
         }
         expect(getAttendancePhase(attendance)).toBe('absence')
+    })
+
+    it('returns "on-leave" when day_status is VACATION', () => {
+        const attendance: TodayAttendanceData = {
+            id: '1',
+            check_in: null,
+            lunch_start: null,
+            lunch_end: null,
+            check_out: null,
+            day_status: 'VACATION',
+            entry_late_seconds: null,
+            entry_late_minutes: null,
+            is_entry_deductible: false,
+            overtime_minutes: 0,
+            overtime_authorized: false,
+            overtime_authorized_at: null,
+            overtime_valuation_method: null,
+            overtime_rate_applied: null,
+            overtime_amount: null,
+            requires_overtime_decision: false,
+        }
+        expect(getAttendancePhase(attendance)).toBe('on-leave')
+    })
+})
+
+describe('isAbsentRow', () => {
+    function makeRow(overrides: Partial<TodayAttendanceRow> = {}): TodayAttendanceRow {
+        return {
+            employee: {
+                id: 'emp-1',
+                code: 'EMP-001',
+                user: { first_name: 'Test', last_name: 'User' },
+                roles: [],
+                daily_wage: null,
+            },
+            attendance: null,
+            schedule: null,
+            today_leave: null,
+            ...overrides,
+        }
+    }
+
+    function makeAttendance(overrides: Partial<TodayAttendanceData> = {}): TodayAttendanceData {
+        return {
+            id: 'att-1',
+            check_in: null,
+            lunch_start: null,
+            lunch_end: null,
+            check_out: null,
+            day_status: 'WORKED',
+            entry_late_seconds: null,
+            entry_late_minutes: null,
+            is_entry_deductible: false,
+            overtime_minutes: 0,
+            overtime_authorized: false,
+            overtime_authorized_at: null,
+            overtime_valuation_method: null,
+            overtime_rate_applied: null,
+            overtime_amount: null,
+            requires_overtime_decision: false,
+            ...overrides,
+        }
+    }
+
+    it('returns true when day_status is ABSENCE', () => {
+        const row = makeRow({ attendance: makeAttendance({ day_status: 'ABSENCE' }) })
+        expect(isAbsentRow(row)).toBe(true)
+    })
+
+    it('returns true when day_status is VACATION', () => {
+        const row = makeRow({ attendance: makeAttendance({ day_status: 'VACATION' }) })
+        expect(isAbsentRow(row)).toBe(true)
+    })
+
+    it('returns true when day_status is LEAVE', () => {
+        const row = makeRow({ attendance: makeAttendance({ day_status: 'LEAVE' }) })
+        expect(isAbsentRow(row)).toBe(true)
+    })
+
+    it('returns true when today_leave is a full-day OPEN_ENDED leave, even without an attendance record yet', () => {
+        const row = makeRow({
+            attendance: null,
+            today_leave: {
+                id: 'leave-1',
+                time_mode: 'OPEN_ENDED',
+                calculation_mode: 'FIXED_PERCENTAGE',
+                is_paid: true,
+                starts_at: null,
+                ends_at: null,
+                note: null,
+            },
+        })
+        expect(isAbsentRow(row)).toBe(true)
+    })
+
+    it('returns false when today_leave is a partial SCHEDULED leave — employee still works part of the day', () => {
+        const row = makeRow({
+            attendance: null,
+            today_leave: {
+                id: 'leave-1',
+                time_mode: 'SCHEDULED',
+                calculation_mode: 'PROPORTIONAL_HOURS',
+                is_paid: true,
+                starts_at: '2026-04-09T19:00:00+00:00',
+                ends_at: '2026-04-09T22:00:00+00:00',
+                note: null,
+            },
+        })
+        expect(isAbsentRow(row)).toBe(false)
+    })
+
+    it('returns false for a pending row with no attendance and no leave', () => {
+        expect(isAbsentRow(makeRow())).toBe(false)
+    })
+
+    it('returns true when day_status is DAY_OFF — a scheduled rest day counts as absent', () => {
+        const row = makeRow({ attendance: makeAttendance({ day_status: 'DAY_OFF' }) })
+        expect(isAbsentRow(row)).toBe(true)
+    })
+
+    it('returns false for a checked-in employee with no leave', () => {
+        const row = makeRow({ attendance: makeAttendance({ check_in: '2026-04-09T13:00:00+00:00' }) })
+        expect(isAbsentRow(row)).toBe(false)
+    })
+})
+
+describe('isHiddenFromGrid', () => {
+    function makeRow(overrides: Partial<TodayAttendanceRow> = {}): TodayAttendanceRow {
+        return {
+            employee: {
+                id: 'emp-1',
+                code: 'EMP-001',
+                user: { first_name: 'Test', last_name: 'User' },
+                roles: [],
+                daily_wage: null,
+            },
+            attendance: null,
+            schedule: null,
+            today_leave: null,
+            ...overrides,
+        }
+    }
+
+    function makeAttendance(overrides: Partial<TodayAttendanceData> = {}): TodayAttendanceData {
+        return {
+            id: 'att-1',
+            check_in: null,
+            lunch_start: null,
+            lunch_end: null,
+            check_out: null,
+            day_status: 'WORKED',
+            entry_late_seconds: null,
+            entry_late_minutes: null,
+            is_entry_deductible: false,
+            overtime_minutes: 0,
+            overtime_authorized: false,
+            overtime_authorized_at: null,
+            overtime_valuation_method: null,
+            overtime_rate_applied: null,
+            overtime_amount: null,
+            requires_overtime_decision: false,
+            ...overrides,
+        }
+    }
+
+    it('returns true when day_status is VACATION', () => {
+        const row = makeRow({ attendance: makeAttendance({ day_status: 'VACATION' }) })
+        expect(isHiddenFromGrid(row)).toBe(true)
+    })
+
+    it('returns false when day_status is LEAVE — stays in grid so the informational leave chip/badge remains reachable', () => {
+        const row = makeRow({ attendance: makeAttendance({ day_status: 'LEAVE' }) })
+        expect(isHiddenFromGrid(row)).toBe(false)
+    })
+
+    it('returns false for a full-day OPEN_ENDED today_leave — the card must stay visible to show the leave chip', () => {
+        const row = makeRow({
+            today_leave: {
+                id: 'leave-1',
+                time_mode: 'OPEN_ENDED',
+                calculation_mode: 'FIXED_PERCENTAGE',
+                is_paid: true,
+                starts_at: null,
+                ends_at: null,
+                note: null,
+            },
+        })
+        expect(isHiddenFromGrid(row)).toBe(false)
+    })
+
+    it('returns false when day_status is ABSENCE — stays in grid so "Justificar falta" remains reachable', () => {
+        const row = makeRow({ attendance: makeAttendance({ day_status: 'ABSENCE' }) })
+        expect(isHiddenFromGrid(row)).toBe(false)
+    })
+
+    it('returns false for a partial SCHEDULED today_leave', () => {
+        const row = makeRow({
+            today_leave: {
+                id: 'leave-1',
+                time_mode: 'SCHEDULED',
+                calculation_mode: 'PROPORTIONAL_HOURS',
+                is_paid: true,
+                starts_at: '2026-04-09T19:00:00+00:00',
+                ends_at: '2026-04-09T22:00:00+00:00',
+                note: null,
+            },
+        })
+        expect(isHiddenFromGrid(row)).toBe(false)
+    })
+
+    it('returns false for a pending row with no attendance and no leave', () => {
+        expect(isHiddenFromGrid(makeRow())).toBe(false)
+    })
+
+    it('returns true when day_status is DAY_OFF — a scheduled rest day never needs action', () => {
+        const row = makeRow({ attendance: makeAttendance({ day_status: 'DAY_OFF' }) })
+        expect(isHiddenFromGrid(row)).toBe(true)
     })
 })
 

--- a/code/webapp/src/types/attendance.ts
+++ b/code/webapp/src/types/attendance.ts
@@ -178,7 +178,7 @@ export type AttendancePhase =
 
 export function getAttendancePhase(attendance: TodayAttendanceData | null): AttendancePhase {
   if (!attendance) return 'pending'
-  if (attendance.day_status === 'LEAVE') return 'on-leave'
+  if (attendance.day_status === 'LEAVE' || attendance.day_status === 'VACATION') return 'on-leave'
   if (attendance.day_status === 'DAY_OFF') return 'day-off'
   if (attendance.day_status === 'ABSENCE') return 'absence'
   if (!attendance.check_in) return 'pending'
@@ -186,6 +186,36 @@ export function getAttendancePhase(attendance: TodayAttendanceData | null): Atte
   if (!attendance.lunch_start) return 'checked-in'
   if (!attendance.lunch_end) return 'at-lunch'
   return 'returned'
+}
+
+/**
+ * True when the employee counts under the "Ausentes" stat: a manually marked
+ * absence, an approved vacation/leave, a scheduled rest day, or a full-day
+ * (OPEN_ENDED) approved leave/permiso. Partial SCHEDULED leaves keep the
+ * employee actionable — the backend never creates an Attendance record for
+ * those (see LeaveGuards::shouldCreateAttendanceRecords), since the employee
+ * is still expected to check in/out normally that day.
+ */
+export function isAbsentRow(row: TodayAttendanceRow): boolean {
+  const phase = getAttendancePhase(row.attendance)
+  if (phase === 'on-leave' || phase === 'absence' || phase === 'day-off') return true
+  return row.today_leave?.time_mode === 'OPEN_ENDED'
+}
+
+/**
+ * True when the row should be removed from the default main working grid
+ * view: an approved VACATION or a scheduled rest day (DAY_OFF) — neither
+ * requires any action from the manager. ABSENCE and LEAVE (day_status LEAVE,
+ * or a full-day OPEN_ENDED leave/permiso) stay in the grid — their cards
+ * expose live, tested functionality that requires the card to remain
+ * visible: ABSENCE shows the "Justificar falta" action
+ * (EmployeeAttendanceCard), and LEAVE shows the informational leave
+ * chip/badge (see attendance-today-leave-context.cy.ts and
+ * attendance-register-leave.cy.ts).
+ */
+export function isHiddenFromGrid(row: TodayAttendanceRow): boolean {
+  const status = row.attendance?.day_status
+  return status === 'VACATION' || status === 'DAY_OFF'
 }
 
 /** Format seconds as "Xm" or "Xh Ym" */

--- a/doc/sprints/sprint-001-attendance-payroll-quality.md
+++ b/doc/sprints/sprint-001-attendance-payroll-quality.md
@@ -33,7 +33,7 @@ A file-level conflict analysis (parsed directly from each SonarCloud Issue's "Af
 
 Expected outcome: a real attendance-correction capability shipped, payroll-close periods can no longer be closed early or as a partial week, the two highest-connected quality debt nodes (#305, #306) cleared, and the sprint's own estimate-vs-tracked comparison populated so future sprints can calibrate estimates against real data.
 
-**Progress as of 2026-07-27:** 4 of 26 scoped Issues completed (15.4%) — #323 (security), #322 (a11y/reliability), #325 (attendance dialog overlay, PR #334 ready to merge), #309 (list-reorder rendering bug, PR #339 ready to merge). All four are in Round 1.
+**Progress as of 2026-07-27:** 5 of 26 scoped Issues completed (19.2%) — #323 (security), #322 (a11y/reliability), #325 (attendance dialog overlay, PR #334 ready to merge), #309 (list-reorder rendering bug, PR #339 ready to merge), #327 (Ausentes stat card, PR #336 ready to merge). All five are in Round 1.
 
 ## 2. Context
 
@@ -61,7 +61,7 @@ Base state: `main` @ `079a316`, 26 open Issues, zero Issues yet linked to a GitH
 | Target completion (deadline) | 2026-08-09 |
 | Calendar duration (planned) | 14 days |
 | Active workdays | — |
-| Progress (Issues completed) | 4 / 26 (15.4%) — #323, #322, #325, #309 |
+| Progress (Issues completed) | 5 / 26 (19.2%) — #323, #322, #325, #309, #327 |
 
 ### How the deadline was set
 
@@ -130,7 +130,7 @@ Lower-value maintainability cleanups are interleaved into the same rounds as hig
 | ✅ | #322 | [Reliability] Mouse events should have corresponding keyboard events | Critical | 1h | 2h | 0.2h | PR #333 | Real a11y/interaction bug. Fixed, SonarCloud + Copilot review passed, merged |
 | ✅ | #325 | Overlay del diálogo "Registrar entrada" no cubre toda la pantalla | High | 0.5h | 1.5h | 0.27h | PR #334 | Fixed — added `container="viewport"` to `ConfirmDialog` in `AttendanceTimeDialog`; portal-to-`document.body` test added, 2 Copilot review comments addressed. **Land before starting #328** — both touch `AttendanceTimeDialog.tsx`. PR ready, merge pending |
 | 🚧 | #329 | Auto-calculate current week for payroll close + Sunday 19:00 gate | High | 3h | 6h | — | — | Prevents closing a wrong/partial payroll period |
-| 🚧 | #327 | Add "Ausentes" stat card, move absent employees out of main grid | High | 2h | 4h | — | — | Frontend-only |
+| ✅ | #327 | Add "Ausentes" stat card, move absent employees out of main grid | High | 2h | 4h | 16.4h | PR #336 | Fixed — 5th "Ausentes" stat card + clickable filter tabs, smart default tab w/ URL persistence, justify-now flow with exit animations, shared `useDialogTransition` hook (full migration → #342). `/finish-pr`'s Devin/DeepWiki readiness gate caught and fixed 5 issues: a CI route-typing break, an exit-animation race, a Custom Hook Convention violation, and an empty-tab-at-end-of-day bug — 0 Bugs on final pass. PR ready, merge pending |
 | ⏳ | #276 | Integrate a real WhatsApp provider in WhatsAppService | Medium | 2h | 4h | — | — | Backend-only, zero overlap with anything |
 | ✅ | #309 | [Maintainability] JSX list components should not use array indexes as key | Medium | 1h | 2h | 0.7h | PR #339 | Fixed 5 array-index keys (data-grid ellipsis, cash line items, product-wizard conversions/balances, dashboard stats); 2 Copilot review bugs fixed (non-functional state updaters causing possible desync under rapid clicks); Vitest coverage added for previously-untested remove-item flows (81.8% on touched files); ESLint + TypeScript clean; PR ready, merge pending |
 | ⏳ | #321 | [Maintainability] Heading elements should have accessible content | Medium | 0.5h | 1h | — | — | a11y |
@@ -273,7 +273,7 @@ Update the comparison as each round finishes — do not wait until sprint closur
 | ✅ | #322 | Backdrop `<div onClick>` → native `<button>` in confirm-dialog.tsx, BranchSwitcher.tsx, Sidebar.tsx (reused `dialog-frame.tsx` idiom) | PR #333 | 621868b | 0.2h | SonarCloud + Copilot review passed; existing Vitest suites (60 tests) pass unmodified; merged |
 | ✅ | #325 | Added `container="viewport"` to `ConfirmDialog` in `AttendanceTimeDialog`, fixing the overlay for all 4 attendance dialogs (check-in, lunch-start, lunch-return, check-out); added a portal-assertion test | PR #334 | — | 0.27h | Vitest 17/17 passing, ESLint + TypeScript clean, 2 Copilot review comments addressed and resolved; manual in-browser verification of the 4 flows still pending (no browser automation available); PR ready, merge pending |
 | 🚧 | #329 | In progress | — | — | — | — |
-| 🚧 | #327 | In progress | — | — | — | — |
+| ✅ | #327 | Added a 5th "Ausentes" stat card, made every stat card a clickable filter tab with a smart default tab + URL persistence, a justify-now prompt with pin/exit-animation flow for "Marcar falta", and extracted a shared `useDialogTransition` hook (full system-wide migration deferred to #342) | PR #336 | — | 16.4h | Vitest 3479+/3479+ passing, PHPUnit 1384 passing, Cypress 46 specs/151 tests (6 pre-existing/unrelated failures verified against a clean baseline); ESLint + TypeScript clean; `/finish-pr`'s Devin/DeepWiki readiness gate found and fixed 5 issues across two passes (a `webapp-lint` CI route-typing break, an exit-animation-skip bug, a race between that fix and the mark-falta mutation's refetch, a Custom Hook Convention violation, and `resolveDefaultFilter` landing on an empty tab at end-of-day) — final pass: 0 Bugs, 0 unresolved flags; PR ready, merge pending |
 | ⏳ | #328 | Not started | — | — | — | — |
 | ⏳ | #276 | Not started | — | — | — | — |
 | ⏳ | #324 | Not started | — | — | — | — |
@@ -318,6 +318,7 @@ Not applicable — sprint just started, no lessons yet. First candidate lesson t
 | Status | Proposed Issue | Title | Reason | Candidate Sprint |
 |---|---:|---|---|---|
 | ⏳ | — | Retrofit real Estimates onto #305–#323 per `doc/conventions/tasks.md` | Current values are rough sizing, not technically scoped | Sprint 001 (before each Issue's round starts) |
+| ⏳ | #342 | Unify dialog component and enter/exit transitions across the system | Discovered while implementing #327: 3 duplicated dialog animation implementations + 6 dialogs with no animation + a separate SlidePanel family; a scoped-to-Attendance version of the shared hook lands in #327's PR, full system migration is cross-cutting frontend work that doesn't fit Sprint 001's scope | Next |
 
 ## 18. Sprint Closure Checklist
 

--- a/doc/tasks/2026-07/327-attendance-absent-stat-card.md
+++ b/doc/tasks/2026-07/327-attendance-absent-stat-card.md
@@ -1,0 +1,242 @@
+# ✨ Task #327: Add an "Ausentes" Stat Card and Move Absent Employees Out of the Main Grid on Attendance Today
+
+## 📖 Story
+
+**English:**
+As a Manager, I need a dedicated "Ausentes" stat card that removes employees with a scheduled or marked absence from the main working grid, so that the Attendance/Today screen only shows the employees I still need to act on.
+
+**Español:**
+Como Manager, necesito una tarjeta de estadística "Ausentes" dedicada que remueva de la cuadrícula principal a los empleados con una ausencia programada o marcada, para que la pantalla de Asistencia/Hoy solo muestre a los empleados sobre los que aún debo actuar.
+
+Employees who belong in this new bucket:
+- Employees with a **scheduled absence** (approved leave/permiso covering today, or `day_status = VACATION`)
+- Employees manually marked absent via "Marcar falta" (`day_status = ABSENCE`)
+
+---
+
+## 🧠 Current state (code audit, confirmed against `origin/main`)
+
+- The attendance index page (`code/webapp/src/pages/attendance/index.tsx`) shows 4 stat cards — Total empleados, Pendientes, En trabajo, Completados (`AttendanceSummaryBar.tsx:62-88`) — and renders every employee row in one grid regardless of status.
+- Stat cards are computed purely client-side by `computeSummary(rows)` (`code/webapp/src/pages/attendance/-use-today-attendance-page.ts:20-33`), which buckets every row via `getAttendancePhase()` into `pending` / `checkedIn` / `done` — the `on-leave`, `day-off`, and `absence` phases are currently folded into the "Completados" bucket, not broken out.
+- `getAttendancePhase()` (`code/webapp/src/types/attendance.ts:132-142`) does **not** handle `day_status === 'VACATION'` at all — a vacationing employee with no check-in falls through to `'pending'` and shows up as actionable in the grid today, the opposite of what we want.
+- The API already returns everything needed — **no backend change required**. Each row already includes `attendance.day_status` plus an independent `today_leave` object (`TodayAttendanceController::__invoke`, `code/api/app/Http/Controllers/Api/V1/Attendances/TodayAttendanceController.php:96-140`; frontend type `TodayLeave`, `attendance.ts:42-50`). Today `today_leave` is only used to render an informational chip inside the card (`EmployeeAttendanceCard.tsx:184-230`) — the row still stays in the main grid.
+- `index.tsx` maps and renders **every** row from `rows` unconditionally — there is no filtering by phase before rendering the grid.
+
+### Key design decision (confirmed via code audit)
+
+`row.today_leave` covers **both** full-day (`OPEN_ENDED`) and partial (`SCHEDULED`) approved leaves. Only `OPEN_ENDED` should count as "absent":
+- Backend (`LeaveGuards::shouldCreateAttendanceRecords`, `code/api/app/Actions/Leaves/Concerns/LeaveGuards.php:86-97`) only creates an `Attendance` record with `day_status = LEAVE` for full-day leaves — `SCHEDULED` (partial) leaves never touch `Attendance`, because "the employee is still expected to check in/out normally that day".
+- `EmployeeAttendanceCard.tsx:271` already derives `isFullDayLeave = leave?.time_mode === 'OPEN_ENDED'` to hide check-in/mark-falta buttons only for full-day leaves.
+- The existing E2E spec `attendance-today-leave-context.cy.ts` asserts that an employee with a `SCHEDULED` partial leave (EMP-008, Vargas Sofia) still shows `Registrar entrada` / `Marcar falta` buttons — i.e. must remain actionable in the grid. Treating any non-null `today_leave` as absent would break this test.
+
+So: **absent (stat count)** = `day_status ∈ {ABSENCE, VACATION, LEAVE}` OR `today_leave?.time_mode === 'OPEN_ENDED'`. Partial `SCHEDULED` leaves keep the employee in the grid, unchanged from today.
+
+`day_status = DAY_OFF` (scheduled rest day) is **not** part of "absent" — it stays folded into "Completados", unchanged from today.
+
+### Second design decision (surfaced to and confirmed by the user)
+
+**ABSENCE-marked employees stay in the main grid**, even though they count toward the "Ausentes" stat. `EmployeeAttendanceCard.tsx:401-414` renders a `phase === 'absence'`-only "Justificar falta" button (`data-testid="btn-justify-absence"`) that converts a marked falta into a justified leave — this action requires the card to be visible. `attendance-day-status.cy.ts` already covers this flow end-to-end (mark falta → card stays visible with the button → justify it). Removing ABSENCE rows from the grid (as the wireframe below literally shows) would make this action unreachable and break that spec.
+
+### Third design decision (surfaced to and confirmed by the user)
+
+Verified against a clean `main` checkout (git stash) that removing **any** `on-leave`-phase row (i.e. `day_status = LEAVE`, whether from a full-day `OPEN_ENDED` leave or from justifying a falta) from the grid is a genuine regression, not a pre-existing flake:
+- `attendance-today-leave-context.cy.ts` — EMP-007's full-day `OPEN_ENDED` leave card disappears entirely (2 tests broke; passed on baseline)
+- `attendance-register-leave.cy.ts` — after justifying an absence into a leave, the card disappears (1 test broke; passed on baseline)
+
+Both rely on the card staying visible to show the informational leave chip (`EmployeeAttendanceCard.tsx` `LeaveChip`) / "Ausencia" badge. (One other failure, `attendance-day-status.cy.ts`'s "Justificar Falta" test, was confirmed **pre-existing** on baseline `main` — unrelated to this change, a latent test-order dependency bug, not touched by this PR.)
+
+So `LEAVE` (day_status) stays in the grid too, same as `ABSENCE` — **only `VACATION` is hidden from the grid**. Predicates as of the first session:
+- `isAbsentRow(row)` — used only for the **stat card count** — `phase ∈ {'on-leave', 'absence'}` OR `today_leave.time_mode === 'OPEN_ENDED'` (unchanged — VACATION/LEAVE/ABSENCE/full-day-leave all count as "Ausente")
+- `isHiddenFromGrid(row)` — used to **filter the main grid** — `attendance?.day_status === 'VACATION'` only. `ABSENCE` and `LEAVE` (and full-day `OPEN_ENDED` leaves, which always carry `day_status = LEAVE` per `LeaveGuards`) stay visible in the grid, unchanged from today.
+
+### Fourth design decision — second session (user feedback after reviewing PR #336)
+
+The user reviewed the shipped behavior and asked for two changes:
+1. **`DAY_OFF` (scheduled rest day) should also count as "Ausente" AND be hidden from the grid** — same treatment as `VACATION`. Confirmed no existing test depends on a `DAY_OFF` card staying visible in the main `/attendance` grid (`DAY_OFF` is auto-managed by `CloseDayAction`, never manually toggled from this screen — the only "Descanso"/`is_day_off` references in Cypress specs are either the unrelated `/attendance/reports/today` page, or the `schedule.is_day_off` flag used by the extra-day-express flow, a different field entirely).
+2. **Every stat card becomes a clickable tab that filters the main grid** — Total/Pendientes/En trabajo/Completados/Ausentes. Confirmed: all 5 cards are clickable, toggle off on second click.
+
+Implementation:
+- `isAbsentRow` and `isHiddenFromGrid` both extended to include `phase === 'day-off'` / `day_status === 'DAY_OFF'`.
+- New `attendanceBucket(row)` helper (`-use-today-attendance-page.ts`) centralizes the phase→bucket mapping, reused by both `computeSummary` and the new `filterRowsForGrid(rows, filter)`.
+- New `AttendanceFilter` type (`'total' | 'pending' | 'checkedIn' | 'done' | 'absent'`) lives in `AttendanceSummaryBar.tsx` alongside `AttendanceSummary`. `null` = no tab selected = today's default view (hide only VACATION/DAY_OFF). Selecting `'total'` or `'absent'` overrides the default to reveal the normally-hidden rows; the others are subsets of the default view.
+- `SummaryStat` changed from a `<div>` to a `<button>` (`aria-pressed`, `data-testid="stat-{total|pending|checked-in|done|absent}"`, active-state ring styling). Clicking the active tab again clears the filter (toggle).
+- Deferred the "En comida" (at-lunch) split into its own issue: **#337**, since the `checkedIn` bucket still lumps `checked-in`/`at-lunch`/`returned` together — out of scope for this session.
+
+**Debugging note:** the first Cypress attempt at asserting the "Ausentes" count via `cy.contains("Ausentes").parent().find("p").first()` intermittently read the "Total empleados" value instead ('10' instead of '3'), even with generous timeouts — root-caused to selector ambiguity, not a logic bug (Vitest coverage of the same bucket/filter logic was green throughout). Fixed by adding explicit `data-testid` attributes to each stat card and switching the Cypress spec to `data-testid`-based selectors — more robust than text/DOM-traversal queries going forward.
+
+### Fifth design decision — third session (smart default tab + URL persistence)
+
+The user asked for two more things: (1) the default tab on page load should be "Pendientes" if anyone is pending, else "En trabajo"; (2) the active tab should persist in the URL (`?tab=`) so a page refresh doesn't lose it.
+
+**This turned out to have a much bigger blast radius than expected.** Landing on a *specific single-bucket* tab by default (rather than the old broad "everything except VACATION/DAY_OFF" default) means employees outside that one bucket are no longer visible on page load. Running the **entire** `attendance-*.cy.ts` suite (not just this feature's own spec) surfaced **37 failing tests across 13 spec files** — flows like check-in, lunch start/return, overtime decisions, close-day, and register-leave routinely need to see employees from *multiple* buckets in the same test (e.g. check in a pending employee while another is already checked in). Asked the user whether the default tab should only be a visual highlight (grid stays unfiltered) or actually filter — confirmed: **actually filter**.
+
+Fixed by:
+- Verifying against a clean baseline (git stash) that only `attendance-day-status.cy.ts` (pre-existing "Justificar Falta" flake, see above) and `attendance-weekly-summary-dialog.cy.ts` (pre-existing calendar-navigation failures, unrelated to this issue) fail without any of this session's changes — everything else genuinely regressed.
+- Adding `cy.get("[data-testid='stat-total']").click({ force: true })` after page load (and after any mid-test re-visit to `/attendance`) in all 11 genuinely-affected specs, restoring full-grid visibility for flows that aren't about the tabs feature itself.
+- Two real bugs found and fixed along the way (not test-only artifacts):
+  1. **Race condition**: a manual tab click issued *before* the initial data fetch resolved was silently overwritten once the smart-default effect fired afterward. Fixed by having `toggleFilter` also flip the `hasAppliedDefaultFilter` ref, so any manual interaction — even one that arrives mid-load — permanently disables the automatic default.
+  2. A `cy.reload()`-based URL-persistence test needed `cy.clock(...)` re-applied after the reload, since a full page reload creates a fresh JS context and drops the mocked `Date`.
+
+Final default-view semantics: `filterRowsForGrid(rows, filter)` — `null` (not yet resolved) → hide VACATION/DAY_OFF; `'total'`/`'absent'` → override to reveal everyone/only-absent; `'pending'`/`'checkedIn'`/`'done'` → that bucket only. `resolveDefaultFilter(summary)` picks `'pending'` if `summary.pending > 0`, else `'checkedIn'`. The `/attendance/` route's `validateSearch` declares an optional `tab` search param; `AttendancePage` mirrors `selectedFilter` into it via `navigate({ search, replace: true })`.
+
+### Sixth design decision — fourth session (justify-now prompt + card exit animation)
+
+The user asked for two more UX refinements to the "Marcar falta" flow:
+1. Right after confirming falta, ask "¿Deseas justificar la falta ahora?" — Yes opens the justify (`RegisterLeaveDialog`) directly; No just leaves it marked (unchanged from before, justify later via the existing "Justificar falta" button).
+2. When that flow concludes (either answer), the card should play a fade-out/slide-out animation instead of disappearing abruptly — since the employee's bucket usually changes to `'absent'`, which the active tab (e.g. "Pendientes") no longer matches.
+
+Implementation:
+- `EmployeeAttendanceCard.tsx` gained a second `ConfirmDialog` (title "¿Deseas justificar la falta ahora?", `variant="info"`) shown right after the falta-confirm dialog closes. Reused the existing `RegisterLeaveDialog`/`showJustifyDialog` state for the "Sí" path.
+- New `.animate-card-exit` keyframes in `index.css` (fade + slight slide, 0.35s) applied via a new `isExiting` prop.
+
+**Bug found via live browser testing** (not caught by Vitest/Cypress, since neither exercises the real refetch-driven bucket change against the whole flow): the card — and the justify-now dialog rendered *inside* it — could get unmounted by the data refetch the instant the falta mutation succeeded, *before* the user ever saw the justify-now prompt, because the row stopped matching the active tab's bucket immediately. Fixed with a two-phase model in `-use-today-attendance-page.ts`:
+  - `pinEmployeeCard(id)` — called the moment "Confirmar falta" is clicked (wrapped around `onMarkDayStatus` in `index.tsx`) — keeps the row rendered, fully interactive, no animation, regardless of bucket, for as long as its dialog flow is in progress.
+  - `onFaltaFlowComplete(id)` — called when the justify-now dialog is dismissed *or* `RegisterLeaveDialog` closes (either outcome) — transitions the row from `'pinned'` to `'exiting'`, which plays `.animate-card-exit` and removes it from `visibleRows` after 350ms.
+  - `cardOverrides: Map<string, 'pinned' | 'exiting'>` replaces the earlier plain `Set` from session 3 to represent this two-phase state.
+
+Verified end-to-end in a live browser (not just Vitest/Cypress) against the dev-lab `sushigo-e` server (port `5175` — note this differs from the default Vite port `5173`, which belongs to a different workspace).
+
+**Follow-up fix (same session, caught by the user in the live demo):** the initial `visibleRows` implementation appended pinned/exiting rows *after* the filtered list, so a card marked falta visibly jumped to the end of the grid instead of staying put. Fixed by refactoring `filterRowsForGrid` around a new per-row `matchesGridFilter` predicate, and building `visibleRows` as a single pass over `data` in its original order (`row => cardOverrides.has(id) || matchesGridFilter(row, filter)`) instead of filter-then-append. Verified with a new Vitest case (row pinned in the *middle* of the list, not at the edges) and re-confirmed live in the browser.
+
+### Eighth design decision — sixth session (`/finish-pr` readiness fixes)
+
+Running `/finish-pr` surfaced a CI failure and, across two Devin/DeepWiki automated-review passes, four real bugs in the code shipped by sessions 3–4 — none previously caught by Vitest/Cypress since they all depend on timing or a specific end-of-day data shape:
+
+1. **`webapp-lint` CI failure**: `useNavigate({ from: '/attendance' })` in `index.tsx` broke TanStack Router's route-typing inference once the generated route tree was regenerated fresh (as CI always does, but a stale local `routeTree.gen.ts` had been masking it). Fixed with the recommended `Route.useNavigate()` pattern, which resolves its own route without a manually-typed `from` string.
+2. **Exit-animation skipped when it shouldn't be** (first pass): `startExitAnimation` needed to distinguish "row still belongs in the active tab" (no animation needed) from "row is actually leaving" (animate out) — the initial fix decided this by reading `data`, checking `matchesGridFilter(row, selectedFilter)`.
+3. **Same fix raced `useMarkDayStatus`'s refetch** (second pass, reported after the first fix shipped): `data` can still reflect the pre-mutation row when the manager dismisses the justify-now prompt quickly, since `useMarkDayStatus` only invalidates/refetches `onSuccess`. Replaced the `data`-based check with a purely `selectedFilter`-based one (`matchesFilterAfterFalta`), since the mark-falta flow is *guaranteed* to end with `day_status` as `ABSENCE` or `LEAVE` regardless of the manager's choice — traced through `RegisterDirectLeaveAction.php` to confirm a partial (`SCHEDULED`) justify-leave never touches the existing `ABSENCE` `Attendance` row, and any other leave type overwrites it to `LEAVE`. This removes the race entirely instead of narrowing the window.
+4. **`EmployeeAttendanceCard` violated the repo's mandatory Custom Hook Convention**: 5 `useState` + a `useEffect` + a `useRef` were inline in the component. Extracted into `use-employee-attendance-card.ts`, owning the falta → justify-now → justify-dialog state machine and the pending↔absence button crossfade; the component is now pure JSX + the hook's returned handlers.
+5. **`resolveDefaultFilter` could land on an empty tab**: it only distinguished "anyone pending" from "nobody pending," falling back to `'checkedIn'` unconditionally — so once every employee had checked out (or nobody was ever checked in, e.g. an all-absent/all-vacation day), the grid loaded with the "En trabajo" tab active and zero matching rows. Changed to cascade `pending → checkedIn → done → absent → null`, landing on the first bucket that actually has anyone in it (falling back to the unfiltered default view only when there are no employees at all).
+
+All five fixes verified via `/finish-pr`'s readiness gate: typecheck/lint clean, the full Vitest suite green, and a second Devin/DeepWiki pass confirming 0 Bugs (down from 2, then a further 2 found on the follow-up pass) and the one "Investigate" flag resolved.
+
+### Seventh design decision — same session (button crossfade polish)
+
+The user asked for one more polish: the "Registrar entrada"/"Marcar falta" buttons should fade out and the "Justificar falta" button should fade in when a falta is marked, instead of swapping abruptly — most visible when the card *doesn't* leave the grid at all (e.g. viewing the "Total"/"Ausentes" tab, where the whole-card exit animation never triggers since the row still matches the filter).
+
+Implementation, scoped narrowly to `EmployeeAttendanceCard.tsx` (local component state only, no hook/parent changes needed):
+- New `.animate-fade-out` keyframes in `index.css`, mirroring the existing `.animate-fade-in`.
+- `displayedActionsPhase` + `actionsFadingOut` local state: on a `pending` ↔ `absence` phase transition specifically (not other phase changes), keep rendering the *old* action block for 200ms with `.animate-fade-out` + `pointer-events-none` (prevents double-clicking a stale button mid-fade), then swap to the new block with `.animate-fade-in`.
+- Deliberately scoped to only the pending/absence swap the user asked about — other phase-conditional blocks (checked-in, at-lunch, etc.) were left untouched to avoid touching their existing, already-tested interaction flows.
+
+---
+
+## 🎨 Wireframe
+
+**Stat cards — naively appending a 5th card breaks the current `grid-cols-2 sm:grid-cols-4` layout:**
+```
+Now (4 cards, sm:grid-cols-4):          Naive +1 card (orphan row):
+┌──────┬──────┬──────┬──────┐          ┌──────┬──────┬──────┬──────┐
+│Total │Pendi.│Enrab.│Compl.│          │Total │Pendi.│Enrab.│Compl.│
+└──────┴──────┴──────┴──────┘          ├──────┴──────┴──────┴──────┤
+                                        │Ausentes  ← spans oddly    │
+                                        └────────────────────────────┘
+```
+Recommended: change the grid to fit 5 evenly (`grid-cols-3 sm:grid-cols-5`):
+```
+┌──────┬──────┬──────┬──────┬────────┐
+│Total │Pendi.│Enrab.│Compl.│Ausentes│
+└──────┴──────┴──────┴──────┴────────┘
+```
+
+**Main grid — only VACATION employees move out into the stat card; ABSENCE and LEAVE stay actionable/visible in the grid:**
+```
+Before:                                 After:
+┌──────┬──────┬──────┬──────┐          ┌──────┬──────┬──────┐
+│Ana   │Beto  │Carla │Dani  │          │Ana   │Beto  │Carla │
+│pend. │work  │ABSENT│done  │          │pend. │work  │ABSENT│
+├──────┼──────┼──────┼──────┤          ├──────┴──────┴──────┘
+│Eva   │      │      │      │          │Dani
+│VACAT.│      │      │      │          │done
+└──────┴──────┴──────┴──────┘          └──────
+                                        (Only Eva/VACATION leaves the grid —
+                                         counted under "Ausentes" instead.
+                                         Carla/ABSENT stays with "Justificar
+                                         falta"; any LEAVE-status card also
+                                         stays, with its leave chip/badge)
+```
+
+---
+
+## ✅ Technical Tasks (frontend-only — no backend change needed)
+
+- [x] 🔧 Extend `getAttendancePhase` to map `day_status === 'VACATION'` to the existing `'on-leave'` phase (same treatment as `LEAVE`)
+- [x] 🔧 Add an `isAbsentRow(row)` predicate (stat count): true when phase is `'on-leave'`/`'absence'`/`'day-off'`, or `row.today_leave?.time_mode === 'OPEN_ENDED'`
+- [x] 🔧 Add an `isHiddenFromGrid(row)` predicate (grid filter): true when `attendance?.day_status` is `VACATION` or `DAY_OFF` — `ABSENCE` and `LEAVE` stay visible by default (existing "Justificar falta" action + leave chip/badge functionality)
+- [x] 🔧 Add an `absent` count to `AttendanceSummary` and `computeSummary()`, no longer folding `on-leave`/`absence`/`VACATION`/`day-off` rows into `done`
+- [x] 📱 Add a 5th `SummaryStat` card "Ausentes" to `AttendanceSummaryBar.tsx`, changing the grid to `grid-cols-3 sm:grid-cols-5` and updating `OvertimeWarning`'s `col-span` to match
+- [x] 📱 In `index.tsx`, filter the main grid via `isHiddenFromGrid`/`filterRowsForGrid` so VACATION/DAY_OFF rows leave the grid by default; ABSENCE and LEAVE rows stay visible/actionable
+- [x] 📱 Make every stat card a clickable tab (`AttendanceFilter`) that filters the main grid; toggles off on second click
+- [x] 🧪 Extend Vitest coverage for `getAttendancePhase`, `isAbsentRow`, `isHiddenFromGrid`, `attendanceBucket`, `filterRowsForGrid`, `computeSummary`, and tab click/active-state behavior
+- [x] 🧪 Cypress happy-path spec covering the "Ausentes" card, DAY_OFF, grid filtering, and tab-click behavior
+- [x] 🧪 Verified against baseline `main` (git stash) that no other existing attendance E2E spec regresses
+- [x] 📂 Deferred "En comida" (at-lunch) tab split to issue #337
+- [x] 🔧 Fold `DAY_OFF` into `isAbsentRow`/`isHiddenFromGrid` (counts as Ausente, hidden from grid by default, same as VACATION)
+- [x] 🔧 Add `resolveDefaultFilter(summary)`: smart default tab is "Pendientes" if anyone is pending, else "En trabajo"
+- [x] 🔧 Fix a race condition where a manual tab click before the initial load resolved was overwritten by the smart-default effect (`toggleFilter` now also flips `hasAppliedDefaultFilter`)
+- [x] 📱 Persist the active tab in the URL (`?tab=`) via the `/attendance/` route's `validateSearch` + `navigate({ search, replace: true })`; restored on page load/reload
+- [x] 🧪 Fixed 11 existing attendance E2E specs that regressed from the smart-default tab narrowing the grid to a single bucket (verified the remaining 2 failures are pre-existing/unrelated via a clean baseline run)
+- [x] 📱 Add a "¿Deseas justificar la falta ahora?" prompt right after confirming "Marcar falta" — Sí opens `RegisterLeaveDialog` directly, No leaves it for later
+- [x] 📱 Add `.animate-card-exit` (fade + slide, 0.35s) played on the card once the falta flow concludes
+- [x] 🔧 Fix a real bug (found via live browser testing): the card and its justify-now dialog could get unmounted by the data refetch before the user ever saw the prompt — fixed with a two-phase `pinEmployeeCard`/`onFaltaFlowComplete` (`cardOverrides: Map<string, 'pinned'|'exiting'>`) model
+- [x] 🧪 Extend Vitest coverage for the justify-now dialog, `isExiting` styling, and the pin→exit state machine
+- [x] 🧪 Extend `attendance-day-status.cy.ts`: decline the new prompt in the existing helper, add a new "justify right away" test
+- [x] 🔍 Verified live in a browser against the `sushigo-e` dev-lab server (port 5175)
+- [x] 🐛 Fix pinned/exiting cards jumping to the end of the grid — rebuild `visibleRows` as a single ordered pass over `data` instead of filter-then-append
+- [x] 📱 Crossfade the pending action buttons out and "Justificar falta" in (`.animate-fade-out`/`.animate-fade-in`) instead of an abrupt swap
+- [x] 🔍 Surveyed every dialog/modal component in `code/webapp/src` (background agent) to scope a system-wide dialog-transition centralization request
+- [x] 🔧 Created GitHub issue #342 tracking full system-wide dialog centralization (3 duplicated animation copies + 6 unanimated dialogs); logged as Sprint 001 Follow-up Work, candidate for next sprint
+- [x] ✨ Extracted `useDialogTransition` shared hook (`components/ui/use-dialog-transition.ts`) and migrated `ConfirmDialog`/`RegisterLeaveDialog` onto it, removing their duplicated `visible`/`animating` state machines
+- [x] 🧪 Added Vitest coverage for `useDialogTransition` (7 tests: visibility, enter/exit classes, scroll lock, Escape handling, exit-complete callback)
+- [x] 🧪 Verified the full 46-spec/151-test Cypress suite; confirmed the 6 failures (the known `attendance-day-status.cy.ts` flake + 5 others) are pre-existing and unrelated by reproducing them identically against a clean baseline with this session's changes stashed out
+
+---
+
+## 🎯 Acceptance Criteria
+
+- [x] A 5th "Ausentes" stat card is shown alongside Total/Pendientes/En trabajo/Completados, evenly laid out (no orphan cell)
+- [x] Employees with `day_status = ABSENCE`, `VACATION`, `LEAVE`, `DAY_OFF`, or an `OPEN_ENDED` `today_leave` are counted under "Ausentes"
+- [x] `VACATION` and `DAY_OFF` employees are excluded from the main grid by default — `ABSENCE` (Justificar falta) and `LEAVE` (leave chip/badge) stay visible, unchanged from today
+- [x] Employees with a `SCHEDULED` (partial) `today_leave` remain in the grid, actionable, unchanged from today
+- [x] Every stat card is a clickable tab: clicking filters the grid to that bucket; "Total" reveals everyone including VACATION/DAY_OFF; clicking the active tab again returns to the default view
+- [x] On page load, the default active tab is "Pendientes" if anyone is pending, else "En trabajo" — a manual click always wins over this default, even if issued before the initial load resolves
+- [x] The active tab persists in the URL and survives a page reload
+- [x] Confirming "Marcar falta" immediately asks whether to justify it now; choosing yes opens the justify dialog directly, no leaves it marked for later
+- [x] The marked card stays fully visible and interactive throughout that prompt/dialog flow, then plays a fade/slide exit animation once it concludes (if it's about to leave the active tab)
+- [x] No backend changes (beyond a new `Testing/` seeder + `test:reset` scenario for the Cypress spec)
+
+---
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `2h`
+- **Pessimistic:** `4h`
+- **Tracked:** `16h24m`
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-07-26", "start": "19:15", "end": "20:51" },
+  { "date": "2026-07-26", "start": "21:20", "end": "01:32" },
+  { "date": "2026-07-27", "start": "01:32", "end": "03:01" },
+  { "date": "2026-07-27", "start": "03:01", "end": "06:03" },
+  { "date": "2026-07-27", "start": "12:50", "end": "14:40" },
+  { "date": "2026-07-27", "start": "15:20", "end": "19:35" }
+]
+```
+
+## 📊 Retrospective
+- **Actual total:** 16h 24m (1h 36m + 4h 12m + 1h 29m + 3h 2m + 1h 50m + 4h 15m)
+- **vs optimistic:** +14h 24m over
+- **vs pessimistic:** +12h 24m over
+
+**Justification:**
+
+Session 1 landed under the optimistic estimate. Sessions 2–5 were driven entirely by user feedback after reviewing the shipped PR, and each added genuinely new scope beyond the original issue: folding `DAY_OFF` into "Ausentes" and making every stat card a clickable tab (session 2), a smart default tab plus URL persistence (session 3), a justify-now prompt/card exit animation/position-preservation fix/button crossfade polish (session 4), and centralizing the dialog enter/exit transition behind a shared hook (session 5). Session 2's debugging detour: the first Cypress assertion for the "Ausentes" count intermittently read the wrong card's value via a fragile `cy.contains().parent().find('p')` chain — root-caused to selector ambiguity (not a logic bug, confirmed via Vitest) and fixed with `data-testid` attributes on each stat card. Session 3's detour was much larger: landing on a specific single-bucket tab by default (rather than the old broad view) turned out to break 37 tests across 13 *other* attendance E2E specs that need to see employees from multiple buckets at once — caught by proactively running the full attendance suite (not just this feature's own spec) before considering the work done, and confirmed via a clean-baseline comparison that only 2 pre-existing, unrelated failures remained. Session 4 stacked several rounds of live-demo feedback: a real race where the justify-now dialog and its card could get unmounted by the data refetch before the user ever saw the prompt (fixed with a two-phase pinned/exiting state machine); a card visibly jumping to the end of the grid instead of staying in place (fixed by rebuilding `visibleRows` as a single ordered pass); and a request to crossfade the action buttons instead of swapping them abruptly. A stray request about an unrelated "Cierre de Nómina" gate (belonging to issue #329 / PR #335 in a different workspace) was correctly declined and not implemented here. Session 5's ask ("centralize enter/exit transitions across every dialog in the system") turned out to have much wider scope than this issue once a full component survey ran: 3 duplicated animation implementations plus 6 dialogs with no animation at all, spread across ~15 files. Per explicit user direction, the full system-wide migration was split into its own issue (#342, logged as Sprint 001 Follow-up Work for the next sprint) rather than expanding this PR's scope; only the shared hook plus its application to Attendance's two dialogs landed here. The full 46-spec/151-test Cypress suite was run (not just the attendance subset) and 6 failures were found; each was reproduced identically against a clean baseline with this session's changes stashed out, confirming none were regressions — one is the previously-documented `attendance-day-status.cy.ts` test-order flake, the other five are unrelated pre-existing flakes (toast/devtools-overlay timing, date/week-number assertions). All 3479 Vitest tests and linters verified green throughout; every visual change was also confirmed live in a browser, not just in automated tests. Session 6 was the `/finish-pr` readiness pass: a `webapp-lint` CI failure (stale local route types masking a real `useNavigate` typing break) and, across two Devin/DeepWiki review passes, four real bugs in sessions 3–4's code — an exit-animation-skip bug, a race between that fix and the mark-falta mutation's refetch, `EmployeeAttendanceCard` violating the mandatory Custom Hook Convention, and `resolveDefaultFilter` landing on an empty tab at end-of-day. None were caught by Vitest/Cypress since all four are timing- or data-shape-dependent; all five were fixed, tested, and re-verified against a clean Devin/DeepWiki pass (0 Bugs) before merge.
+
+---
+
+## 🔗 References
+
+- GitHub issue: [#327](https://github.com/pakodiazdev/sushigo/issues/327)

--- a/doc/tasks/backlog/337-en-comida-stat-tab.md
+++ b/doc/tasks/backlog/337-en-comida-stat-tab.md
@@ -1,0 +1,48 @@
+# ✨ Task #337: Add "En comida" Stat Tab for Employees at Lunch on Attendance Today
+
+## 📖 Story
+
+**English:**
+As a Manager, I need a dedicated "En comida" stat tab on the Attendance/Today screen, so that I can quickly see which employees are currently out at lunch, separate from employees who are actively checked in and working.
+
+**Español:**
+Como Manager, necesito una pestaña de estadística "En comida" dedicada en la pantalla de Asistencia/Hoy, para poder ver rápidamente qué empleados están actualmente en su hora de comida, separado de los empleados que están activamente trabajando.
+
+---
+
+## 🧠 Context
+
+Deferred from #327 / PR #336 (which added the "Ausentes" stat tab and made all stat cards clickable filters over the main grid).
+
+Currently, `computeSummary()` (`code/webapp/src/pages/attendance/-use-today-attendance-page.ts`) lumps three distinct `AttendancePhase` values — `checked-in`, `at-lunch`, and `returned` — into a single `checkedIn` bucket / "En trabajo" tab. There's no way to see, at a glance, how many employees are currently at lunch vs. actively working.
+
+---
+
+## ✅ Technical Tasks
+
+- [ ] 🔧 Add an `atLunch` count to `AttendanceSummary` / `computeSummary()`, splitting the `at-lunch` phase out of the `checkedIn` bucket
+- [ ] 📱 Add a 6th `SummaryStat` "En comida" tab to `AttendanceSummaryBar.tsx`, adjusting the stat grid layout so 6 cards lay out evenly
+- [ ] 📱 Wire "En comida" into the tab-filter behavior introduced in #327/#336 (clicking it filters the main grid to only `at-lunch` employees)
+- [ ] 🧪 Extend Vitest coverage for the new bucket and tab filter
+- [ ] 🧪 Cypress coverage for the new tab
+
+---
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `1h`
+- **Pessimistic:** `2h`
+- **Tracked:** `0h`
+
+### 📅 Sessions
+```json
+[]
+```
+
+---
+
+## 🔗 References
+
+- GitHub issue: [#337](https://github.com/pakodiazdev/sushigo/issues/337)
+- Follows up on #327 / PR #336


### PR DESCRIPTION
## Summary
Closes #327
Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/336

- Adds a 5th "Ausentes" stat card to the Attendance/Today screen, counting employees with `day_status = ABSENCE`, `VACATION`, `LEAVE`, `DAY_OFF` (scheduled rest day), or a full-day (`OPEN_ENDED`) approved leave/permiso
- Fixes a latent bug: `day_status = VACATION` previously fell through `getAttendancePhase` to `'pending'`, making a vacationing employee with no check-in show up as actionable
- By default, only `VACATION` and `DAY_OFF` are removed from the main working grid (counted under "Ausentes" instead) — `ABSENCE` and `LEAVE` stay visible by default, since their cards expose existing, tested functionality (`ABSENCE` → "Justificar falta" action; `LEAVE`/full-day-leave → informational leave chip/badge)
- **Every stat card is a clickable tab** that filters the main grid: click "Pendientes"/"En trabajo"/"Completados" to narrow the grid to that bucket; click "Total" to reveal literally everyone (including the normally-hidden VACATION/DAY_OFF rows); click "Ausentes" to see only absent employees; clicking the active tab again returns to the default view
- **Smart default tab on page load**: lands on "Pendientes" if anyone is pending, otherwise "En trabajo" — a manual click always wins over this default, even one issued before the initial load resolves
- **The active tab persists in the URL** (`?tab=`) so a page refresh doesn't lose the selected view
- **"Marcar falta" now asks whether to justify it right away**: confirming falta immediately prompts "¿Deseas justificar la falta ahora?" — Sí opens the justify dialog directly, No leaves it marked for later (existing "Justificar falta" button, unchanged)
- **The card animates out** (fade + slide, 0.35s) once that flow concludes, instead of disappearing abruptly from the grid — it stays in its original grid position throughout the whole flow, no jump to the end
- **The action buttons crossfade** ("Registrar entrada"/"Marcar falta" fade out, "Justificar falta" fades in) instead of swapping abruptly — most visible on "Total"/"Ausentes" tabs, where the card doesn't leave the grid at all
- Adjusts the stat bar grid to `grid-cols-3 sm:grid-cols-5` so 5 cards lay out evenly (no orphan cell)
- **`ConfirmDialog` and `RegisterLeaveDialog` now share a single `useDialogTransition` hook** (`components/ui/use-dialog-transition.ts`) instead of each duplicating the same enter/exit fade-scale state machine — a subtle, consistent transition on the falta-confirm, ask-justify, and "Registrar ausencia" dialogs
- No backend business-logic changes — only a new `Testing/` seeder + `test:reset` scenario to support the new Cypress spec

### Design decisions worth flagging for review
- The issue's wireframe originally showed both `ABSENCE`- and `LEAVE`-status employees removed from the grid. Verifying against a clean `main` checkout showed this breaks 4 tests across 3 existing E2E specs — all currently rely on the card staying visible. Scope was narrowed to hiding only `VACATION`/`DAY_OFF` from the grid after confirming this with the repo owner. One separate, pre-existing test-order flake in `attendance-day-status.cy.ts` was found on baseline `main` (unrelated to this change, not fixed here).
- The tab-filter behavior, folding `DAY_OFF` into "Ausentes", the smart default tab, URL persistence, and the justify-now/exit-animation refinements were all added in follow-up sessions after the repo owner reviewed the initial implementation.
- **The smart default tab turned out to have a much wider blast radius than expected**: landing on a single-bucket tab by default broke 37 tests across 13 *other* attendance E2E specs (check-in, lunch start/return, overtime decisions, close-day, register-leave, etc.) that need to see employees from multiple buckets in the same test. Caught by running the full `attendance-*.cy.ts` suite (not just this feature's own spec) before considering the work done. Fixed all 11 genuinely-affected specs; verified against a clean baseline that only 2 pre-existing, unrelated failures remain.
- Found and fixed **two** genuine race conditions along the way: (1) a tab click issued before the initial data load resolved could be silently overwritten once the smart-default effect fired; (2) the justify-now dialog and its card could get unmounted by the data refetch before the user ever saw the prompt — the second one was only caught via live browser testing, not by Vitest/Cypress, since neither exercises the exact refetch timing a real user hits. Fixed with a two-phase `pinEmployeeCard`/`onFaltaFlowComplete` state machine.
- Also caught live: the pinned/exiting card was appended after the filtered list, so it visibly jumped to the end of the grid instead of staying in place. Fixed by rebuilding `visibleRows` as a single pass over the data in its original order.
- The "En comida" (at-lunch) bucket is intentionally **not** split out of "En trabajo" in this PR — deferred to **#337**.
- A full audit of every dialog/modal in the webapp found **3 duplicated copies** of this same animation logic (`ConfirmDialog`, `RegisterLeaveDialog`, and a third copy scoped to `components/employees/`) plus **6 dialogs with no animation at all**. Fully unifying all of them touches ~15 files unrelated to this issue's scope, so that migration is tracked separately in **#342** (candidate for next sprint) — this PR only introduces the shared hook and applies it to the two Attendance dialogs already in scope here.

## Test plan
- [x] Vitest full suite: 3479/3479 passing (7 new tests for `useDialogTransition`)
- [x] PHPUnit full suite: `php artisan test` — 1384 passed
- [x] Cypress: full E2E suite (46 specs, 151 tests) — 6 failures, none attributable to this PR's changes: 1 is the known pre-existing `attendance-day-status.cy.ts` test-order flake; the other 5 (`attendance-exempt-employee`, `attendance-weekly-summary-dialog` ×6, `employee-vacation-entitlement`, `extra-day-employee-request`) were reproduced identically against a clean baseline with this PR's dialog changes stashed out — confirmed pre-existing/unrelated (toast/devtools-overlay timing and date/week-number assertions, none reference `ConfirmDialog`/`RegisterLeaveDialog`)
- [x] Linters: Pint ✅ · ESLint ✅ (0 errors) · TypeScript ✅ (0 errors)
- [x] Manually verified live in a browser against the `sushigo-e` dev-lab server

## Manual Testing
1. Log in as `admin@sushigo.com`, go to Asistencia (`/attendance`)
2. Confirm the page lands on "Pendientes" if there's anyone pending, otherwise "En trabajo" — and the URL shows `?tab=pending` (or `checkedIn`)
3. Mark an employee as `VACATION` or confirm one has a scheduled `DAY_OFF` — confirm their card is **not** in any single-bucket tab, and the "Ausentes" count includes them
4. Click "Ausentes" — confirm the grid shows *only* absent employees (including VACATION/DAY_OFF); click it again to toggle back
5. Click "Total empleados" — confirm literally every employee appears
6. Click "Pendientes" / "En trabajo" / "Completados" — confirm the grid narrows to just that bucket each time
7. Click a different tab, then reload the page — confirm the same tab is still active and the URL still reflects it
8. Click "Marcar falta" on a pending employee, confirm it — confirm a new "¿Deseas justificar la falta ahora?" prompt appears, and the card is still fully visible underneath
9. Click "Ahora no" — confirm the card plays a fade/slide-out animation before leaving the grid (if the active tab no longer matches its bucket)
10. Repeat marking falta on another employee, but choose "Justificar ahora" — confirm the "Registrar ausencia" dialog opens directly; complete or cancel it, and confirm the card animates out the same way
11. Confirm an employee with an approved full-day leave (`LEAVE`) also shows up under "Ausentes"/"Total" with its informational leave chip
12. Confirm the stat bar shows 5 evenly-laid-out cards with no orphan cell, on both mobile and desktop widths
13. Confirm the falta-confirm, ask-justify, and "Registrar ausencia" dialogs each fade/scale in and out smoothly (no abrupt appear/disappear)

## Workspace
`sushigo-e` — `feature/327-attendance-absent-stat-card`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


