### PR TITLE
🔨 [#309][a] - Replace array-index React keys with stable identifiers 🔑

### DIFF
--- a/code/webapp/src/components/cash/__tests__/create-adjustment-dialog.test.tsx
+++ b/code/webapp/src/components/cash/__tests__/create-adjustment-dialog.test.tsx
@@ -178,6 +178,32 @@ describe('CreateAdjustmentDialog', () => {
         expect(updatedAmountInputs.length).toBe(initialAmountInputs.length + 1)
     })
 
+    it('removes a line and keeps the remaining line values when there is more than one line', () => {
+        const { container } = render(
+            <CreateAdjustmentDialog
+                isOpen={true}
+                onClose={mockOnClose}
+                onSuccess={mockOnSuccess}
+            />,
+            { wrapper: createWrapper() },
+        )
+
+        const addButton = screen.getByText(/Agregar Línea/i)
+        fireEvent.click(addButton)
+
+        const amountInputs = screen.getAllByPlaceholderText('0.00')
+        fireEvent.change(amountInputs[0]!, { target: { value: '100' } })
+        fireEvent.change(amountInputs[1]!, { target: { value: '200' } })
+
+        const removeButtons = container.querySelectorAll('button.text-red-600')
+        expect(removeButtons.length).toBe(2)
+        fireEvent.click(removeButtons[0]!)
+
+        const remainingAmountInputs = screen.getAllByPlaceholderText('0.00')
+        expect(remainingAmountInputs.length).toBe(1)
+        expect((remainingAmountInputs[0] as HTMLInputElement).value).toBe('200')
+    })
+
     it('shows the terminal selector and allows picking a terminal for CARD tender type', () => {
         const { container } = render(
             <CreateAdjustmentDialog

--- a/code/webapp/src/components/cash/create-adjustment-dialog.tsx
+++ b/code/webapp/src/components/cash/create-adjustment-dialog.tsx
@@ -41,6 +41,7 @@ export function CreateAdjustmentDialog({
   const [lines, setLines] = useState<CashAdjustmentLineFormData[]>([
     { tender_type: TenderType.CASH, amount: '', currency: 'MXN' }
   ])
+  const [lineKeys, setLineKeys] = useState<string[]>([crypto.randomUUID()])
 
   // Queries
   const { data: sessionsData, isLoading: loadingSessions } = useCashSessions(
@@ -68,17 +69,18 @@ export function CreateAdjustmentDialog({
       setSourceSystem('')
       setNotes('')
       setLines([{ tender_type: TenderType.CASH, amount: '', currency: 'MXN' }])
+      setLineKeys([crypto.randomUUID()])
     }
   }, [isOpen, preselectedSessionId])
 
   const handleAddLine = () => {
-    setLines([...lines, { tender_type: TenderType.CASH, amount: '', currency: 'MXN' }])
+    setLines((prev) => [...prev, { tender_type: TenderType.CASH, amount: '', currency: 'MXN' }])
+    setLineKeys((prev) => [...prev, crypto.randomUUID()])
   }
 
   const handleRemoveLine = (index: number) => {
-    if (lines.length > 1) {
-      setLines(lines.filter((_, i) => i !== index))
-    }
+    setLines((prev) => (prev.length > 1 ? prev.filter((_, i) => i !== index) : prev))
+    setLineKeys((prev) => (prev.length > 1 ? prev.filter((_, i) => i !== index) : prev))
   }
 
   const handleLineChange = <K extends keyof CashAdjustmentLineFormData>(index: number, field: K, value: CashAdjustmentLineFormData[K]) => {
@@ -235,7 +237,7 @@ export function CreateAdjustmentDialog({
 
           <div className="space-y-3">
             {lines.map((line, index) => (
-              <Card key={index} className="p-4">
+              <Card key={lineKeys[index]} className="p-4">
                 <div className="space-y-3">
                   <div className="flex items-center justify-between">
                     <span className="text-sm font-medium">Línea {index + 1}</span>

--- a/code/webapp/src/components/dashboard/Dashboard.tsx
+++ b/code/webapp/src/components/dashboard/Dashboard.tsx
@@ -282,8 +282,8 @@ export default function Dashboard() {
 
             {/* Stats Grid */}
             <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-                {data.stats.map((stat, index) => (
-                    <StatCard key={index} stat={stat} />
+                {data.stats.map((stat) => (
+                    <StatCard key={stat.title} stat={stat} />
                 ))}
             </div>
 

--- a/code/webapp/src/components/inventory/__tests__/product-wizard.test.tsx
+++ b/code/webapp/src/components/inventory/__tests__/product-wizard.test.tsx
@@ -177,6 +177,68 @@ describe('ProductWizard', () => {
         expect(screen.getByText('Variante del Producto')).toBeDefined()
     })
 
+    it('removes a conversion and an opening balance while keeping the remaining values', async () => {
+        createItem.mockResolvedValue({ data: { data: { id: 100 } } })
+        createVariant.mockResolvedValue({ data: { data: { id: 200 } } })
+        apiPost.mockResolvedValue({ data: {} })
+
+        render(<ProductWizard onSuccess={onSuccess} onCancel={onCancel} />, { wrapper: createWrapper() })
+
+        await waitFor(() => expect(apiGet).toHaveBeenCalled())
+        await fillStep1()
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', { name: /siguiente/i }))
+        })
+        await waitFor(() => expect(createItem).toHaveBeenCalled())
+
+        await waitFor(() => expect(screen.getByText('Variante del Producto')).toBeDefined())
+        fireEvent.change(screen.getByPlaceholderText('ej., ROLL-001-8PZ'), { target: { value: 'ROLL-001-8PZ' } })
+        fireEvent.change(screen.getByPlaceholderText('ej., California Roll 8 piezas'), { target: { value: 'California Roll 8pz' } })
+        fireEvent.change(screen.getByDisplayValue('Seleccione una unidad'), { target: { value: '1' } })
+        fireEvent.change(screen.getByPlaceholderText('0.00'), { target: { value: '55.5' } })
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', { name: /siguiente/i }))
+        })
+        await waitFor(() => expect(createVariant).toHaveBeenCalled())
+
+        // Step 3: add two conversions, remove the first, keep the second's value
+        await waitFor(() => expect(screen.getByText('Conversiones de Unidad')).toBeDefined())
+        fireEvent.click(screen.getByText('+ Agregar Conversión'))
+        fireEvent.change(screen.getByPlaceholderText('1.0'), { target: { value: '2' } })
+
+        fireEvent.click(screen.getByText('+ Agregar Conversión'))
+        const conversionSelects = screen.getAllByDisplayValue('Seleccione')
+        fireEvent.change(conversionSelects[2]!, { target: { value: '1' } }) // second conversion from_uom_id
+        fireEvent.change(conversionSelects[3]!, { target: { value: '1' } }) // second conversion to_uom_id
+        fireEvent.change(screen.getAllByPlaceholderText('1.0')[1]!, { target: { value: '3' } })
+
+        fireEvent.click(screen.getAllByText('Eliminar')[0]!)
+
+        const remainingFactorInputs = screen.getAllByPlaceholderText('1.0')
+        expect(remainingFactorInputs.length).toBe(1)
+        expect((remainingFactorInputs[0] as HTMLInputElement).value).toBe('3')
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', { name: /siguiente/i }))
+        })
+
+        // Step 4: add two opening balances, remove the first, keep the second's quantity
+        await waitFor(() => expect(screen.getByText('Existencias Iniciales')).toBeDefined())
+        fireEvent.click(screen.getByText('+ Agregar Ubicación'))
+        fireEvent.change(screen.getAllByPlaceholderText('0.00')[0]!, { target: { value: '10' } })
+
+        fireEvent.click(screen.getByText('+ Agregar Ubicación'))
+        fireEvent.change(screen.getAllByPlaceholderText('0.00')[2]!, { target: { value: '20' } })
+
+        fireEvent.click(screen.getAllByText('Eliminar')[0]!)
+
+        const remainingQuantityInputs = screen.getAllByPlaceholderText('0.00')
+        expect(remainingQuantityInputs.length).toBe(2)
+        expect((remainingQuantityInputs[0] as HTMLInputElement).value).toBe('20')
+    })
+
     it('shows an error when registering the opening balance fails', async () => {
         createItem.mockResolvedValue({ data: { data: { id: 100 } } })
         createVariant.mockResolvedValue({ data: { data: { id: 200 } } })

--- a/code/webapp/src/components/inventory/product-wizard.tsx
+++ b/code/webapp/src/components/inventory/product-wizard.tsx
@@ -88,6 +88,8 @@ export function ProductWizard({ onSuccess, onCancel }: ProductWizardProps) {
     const { showSuccess, showError } = useToast()
     const [currentStep, setCurrentStep] = useState(1)
     const [wizardData, setWizardData] = useState<WizardData>(INITIAL_DATA)
+    const [conversionKeys, setConversionKeys] = useState<string[]>([])
+    const [balanceKeys, setBalanceKeys] = useState<string[]>([])
     const [errors, setErrors] = useState<Record<string, string>>({})
     const [createdItemId, setCreatedItemId] = useState<number | null>(null)
     const [createdVariantId, setCreatedVariantId] = useState<number | null>(null)
@@ -180,6 +182,7 @@ export function ProductWizard({ onSuccess, onCancel }: ProductWizardProps) {
                 { from_uom_id: 0, to_uom_id: 0, factor: 1 },
             ],
         }))
+        setConversionKeys((prev) => [...prev, crypto.randomUUID()])
     }
 
     const updateConversion = (index: number, field: keyof WizardData['conversions'][number], value: number) => {
@@ -196,6 +199,7 @@ export function ProductWizard({ onSuccess, onCancel }: ProductWizardProps) {
             ...prev,
             conversions: prev.conversions.filter((_, i) => i !== index),
         }))
+        setConversionKeys((prev) => prev.filter((_, i) => i !== index))
     }
 
     const addOpeningBalance = () => {
@@ -206,11 +210,12 @@ export function ProductWizard({ onSuccess, onCancel }: ProductWizardProps) {
                 {
                     inventory_location_id: 0,
                     quantity: 0,
-                    uom_id: wizardData.variant.uom_id || 0,
+                    uom_id: prev.variant.uom_id || 0,
                     unit_cost: 0,
                 },
             ],
         }))
+        setBalanceKeys((prev) => [...prev, crypto.randomUUID()])
     }
 
     const updateOpeningBalance = (index: number, field: keyof WizardData['openingBalances'][number], value: number) => {
@@ -227,6 +232,7 @@ export function ProductWizard({ onSuccess, onCancel }: ProductWizardProps) {
             ...prev,
             openingBalances: prev.openingBalances.filter((_, i) => i !== index),
         }))
+        setBalanceKeys((prev) => prev.filter((_, i) => i !== index))
     }
 
     const validateStep1 = (): boolean => {
@@ -663,7 +669,7 @@ export function ProductWizard({ onSuccess, onCancel }: ProductWizardProps) {
                             <>
                                 {wizardData.conversions.map((conversion, index) => (
                                     <div
-                                        key={index}
+                                        key={conversionKeys[index]}
                                         className="rounded-lg border border-gray-200 p-4 space-y-4"
                                     >
                                         <div className="flex items-center justify-between">
@@ -754,7 +760,7 @@ export function ProductWizard({ onSuccess, onCancel }: ProductWizardProps) {
 
                         {wizardData.openingBalances.map((balance, index) => (
                             <div
-                                key={index}
+                                key={balanceKeys[index]}
                                 className="rounded-lg border border-gray-200 p-4 space-y-4"
                             >
                                 <div className="flex items-center justify-between">

--- a/code/webapp/src/components/ui/__tests__/data-grid.test.tsx
+++ b/code/webapp/src/components/ui/__tests__/data-grid.test.tsx
@@ -337,6 +337,38 @@ describe('DataGrid', () => {
             const currentPageButton = container.querySelector('[aria-current="page"]')
             expect(currentPageButton?.className).toContain('bg-primary')
         })
+
+        it('renders ellipsis on both sides when current page is in the middle of a long range', () => {
+            const onPageChange = vi.fn()
+            const { container, getAllByText } = render(
+                <DataGrid
+                    data={testData}
+                    columns={testColumns}
+                    pagination={{
+                        currentPage: 10,
+                        totalPages: 20,
+                        onPageChange,
+                    }}
+                />
+            )
+
+            // Two ellipsis spans per responsive nav (5/7/10-button breakpoints), each with a unique key
+            const ellipses = getAllByText('…')
+            expect(ellipses.length).toBeGreaterThan(0)
+            ellipses.forEach((el) => expect(el.tagName).toBe('SPAN'))
+
+            // First and last page are still reachable
+            const buttons = Array.from(container.querySelectorAll('button'))
+            const firstPageButton = buttons.find(btn => btn.textContent === '1')
+            expect(firstPageButton).toBeDefined()
+            fireEvent.click(firstPageButton!)
+            expect(onPageChange).toHaveBeenCalledWith(1)
+
+            const lastPageButton = buttons.find(btn => btn.textContent === '20')
+            expect(lastPageButton).toBeDefined()
+            fireEvent.click(lastPageButton!)
+            expect(onPageChange).toHaveBeenCalledWith(20)
+        })
     })
 
     describe('column visibility', () => {

--- a/code/webapp/src/components/ui/data-grid.tsx
+++ b/code/webapp/src/components/ui/data-grid.tsx
@@ -164,7 +164,7 @@ export function DataGrid<T extends { id: string | number }>({
     return pages.map((page, i) => {
       if (page === 'ellipsis') {
         return (
-          <span key={`ellipsis-${i}`} className={cn(PAGE_BTN_BASE, 'cursor-default text-muted-foreground')}>
+          <span key={`ellipsis-${pages[i - 1]}`} className={cn(PAGE_BTN_BASE, 'cursor-default text-muted-foreground')}>
             &hellip;
           </span>
         )

--- a/doc/sprints/sprint-001-attendance-payroll-quality.md
+++ b/doc/sprints/sprint-001-attendance-payroll-quality.md
@@ -6,7 +6,7 @@ status: In Progress
 created: 2026-07-25
 started: 2026-07-26
 completed:
-last_updated: 2026-07-26
+last_updated: 2026-07-27
 
 base_branch: main
 base_commit: 079a316
@@ -33,7 +33,7 @@ A file-level conflict analysis (parsed directly from each SonarCloud Issue's "Af
 
 Expected outcome: a real attendance-correction capability shipped, payroll-close periods can no longer be closed early or as a partial week, the two highest-connected quality debt nodes (#305, #306) cleared, and the sprint's own estimate-vs-tracked comparison populated so future sprints can calibrate estimates against real data.
 
-**Progress as of 2026-07-26:** 3 of 26 scoped Issues completed (11.5%) — #323 (security), #322 (a11y/reliability), #325 (attendance dialog overlay, PR #334 ready to merge). All three are in Round 1.
+**Progress as of 2026-07-27:** 4 of 26 scoped Issues completed (15.4%) — #323 (security), #322 (a11y/reliability), #325 (attendance dialog overlay, PR #334 ready to merge), #309 (list-reorder rendering bug, PR #339 ready to merge). All four are in Round 1.
 
 ## 2. Context
 
@@ -61,7 +61,7 @@ Base state: `main` @ `079a316`, 26 open Issues, zero Issues yet linked to a GitH
 | Target completion (deadline) | 2026-08-09 |
 | Calendar duration (planned) | 14 days |
 | Active workdays | — |
-| Progress (Issues completed) | 3 / 26 (11.5%) — #323, #322, #325 |
+| Progress (Issues completed) | 4 / 26 (15.4%) — #323, #322, #325, #309 |
 
 ### How the deadline was set
 
@@ -132,7 +132,7 @@ Lower-value maintainability cleanups are interleaved into the same rounds as hig
 | 🚧 | #329 | Auto-calculate current week for payroll close + Sunday 19:00 gate | High | 3h | 6h | — | — | Prevents closing a wrong/partial payroll period |
 | 🚧 | #327 | Add "Ausentes" stat card, move absent employees out of main grid | High | 2h | 4h | — | — | Frontend-only |
 | ⏳ | #276 | Integrate a real WhatsApp provider in WhatsAppService | Medium | 2h | 4h | — | — | Backend-only, zero overlap with anything |
-| ⏳ | #309 | [Maintainability] JSX list components should not use array indexes as key | Medium | 1h | 2h | — | — | Real rendering-bug risk on list reorder, not just style |
+| ✅ | #309 | [Maintainability] JSX list components should not use array indexes as key | Medium | 1h | 2h | 0.7h | PR #339 | Fixed 5 array-index keys (data-grid ellipsis, cash line items, product-wizard conversions/balances, dashboard stats); 2 Copilot review bugs fixed (non-functional state updaters causing possible desync under rapid clicks); Vitest coverage added for previously-untested remove-item flows (81.8% on touched files); ESLint + TypeScript clean; PR ready, merge pending |
 | ⏳ | #321 | [Maintainability] Heading elements should have accessible content | Medium | 0.5h | 1h | — | — | a11y |
 | ⏳ | #314 | [Maintainability] Unused React typed props should be removed | Low (filler) | 1h | 2h | — | — | Conflict-free, fills spare capacity |
 | ⏳ | #315 | [Maintainability] Functions should not be nested too deeply | Low (filler) | 0.5h | 1h | — | — | Conflict-free, fills spare capacity |
@@ -277,7 +277,8 @@ Update the comparison as each round finishes — do not wait until sprint closur
 | ⏳ | #328 | Not started | — | — | — | — |
 | ⏳ | #276 | Not started | — | — | — | — |
 | ⏳ | #324 | Not started | — | — | — | — |
-| ⏳ | #305–#321 (17 remaining SonarCloud Issues) | Not started | — | — | — | — |
+| ✅ | #309 | Fixed 5 array-index keys (data-grid ellipsis, cash line items, product-wizard conversions/balances, dashboard stats) with stable identifiers (`crypto.randomUUID()`-backed parallel key arrays where the item objects post directly to the API, `pages[i-1]`/`stat.title` where a natural stable value existed) | PR #339 | — | 0.7h | ESLint + TypeScript clean, Vitest 47/47 passing; 2 Copilot review comments fixed (non-functional `setState` updaters in `handleAddLine`/`handleRemoveLine` and stale-closure `uom_id` read in `addOpeningBalance` — both could desync state under rapid clicks); added coverage for previously-untested remove-item flows, raising touched-file line coverage 75.4% → 81.8%; PR ready, merge pending |
+| ⏳ | #305–#308, #310–#321 (16 remaining SonarCloud Issues) | Not started | — | — | — | — |
 | ⏳ | #85 | Not started | — | — | — | — |
 | 🚧 | #340 | Opportunistic work (§5.4) — `.claude/settings.json` un-ignored and versioned in `sushigo-c`; read-only permission allowlist added | — | — | — | Not scheduled into a round — see §5.4 |
 

--- a/doc/tasks/2026-07/309-array-index-keys.md
+++ b/doc/tasks/2026-07/309-array-index-keys.md
@@ -1,0 +1,60 @@
+# 🔨 Task #309: JSX list components should not use array indexes as key
+
+**Type:** 🔨 Refactor / Code Quality
+**Priority:** Medium
+**Detected by:** SonarCloud — `typescript:S6479` (Maintainability, MAJOR)
+**SonarCloud project:** [pakodiazdev_sushigo-webapp](https://sonarcloud.io/project/issues?id=pakodiazdev_sushigo-webapp&rules=typescript:S6479)
+
+---
+
+## 📋 Description
+
+SonarCloud flagged 5 occurrences of `key={index}` (or index-derived keys) in list-rendering `.map()` calls across the webapp. Using the array index as the React `key` breaks item identity across insertions/reorders/deletions. Each occurrence needs a stable, unique key derived from the item's own data instead of its position.
+
+## 🔍 Affected locations
+
+| File | Line | Fix approach |
+|---|---|---|
+| `src/components/ui/data-grid.tsx` | 167 | Pagination ellipsis. `pages` array is monotonic (`1 … ellipsis … N`); key off the preceding page number (`ellipsis-${pages[i-1]}`) instead of loop index — always unique/stable. |
+| `src/components/cash/create-adjustment-dialog.tsx` | 238 | `lines.map((line, index) => <Card key={index}>`. `CashAdjustmentLineFormData` has no id and is posted verbatim to the API, so no id field is added to it. Track a parallel `lineKeys: string[]` state (`crypto.randomUUID()`), synced in `handleAddLine`/`handleRemoveLine`. |
+| `src/components/inventory/product-wizard.tsx` | 666 | `wizardData.conversions.map((conversion, index) => <div key={index}>`. Same constraint (`conv` posted to `/uom-conversions`). Parallel `conversionKeys: string[]` state, synced in `addConversion`/`removeConversion`. |
+| `src/components/inventory/product-wizard.tsx` | 757 | `wizardData.openingBalances.map((balance, index) => <div key={index}>`. Parallel `balanceKeys: string[]` state, synced in `addOpeningBalance`/`removeOpeningBalance`. |
+| `src/components/dashboard/Dashboard.tsx` | 286 | `data.stats.map((stat, index) => <StatCard key={index}>`. `Stat.title` is unique in the dataset — use `key={stat.title}`. |
+
+---
+
+## 🎯 Acceptance Criteria
+
+- [x] All 5 flagged locations use a stable, unique, non-index-derived key
+- [x] No new `any` usage, no data transformation moved into controllers (n/a — frontend only)
+- [x] `npm run lint` and `npm run typecheck` pass with 0 errors
+- [x] Existing Vitest and Cypress suites pass unchanged (pure refactor, no behavior change); added targeted Vitest coverage for the previously-untested remove-item flows to keep new-code coverage >= 80%
+- [ ] SonarCloud shows 0 new occurrences of `typescript:S6479` on the PR
+
+---
+
+## 🔗 References
+
+- GitHub issue: [#309](https://github.com/pakodiazdev/sushigo/issues/309)
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `1h` · **Pessimistic:** `2h` · **Tracked:** `42m`
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-07-27", "start": "01:45", "end": "02:15" },
+  { "date": "2026-07-27", "start": "02:15", "end": "02:27" }
+]
+```
+
+## 📊 Retrospective
+- **Actual total:** 42m (30 min + 12 min)
+- **vs optimistic:** −18m
+- **vs pessimistic:** −1h 18m
+
+**Justification:**
+
+Finished under the optimistic estimate — the fix was mechanical (5 well-scoped `key` replacements) with no unplanned rework. Deviations from the original no-new-tests scope: added Vitest coverage for the previously-untested "remove item" flows to keep new-code coverage above 80% (session 1), then addressed 3 PR review comments in session 2 — two real bugs (stale closures/non-functional state updates in `handleAddLine`/`handleRemoveLine` and `addOpeningBalance` that could desync state under rapid clicks) and a missing task-file retrospective. Both sessions were fast since the components already had test scaffolding and the review feedback was precise and actionable.


### PR DESCRIPTION
## Summary
Closes #309
Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/339

- Fixed 5 SonarCloud `typescript:S6479` (Maintainability, MAJOR) occurrences of `key={index}` in `.map()` list rendering
- `data-grid.tsx`: pagination ellipsis now keyed off the adjacent page number instead of the loop index (pages array is monotonic, so this is stable and unique)
- `create-adjustment-dialog.tsx` / `product-wizard.tsx`: added parallel `*Keys: string[]` state (via `crypto.randomUUID()`) kept in sync with add/remove handlers — the underlying line/conversion/balance objects are posted verbatim to the API, so no id field was added to those types
- `Dashboard.tsx`: stat cards now keyed by `stat.title` (unique in the dataset)
- Added Vitest coverage for the previously-untested "remove item" flows (line/conversion/opening-balance removal, pagination ellipsis rendering) that exercise the new key logic — combined line coverage across the 4 touched files went from 75.4% to 81.8%
- Pure refactor — no behavior change

## Test plan
- [x] ESLint: 0 errors
- [x] TypeScript: 0 errors
- [x] Vitest: `npx vitest run src/components/inventory/__tests__/product-wizard.test.tsx src/components/ui/__tests__/data-grid.test.tsx src/components/cash/__tests__/create-adjustment-dialog.test.tsx src/components/dashboard/__tests__/Dashboard.test.tsx` — 47/47 passed
- [x] Line coverage across touched files: 81.8% (target >=80% on new code)
- [ ] SonarCloud: 0 new occurrences of `typescript:S6479`

## Manual Testing
No behavior change — key stability is not user-visible. To confirm the fix does not regress UI behavior:
1. **Data grid pagination**: go to any paginated list (e.g. Inventory > Items) with enough pages to show an ellipsis (`...`) on both sides of the current page. Click through several pages, confirm the ellipsis and page buttons render correctly.
2. **Cash adjustment dialog**: open "Registrar Ajuste" on a cash session, add 2–3 lines, remove the middle one, confirm the remaining lines keep their entered values correctly.
3. **Product wizard**: create a new stocked product, in step 3 add 2–3 UoM conversions and remove the first one, confirm remaining rows keep correct values; repeat for step 4 opening balances.
4. **Dashboard**: load the dashboard, confirm the 4 stat cards render in order with correct values.

## Workspace
`sushigo-a` — `refactor/309-array-index-keys`

🤖 Generated with [Claude Code](https://claude.com/claude-code)