### PR TITLE
🔨 [#316][e] - Remove redundant return in Layout redirect effect 🧹

### DIFF
--- a/code/webapp/src/components/layout/Layout.tsx
+++ b/code/webapp/src/components/layout/Layout.tsx
@@ -52,7 +52,6 @@ export default function Layout() {
 
         if (shouldRedirectToLogin) {
             router.navigate({ to: '/login' });
-            return;
         }
     }, [isAuthenticated, currentPath, user, router, isLoading, isPublicRoute]);
 

--- a/doc/tasks/2026-07/316-redundant-jump-statement.md
+++ b/doc/tasks/2026-07/316-redundant-jump-statement.md
@@ -21,9 +21,9 @@ SonarCloud flagged 1 occurrence of a redundant `return` statement in `sushigo-we
 
 ## 🎯 Acceptance Criteria
 
-- [ ] Redundant `return` at `Layout.tsx:55` removed
-- [ ] No behavior change (auth redirect flow works identically)
-- [ ] `npm run lint` and `npm run typecheck` pass with 0 errors
+- [x] Redundant `return` at `Layout.tsx:55` removed
+- [x] No behavior change (auth redirect flow works identically)
+- [x] `npm run lint` and `npm run typecheck` pass with 0 errors
 - [ ] SonarCloud shows 0 new occurrences of `typescript:S3626` on the PR
 
 ---
@@ -35,11 +35,20 @@ SonarCloud flagged 1 occurrence of a redundant `return` statement in `sushigo-we
 ## ⏱️ Time
 
 ### 📊 Estimates
-- **Optimistic:** `10m` · **Pessimistic:** `30m` · **Tracked:** _in progress_
+- **Optimistic:** `10m` · **Pessimistic:** `30m` · **Tracked:** `3m`
 
 ### 📅 Sessions
 ```json
 [
-  { "date": "2026-07-27", "start": "20:38", "end": "?" }
+  { "date": "2026-07-27", "start": "20:38", "end": "20:41" }
 ]
 ```
+
+## 📊 Retrospective
+- **Actual total:** 3m
+- **vs optimistic:** −7m
+- **vs pessimistic:** −27m
+
+**Justification:**
+
+Finished well under the optimistic estimate — a single-line redundant `return;` removal with existing test coverage (`Layout.test.tsx`, 10/10 passing) already validating the redirect flow, no new tests needed, lint and typecheck clean on the first pass.

--- a/doc/tasks/2026-07/316-redundant-jump-statement.md
+++ b/doc/tasks/2026-07/316-redundant-jump-statement.md
@@ -1,0 +1,45 @@
+# 🔨 Task #316: Jump statements should not be redundant (typescript:S3626)
+
+**Type:** 🔨 Refactor / Code Quality
+**Priority:** Low
+**Detected by:** SonarCloud — `typescript:S3626` (Maintainability, MINOR)
+**SonarCloud project:** [pakodiazdev_sushigo-webapp](https://sonarcloud.io/project/issues?id=pakodiazdev_sushigo-webapp&rules=typescript:S3626)
+
+---
+
+## 📋 Description
+
+SonarCloud flagged 1 occurrence of a redundant `return` statement in `sushigo-webapp`. The `return` has no effect on control flow and can be safely removed.
+
+## 🔍 Affected locations
+
+| File | Line | Fix approach |
+|---|---|---|
+| `src/components/layout/Layout.tsx` | 55 | `return;` inside the `shouldRedirectToLogin` branch of the redirect `useEffect` is the last statement of the effect callback — remove it, the `router.navigate({ to: '/login' })` call above it is unaffected. |
+
+---
+
+## 🎯 Acceptance Criteria
+
+- [ ] Redundant `return` at `Layout.tsx:55` removed
+- [ ] No behavior change (auth redirect flow works identically)
+- [ ] `npm run lint` and `npm run typecheck` pass with 0 errors
+- [ ] SonarCloud shows 0 new occurrences of `typescript:S3626` on the PR
+
+---
+
+## 🔗 References
+
+- GitHub issue: [#316](https://github.com/pakodiazdev/sushigo/issues/316)
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `10m` · **Pessimistic:** `30m` · **Tracked:** _in progress_
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-07-27", "start": "20:38", "end": "?" }
+]
+```


### PR DESCRIPTION
## Summary
Closes #316
Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/345

- 🧹 Removed a redundant `return;` flagged by SonarCloud (`typescript:S3626`, MINOR) at `src/components/layout/Layout.tsx:55` — it was the last statement in the redirect `useEffect` callback, so it had no effect on control flow
- ✅ No behavior change — the auth redirect logic is identical

## Test plan
- [x] Vitest: `npx vitest run src/components/layout/__tests__/Layout.test.tsx` — 10/10 passing
- [x] Linters: ESLint ✅ (0 errors, pre-existing unrelated warnings) · TypeScript ✅

## Manual Testing
1. Log out and visit any protected route (e.g. `/`) while unauthenticated — confirm you're redirected to `/login`
2. Log in as `admin@sushigo.com` and visit `/login` directly — confirm you're redirected to `/`
3. Behavior is unchanged from before this PR; this is a pure dead-code removal

## Workspace
`sushigo-e` — `refactor/316-redundant-jump-statement`

🤖 Generated with [Claude Code](https://claude.com/claude-code)