### PR TITLE
🔨 [#314][c] - Remove unused React typed props 🧹

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Development is organized into documented sprints — see [`doc/conventions/sprin
 | Sprint | Title | Status | Started | Completed | Target | Document |
 |---|---|---|---|---|---|---|
 | 000 | Introduction | Completed | 2026-07-26 | 2026-07-26 | — | [sprint-000-introduction.md](doc/sprints/sprint-000-introduction.md) |
-| 001 | Attendance, Payroll & Quality | In Progress | 2026-07-26 | 23.1% | 2026-08-09 | [sprint-001-attendance-payroll-quality.md](doc/sprints/sprint-001-attendance-payroll-quality.md) |
+| 001 | Attendance, Payroll & Quality | In Progress | 2026-07-26 | 26.9% | 2026-08-09 | [sprint-001-attendance-payroll-quality.md](doc/sprints/sprint-001-attendance-payroll-quality.md) |
 
 ## Development tips
 

--- a/code/webapp/src/components/inventory/__tests__/variant-details.test.tsx
+++ b/code/webapp/src/components/inventory/__tests__/variant-details.test.tsx
@@ -69,7 +69,6 @@ describe('VariantDetails', () => {
 
     const mockOnEdit = vi.fn()
     const mockOnDelete = vi.fn()
-    const mockOnClose = vi.fn()
 
     beforeEach(() => {
         vi.clearAllMocks()
@@ -85,7 +84,6 @@ describe('VariantDetails', () => {
                 variant={mockVariant}
                 onEdit={mockOnEdit}
                 onDelete={mockOnDelete}
-                onClose={mockOnClose}
             />,
             { wrapper: createWrapper() },
         )
@@ -99,7 +97,6 @@ describe('VariantDetails', () => {
                 variant={mockVariant}
                 onEdit={mockOnEdit}
                 onDelete={mockOnDelete}
-                onClose={mockOnClose}
             />,
             { wrapper: createWrapper() },
         )
@@ -113,7 +110,6 @@ describe('VariantDetails', () => {
                 variant={mockVariant}
                 onEdit={mockOnEdit}
                 onDelete={mockOnDelete}
-                onClose={mockOnClose}
             />,
             { wrapper: createWrapper() },
         )
@@ -129,7 +125,6 @@ describe('VariantDetails', () => {
                 variant={inactiveVariant}
                 onEdit={mockOnEdit}
                 onDelete={mockOnDelete}
-                onClose={mockOnClose}
             />,
             { wrapper: createWrapper() },
         )
@@ -143,7 +138,6 @@ describe('VariantDetails', () => {
                 variant={mockVariant}
                 onEdit={mockOnEdit}
                 onDelete={mockOnDelete}
-                onClose={mockOnClose}
             />,
             { wrapper: createWrapper() },
         )
@@ -157,7 +151,6 @@ describe('VariantDetails', () => {
                 variant={mockVariant}
                 onEdit={mockOnEdit}
                 onDelete={mockOnDelete}
-                onClose={mockOnClose}
             />,
             { wrapper: createWrapper() },
         )
@@ -171,7 +164,6 @@ describe('VariantDetails', () => {
                 variant={mockVariant}
                 onEdit={mockOnEdit}
                 onDelete={mockOnDelete}
-                onClose={mockOnClose}
             />,
             { wrapper: createWrapper() },
         )

--- a/code/webapp/src/components/inventory/variant-details.tsx
+++ b/code/webapp/src/components/inventory/variant-details.tsx
@@ -19,7 +19,6 @@ interface VariantDetailsProps {
   variant: ItemVariant
   onEdit: () => void
   onDelete: () => void
-  onClose: () => void
 }
 
 export function VariantDetails({ variant, onEdit, onDelete }: VariantDetailsProps) {

--- a/code/webapp/src/components/ui/logo.tsx
+++ b/code/webapp/src/components/ui/logo.tsx
@@ -4,7 +4,6 @@ import logoImage from '@/assets/sushigo-logo.png';
 interface LogoProps {
     className?: string;
     collapsed?: boolean;
-    showText?: boolean;
 }
 
 export function Logo({ className, collapsed = false }: LogoProps) {

--- a/code/webapp/src/pages/inventory/item-variants.tsx
+++ b/code/webapp/src/pages/inventory/item-variants.tsx
@@ -217,7 +217,6 @@ export function ItemVariantsPage() {
             variant={selectedVariant}
             onEdit={() => handleEdit(selectedVariant)}
             onDelete={() => handleDelete(selectedVariant.id)}
-            onClose={() => setIsDetailsPanelOpen(false)}
           />
         )}
       </SlidePanel>

--- a/doc/sprints/sprint-001-attendance-payroll-quality.md
+++ b/doc/sprints/sprint-001-attendance-payroll-quality.md
@@ -33,7 +33,7 @@ A file-level conflict analysis (parsed directly from each SonarCloud Issue's "Af
 
 Expected outcome: a real attendance-correction capability shipped, payroll-close periods can no longer be closed early or as a partial week, the two highest-connected quality debt nodes (#305, #306) cleared, and the sprint's own estimate-vs-tracked comparison populated so future sprints can calibrate estimates against real data.
 
-**Progress as of 2026-07-27:** 6 of 26 scoped Issues completed (23.1%) — #323 (security), #322 (a11y/reliability), #325 (attendance dialog overlay, PR #334 ready to merge), #309 (list-reorder rendering bug, PR #339 ready to merge), #327 (Ausentes stat card, PR #336 ready to merge), #329 (payroll close week gate, PR #335 ready to merge). All six are in Round 1.
+**Progress as of 2026-07-27:** 7 of 26 scoped Issues completed (26.9%) — #323 (security), #322 (a11y/reliability), #325 (attendance dialog overlay, PR #334 ready to merge), #309 (list-reorder rendering bug, PR #339 ready to merge), #327 (Ausentes stat card, PR #336 ready to merge), #329 (payroll close week gate, PR #335 ready to merge), #314 (unused React typed props removed, PR #343 ready to merge). All seven are in Round 1.
 
 ## 2. Context
 
@@ -61,7 +61,7 @@ Base state: `main` @ `079a316`, 26 open Issues, zero Issues yet linked to a GitH
 | Target completion (deadline) | 2026-08-09 |
 | Calendar duration (planned) | 14 days |
 | Active workdays | — |
-| Progress (Issues completed) | 6 / 26 (23.1%) — #323, #322, #325, #309, #327, #329 |
+| Progress (Issues completed) | 7 / 26 (26.9%) — #323, #322, #325, #309, #327, #329, #314 |
 
 ### How the deadline was set
 
@@ -134,7 +134,7 @@ Lower-value maintainability cleanups are interleaved into the same rounds as hig
 | ⏳ | #276 | Integrate a real WhatsApp provider in WhatsAppService | Medium | 2h | 4h | — | — | Backend-only, zero overlap with anything |
 | ✅ | #309 | [Maintainability] JSX list components should not use array indexes as key | Medium | 1h | 2h | 0.7h | PR #339 | Fixed 5 array-index keys (data-grid ellipsis, cash line items, product-wizard conversions/balances, dashboard stats); 2 Copilot review bugs fixed (non-functional state updaters causing possible desync under rapid clicks); Vitest coverage added for previously-untested remove-item flows (81.8% on touched files); ESLint + TypeScript clean; PR ready, merge pending |
 | ⏳ | #321 | [Maintainability] Heading elements should have accessible content | Medium | 0.5h | 1h | — | — | a11y |
-| ⏳ | #314 | [Maintainability] Unused React typed props should be removed | Low (filler) | 1h | 2h | — | — | Conflict-free, fills spare capacity |
+| ✅ | #314 | [Maintainability] Unused React typed props should be removed | Low (filler) | 1h | 2h | 0.03h | PR #343 | Fixed — removed unused `onClose` from `VariantDetailsProps` and `showText` from `LogoProps` (both dead, confirmed no call site read them). Vitest 7/7, ESLint + TypeScript clean, Devin/DeepWiki 0 bugs/0 flags, 12/12 checks. PR ready, merge pending |
 | ⏳ | #315 | [Maintainability] Functions should not be nested too deeply | Low (filler) | 0.5h | 1h | — | — | Conflict-free, fills spare capacity |
 | ⏳ | #316 | [Maintainability] Jump statements should not be redundant | Low (filler) | 0.5h | 1h | — | — | Conflict-free, fills spare capacity |
 | ⏳ | #317 | [Maintainability] "catch" clauses should do more than rethrow | Low (filler) | 0.5h | 1h | — | — | Conflict-free, fills spare capacity |
@@ -278,7 +278,8 @@ Update the comparison as each round finishes — do not wait until sprint closur
 | ⏳ | #276 | Not started | — | — | — | — |
 | ⏳ | #324 | Not started | — | — | — | — |
 | ✅ | #309 | Fixed 5 array-index keys (data-grid ellipsis, cash line items, product-wizard conversions/balances, dashboard stats) with stable identifiers (`crypto.randomUUID()`-backed parallel key arrays where the item objects post directly to the API, `pages[i-1]`/`stat.title` where a natural stable value existed) | PR #339 | — | 0.7h | ESLint + TypeScript clean, Vitest 47/47 passing; 2 Copilot review comments fixed (non-functional `setState` updaters in `handleAddLine`/`handleRemoveLine` and stale-closure `uom_id` read in `addOpeningBalance` — both could desync state under rapid clicks); added coverage for previously-untested remove-item flows, raising touched-file line coverage 75.4% → 81.8%; PR ready, merge pending |
-| ⏳ | #305–#308, #310–#321 (16 remaining SonarCloud Issues) | Not started | — | — | — | — |
+| ✅ | #314 | Removed unused `onClose` from `VariantDetailsProps` (`variant-details.tsx`, dead — the owning `SlidePanel` already handles closing) and `showText` from `LogoProps` (`logo.tsx`, no call site anywhere passed it); dropped the now-invalid call-site prop and unused test mock | PR #343 | — | 0.03h | Vitest 7/7 passing, ESLint + TypeScript clean; Devin/DeepWiki: 0 bugs, 0 flags, 12/12 checks; 0 review threads; commit already a single commit; PR ready, merge pending |
+| ⏳ | #305–#308, #310–#313, #315–#321 (15 remaining SonarCloud Issues) | Not started | — | — | — | — |
 | ⏳ | #85 | Not started | — | — | — | — |
 | 🚧 | #340 | Opportunistic work (§5.4) — `.claude/settings.json` un-ignored and versioned in `sushigo-c`; read-only permission allowlist added | — | — | — | Not scheduled into a round — see §5.4 |
 

--- a/doc/tasks/2026-07/314-remove-unused-props.md
+++ b/doc/tasks/2026-07/314-remove-unused-props.md
@@ -1,0 +1,72 @@
+# 🔨 Task #314: Unused React typed props should be removed (typescript:S6767)
+
+## 📖 Story
+
+**English:**
+As a developer, I need to remove unused typed props flagged by SonarCloud in `sushigo-webapp`, so the component interfaces accurately reflect what's actually consumed and the project's maintainability debt stays clean.
+
+**Español:**
+Como desarrollador, necesito eliminar las props tipadas no utilizadas reportadas por SonarCloud en `sushigo-webapp`, para que las interfaces de los componentes reflejen fielmente lo que realmente se consume y se mantenga limpia la deuda de mantenibilidad del proyecto.
+
+---
+
+## 🔍 SonarCloud Finding
+
+| Rule | Category | Severity | File | Line |
+|---|---|---|---|---|
+| `typescript:S6767` | Maintainability | MINOR | `src/components/inventory/variant-details.tsx` | 22 |
+| `typescript:S6767` | Maintainability | MINOR | `src/components/ui/logo.tsx` | 7 |
+
+**Message:** "Remove this unused prop" — prop declared in the component's type/interface but never read inside the component body.
+
+## ✅ Technical Tasks
+
+- [x] 🔍 Inspect `variant-details.tsx:22` — confirmed `onClose` is declared in `VariantDetailsProps` but `VariantDetails` only destructures `variant`, `onEdit`, `onDelete`. The panel's own `SlidePanel` wrapper (in `item-variants.tsx`) already owns closing behavior — `VariantDetails`'s `onClose` was dead.
+- [x] 🔍 Inspect `logo.tsx:7` — confirmed `showText` is declared in `LogoProps` but `Logo` only destructures `className`, `collapsed`. No call site anywhere passes `showText`.
+- [x] 🔧 Remove `onClose` from `VariantDetailsProps` in `variant-details.tsx`
+- [x] 🔧 Remove the now-invalid `onClose={...}` prop passed to `<VariantDetails>` in `item-variants.tsx`
+- [x] 🔧 Remove `onClose={mockOnClose}` from all render calls and the unused `mockOnClose` mock in `variant-details.test.tsx`
+- [x] 🔧 Remove `showText` from `LogoProps` in `logo.tsx`
+- [x] 🧪 Run Vitest suite for `variant-details.test.tsx` — confirm still green
+- [x] 🎨 Run ESLint + TypeScript check — 0 errors
+
+## 🎯 Acceptance Criteria
+
+- [x] `onClose` removed from `VariantDetailsProps`, no call site passes it
+- [x] `showText` removed from `LogoProps`
+- [x] No behavior change — existing tests pass unmodified in intent (only the invalid prop dropped)
+- [x] ESLint + TypeScript pass with 0 errors
+
+## 🚫 Explicitly Out of Scope
+
+- No new tests added — this is a pure dead-prop removal with no behavior change, nothing new to cover
+
+---
+
+## 🔗 References
+
+- GitHub issue: [#314](https://github.com/pakodiazdev/sushigo/issues/314)
+- SonarCloud project: [pakodiazdev_sushigo-webapp](https://sonarcloud.io/project/issues?id=pakodiazdev_sushigo-webapp&rules=typescript:S6767)
+
+---
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `0.25h` · **Pessimistic:** `0.75h` · **Tracked:** `2m`
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-07-27", "start": "20:22", "end": "20:24" }
+]
+```
+
+## 📊 Retrospective
+- **Actual total:** 2m (2m)
+- **vs optimistic:** −13m
+- **vs pessimistic:** −43m
+
+**Justification:**
+
+Both flagged locations were confirmed dead on inspection (`VariantDetails`'s `onClose` was shadowed by the owning `SlidePanel`'s own close handler; `Logo`'s `showText` had zero call sites anywhere in the codebase), so the fix was a pure prop removal with no design ambiguity: 4 one-line deletions plus dropping the corresponding call-site prop and unused test mock. Vitest, ESLint, and `tsc --noEmit` all passed on the first run.


### PR DESCRIPTION
## Summary
Closes #314
Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/343

- 🧹 Removed unused `onClose` prop from `VariantDetailsProps` (`variant-details.tsx`) — the owning `SlidePanel` wrapper already handles closing, so this prop was dead
- 🧹 Removed unused `showText` prop from `LogoProps` (`logo.tsx`) — no call site anywhere passes it
- 🧹 Dropped the now-invalid `onClose` call-site prop in `item-variants.tsx` and the unused `mockOnClose` mock in `variant-details.test.tsx`

Resolves SonarCloud `typescript:S6767` (2 occurrences).

## Test plan
- [x] Vitest: `npx vitest run src/components/inventory/__tests__/variant-details.test.tsx` — 7/7 passing
- [x] Linters: ESLint ✅ · TypeScript (`tsc --noEmit`) ✅

## Manual Testing
No behavior change — both props were unused before removal, so there is nothing user-facing to exercise. Verification is purely structural:
1. Open the Inventory → Item Variants page, click a variant row to open the details panel — panel still opens/closes via the `SlidePanel` `X` button exactly as before
2. Confirm `npx tsc --noEmit` and `npm run lint` report 0 errors

## Workspace
`sushigo-c` — `refactor/314-remove-unused-props`

🤖 Generated with [Claude Code](https://claude.com/claude-code)