### PR TITLE
🔨 [#305][c] - Mark component prop types as Readonly 🔒

### DIFF
--- a/code/webapp/src/components/cash/bank-account-form.tsx
+++ b/code/webapp/src/components/cash/bank-account-form.tsx
@@ -46,7 +46,7 @@ export function BankAccountForm({
     isOpen,
     onClose,
     onSuccess,
-}: BankAccountFormProps) {
+}: Readonly<BankAccountFormProps>) {
     const isEditing = !!account
 
     const {

--- a/code/webapp/src/components/cash/cash-register-form.tsx
+++ b/code/webapp/src/components/cash/cash-register-form.tsx
@@ -44,7 +44,7 @@ export function CashRegisterForm({
     isOpen,
     onClose,
     onSuccess,
-}: CashRegisterFormProps) {
+}: Readonly<CashRegisterFormProps>) {
     const isEditing = !!register
 
     const {

--- a/code/webapp/src/components/cash/cash-register-list.tsx
+++ b/code/webapp/src/components/cash/cash-register-list.tsx
@@ -11,7 +11,7 @@ interface CashRegisterListProps {
     onCreate: () => void
 }
 
-export function CashRegisterList({ onEdit, onCreate }: CashRegisterListProps) {
+export function CashRegisterList({ onEdit, onCreate }: Readonly<CashRegisterListProps>) {
     const { data, isLoading } = useCashRegisters({ per_page: 20, page: 1 })
 
     const columns: Column<CashRegister>[] = [

--- a/code/webapp/src/components/cash/cash-terminal-form.tsx
+++ b/code/webapp/src/components/cash/cash-terminal-form.tsx
@@ -45,7 +45,7 @@ export function CashTerminalForm({
     isOpen,
     onClose,
     onSuccess,
-}: CashTerminalFormProps) {
+}: Readonly<CashTerminalFormProps>) {
     const isEditing = !!terminal
 
     const {

--- a/code/webapp/src/components/cash/cash-utils.tsx
+++ b/code/webapp/src/components/cash/cash-utils.tsx
@@ -11,7 +11,7 @@ interface CashRegisterTypeBadgeProps {
     className?: string
 }
 
-export function CashRegisterTypeBadge({ type, className }: CashRegisterTypeBadgeProps) {
+export function CashRegisterTypeBadge({ type, className }: Readonly<CashRegisterTypeBadgeProps>) {
     const variants: Record<CashRegisterType, { label: string; className: string }> = {
         [CashRegisterType.ON_PREMISE]: {
             label: 'Local',
@@ -45,7 +45,7 @@ interface SessionStatusBadgeProps {
     className?: string
 }
 
-export function SessionStatusBadge({ status, className }: SessionStatusBadgeProps) {
+export function SessionStatusBadge({ status, className }: Readonly<SessionStatusBadgeProps>) {
     const variants: Record<SessionStatus, { label: string; className: string }> = {
         [SessionStatus.DRAFT]: {
             label: 'En proceso',
@@ -75,7 +75,7 @@ interface TenderTypeBadgeProps {
     className?: string
 }
 
-export function TenderTypeBadge({ type, className }: TenderTypeBadgeProps) {
+export function TenderTypeBadge({ type, className }: Readonly<TenderTypeBadgeProps>) {
     const variants: Record<TenderType, { label: string; className: string }> = {
         [TenderType.CASH]: {
             label: 'Efectivo',
@@ -110,7 +110,7 @@ interface AdjustmentTypeBadgeProps {
     className?: string
 }
 
-export function AdjustmentTypeBadge({ type, direction, className }: AdjustmentTypeBadgeProps) {
+export function AdjustmentTypeBadge({ type, direction, className }: Readonly<AdjustmentTypeBadgeProps>) {
     const isInflow = direction === Direction.INFLOW
 
     const variants: Record<AdjustmentType, { label: string; inflowClass: string; outflowClass: string }> = {

--- a/code/webapp/src/components/cash/create-adjustment-dialog.tsx
+++ b/code/webapp/src/components/cash/create-adjustment-dialog.tsx
@@ -31,7 +31,7 @@ export function CreateAdjustmentDialog({
   onClose,
   onSuccess,
   cashSessionId: preselectedSessionId,
-}: CreateAdjustmentDialogProps) {
+}: Readonly<CreateAdjustmentDialogProps>) {
   // Form state
   const [cashSessionId, setCashSessionId] = useState<string>(preselectedSessionId || '')
   const [type, setType] = useState<AdjustmentType>(AdjustmentType.EXTERNAL_IMPORT)

--- a/code/webapp/src/components/cash/open-session-dialog.tsx
+++ b/code/webapp/src/components/cash/open-session-dialog.tsx
@@ -20,7 +20,7 @@ export function OpenSessionDialog({
   onClose,
   onSuccess,
   branchId,
-}: OpenSessionDialogProps) {
+}: Readonly<OpenSessionDialogProps>) {
   const [cashRegisterId, setCashRegisterId] = useState('')
   const [operatingDate, setOperatingDate] = useState('')
   const [openingBalance, setOpeningBalance] = useState('')

--- a/code/webapp/src/components/dashboard/Dashboard.tsx
+++ b/code/webapp/src/components/dashboard/Dashboard.tsx
@@ -104,7 +104,7 @@ const fetchDashboardData = async (): Promise<DashboardData> => {
     };
 };
 
-function StatCard({ stat }: { stat: Stat }) {
+function StatCard({ stat }: Readonly<{ stat: Stat }>) {
     const Icon = stat.icon;
     const isPositive = stat.trending === 'up';
 
@@ -136,7 +136,7 @@ function StatCard({ stat }: { stat: Stat }) {
     );
 }
 
-function SessionCard({ session, onRegisterAdjustment }: { session: CashSession; onRegisterAdjustment: (id: string) => void }) {
+function SessionCard({ session, onRegisterAdjustment }: Readonly<{ session: CashSession; onRegisterAdjustment: (id: string) => void }>) {
     // Usar el current_balance que viene directamente de la sesión (calculado en el backend)
     const currentBalance = session.current_balance || session.opening_balance || '0.00';
 

--- a/code/webapp/src/components/dev/DevDebugger.tsx
+++ b/code/webapp/src/components/dev/DevDebugger.tsx
@@ -348,7 +348,7 @@ interface SectionProps {
     readonly children: React.ReactNode
 }
 
-function Section({ id, icon: Icon, title, isExpanded, onToggle, badge, children }: SectionProps) {
+function Section({ id, icon: Icon, title, isExpanded, onToggle, badge, children }: Readonly<SectionProps>) {
     return (
         <div id={id} className="bg-gray-800 rounded-lg overflow-hidden">
             <button
@@ -386,7 +386,7 @@ interface InfoRowProps {
     highlight?: boolean
 }
 
-function InfoRow({ label, value, highlight }: InfoRowProps) {
+function InfoRow({ label, value, highlight }: Readonly<InfoRowProps>) {
     return (
         <div className="flex justify-between items-center gap-3">
             <span className="text-gray-400">{label}:</span>
@@ -406,7 +406,7 @@ interface MinimizedDebuggerProps {
     readonly renderQuickLinks: (hoverBgClass: string) => React.ReactNode
 }
 
-function MinimizedDebugger({ isMobile, dragRef, position, handleMouseDown, toggleMinimized, renderQuickLinks }: MinimizedDebuggerProps) {
+function MinimizedDebugger({ isMobile, dragRef, position, handleMouseDown, toggleMinimized, renderQuickLinks }: Readonly<MinimizedDebuggerProps>) {
     if (isMobile) {
         return (
             <div
@@ -466,7 +466,7 @@ interface RolesPermissionsSectionProps {
     readonly isAdmin: boolean
 }
 
-function RolesPermissionsSection({ user, isAdmin }: RolesPermissionsSectionProps) {
+function RolesPermissionsSection({ user, isAdmin }: Readonly<RolesPermissionsSectionProps>) {
     if (!user) {
         return <p className="text-xs text-gray-400">No autenticado</p>
     }
@@ -548,7 +548,7 @@ function DevLoginSection({
     isLoadingDevUsers,
     loggingInUserId,
     onLogin,
-}: DevLoginSectionProps) {
+}: Readonly<DevLoginSectionProps>) {
     const [permissionInputFocused, setPermissionInputFocused] = useState(false)
 
     let permissionDropdownItems: string[] = []

--- a/code/webapp/src/components/employees/deactivate-form.tsx
+++ b/code/webapp/src/components/employees/deactivate-form.tsx
@@ -17,7 +17,7 @@ interface DeactivateFormProps {
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
-export function DeactivateForm({ isLoading, onSubmit, onCancel }: DeactivateFormProps) {
+export function DeactivateForm({ isLoading, onSubmit, onCancel }: Readonly<DeactivateFormProps>) {
   const { form, today } = useDeactivateForm()
   const {
     register,

--- a/code/webapp/src/components/employees/employee-detail-view.tsx
+++ b/code/webapp/src/components/employees/employee-detail-view.tsx
@@ -43,7 +43,7 @@ export function EmployeeDetailView({
   isDeactivating,
   isRehiring,
   isTogglingActive,
-}: EmployeeDetailViewProps) {
+}: Readonly<EmployeeDetailViewProps>) {
   const {
     hasActivePeriod,
     isLoading,

--- a/code/webapp/src/components/employees/employee-edit-create-form.tsx
+++ b/code/webapp/src/components/employees/employee-edit-create-form.tsx
@@ -133,7 +133,7 @@ export function EmployeeEditCreateForm({
   onCancel,
   suggestedCode,
   isSuggestedCodeLoading,
-}: EmployeeEditCreateFormProps) {
+}: Readonly<EmployeeEditCreateFormProps>) {
   const canEditContact = mode === 'create' || isAdmin
 
   // Fresh per mount — avoids stale module-level date when the app stays open past midnight.

--- a/code/webapp/src/components/employees/employee-filters.tsx
+++ b/code/webapp/src/components/employees/employee-filters.tsx
@@ -29,7 +29,7 @@ export function EmployeeFilters({
   status,
   onFilterChange,
   onNew,
-}: EmployeeFiltersProps) {
+}: Readonly<EmployeeFiltersProps>) {
   return (
     <div className="flex flex-wrap items-center gap-3">
       <SearchInput

--- a/code/webapp/src/components/employees/employee-info-header.tsx
+++ b/code/webapp/src/components/employees/employee-info-header.tsx
@@ -24,7 +24,7 @@ interface EmployeeInfoHeaderProps {
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
-export function EmployeeInfoHeader({ employee, hasActivePeriod }: EmployeeInfoHeaderProps) {
+export function EmployeeInfoHeader({ employee, hasActivePeriod }: Readonly<EmployeeInfoHeaderProps>) {
   return (
     <div className="space-y-6">
       {/* Name + status badges */}

--- a/code/webapp/src/components/employees/employment-period-card.tsx
+++ b/code/webapp/src/components/employees/employment-period-card.tsx
@@ -15,7 +15,7 @@ interface EmploymentPeriodCardProps {
   period: EmploymentPeriod
 }
 
-export function EmploymentPeriodCard({ period }: EmploymentPeriodCardProps) {
+export function EmploymentPeriodCard({ period }: Readonly<EmploymentPeriodCardProps>) {
   return (
     <Card>
       <CardContent className="p-4">

--- a/code/webapp/src/components/employees/employment-periods-section.tsx
+++ b/code/webapp/src/components/employees/employment-periods-section.tsx
@@ -6,7 +6,7 @@ interface EmploymentPeriodsSectionProps {
   periods: EmploymentPeriod[]
 }
 
-export function EmploymentPeriodsSection({ periods }: EmploymentPeriodsSectionProps) {
+export function EmploymentPeriodsSection({ periods }: Readonly<EmploymentPeriodsSectionProps>) {
   return (
     <div className="space-y-4">
       <h3 className="text-sm font-semibold text-foreground">Periodos Laborales</h3>

--- a/code/webapp/src/components/employees/register-wage-form.tsx
+++ b/code/webapp/src/components/employees/register-wage-form.tsx
@@ -17,7 +17,7 @@ interface RegisterWageFormProps {
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
-export function RegisterWageForm({ employeeId, onSuccess, onCancel }: RegisterWageFormProps) {
+export function RegisterWageForm({ employeeId, onSuccess, onCancel }: Readonly<RegisterWageFormProps>) {
     const createWage = useCreateWage()
 
     const {

--- a/code/webapp/src/components/employees/rehire-form.tsx
+++ b/code/webapp/src/components/employees/rehire-form.tsx
@@ -22,7 +22,7 @@ interface RehireFormProps {
  * it internally from the auth store, following the same pattern as
  * `useEmployeeDetailActions`.
  */
-export function RehireForm({ isLoading, onSubmit, onCancel }: RehireFormProps) {
+export function RehireForm({ isLoading, onSubmit, onCancel }: Readonly<RehireFormProps>) {
   const { form, today, effectiveBranch } = useRehireForm()
   const {
     register,

--- a/code/webapp/src/components/employees/wage-history-card.tsx
+++ b/code/webapp/src/components/employees/wage-history-card.tsx
@@ -23,7 +23,7 @@ interface WageHistoryCardProps {
     wage: WageHistory
 }
 
-export function WageHistoryCard({ wage }: WageHistoryCardProps) {
+export function WageHistoryCard({ wage }: Readonly<WageHistoryCardProps>) {
     const isActive = !wage.effective_to
     const weeklyGross = Number.parseFloat(wage.hourly_rate) * wage.weekly_scheduled_hours
 

--- a/code/webapp/src/components/employees/wage-history-section.tsx
+++ b/code/webapp/src/components/employees/wage-history-section.tsx
@@ -9,7 +9,7 @@ interface WageHistorySectionProps {
     employeeId: string
 }
 
-export function WageHistorySection({ employeeId }: WageHistorySectionProps) {
+export function WageHistorySection({ employeeId }: Readonly<WageHistorySectionProps>) {
     const [showForm, setShowForm] = useState(false)
     const { data: wages, isLoading, error } = useWageHistory(employeeId)
 

--- a/code/webapp/src/components/employees/wage-summary.tsx
+++ b/code/webapp/src/components/employees/wage-summary.tsx
@@ -21,7 +21,7 @@ interface WageSummaryProps {
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
-export function WageSummary({ weeklySalary, weeklyHours }: WageSummaryProps) {
+export function WageSummary({ weeklySalary, weeklyHours }: Readonly<WageSummaryProps>) {
     const calculations = useWageCalculations({ weeklySalary, weeklyHours })
 
     if (!calculations) {

--- a/code/webapp/src/components/inventory/item-details.tsx
+++ b/code/webapp/src/components/inventory/item-details.tsx
@@ -28,7 +28,7 @@ export function ItemDetails({
   onEdit,
   onDelete,
   onViewVariants,
-}: ItemDetailsProps) {
+}: Readonly<ItemDetailsProps>) {
   // Fetch variants for this item
   const { data: variantsData } = useQuery({
     queryKey: ['item-variants', item.id],

--- a/code/webapp/src/components/inventory/item-form.tsx
+++ b/code/webapp/src/components/inventory/item-form.tsx
@@ -28,7 +28,7 @@ interface ItemFormProps {
   onCancel: () => void
 }
 
-export function ItemForm({ item, onSuccess, onCancel }: ItemFormProps) {
+export function ItemForm({ item, onSuccess, onCancel }: Readonly<ItemFormProps>) {
   const isEditing = !!item
 
   const {

--- a/code/webapp/src/components/inventory/location-details.tsx
+++ b/code/webapp/src/components/inventory/location-details.tsx
@@ -25,7 +25,7 @@ export function LocationDetails({
   location,
   onEdit,
   onDelete,
-}: LocationDetailsProps) {
+}: Readonly<LocationDetailsProps>) {
   // Fetch stock summary for this location
   const { data: stockData } = useQuery({
     queryKey: ['stock-by-location', location.id],

--- a/code/webapp/src/components/inventory/location-form.tsx
+++ b/code/webapp/src/components/inventory/location-form.tsx
@@ -30,7 +30,7 @@ interface LocationFormProps {
   onCancel: () => void
 }
 
-export function LocationForm({ location, onSuccess, onCancel }: LocationFormProps) {
+export function LocationForm({ location, onSuccess, onCancel }: Readonly<LocationFormProps>) {
   const isEditing = !!location
 
   // Use shared query hook for operating units

--- a/code/webapp/src/components/inventory/opening-balance-form.tsx
+++ b/code/webapp/src/components/inventory/opening-balance-form.tsx
@@ -39,7 +39,7 @@ export function OpeningBalanceForm({
   onCancel,
   preselectedLocationId,
   preselectedVariantId,
-}: OpeningBalanceFormProps) {
+}: Readonly<OpeningBalanceFormProps>) {
   const [selectedVariant, setSelectedVariant] = useState<ItemVariant | null>(null)
 
   // Use shared query hooks

--- a/code/webapp/src/components/inventory/product-wizard.tsx
+++ b/code/webapp/src/components/inventory/product-wizard.tsx
@@ -90,7 +90,7 @@ function getStepCircleClass(isComplete: boolean, isCurrent: boolean): string {
     return 'border-gray-300 bg-white'
 }
 
-export function ProductWizard({ onSuccess, onCancel }: ProductWizardProps) {
+export function ProductWizard({ onSuccess, onCancel }: Readonly<ProductWizardProps>) {
     const { showSuccess, showError } = useToast()
     const [currentStep, setCurrentStep] = useState(1)
     const [wizardData, setWizardData] = useState<WizardData>(INITIAL_DATA)

--- a/code/webapp/src/components/inventory/stock-out-form.tsx
+++ b/code/webapp/src/components/inventory/stock-out-form.tsx
@@ -50,7 +50,7 @@ export function StockOutForm({
   onCancel,
   preselectedLocationId,
   preselectedVariantId,
-}: StockOutFormProps) {
+}: Readonly<StockOutFormProps>) {
   const { showWarning, showSuccess } = useToast()
   const [selectedVariant, setSelectedVariant] = useState<ItemVariant | null>(null)
   const [variantStocks, setVariantStocks] = useState<Stock[]>([])
@@ -367,7 +367,7 @@ function getStockPanelTextToneClass(hasInsufficientStock: boolean, hasLowStock: 
   return 'text-blue-900'
 }
 
-function StockInfoPanel({ locationStock, selectedVariant, hasLowStock, hasInsufficientStock }: StockInfoPanelProps) {
+function StockInfoPanel({ locationStock, selectedVariant, hasLowStock, hasInsufficientStock }: Readonly<StockInfoPanelProps>) {
   return (
     <div
       className={`border rounded-lg p-3 text-sm ${getStockPanelToneClass(hasInsufficientStock, hasLowStock)}`}
@@ -425,7 +425,7 @@ interface ProfitAnalysisPanelProps {
   readonly unitCost: number
 }
 
-function ProfitAnalysisPanel({ profitAmount, profitMargin, totalRevenue, totalCost, unitCost }: ProfitAnalysisPanelProps) {
+function ProfitAnalysisPanel({ profitAmount, profitMargin, totalRevenue, totalCost, unitCost }: Readonly<ProfitAnalysisPanelProps>) {
   return (
     <div
       className={`border rounded-lg p-4 ${profitAmount >= 0

--- a/code/webapp/src/components/inventory/variant-details.tsx
+++ b/code/webapp/src/components/inventory/variant-details.tsx
@@ -21,7 +21,7 @@ interface VariantDetailsProps {
   onDelete: () => void
 }
 
-export function VariantDetails({ variant, onEdit, onDelete }: VariantDetailsProps) {
+export function VariantDetails({ variant, onEdit, onDelete }: Readonly<VariantDetailsProps>) {
   // Fetch current stock for this variant
   const { data: stockData } = useQuery({
     queryKey: ['stock-by-variant', variant.id],

--- a/code/webapp/src/components/inventory/variant-form.tsx
+++ b/code/webapp/src/components/inventory/variant-form.tsx
@@ -35,7 +35,7 @@ interface VariantFormProps {
   preselectedItemId?: number
 }
 
-export function VariantForm({ variant, onSuccess, onCancel, preselectedItemId }: VariantFormProps) {
+export function VariantForm({ variant, onSuccess, onCancel, preselectedItemId }: Readonly<VariantFormProps>) {
   const isEditing = !!variant
 
   // Use shared query hooks

--- a/code/webapp/src/components/ui/badge.tsx
+++ b/code/webapp/src/components/ui/badge.tsx
@@ -4,7 +4,7 @@ export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
     variant?: 'default' | 'success' | 'error' | 'warning' | 'info'
 }
 
-export function Badge({ className, variant = 'default', ...props }: BadgeProps) {
+export function Badge({ className, variant = 'default', ...props }: Readonly<BadgeProps>) {
     const variantClasses = {
         default: 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300',
         success: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',

--- a/code/webapp/src/components/ui/breadcrumbs.tsx
+++ b/code/webapp/src/components/ui/breadcrumbs.tsx
@@ -27,7 +27,7 @@ interface BreadcrumbsProps {
  * ]} />
  * ```
  */
-export function Breadcrumbs({ className, items }: BreadcrumbsProps) {
+export function Breadcrumbs({ className, items }: Readonly<BreadcrumbsProps>) {
   const routerState = useRouterState();
   const currentPath = routerState.location.pathname;
 

--- a/code/webapp/src/components/ui/data-grid.tsx
+++ b/code/webapp/src/components/ui/data-grid.tsx
@@ -108,7 +108,7 @@ export function DataGrid<T extends { id: string | number }>({
   onPerPageChange,
   totalResults,
   skeletonRows = 5,
-}: DataGridProps<T>) {
+}: Readonly<DataGridProps<T>>) {
   function handleSortClick(sortKey: string) {
     if (!onSortChange) return
     const idx = sorting.findIndex(s => s.key === sortKey)

--- a/code/webapp/src/components/ui/dropdown-menu.tsx
+++ b/code/webapp/src/components/ui/dropdown-menu.tsx
@@ -5,7 +5,7 @@ export interface DropdownMenuProps {
   children: React.ReactNode
 }
 
-export function DropdownMenu({ children }: DropdownMenuProps) {
+export function DropdownMenu({ children }: Readonly<DropdownMenuProps>) {
   return <div className="relative inline-block">{children}</div>
 }
 
@@ -13,7 +13,7 @@ export interface DropdownMenuTriggerProps extends React.ButtonHTMLAttributes<HTM
   children: React.ReactNode
 }
 
-export function DropdownMenuTrigger({ children, className, ...props }: DropdownMenuTriggerProps) {
+export function DropdownMenuTrigger({ children, className, ...props }: Readonly<DropdownMenuTriggerProps>) {
   return (
     <button
       type="button"
@@ -31,7 +31,7 @@ export interface DropdownMenuContentProps {
   open?: boolean
 }
 
-export function DropdownMenuContent({ children, align = 'right', open }: DropdownMenuContentProps) {
+export function DropdownMenuContent({ children, align = 'right', open }: Readonly<DropdownMenuContentProps>) {
   if (!open) return null
 
   return (
@@ -51,7 +51,7 @@ export interface DropdownMenuItemProps extends React.ButtonHTMLAttributes<HTMLBu
   icon?: React.ReactNode
 }
 
-export function DropdownMenuItem({ children, icon, className, ...props }: DropdownMenuItemProps) {
+export function DropdownMenuItem({ children, icon, className, ...props }: Readonly<DropdownMenuItemProps>) {
   return (
     <button
       type="button"

--- a/code/webapp/src/components/ui/filter-select.tsx
+++ b/code/webapp/src/components/ui/filter-select.tsx
@@ -25,7 +25,7 @@ export function FilterSelect({
   placeholder = 'All',
   showIcon = true,
   className,
-}: FilterSelectProps) {
+}: Readonly<FilterSelectProps>) {
   return (
     <div className={cn('flex items-center gap-2', className)}>
       {showIcon && <Filter className="h-4 w-4 text-muted-foreground" />}

--- a/code/webapp/src/components/ui/form-fields.tsx
+++ b/code/webapp/src/components/ui/form-fields.tsx
@@ -17,7 +17,7 @@ export function FormField({
   required,
   className,
   children,
-}: FormFieldProps) {
+}: Readonly<FormFieldProps>) {
   return (
     <div className={cn('space-y-1', className)}>
       {label && (

--- a/code/webapp/src/components/ui/info-tooltip.tsx
+++ b/code/webapp/src/components/ui/info-tooltip.tsx
@@ -5,7 +5,7 @@ interface InfoTooltipProps {
     className?: string
 }
 
-export function InfoTooltip({ text, className = '' }: InfoTooltipProps) {
+export function InfoTooltip({ text, className = '' }: Readonly<InfoTooltipProps>) {
     return (
         <span className={`relative inline-flex ml-1 group cursor-help ${className}`}>
             <Info className="h-3.5 w-3.5 text-muted-foreground hover:text-blue-500 transition-colors" />

--- a/code/webapp/src/components/ui/logo.tsx
+++ b/code/webapp/src/components/ui/logo.tsx
@@ -6,7 +6,7 @@ interface LogoProps {
     collapsed?: boolean;
 }
 
-export function Logo({ className, collapsed = false }: LogoProps) {
+export function Logo({ className, collapsed = false }: Readonly<LogoProps>) {
     if (collapsed) {
         return (
             <div className={cn(
@@ -48,7 +48,7 @@ interface LogoIconProps {
     className?: string;
 }
 
-export function LogoIcon({ className }: LogoIconProps) {
+export function LogoIcon({ className }: Readonly<LogoIconProps>) {
     return (
         <div className={cn(
             "w-10 h-10 rounded-full overflow-hidden",
@@ -72,7 +72,7 @@ interface LogoFullProps {
 }
 
 // Versión horizontal del logo (imagen completa sin círculo)
-export function LogoFull({ className, height = 40 }: LogoFullProps) {
+export function LogoFull({ className, height = 40 }: Readonly<LogoFullProps>) {
     return (
         <div className={cn("flex items-center", className)}>
             <img

--- a/code/webapp/src/components/ui/page-container.tsx
+++ b/code/webapp/src/components/ui/page-container.tsx
@@ -4,7 +4,7 @@ interface PageContainerProps {
     children: ReactNode;
 }
 
-export function PageContainer({ children }: PageContainerProps) {
+export function PageContainer({ children }: Readonly<PageContainerProps>) {
     return (
         <div className="p-6 max-w-7xl mx-auto space-y-6">
             {children}

--- a/code/webapp/src/components/ui/page-header.tsx
+++ b/code/webapp/src/components/ui/page-header.tsx
@@ -7,7 +7,7 @@ interface PageHeaderProps {
     children?: ReactNode;
 }
 
-export function PageHeader({ title, description, action, children }: PageHeaderProps) {
+export function PageHeader({ title, description, action, children }: Readonly<PageHeaderProps>) {
     return (
         <div className="space-y-1 p-6 rounded-xl bg-gradient-to-r from-sushigo-navy/5 via-sushigo-coral/5 to-sushigo-cream/50 border border-sushigo-cream/50">
             <div className="flex items-center justify-between">

--- a/code/webapp/src/components/ui/search-input.tsx
+++ b/code/webapp/src/components/ui/search-input.tsx
@@ -17,7 +17,7 @@ export function SearchInput({
   placeholder = 'Search...',
   debounceMs = 300,
   className,
-}: SearchInputProps) {
+}: Readonly<SearchInputProps>) {
   const [localValue, setLocalValue] = useState(value)
 
   // Keep a stable ref to onChange so the debounce effect never re-fires

--- a/code/webapp/src/components/ui/slide-panel.tsx
+++ b/code/webapp/src/components/ui/slide-panel.tsx
@@ -66,7 +66,7 @@ export function SlidePanel({
   animationDuration = SLIDE_PANEL_DEFAULT_DURATION_MS,
   autoScrollOnFocus = true,
   scrollMargin = SLIDE_PANEL_DEFAULT_SCROLL_MARGIN,
-}: SlidePanelProps) {
+}: Readonly<SlidePanelProps>) {
   const panelRef = useRef<HTMLDivElement>(null)
   const contentRef = useRef<HTMLDivElement>(null)
   const overlayRef = useRef<HTMLDivElement>(null)

--- a/code/webapp/src/components/ui/toast-provider.tsx
+++ b/code/webapp/src/components/ui/toast-provider.tsx
@@ -16,7 +16,7 @@ function generateToastId(): string {
   return `toast-${Date.now()}-${toastFallbackCounter}`
 }
 
-export function ToastProvider({ children }: { children: ReactNode }) {
+export function ToastProvider({ children }: Readonly<{ children: ReactNode }>) {
   const [toasts, setToasts] = useState<ToastWithId[]>([])
 
   const removeToast = useCallback((id: string) => {

--- a/code/webapp/src/components/ui/toast.tsx
+++ b/code/webapp/src/components/ui/toast.tsx
@@ -43,7 +43,7 @@ export function Toast({
   variant = 'info',
   duration = 5000,
   onClose,
-}: ToastProps) {
+}: Readonly<ToastProps>) {
   const style = variantStyles[variant]
   const Icon = style.iconComponent
 

--- a/code/webapp/src/components/ui/toggle-switch.tsx
+++ b/code/webapp/src/components/ui/toggle-switch.tsx
@@ -7,7 +7,7 @@ interface ToggleSwitchProps {
     disabled?: boolean
 }
 
-export function ToggleSwitch({ label, checked, onChange, disabled = false }: ToggleSwitchProps) {
+export function ToggleSwitch({ label, checked, onChange, disabled = false }: Readonly<ToggleSwitchProps>) {
     const id = useId()
 
     return (

--- a/code/webapp/src/contexts/SidebarContext.tsx
+++ b/code/webapp/src/contexts/SidebarContext.tsx
@@ -5,7 +5,7 @@ interface SidebarProviderProps {
     children: ReactNode;
 }
 
-export function SidebarProvider({ children }: SidebarProviderProps) {
+export function SidebarProvider({ children }: Readonly<SidebarProviderProps>) {
     const [isCollapsed, setIsCollapsed] = useState(false);
     const [isMobileOpen, setIsMobileOpen] = useState(false);
 

--- a/code/webapp/src/contexts/ThemeContext.tsx
+++ b/code/webapp/src/contexts/ThemeContext.tsx
@@ -5,7 +5,7 @@ interface ThemeProviderProps {
     children: ReactNode;
 }
 
-export function ThemeProvider({ children }: ThemeProviderProps) {
+export function ThemeProvider({ children }: Readonly<ThemeProviderProps>) {
     const [theme, setTheme] = useState<Theme>(() => {
         const savedTheme = localStorage.getItem('theme') as Theme | null;
         return savedTheme || 'light';

--- a/code/webapp/src/pages/stock-dashboard.tsx
+++ b/code/webapp/src/pages/stock-dashboard.tsx
@@ -409,7 +409,7 @@ function SummaryCard({
   icon: Icon,
   iconColor,
   bgColor,
-}: SummaryCardProps) {
+}: Readonly<SummaryCardProps>) {
   return (
     <div className="rounded-lg border border-gray-200 bg-white p-6">
       <div className="flex items-start justify-between mb-4">


### PR DESCRIPTION
## Summary
Closes #305
Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/367

- 🔒 Wrapped destructured prop types in `Readonly<>` across the 48 files listed in the SonarCloud finding for rule `typescript:S6759`
- 🔒 Covered three shapes: named `interface FooProps`, generic `interface FooProps<T>`, and inline anonymous object prop types
- ✅ Type-only change — no behavior modified

## Test plan
- [x] `tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (28 pre-existing unrelated warnings)
- [x] `npx vitest run` — 242 files / 3568 tests passed, 3 pre-existing skips

## Manual Testing
This is a type-level refactor with no runtime behavior change. Verification is via the automated checks above:
1. Run `cd code/webapp && npm run typecheck` — expect 0 errors
2. Run `cd code/webapp && npm run lint` — expect 0 errors
3. Run `cd code/webapp && npx vitest run` — expect all tests passing

## Notes
The SonarCloud finding originally listed 61 occurrences; some additional unwrapped prop-type signatures exist elsewhere in `src/` that were **not** in the issue's "Affected locations" list. Per discussion, this PR stays scoped to exactly the 48 files/61 occurrences named in the issue — the rest can be a follow-up if SonarCloud flags them as new code.

## Workspace
`sushigo-c` — `refactor/305-readonly-component-props`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
