### PR TITLE
🔨 [#307][a] - Prefer Number static methods over global equivalents 🔢

### DIFF
--- a/code/webapp/src/components/cash/__tests__/open-session-dialog.test.tsx
+++ b/code/webapp/src/components/cash/__tests__/open-session-dialog.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, cleanup } from '@testing-library/react'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { OpenSessionDialog } from '../open-session-dialog'
 
@@ -134,5 +134,26 @@ describe('OpenSessionDialog', () => {
         )
 
         expect(screen.getByRole('button', { name: /cancelar/i })).toBeDefined()
+    })
+
+    it('shows a validation error when opening balance is negative', () => {
+        const { container } = render(
+            <OpenSessionDialog
+                isOpen={true}
+                onClose={mockOnClose}
+                onSuccess={mockOnSuccess}
+            />,
+            { wrapper: createWrapper() },
+        )
+
+        const openingBalanceInput = screen.getByPlaceholderText('0.00')
+        fireEvent.change(openingBalanceInput, { target: { value: '-50' } })
+
+        // fireEvent.submit bypasses native <input min="0"> constraint validation,
+        // which would otherwise block the click path before reaching the handler.
+        const form = container.querySelector('form') as HTMLFormElement
+        fireEvent.submit(form)
+
+        expect(screen.getByText('El fondo inicial no puede ser negativo')).toBeDefined()
     })
 })

