### PR TITLE
✨ [#337][a] - Add "En comida" stat tab for employees at lunch ☕

### DIFF
--- a/code/api/app/Console/Commands/TestReset.php
+++ b/code/api/app/Console/Commands/TestReset.php
@@ -8,6 +8,7 @@ use Database\Seeders\OvertimeLftTierSeeder;
 use Database\Seeders\PunctualityBonusGroupSeeder;
 use Database\Seeders\PunctualityRangeSeeder;
 use Database\Seeders\Testing\AttendanceAbsentStatCardSeeder;
+use Database\Seeders\Testing\AttendanceLunchStatTabSeeder;
 use Database\Seeders\Testing\AttendanceTestSeeder;
 use Database\Seeders\Testing\AttendanceTodayLeaveSeeder;
 use Database\Seeders\Testing\CloseDayHappyPathSeeder;
@@ -55,6 +56,10 @@ class TestReset extends Command
         'attendance-absent-stat-card' => [
             AttendanceTestSeeder::class,
             AttendanceAbsentStatCardSeeder::class,
+        ],
+        'attendance-lunch-stat-tab' => [
+            AttendanceTestSeeder::class,
+            AttendanceLunchStatTabSeeder::class,
         ],
         'close-day-happy' => [
             AttendanceTestSeeder::class,

--- a/code/api/database/seeders/Testing/AttendanceLunchStatTabSeeder.php
+++ b/code/api/database/seeders/Testing/AttendanceLunchStatTabSeeder.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Database\Seeders\Testing;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+/**
+ * "En comida" stat tab seeder — one employee per bucket, including the
+ * at-lunch bucket split out of checkedIn, for the attendance-lunch-stat-tab
+ * Cypress spec:
+ *   EMP-001 Mendoza, Carlos   → no attendance record (pending)
+ *   EMP-002 García, María     → checked in, no lunch (checkedIn)
+ *   EMP-003 López, Pedro      → checked in, at lunch, no lunch_end (atLunch)
+ *   EMP-004 Ramírez, Ana      → checked in, lunch done, back at work (checkedIn — "returned")
+ *   EMP-005 Sánchez, Roberto  → checked out (done)
+ *
+ * Employees must already exist (AttendanceTestSeeder ran first).
+ */
+class AttendanceLunchStatTabSeeder extends Seeder
+{
+    private const TEST_DATE = '2026-04-09';
+
+    private const CHECK_IN_UTC = '2026-04-09 19:00:00';
+
+    private const LUNCH_START_UTC = '2026-04-09 20:00:00';
+
+    private const LUNCH_END_UTC = '2026-04-09 20:30:00';
+
+    private const CHECK_OUT_UTC = '2026-04-09 23:00:00';
+
+    public function run(): void
+    {
+        $now = now();
+
+        $employeeIdMap = DB::table('employees')
+            ->whereIn('code', ['EMP-002', 'EMP-003', 'EMP-004', 'EMP-005'])
+            ->pluck('id', 'code')
+            ->toArray();
+
+        DB::table('attendances')->insert([
+            $this->buildRow($employeeIdMap['EMP-002'], self::CHECK_IN_UTC, null, null, null, $now),
+            $this->buildRow($employeeIdMap['EMP-003'], self::CHECK_IN_UTC, self::LUNCH_START_UTC, null, null, $now),
+            $this->buildRow($employeeIdMap['EMP-004'], self::CHECK_IN_UTC, self::LUNCH_START_UTC, self::LUNCH_END_UTC, null, $now),
+            $this->buildRow($employeeIdMap['EMP-005'], self::CHECK_IN_UTC, self::LUNCH_START_UTC, self::LUNCH_END_UTC, self::CHECK_OUT_UTC, $now),
+        ]);
+    }
+
+    private function buildRow(int $employeeId, ?string $checkIn, ?string $lunchStart, ?string $lunchEnd, ?string $checkOut, mixed $now): array
+    {
+        return [
+            'employee_id' => $employeeId,
+            'date' => self::TEST_DATE,
+            'check_in' => $checkIn,
+            'check_out' => $checkOut,
+            'lunch_start' => $lunchStart,
+            'lunch_end' => $lunchEnd,
+            'entry_late_seconds' => 0,
+            'lunch_late_seconds' => 0,
+            'net_worked_minutes' => null,
+            'overtime_minutes' => 0,
+            'overtime_authorized' => false,
+            'overtime_authorized_by' => null,
+            'overtime_authorized_at' => null,
+            'day_status' => 'WORKED',
+            'confirmed_by' => null,
+            'meta' => null,
+            'public_id' => (string) Str::ulid(),
+            'created_at' => $now,
+            'updated_at' => $now,
+        ];
+    }
+}

--- a/code/webapp/cypress/e2e/attendance-absent-stat-card.cy.ts
+++ b/code/webapp/cypress/e2e/attendance-absent-stat-card.cy.ts
@@ -67,16 +67,16 @@ function clickTab(tab: StatTab) {
 // ── Stat card ────────────────────────────────────────────────────────────────
 
 describe("Ausentes stat card", () => {
-  it("shows a 5th 'Ausentes' card counting VACATION, ABSENCE and DAY_OFF employees", () => {
+  it("shows an 'Ausentes' card counting VACATION, ABSENCE and DAY_OFF employees", () => {
     cy.get("[data-testid='stat-absent']", { timeout: 10_000 })
       .find("p")
       .first()
       .should("have.text", "3");
   });
 
-  it("lays out 5 stat cards evenly (no orphan cell)", () => {
+  it("lays out 6 stat cards evenly (no orphan cell)", () => {
     cy.get("[data-testid='stat-absent']", { timeout: 10_000 }).closest("div.grid").should("have.class", "grid-cols-3");
-    cy.get("[data-testid='stat-absent']").closest("div.grid").should("have.class", "sm:grid-cols-5");
+    cy.get("[data-testid='stat-absent']").closest("div.grid").should("have.class", "sm:grid-cols-6");
   });
 });
 

--- a/code/webapp/cypress/e2e/attendance-lunch-stat-tab.cy.ts
+++ b/code/webapp/cypress/e2e/attendance-lunch-stat-tab.cy.ts
@@ -1,0 +1,128 @@
+/**
+ * Attendance Today — "En comida" Stat Card & Tab Filter — E2E happy-path tests
+ *
+ * Covers issue #337: a dedicated "En comida" stat card that splits the
+ * `at-lunch` phase out of the "En trabajo" bucket, and wires it into the
+ * clickable tab-filter behavior introduced in #327/#336.
+ *
+ * Test date: 2026-04-09 (Thursday, a work day for all seeded employees)
+ *
+ * Employees used (seeded by AttendanceLunchStatTabSeeder):
+ *   EMP-001  Mendoza, Carlos   → no attendance record (pending)          — bucket: pending
+ *   EMP-002  García, María     → checked in, no lunch                    — bucket: checkedIn
+ *   EMP-003  López, Pedro      → checked in, at lunch (no lunch_end)     — bucket: atLunch
+ *   EMP-004  Ramírez, Ana      → checked in, lunch done ("returned")     — bucket: checkedIn
+ *   EMP-005  Sánchez, Roberto  → checked out                             — bucket: done
+ *
+ * Since EMP-001 is pending, the page is expected to land on the "Pendientes"
+ * tab by default.
+ *
+ * Para correr solo este archivo:
+ *   make cypress-spec SPEC=attendance-lunch-stat-tab
+ */
+
+import users from "../fixtures/users.json";
+
+const { email: adminEmail, password: adminPassword } = users.admin;
+
+// ── Suite setup ──────────────────────────────────────────────────────────────
+
+before(() => {
+  cy.task("test:reset", "attendance-lunch-stat-tab", { timeout: 60_000 });
+});
+
+// Test time: 18:00 CDMX on 2026-04-09, after every seeded event (last one is
+// Sánchez's check-out at 17:00 CDMX / 23:00 UTC)
+const TEST_TIME_ISO = "2026-04-09T18:00:00-06:00";
+const TEST_TIME_UTC = new Date("2026-04-10T00:00:00Z");
+
+beforeEach(() => {
+  cy.intercept({ url: /\/api\/v1\// }, (req) => {
+    req.headers["X-Test-Time"] = TEST_TIME_ISO;
+    req.continue();
+  }).as("apiWithTestTime");
+
+  cy.loginByApi(adminEmail, adminPassword);
+  cy.visitWithAuth("/attendance");
+  cy.url().should("include", "/attendance", { timeout: 10_000 });
+  // Wait for a stable page element before checking for the dev debugger —
+  // calling closeDevDebugger() immediately after navigation can no-op if the
+  // overlay mounts slightly later, leaving it to cover the UI mid-test.
+  cy.get("[data-testid='stat-total']", { timeout: 10_000 }).should("be.visible");
+  cy.closeDevDebugger();
+
+  cy.clock(TEST_TIME_UTC.getTime(), ["Date"]);
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+type StatTab = "total" | "pending" | "checked-in" | "at-lunch" | "done" | "absent";
+
+/** Clicks a stat card by its data-testid (they're buttons acting as tabs). */
+function clickTab(tab: StatTab) {
+  cy.get(`[data-testid='stat-${tab}']`, { timeout: 10_000 }).click({ force: true });
+}
+
+// ── Stat card ────────────────────────────────────────────────────────────────
+
+describe("En comida stat card", () => {
+  it("shows a 6th 'En comida' card counting only the at-lunch employee (López)", () => {
+    cy.get("[data-testid='stat-at-lunch']", { timeout: 10_000 })
+      .find("p")
+      .first()
+      .should("have.text", "1");
+  });
+
+  it("lays out 6 stat cards evenly (no orphan cell)", () => {
+    cy.get("[data-testid='stat-at-lunch']", { timeout: 10_000 }).closest("div.grid").should("have.class", "grid-cols-3");
+    cy.get("[data-testid='stat-at-lunch']").closest("div.grid").should("have.class", "sm:grid-cols-6");
+  });
+});
+
+// ── Tab filter behavior ────────────────────────────────────────────────────────
+
+describe("'En comida' as a tab", () => {
+  it("clicking 'En comida' reveals only López, hiding everyone else", () => {
+    clickTab("at-lunch");
+
+    cy.contains("López", { timeout: 10_000 }).should("be.visible");
+    cy.contains("Mendoza").should("not.exist");
+    cy.contains("García").should("not.exist");
+    cy.contains("Ramírez").should("not.exist");
+    cy.contains("Sánchez").should("not.exist");
+  });
+
+  it("clicking 'En trabajo' shows García and Ramírez (checked-in + returned), but not López (at lunch)", () => {
+    clickTab("checked-in");
+
+    cy.contains("García", { timeout: 10_000 }).should("be.visible");
+    cy.contains("Ramírez").should("be.visible");
+    cy.contains("López").should("not.exist");
+  });
+
+  it("clicking 'Total empleados' shows literally everyone, including López", () => {
+    clickTab("total");
+
+    cy.contains("Mendoza", { timeout: 10_000 }).should("be.visible");
+    cy.contains("García").should("be.visible");
+    cy.contains("López").should("be.visible");
+    cy.contains("Ramírez").should("be.visible");
+    cy.contains("Sánchez").should("be.visible");
+  });
+});
+
+// ── URL persistence ─────────────────────────────────────────────────────────────
+
+describe("Selected 'En comida' tab persists in the URL", () => {
+  it("updates the URL when 'En comida' is clicked, and restores it after a reload", () => {
+    clickTab("at-lunch");
+    cy.url().should("include", "tab=atLunch");
+
+    cy.reload();
+    cy.clock(TEST_TIME_UTC.getTime(), ["Date"]);
+
+    cy.url({ timeout: 10_000 }).should("include", "tab=atLunch");
+    cy.get("[data-testid='stat-at-lunch']", { timeout: 10_000 }).should("have.attr", "aria-pressed", "true");
+    cy.contains("López", { timeout: 10_000 }).should("be.visible");
+  });
+});

--- a/code/webapp/src/components/attendance/AttendanceSummaryBar.tsx
+++ b/code/webapp/src/components/attendance/AttendanceSummaryBar.tsx
@@ -1,4 +1,4 @@
-import { Clock, CheckCircle2, XCircle, AlertTriangle, Users, UserX } from 'lucide-react'
+import { Clock, CheckCircle2, XCircle, AlertTriangle, Users, UserX, Coffee } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 // ── Types ──────────────────────────────────────────────────────────────────────
@@ -7,13 +7,14 @@ export interface AttendanceSummary {
     total: number
     pending: number
     checkedIn: number
+    atLunch: number
     done: number
     absent: number
     withOvertime: number
 }
 
 /** Which stat tab is filtering the main grid — `null` means no tab is active (default view). */
-export type AttendanceFilter = 'total' | 'pending' | 'checkedIn' | 'done' | 'absent'
+export type AttendanceFilter = 'total' | 'pending' | 'checkedIn' | 'atLunch' | 'done' | 'absent'
 
 // ── Sub-components ─────────────────────────────────────────────────────────────
 
@@ -57,7 +58,7 @@ export function OvertimeWarning({ count }: Readonly<OvertimeWarningProps>) {
     if (count === 0) return null
 
     return (
-        <div className="col-span-3 sm:col-span-5">
+        <div className="col-span-3 sm:col-span-6">
             <div className="flex items-center gap-2 px-4 py-2 rounded-lg bg-yellow-50 dark:bg-yellow-950/30 border border-yellow-200 dark:border-yellow-800">
                 <AlertTriangle className="h-4 w-4 text-yellow-600 dark:text-yellow-400 shrink-0" />
                 <p className="text-sm text-yellow-800 dark:text-yellow-300">
@@ -80,7 +81,7 @@ export interface AttendanceSummaryBarProps {
 
 export function AttendanceSummaryBar({ summary, activeFilter = null, onFilterChange }: Readonly<AttendanceSummaryBarProps>) {
     return (
-        <div className="grid grid-cols-3 sm:grid-cols-5 gap-3">
+        <div className="grid grid-cols-3 sm:grid-cols-6 gap-3">
             <SummaryStat
                 label="Total empleados"
                 value={summary.total}
@@ -107,6 +108,15 @@ export function AttendanceSummaryBar({ summary, activeFilter = null, onFilterCha
                 active={activeFilter === 'checkedIn'}
                 onClick={() => onFilterChange?.('checkedIn')}
                 testId="stat-checked-in"
+            />
+            <SummaryStat
+                label="En comida"
+                value={summary.atLunch}
+                icon={<Coffee className="h-4 w-4" />}
+                colorClass="text-orange-600 dark:text-orange-400"
+                active={activeFilter === 'atLunch'}
+                onClick={() => onFilterChange?.('atLunch')}
+                testId="stat-at-lunch"
             />
             <SummaryStat
                 label="Completados"

--- a/code/webapp/src/components/attendance/__tests__/AttendanceSummaryBar.test.tsx
+++ b/code/webapp/src/components/attendance/__tests__/AttendanceSummaryBar.test.tsx
@@ -125,6 +125,7 @@ describe('AttendanceSummaryBar', () => {
         total: 10,
         pending: 3,
         checkedIn: 4,
+        atLunch: 5,
         done: 2,
         absent: 1,
         withOvertime: 1,
@@ -151,6 +152,13 @@ describe('AttendanceSummaryBar', () => {
         expect(getByText('4')).toBeDefined()
     })
 
+    it('renders at-lunch count', () => {
+        const { getByText } = render(<AttendanceSummaryBar summary={defaultSummary} />)
+
+        expect(getByText('En comida')).toBeDefined()
+        expect(getByText('5')).toBeDefined()
+    })
+
     it('renders done count', () => {
         const { getByText } = render(<AttendanceSummaryBar summary={defaultSummary} />)
 
@@ -167,18 +175,19 @@ describe('AttendanceSummaryBar', () => {
         expect(value?.textContent).toBe('1')
     })
 
-    it('applies grid-cols-3 sm:grid-cols-5 so 5 cards fit evenly', () => {
+    it('applies grid-cols-3 sm:grid-cols-6 so 6 cards fit evenly', () => {
         const { container } = render(<AttendanceSummaryBar summary={defaultSummary} />)
 
         const grid = container.firstChild as HTMLElement
         expect(grid?.className).toContain('grid-cols-3')
-        expect(grid?.className).toContain('sm:grid-cols-5')
+        expect(grid?.className).toContain('sm:grid-cols-6')
     })
 
     it.each<[string, AttendanceFilter]>([
         ['Total empleados', 'total'],
         ['Pendientes', 'pending'],
         ['En trabajo', 'checkedIn'],
+        ['En comida', 'atLunch'],
         ['Completados', 'done'],
         ['Ausentes', 'absent'],
     ])('clicking "%s" calls onFilterChange with "%s"', (label, filter) => {
@@ -235,6 +244,7 @@ describe('AttendanceSummaryBar', () => {
             total: 0,
             pending: 0,
             checkedIn: 0,
+            atLunch: 0,
             done: 0,
             absent: 0,
             withOvertime: 0,
@@ -243,6 +253,6 @@ describe('AttendanceSummaryBar', () => {
 
         // All zero values should be rendered
         const zeros = getAllByText('0')
-        expect(zeros.length).toBeGreaterThanOrEqual(5)
+        expect(zeros.length).toBeGreaterThanOrEqual(6)
     })
 })

--- a/code/webapp/src/pages/attendance/-use-today-attendance-page.ts
+++ b/code/webapp/src/pages/attendance/-use-today-attendance-page.ts
@@ -19,7 +19,7 @@ export interface PendingAttendanceData {
   currentValue?: string | null
 }
 
-type AttendanceBucket = 'pending' | 'checkedIn' | 'done' | 'absent'
+type AttendanceBucket = 'pending' | 'checkedIn' | 'atLunch' | 'done' | 'absent'
 
 /** Which stat bucket a row belongs to (exported for testing) */
 export function attendanceBucket(row: TodayAttendanceRow): AttendanceBucket {
@@ -27,24 +27,26 @@ export function attendanceBucket(row: TodayAttendanceRow): AttendanceBucket {
   const phase = getAttendancePhase(row.attendance)
   if (phase === 'pending') return 'pending'
   if (phase === 'done') return 'done'
+  if (phase === 'at-lunch') return 'atLunch'
   return 'checkedIn'
 }
 
 /** Computes attendance summary from rows (exported for testing) */
 export function computeSummary(rows: TodayAttendanceRow[]): AttendanceSummary {
-  let pending = 0, checkedIn = 0, done = 0, absent = 0, withOvertime = 0
+  let pending = 0, checkedIn = 0, atLunch = 0, done = 0, absent = 0, withOvertime = 0
 
   for (const row of rows) {
     const bucket = attendanceBucket(row)
     if (bucket === 'pending') pending++
     else if (bucket === 'checkedIn') checkedIn++
+    else if (bucket === 'atLunch') atLunch++
     else if (bucket === 'done') done++
     else absent++
 
     if ((row.attendance?.overtime_minutes ?? 0) > 0) withOvertime++
   }
 
-  return { total: rows.length, pending, checkedIn, done, absent, withOvertime }
+  return { total: rows.length, pending, checkedIn, atLunch, done, absent, withOvertime }
 }
 
 /**
@@ -70,16 +72,17 @@ export function filterRowsForGrid(rows: TodayAttendanceRow[], filter: Attendance
 /**
  * Smart default tab applied once the page's first data load resolves and no
  * tab was already chosen (e.g. from the URL). Cascades through the buckets in
- * priority order — Pendientes, then En trabajo, then Completados, then
- * Ausentes — landing on the first one that actually has anyone in it, so the
- * manager never lands on an empty single-bucket tab (e.g. once everyone has
- * checked out, or on a day where every employee is on vacation). Falls back
- * to `null` (the default full view) only when there are no employees at all.
- * Exported for testing.
+ * priority order — Pendientes, then En trabajo, then En comida, then
+ * Completados, then Ausentes — landing on the first one that actually has
+ * anyone in it, so the manager never lands on an empty single-bucket tab
+ * (e.g. once everyone has checked out, or on a day where every employee is
+ * on vacation). Falls back to `null` (the default full view) only when there
+ * are no employees at all. Exported for testing.
  */
 export function resolveDefaultFilter(summary: AttendanceSummary): AttendanceFilter | null {
   if (summary.pending > 0) return 'pending'
   if (summary.checkedIn > 0) return 'checkedIn'
+  if (summary.atLunch > 0) return 'atLunch'
   if (summary.done > 0) return 'done'
   if (summary.absent > 0) return 'absent'
   return null

--- a/code/webapp/src/pages/attendance/__tests__/use-today-attendance-page.test.ts
+++ b/code/webapp/src/pages/attendance/__tests__/use-today-attendance-page.test.ts
@@ -117,6 +117,7 @@ describe('computeSummary', () => {
       total: 0,
       pending: 0,
       checkedIn: 0,
+      atLunch: 0,
       done: 0,
       absent: 0,
       withOvertime: 0,
@@ -181,7 +182,7 @@ describe('computeSummary', () => {
     expect(result.withOvertime).toBe(1)
   })
 
-  it('counts at-lunch as checkedIn', () => {
+  it('counts at-lunch as atLunch, not checkedIn', () => {
     const rows = [
       makeRow({
         attendance: {
@@ -192,7 +193,8 @@ describe('computeSummary', () => {
       }),
     ]
     const result = computeSummary(rows)
-    expect(result.checkedIn).toBe(1)
+    expect(result.atLunch).toBe(1)
+    expect(result.checkedIn).toBe(0)
   })
 
   it('counts returned as checkedIn', () => {
@@ -208,6 +210,7 @@ describe('computeSummary', () => {
     ]
     const result = computeSummary(rows)
     expect(result.checkedIn).toBe(1)
+    expect(result.atLunch).toBe(0)
   })
 
   it('counts ABSENCE, VACATION and LEAVE day_status as absent — not done', () => {
@@ -286,11 +289,16 @@ describe('attendanceBucket', () => {
     expect(attendanceBucket(makeRow())).toBe('pending')
   })
 
-  it('returns "checkedIn" for checked-in/at-lunch/returned rows', () => {
+  it('returns "checkedIn" for checked-in/returned rows', () => {
     const checkedIn = makeRow({ attendance: { id: 'a', check_in: '2026-04-01T13:00:00Z' } as TodayAttendanceRow['attendance'] })
-    const atLunch = makeRow({ attendance: { id: 'a', check_in: '2026-04-01T13:00:00Z', lunch_start: '2026-04-01T14:00:00Z' } as TodayAttendanceRow['attendance'] })
+    const returned = makeRow({ attendance: { id: 'a', check_in: '2026-04-01T13:00:00Z', lunch_start: '2026-04-01T14:00:00Z', lunch_end: '2026-04-01T15:00:00Z' } as TodayAttendanceRow['attendance'] })
     expect(attendanceBucket(checkedIn)).toBe('checkedIn')
-    expect(attendanceBucket(atLunch)).toBe('checkedIn')
+    expect(attendanceBucket(returned)).toBe('checkedIn')
+  })
+
+  it('returns "atLunch" for at-lunch rows', () => {
+    const atLunch = makeRow({ attendance: { id: 'a', check_in: '2026-04-01T13:00:00Z', lunch_start: '2026-04-01T14:00:00Z' } as TodayAttendanceRow['attendance'] })
+    expect(attendanceBucket(atLunch)).toBe('atLunch')
   })
 
   it('returns "done" for a checked-out row', () => {
@@ -332,17 +340,21 @@ describe('filterRowsForGrid', () => {
         employee: { id: 'e6', code: 'E6', user: { first_name: 'F', last_name: 'F' }, roles: [], daily_wage: null },
         attendance: { id: 'a6', day_status: 'DAY_OFF' } as TodayAttendanceRow['attendance'],
       }), // absent — hidden by default
+      makeRow({
+        employee: { id: 'e7', code: 'E7', user: { first_name: 'G', last_name: 'G' }, roles: [], daily_wage: null },
+        attendance: { id: 'a7', check_in: '2026-04-01T13:00:00Z', lunch_start: '2026-04-01T14:00:00Z' } as TodayAttendanceRow['attendance'],
+      }), // atLunch
     ]
   }
 
   it('with null filter, shows everyone except VACATION/DAY_OFF (default view)', () => {
     const visible = filterRowsForGrid(rowsFixture(), null)
-    expect(visible.map((r) => r.employee.code)).toEqual(['E1', 'E2', 'E3', 'E4'])
+    expect(visible.map((r) => r.employee.code)).toEqual(['E1', 'E2', 'E3', 'E4', 'E7'])
   })
 
   it('with "total" filter, shows literally everyone including VACATION/DAY_OFF', () => {
     const visible = filterRowsForGrid(rowsFixture(), 'total')
-    expect(visible).toHaveLength(6)
+    expect(visible).toHaveLength(7)
   })
 
   it('with "absent" filter, shows only ABSENCE/VACATION/DAY_OFF rows', () => {
@@ -360,6 +372,11 @@ describe('filterRowsForGrid', () => {
     expect(visible.map((r) => r.employee.code)).toEqual(['E2'])
   })
 
+  it('with "atLunch" filter, shows only the at-lunch row', () => {
+    const visible = filterRowsForGrid(rowsFixture(), 'atLunch')
+    expect(visible.map((r) => r.employee.code)).toEqual(['E7'])
+  })
+
   it('with "done" filter, shows only the done row', () => {
     const visible = filterRowsForGrid(rowsFixture(), 'done')
     expect(visible.map((r) => r.employee.code)).toEqual(['E3'])
@@ -372,27 +389,32 @@ describe('filterRowsForGrid', () => {
 
 describe('resolveDefaultFilter', () => {
   it('returns "pending" when there is at least one pending employee', () => {
-    const summary = { total: 3, pending: 2, checkedIn: 1, done: 0, absent: 0, withOvertime: 0 }
+    const summary = { total: 3, pending: 2, checkedIn: 1, atLunch: 0, done: 0, absent: 0, withOvertime: 0 }
     expect(resolveDefaultFilter(summary)).toBe('pending')
   })
 
   it('returns "checkedIn" when there are no pending employees', () => {
-    const summary = { total: 3, pending: 0, checkedIn: 1, done: 2, absent: 0, withOvertime: 0 }
+    const summary = { total: 3, pending: 0, checkedIn: 1, atLunch: 0, done: 2, absent: 0, withOvertime: 0 }
     expect(resolveDefaultFilter(summary)).toBe('checkedIn')
   })
 
-  it('returns "done" when nobody is pending or checked in, but someone has finished', () => {
-    const summary = { total: 2, pending: 0, checkedIn: 0, done: 1, absent: 1, withOvertime: 0 }
+  it('returns "atLunch" when nobody is pending or checked in, but someone is at lunch', () => {
+    const summary = { total: 2, pending: 0, checkedIn: 0, atLunch: 1, done: 0, absent: 1, withOvertime: 0 }
+    expect(resolveDefaultFilter(summary)).toBe('atLunch')
+  })
+
+  it('returns "done" when nobody is pending, checked in or at lunch, but someone has finished', () => {
+    const summary = { total: 2, pending: 0, checkedIn: 0, atLunch: 0, done: 1, absent: 1, withOvertime: 0 }
     expect(resolveDefaultFilter(summary)).toBe('done')
   })
 
   it('returns "absent" when everyone is absent and no other bucket has anyone', () => {
-    const summary = { total: 1, pending: 0, checkedIn: 0, done: 0, absent: 1, withOvertime: 0 }
+    const summary = { total: 1, pending: 0, checkedIn: 0, atLunch: 0, done: 0, absent: 1, withOvertime: 0 }
     expect(resolveDefaultFilter(summary)).toBe('absent')
   })
 
   it('returns null when there are no employees at all, instead of landing on an empty bucket tab', () => {
-    const summary = { total: 0, pending: 0, checkedIn: 0, done: 0, absent: 0, withOvertime: 0 }
+    const summary = { total: 0, pending: 0, checkedIn: 0, atLunch: 0, done: 0, absent: 0, withOvertime: 0 }
     expect(resolveDefaultFilter(summary)).toBeNull()
   })
 })
@@ -910,6 +932,7 @@ describe('useTodayAttendancePage', () => {
         total: 1,
         pending: 1,
         checkedIn: 0,
+        atLunch: 0,
         done: 0,
         absent: 0,
         withOvertime: 0,
@@ -959,6 +982,28 @@ describe('useTodayAttendancePage', () => {
 
       await waitFor(() => expect(result.current.isLoading).toBe(false))
       await waitFor(() => expect(result.current.selectedFilter).toBe('checkedIn'))
+    })
+
+    it('defaults to "atLunch" once loaded when nobody is pending or checked in, but someone is at lunch', async () => {
+      vi.mocked(attendanceApi.daily).mockResolvedValue({
+        data: {
+          data: [
+            makeRow({
+              attendance: {
+                id: 'att-1',
+                check_in: '2026-04-01T13:00:00Z',
+                lunch_start: '2026-04-01T14:00:00Z',
+              } as TodayAttendanceRow['attendance'],
+            }),
+          ],
+        },
+      } as never)
+
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+      await waitFor(() => expect(result.current.selectedFilter).toBe('atLunch'))
     })
 
     it('keeps an explicit initialFilter (e.g. from the URL) instead of applying the smart default', async () => {

--- a/code/webapp/src/pages/attendance/index.tsx
+++ b/code/webapp/src/pages/attendance/index.tsx
@@ -35,7 +35,7 @@ import type { PendingAttendanceData } from './-use-today-attendance-page'
 import type { AttendanceFilter } from '@/components/attendance'
 import type { TodayAttendanceEmployee, OvertimePendingEntry, OvertimeValuationMethod } from '@/types/attendance'
 
-const ATTENDANCE_FILTERS: readonly AttendanceFilter[] = ['total', 'pending', 'checkedIn', 'done', 'absent']
+const ATTENDANCE_FILTERS: readonly AttendanceFilter[] = ['total', 'pending', 'checkedIn', 'atLunch', 'done', 'absent']
 
 function isAttendanceFilter(value: unknown): value is AttendanceFilter {
   return typeof value === 'string' && (ATTENDANCE_FILTERS as readonly string[]).includes(value)

--- a/doc/sprints/sprint-001-attendance-payroll-quality.md
+++ b/doc/sprints/sprint-001-attendance-payroll-quality.md
@@ -324,6 +324,7 @@ Not applicable — sprint just started, no lessons yet. First candidate lesson t
 |---|---:|---|---|---|
 | ⏳ | — | Retrofit real Estimates onto #305–#323 per `doc/conventions/tasks.md` | Current values are rough sizing, not technically scoped | Sprint 001 (before each Issue's round starts) |
 | ⏳ | #342 | Unify dialog component and enter/exit transitions across the system | Discovered while implementing #327: 3 duplicated dialog animation implementations + 6 dialogs with no animation + a separate SlidePanel family; a scoped-to-Attendance version of the shared hook lands in #327's PR, full system migration is cross-cutting frontend work that doesn't fit Sprint 001's scope | Next |
+| ✅ | #337 | Add "En comida" stat tab for employees at lunch on Attendance Today | Deferred from #327/PR #336: `computeSummary()` lumped `checked-in`/`at-lunch`/`returned` into one "En trabajo" bucket with no way to see who's at lunch. Completed same-sprint as a mechanical extension of #327's bucket-split + clickable-tab pattern — 0.5h tracked, PR #350 ready, merge pending | Sprint 001 |
 
 ## 18. Sprint Closure Checklist
 

--- a/doc/tasks/2026-07/337-en-comida-stat-tab.md
+++ b/doc/tasks/2026-07/337-en-comida-stat-tab.md
@@ -20,11 +20,11 @@ Currently, `computeSummary()` (`code/webapp/src/pages/attendance/-use-today-atte
 
 ## ✅ Technical Tasks
 
-- [ ] 🔧 Add an `atLunch` count to `AttendanceSummary` / `computeSummary()`, splitting the `at-lunch` phase out of the `checkedIn` bucket
-- [ ] 📱 Add a 6th `SummaryStat` "En comida" tab to `AttendanceSummaryBar.tsx`, adjusting the stat grid layout so 6 cards lay out evenly
-- [ ] 📱 Wire "En comida" into the tab-filter behavior introduced in #327/#336 (clicking it filters the main grid to only `at-lunch` employees)
-- [ ] 🧪 Extend Vitest coverage for the new bucket and tab filter
-- [ ] 🧪 Cypress coverage for the new tab
+- [x] 🔧 Add an `atLunch` count to `AttendanceSummary` / `computeSummary()`, splitting the `at-lunch` phase out of the `checkedIn` bucket
+- [x] 📱 Add a 6th `SummaryStat` "En comida" tab to `AttendanceSummaryBar.tsx`, adjusting the stat grid layout so 6 cards lay out evenly
+- [x] 📱 Wire "En comida" into the tab-filter behavior introduced in #327/#336 (clicking it filters the main grid to only `at-lunch` employees)
+- [x] 🧪 Extend Vitest coverage for the new bucket and tab filter
+- [x] 🧪 Cypress coverage for the new tab
 
 ---
 
@@ -33,12 +33,23 @@ Currently, `computeSummary()` (`code/webapp/src/pages/attendance/-use-today-atte
 ### 📊 Estimates
 - **Optimistic:** `1h`
 - **Pessimistic:** `2h`
-- **Tracked:** `0h`
+- **Tracked:** `0.5h`
 
 ### 📅 Sessions
 ```json
-[]
+[
+  { "date": "2026-07-28", "start": "19:41", "end": "20:12" }
+]
 ```
+
+## 📊 Retrospective
+- **Actual total:** 31m (31 min)
+- **vs optimistic:** −29m
+- **vs pessimistic:** −1h 29m
+
+**Justification:**
+
+Finished comfortably under the optimistic estimate. #327/#336 had already built out every piece of infrastructure this task needed to extend — the bucket-splitting pattern in `computeSummary()`/`attendanceBucket()`, the clickable `SummaryStat` tab wiring, the smart-default cascade, and the `?tab=` URL persistence — so adding `atLunch` was a mechanical extension of an existing pattern rather than new design work. No unplanned rework or blockers came up; the only backend addition was a small seeder for the new Cypress spec, mirroring `AttendanceAbsentStatCardSeeder`.
 
 ---
 


### PR DESCRIPTION
## Summary
Closes #337
Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/350

- ☕ Split the `at-lunch` `AttendancePhase` out of the `checkedIn` bucket into a new `atLunch` bucket in `computeSummary()` / `attendanceBucket()`
- 📱 Added a 6th "En comida" `SummaryStat` card to `AttendanceSummaryBar.tsx` (Coffee icon, amber/orange), grid now lays out 6 cards evenly (`sm:grid-cols-6`)
- 🎚️ Wired `atLunch` into the tab-filter behavior from #327/#336 (click filters the grid to `at-lunch` employees), the smart default-tab cascade, and the `?tab=` URL param
- ✅ Extended Vitest coverage for the new bucket, tab filter and default cascade
- ✅ Added Cypress spec `attendance-lunch-stat-tab.cy.ts` covering the new tab happy path, plus a new backend seeder (`AttendanceLunchStatTabSeeder`) for it
- 🔧 Updated the existing `attendance-absent-stat-card.cy.ts` grid-layout assertion for the new 6-column layout

## Test plan
- [x] Vitest: `npx vitest run src/pages/attendance/__tests__/use-today-attendance-page.test.ts src/components/attendance/__tests__/AttendanceSummaryBar.test.tsx` (124 tests) + full suite (3549 tests)
- [x] PHPUnit: `php artisan test --filter=Attendance` (754 tests)
- [x] Cypress E2E: `attendance-lunch-stat-tab.cy.ts` (6/6 passing) and `attendance-absent-stat-card.cy.ts` regression (10/10 passing) against the dev-lab E2E stack
- [x] Linters: Pint ✅ · ESLint ✅ · TypeScript ✅

## Manual Testing
1. Log in as `admin@sushigo.com` on `/attendance`
2. Confirm the stat bar now shows 6 cards: Total, Pendientes, En trabajo, En comida, Completados, Ausentes, laid out evenly
3. Register a check-in and a lunch-start for an employee (no lunch-return yet) — the "En comida" count should increment and "En trabajo" should not include them
4. Click "En comida" — the grid filters to only employees currently at lunch
5. Register the lunch-return for that employee — they move back into "En trabajo", and "En comida" decrements
6. Reload the page while "En comida" is the active tab — the tab and filtered grid persist via the `?tab=atLunch` URL param

## Workspace
`sushigo-a` — `feature/337-en-comida-stat-tab`

🤖 Generated with [Claude Code](https://claude.com/claude-code)