### PR TITLE
🔨 [#321][b] - Give CardTitle heading accessible content ♿

### DIFF
--- a/code/webapp/src/components/ui/card.tsx
+++ b/code/webapp/src/components/ui/card.tsx
@@ -26,8 +26,14 @@ const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDiv
 )
 CardHeader.displayName = "CardHeader"
 
-const CardTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
-    ({ className, ...props }, ref) => (
+interface CardTitleProps extends React.HTMLAttributes<HTMLHeadingElement> {
+    children: React.ReactNode
+}
+
+// children is required and rendered explicitly (not via ...props spread) so
+// the heading always has verifiable accessible content (SonarCloud typescript:S6850)
+const CardTitle = React.forwardRef<HTMLHeadingElement, CardTitleProps>(
+    ({ className, children, ...props }, ref) => (
         <h3
             ref={ref}
             className={cn(
@@ -35,7 +41,9 @@ const CardTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTML
                 className
             )}
             {...props}
-        />
+        >
+            {children}
+        </h3>
     )
 )
 CardTitle.displayName = "CardTitle"

--- a/doc/tasks/2026-07/321-card-title-heading-content.md
+++ b/doc/tasks/2026-07/321-card-title-heading-content.md
@@ -1,0 +1,58 @@
+# 🔨 Task #321: Heading elements should have accessible content (typescript:S6850)
+
+## 📖 Story
+
+**English:**
+As a developer, I need `CardTitle` in the shared UI kit to expose accessible heading content explicitly, so SonarCloud's static analysis (and assistive technology) can verify the rendered `<h3>` always has meaningful, non-empty content instead of relying on an opaque `...props` spread.
+
+**Español:**
+Como desarrollador, necesito que `CardTitle` en el kit de UI compartido exponga explícitamente el contenido accesible del encabezado, para que el análisis estático de SonarCloud (y la tecnología asistiva) pueda verificar que el `<h3>` renderizado siempre tiene contenido significativo y no vacío, en lugar de depender de un `...props` spread opaco.
+
+---
+
+## 🔍 SonarCloud Finding
+
+| Rule | Category | Severity | File | Line |
+|---|---|---|---|---|
+| `typescript:S6850` | Maintainability | MAJOR | `src/components/ui/card.tsx` | 31 |
+
+**Message:** Heading elements (`<h1>`–`<h6>`) should have accessible, non-empty text content.
+
+## ✅ Technical Tasks
+
+- [x] 🔍 Inspect `card.tsx` — `CardTitle` renders `<h3 {...props} />`, so content only flows through a generic props spread that Sonar's static analyzer can't verify as non-empty
+- [x] 🔍 Audit all real usages (`WeeklySummaryDialog`, `Dashboard`, `login`, `reset-password`, `forgot-password`) — all pass meaningful text/icon+text children, confirming this is a static-analysis false positive rather than a real a11y bug
+- [x] 🔨 Make `children` explicit and required on `CardTitleProps`, rendering `{children}` inside `<h3>` instead of relying solely on `{...props}`
+- [x] ✅ Confirm existing `CardTitle` tests in `card.test.tsx` still pass unchanged
+
+## 🎯 Acceptance Criteria
+
+- [x] `CardTitle` requires `children` at the TypeScript level and renders them explicitly inside the `<h3>`
+- [x] No behavior change for existing consumers — all already pass text children
+- [x] SonarCloud `typescript:S6850` finding at `card.tsx:31` is resolved
+
+## 🚫 Explicitly Out of Scope
+
+- No changes to `CardDescription`, `CardHeader`, `CardContent`, `CardFooter` — the Sonar finding is specific to the heading element (`CardTitle`) only
+
+---
+
+## 🔗 References
+
+- SonarCloud project: https://sonarcloud.io/project/issues?id=pakodiazdev_sushigo-webapp&rules=typescript:S6850
+- Rule: `typescript:S6850`
+- Issue: https://github.com/pakodiazdev/sushigo/issues/321
+
+---
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `0.25h` · **Pessimistic:** `1h` · **Tracked:** _in progress_
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-07-27", "start": "01:45", "end": "?" }
+]
+```

--- a/doc/tasks/2026-07/321-card-title-heading-content.md
+++ b/doc/tasks/2026-07/321-card-title-heading-content.md
@@ -48,11 +48,20 @@ Como desarrollador, necesito que `CardTitle` en el kit de UI compartido exponga 
 ## ⏱️ Time
 
 ### 📊 Estimates
-- **Optimistic:** `0.25h` · **Pessimistic:** `1h` · **Tracked:** _in progress_
+- **Optimistic:** `0.25h` · **Pessimistic:** `1h` · **Tracked:** `5m`
 
 ### 📅 Sessions
 ```json
 [
-  { "date": "2026-07-27", "start": "01:45", "end": "?" }
+  { "date": "2026-07-27", "start": "01:45", "end": "01:48" }
 ]
 ```
+
+## 📊 Retrospective
+- **Actual total:** 3m (5m rounded)
+- **vs optimistic:** −12m
+- **vs pessimistic:** −57m
+
+**Justification:**
+
+The fix was a single, well-understood change: make `CardTitle`'s `children` prop required and render it explicitly inside the `<h3>` instead of via `...props` spread. All 7 real usages already passed meaningful text children, so no callers needed changes — confirmed by a clean `tsc --noEmit`. No unplanned rework or scope discovery occurred.


### PR DESCRIPTION
## Summary
Closes #321
Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/338

- 🔍 `CardTitle` rendered its `<h3>` as `<h3 {...props} />`, so SonarCloud's static analyzer couldn't verify the heading always has non-empty accessible content, flagging `typescript:S6850`
- ♿ Made `children` a required prop on `CardTitle` and render it explicitly inside the `<h3>` instead of relying solely on the `...props` spread
- ✅ No behavior change — all 7 real usages (`WeeklySummaryDialog`, `Dashboard`, `login`, `reset-password`, `forgot-password`) already pass meaningful text/icon children; confirmed with a clean `tsc --noEmit` and the full Vitest suite (240 files / 3410 tests passing)

## Test plan
- [x] Vitest: `npx vitest run src/components/ui/__tests__/card.test.tsx` (12 tests passing)
- [x] Vitest full suite: `npx vitest run` (240 files / 3410 tests passing)
- [x] Linters: ESLint ✅ (0 errors) · TypeScript ✅ (`tsc --noEmit` clean)

## Manual Testing
1. Run `cd code/webapp && npm run dev`
2. Visit `/login`, `/dashboard`, or any page using `Card`/`CardTitle` (e.g. login screen, dashboard quick actions)
3. Confirm card headings render visually identical to before (title text, icon + text combos)
4. Open DevTools and confirm the `<h3>` element still contains the visible text as its accessible content

## Workspace
`sushigo-b` — `refactor/321-card-title-heading-content`

🤖 Generated with [Claude Code](https://claude.com/claude-code)