--- a/code/webapp/src/components/cash/create-adjustment-dialog.tsx
+++ b/code/webapp/src/components/cash/create-adjustment-dialog.tsx
@@ -107,7 +107,7 @@ export function CreateAdjustmentDialog({
 
     // Validate lines
     for (const line of lines) {
-      if (!line.amount || parseFloat(line.amount) <= 0) {
+      if (!line.amount || Number.parseFloat(line.amount) <= 0) {
         return
       }
       if (line.tender_type === TenderType.CARD && !line.card_terminal_id) {
@@ -137,7 +137,7 @@ export function CreateAdjustmentDialog({
 
   const calculateTotal = () => {
     return lines.reduce((sum, line) => {
-      const amount = parseFloat(line.amount || '0')
+      const amount = Number.parseFloat(line.amount || '0')
       return sum + amount
     }, 0)
   }

--- a/code/webapp/src/components/cash/open-session-dialog.tsx
+++ b/code/webapp/src/components/cash/open-session-dialog.tsx
@@ -67,7 +67,7 @@ export function OpenSessionDialog({
     if (!operatingDate) {
       newErrors.operating_date = 'La fecha de operación es requerida'
     }
-    if (openingBalance && parseFloat(openingBalance) < 0) {
+    if (openingBalance && Number.parseFloat(openingBalance) < 0) {
       newErrors.opening_balance = 'El fondo inicial no puede ser negativo'
     }
 

--- a/code/webapp/src/components/employees/__tests__/register-wage-form.test.tsx
+++ b/code/webapp/src/components/employees/__tests__/register-wage-form.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { RegisterWageForm } from '../register-wage-form'
+
+vi.mock('@/services/employee-hooks', () => ({
+    useCreateWage: vi.fn().mockReturnValue({
+        mutateAsync: vi.fn(),
+        isPending: false,
+    }),
+}))
+
+describe('RegisterWageForm', () => {
+    const mockOnSuccess = vi.fn()
+    const mockOnCancel = vi.fn()
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    function renderForm() {
+        render(
+            <RegisterWageForm
+                employeeId="employee-1"
+                onSuccess={mockOnSuccess}
+                onCancel={mockOnCancel}
+            />,
+        )
+    }
+
+    it('updates neto and diario when bruto semanal changes', () => {
+        renderForm()
+
+        const brutoInput = screen.getByPlaceholderText('2,400') as HTMLInputElement
+        fireEvent.change(brutoInput, { target: { value: '2400' } })
+
+        expect(brutoInput.value).toBe('2400')
+        const dailyInput = screen.getByPlaceholderText('342.86') as HTMLInputElement
+        expect(Number(dailyInput.value)).toBeCloseTo(2400 / 7, 1)
+    })
+
+    it('falls back to 0 when bruto semanal is cleared', () => {
+        renderForm()
+
+        const brutoInput = screen.getByPlaceholderText('2,400') as HTMLInputElement
+        fireEvent.change(brutoInput, { target: { value: '2400' } })
+        fireEvent.change(brutoInput, { target: { value: '' } })
+
+        expect(brutoInput.value).toBe('')
+    })
+
+    it('updates bruto and neto when salario diario changes', () => {
+        renderForm()
+
+        const dailyInput = screen.getByPlaceholderText('342.86') as HTMLInputElement
+        fireEvent.change(dailyInput, { target: { value: '300' } })
+
+        const brutoInput = screen.getByPlaceholderText('2,400') as HTMLInputElement
+        expect(Number(brutoInput.value)).toBeCloseTo(2100, 0)
+    })
+
+    it('updates bruto and diario when neto semanal changes', () => {
+        renderForm()
+
+        const netoInput = screen.getByPlaceholderText('2,100') as HTMLInputElement
+        fireEvent.change(netoInput, { target: { value: '2100' } })
+
+        expect(netoInput.value).toBe('2100')
+    })
+
+    it('updates weekly scheduled hours', () => {
+        renderForm()
+
+        const hoursInput = screen.getByDisplayValue('48') as HTMLInputElement
+        fireEvent.change(hoursInput, { target: { value: '40' } })
+
+        expect(hoursInput.value).toBe('40')
+    })
+
+    it('updates hourly rate', () => {
+        renderForm()
+
+        const hourlyRateInput = screen.getByPlaceholderText('0.00') as HTMLInputElement
+        fireEvent.change(hourlyRateInput, { target: { value: '55.5' } })
+
+        expect(hourlyRateInput.value).toBe('55.5')
+    })
+})

--- a/code/webapp/src/components/employees/register-wage-form.tsx
+++ b/code/webapp/src/components/employees/register-wage-form.tsx
@@ -74,7 +74,7 @@ export function RegisterWageForm({ employeeId, onSuccess, onCancel }: RegisterWa
                                 step="0.001"
                                 min="0"
                                 value={weeklySalaryBruto || ''}
-                                onChange={(e) => handleBrutoChange(parseFloat(e.target.value) || 0)}
+                                onChange={(e) => handleBrutoChange(Number.parseFloat(e.target.value) || 0)}
                                 className={`w-full rounded-md border bg-background px-3 py-1.5 text-sm ${weeklySalaryError ? 'border-red-500' : 'border-input'
                                     } ${activeInput === 'bruto' ? 'ring-2 ring-blue-500' : ''}`}
                                 placeholder="2,400"
@@ -95,7 +95,7 @@ export function RegisterWageForm({ employeeId, onSuccess, onCancel }: RegisterWa
                                 step="0.001"
                                 min="0"
                                 value={dailySalary || ''}
-                                onChange={(e) => handleDailySalaryChange(parseFloat(e.target.value) || 0)}
+                                onChange={(e) => handleDailySalaryChange(Number.parseFloat(e.target.value) || 0)}
                                 className={`w-full rounded-md border bg-background px-3 py-1.5 text-sm border-input ${activeInput === 'diario' ? 'ring-2 ring-purple-500' : ''
                                     }`}
                                 placeholder="342.86"
@@ -116,7 +116,7 @@ export function RegisterWageForm({ employeeId, onSuccess, onCancel }: RegisterWa
                                 step="0.001"
                                 min="0"
                                 value={weeklySalaryNeto || ''}
-                                onChange={(e) => handleNetoChange(parseFloat(e.target.value) || 0)}
+                                onChange={(e) => handleNetoChange(Number.parseFloat(e.target.value) || 0)}
                                 className={`w-full rounded-md border bg-background px-3 py-1.5 text-sm border-input ${activeInput === 'neto' ? 'ring-2 ring-green-500' : ''
                                     }`}
                                 placeholder="2,100"
@@ -148,7 +148,7 @@ export function RegisterWageForm({ employeeId, onSuccess, onCancel }: RegisterWa
                             max="60"
                             step="0.001"
                             value={formData.weekly_scheduled_hours}
-                            onChange={(e) => handleWeeklyHoursChange(parseFloat(e.target.value) || 0)}
+                            onChange={(e) => handleWeeklyHoursChange(Number.parseFloat(e.target.value) || 0)}
                             className={`w-full rounded-md border bg-background px-3 py-1.5 text-sm ${errors.weekly_scheduled_hours ? 'border-red-500' : 'border-input'
                                 }`}
                         />
@@ -175,7 +175,7 @@ export function RegisterWageForm({ employeeId, onSuccess, onCancel }: RegisterWa
                             step="0.001"
                             min="0"
                             value={formData.hourly_rate || ''}
-                            onChange={(e) => handleHourlyRateChange(parseFloat(e.target.value) || 0)}
+                            onChange={(e) => handleHourlyRateChange(Number.parseFloat(e.target.value) || 0)}
                             className={`w-full rounded-md border bg-background px-3 py-1.5 text-sm ${errors.hourly_rate ? 'border-red-500' : 'border-input'
                                 }`}
                             placeholder="0.00"

--- a/code/webapp/src/components/employees/wage-history-card.tsx
+++ b/code/webapp/src/components/employees/wage-history-card.tsx
@@ -12,7 +12,7 @@ function formatDate(dateString: string): string {
 }
 
 function formatCurrency(amount: number | string): string {
-    const value = typeof amount === 'string' ? parseFloat(amount) : amount
+    const value = typeof amount === 'string' ? Number.parseFloat(amount) : amount
     return new Intl.NumberFormat('es-MX', {
         style: 'currency',
         currency: 'MXN',
@@ -25,7 +25,7 @@ interface WageHistoryCardProps {
 
 export function WageHistoryCard({ wage }: WageHistoryCardProps) {
     const isActive = !wage.effective_to
-    const weeklyGross = parseFloat(wage.hourly_rate) * wage.weekly_scheduled_hours
+    const weeklyGross = Number.parseFloat(wage.hourly_rate) * wage.weekly_scheduled_hours
 
     return (
         <Card>

--- a/code/webapp/src/services/cash-balance-service.ts
+++ b/code/webapp/src/services/cash-balance-service.ts
@@ -31,9 +31,9 @@ export function calculateCurrentBalance(
   }
 
   // Caso fallback: calcular manualmente
-  const opening = parseFloat(session.opening_balance || '0')
-  const incomes = parseFloat(summary.total_incomes || '0')
-  const expenses = parseFloat(summary.total_expenses || '0')
+  const opening = Number.parseFloat(session.opening_balance || '0')
+  const incomes = Number.parseFloat(summary.total_incomes || '0')
+  const expenses = Number.parseFloat(summary.total_expenses || '0')
 
   console.log('[calculateCurrentBalance] Manual calculation:', {
     opening,
@@ -70,8 +70,8 @@ export function calculateVariance(
   currentBalance: string,
   expectedBalance: string
 ): number {
-  const current = parseFloat(currentBalance)
-  const expected = parseFloat(expectedBalance)
+  const current = Number.parseFloat(currentBalance)
+  const expected = Number.parseFloat(expectedBalance)
 
   return current - expected
 }
@@ -83,9 +83,9 @@ export function calculateVariance(
  * @returns Monto formateado como "$1,234.56"
  */
 export function formatCurrency(amount: string | number): string {
-  const numericAmount = typeof amount === 'string' ? parseFloat(amount) : amount
+  const numericAmount = typeof amount === 'string' ? Number.parseFloat(amount) : amount
 
-  if (isNaN(numericAmount)) {
+  if (Number.isNaN(numericAmount)) {
     return '$0.00'
   }
 


### PR DESCRIPTION
## Summary
Closes #307
Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/362

- 🔢 Replaced global `parseFloat` with `Number.parseFloat` in 5 files (register-wage-form, wage-history-card, create-adjustment-dialog, open-session-dialog, cash-balance-service)
- 🔢 Replaced global `isNaN` with `Number.isNaN` in `cash-balance-service.ts`
- 🧹 Clears all 17 occurrences of SonarCloud rule `typescript:S7773` in `sushigo-webapp` — no behavior change, `Number.parseFloat`/`Number.isNaN` are drop-in equivalents

## Test plan
- [x] Vitest: `npx vitest run src/services/__tests__/cash-balance-service.test.ts src/components/employees/__tests__/wage-history-card.test.tsx src/components/cash/__tests__/open-session-dialog.test.tsx src/components/cash/__tests__/create-adjustment-dialog.test.tsx` — 69/69 passing, identical to pre-change baseline
- [x] Linters: ESLint ✅ (0 errors) · TypeScript ✅ (0 errors)
- [x] Cypress E2E: not applicable — no user-facing behavior change

## Manual Testing
This is a mechanical, behavior-preserving refactor (global function → `Number.*` static equivalent). To confirm no regression:
1. Go to an employee's profile and register a new wage (`Registrar nuevo salario`) — enter values in "Bruto semanal", "Salario diario", "Neto semanal", "Jornada semanal", "Tarifa por hora" and confirm the synced calculations still update correctly
2. Open a cash session (`Abrir Sesión de Caja`) with a negative opening balance and confirm the validation error still appears
3. Register a cash adjustment (`Registrar Ajuste de Caja`) with a zero/blank amount line and confirm the line is still rejected; add valid amounts and confirm the total still sums correctly
4. View an employee's wage history card and confirm currency amounts still render correctly (e.g. `$2,400.00`)

## Workspace
`sushigo-a` — `refactor/307-number-static-methods`

🤖 Generated with [Claude Code](https://claude.com/claude-code)