### PR TITLE
🔨 [#368][a] - Log logout catch error in auth.store 🪵

### DIFF
--- a/code/webapp/src/stores/__tests__/auth.store.test.ts
+++ b/code/webapp/src/stores/__tests__/auth.store.test.ts
@@ -1,10 +1,12 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import {
     extractBranchesFromUser,
     checkIsAdmin,
     checkIsSuperAdmin,
     checkPermission,
+    useAuthStore,
 } from '@/stores/auth.store'
+import { authService } from '@/services/auth.service'
 import type { User, Branch, Role, Permission, OperatingUnitAssignment, OperatingUnit } from '@/types/auth'
 
 // ─── Test Fixtures ─────────────────────────────────────────────────────────────
@@ -328,5 +330,53 @@ describe('checkPermission', () => {
         expect(checkPermission(user, 'view-reports')).toBe(true)
         expect(checkPermission(user, 'edit-profile')).toBe(true)
         expect(checkPermission(user, 'delete-users')).toBe(false)
+    })
+})
+
+// ─── logout ────────────────────────────────────────────────────────────────────
+
+describe('logout', () => {
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('clears auth state even when authService.logout rejects', async () => {
+        const logoutError = new Error('Network error')
+        vi.spyOn(authService, 'logout').mockRejectedValueOnce(logoutError)
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+        useAuthStore.setState({
+            user: createUser(),
+            token: 'token-123',
+            isAuthenticated: true,
+        })
+
+        await useAuthStore.getState().logout()
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            expect.stringContaining('[auth.store]'),
+            logoutError,
+        )
+        expect(useAuthStore.getState().user).toBeNull()
+        expect(useAuthStore.getState().token).toBeNull()
+        expect(useAuthStore.getState().isAuthenticated).toBe(false)
+    })
+
+    it('clears auth state when authService.logout succeeds', async () => {
+        vi.spyOn(authService, 'logout').mockResolvedValueOnce(undefined)
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+        useAuthStore.setState({
+            user: createUser(),
+            token: 'token-123',
+            isAuthenticated: true,
+        })
+
+        await useAuthStore.getState().logout()
+
+        expect(consoleErrorSpy).not.toHaveBeenCalled()
+        expect(useAuthStore.getState().user).toBeNull()
+        expect(useAuthStore.getState().token).toBeNull()
+        expect(useAuthStore.getState().isAuthenticated).toBe(false)
     })
 })

--- a/code/webapp/src/stores/auth.store.ts
+++ b/code/webapp/src/stores/auth.store.ts
@@ -168,8 +168,8 @@ export const useAuthStore = create<AuthState>()(
       logout: async () => {
         try {
           await authService.logout();
-        } catch (_err) {
-          // Silently handle logout errors - we'll clear state anyway
+        } catch (err) {
+          console.error('[auth.store] Failed to notify backend of logout:', err);
         } finally {
           set({
             user: null,

--- a/doc/tasks/2026-07/368-log-logout-catch-error.md
+++ b/doc/tasks/2026-07/368-log-logout-catch-error.md
@@ -1,0 +1,64 @@
+# 🔨 [Maintainability] logout() silently swallows its catch error in auth.store.ts
+
+## Description
+
+`auth.store.ts`'s `logout()` action has a `catch (_err)` block (line 171) that silently discards the caught error with only a comment — no logging, no user feedback:
+
+```ts
+try {
+  await authService.logout();
+} catch (_err) {
+  // Silently handle logout errors - we'll clear state anyway
+} finally {
+  set({ ... });
+}
+```
+
+Flagged by Devin/DeepWiki (Investigate severity) during review of PR #364, which fixed the same anti-pattern at two other locations in this file and in `create-adjustment-dialog.tsx` for SonarCloud rule `typescript:S2486`. This location wasn't part of SonarCloud's original 2-location report for that issue, so it was intentionally left out of #313's scope and filed here separately instead.
+
+## Reason
+
+Even though clearing local auth state regardless of the API call's outcome is correct behavior (the user is logged out client-side either way), swallowing the actual error with no log entry hides real failures (network errors, 500s, auth service outages) from anyone debugging why a user's logout silently failed to reach the backend.
+
+## Objective
+
+The `catch` block in `logout()` logs the caught error (e.g. via `console.error`, matching the pattern already used elsewhere in this file at lines 66 and 245) before falling through to the existing `finally` state-clearing logic. No behavior change — the client still always logs the user out locally.
+
+## ✅ Technical Tasks
+- [x] 🐛 Log the caught error in `auth.store.ts`'s `logout()` catch block
+
+## 🎯 Acceptance Criteria
+- [x] The catch block calls `console.error` with a descriptive prefix and the error
+- [x] Existing behavior (local auth state always cleared on logout, regardless of API outcome) is unchanged
+- [x] Lint and typecheck pass
+
+## 🔗 References
+- Related: #313, PR #364 (fixed the same anti-pattern at 2 other locations)
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `0.25h` · **Pessimistic:** `0.5h` · **Tracked:** `2m`
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-07-30", "start": "02:44", "end": "02:46" }
+]
+```
+
+## 📊 Retrospective
+- **Actual total:** 2m (2m)
+- **vs optimistic:** −13m
+- **vs pessimistic:** −28m
+
+**Justification:** This was a single-line, well-precedented fix — the exact same `console.error`
+pattern had already been applied twice in this same file by PR #364/#313, so there was no
+investigation needed, just applying the established pattern to the third location plus a small
+Vitest suite covering the `logout()` success/failure paths. One round of review response (a
+Copilot comment asking for an additional `token` assertion) was addressed and resolved without
+needing to reopen a session, since it fell within the same sitting.
+
+
+
+


### PR DESCRIPTION
## Summary
Closes #368
Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/370

- 🪵 Log the caught error in `auth.store.ts`'s `logout()` catch block via `console.error`, matching the pattern already used elsewhere in the file (lines 66, 245)
- 🔒 No behavior change — local auth state is still always cleared in `finally`, regardless of the API call's outcome
- ✅ Added tests covering both the success and failure paths of `logout()`

This completes the location intentionally left out of #313's scope (flagged separately by Devin/DeepWiki during PR #364 review).

## Test plan
- [x] Vitest: `npx vitest run src/stores/__tests__/auth.store.test.ts` (32 passed)
- [x] Linters: ESLint ✅ · TypeScript ✅

## Manual Testing
1. Log in to the webapp
2. Open DevTools → Network tab, and block/throttle the `/auth/logout` request (e.g. via "Offline" mode or blocking the request URL)
3. Click "Logout"
4. Confirm the user is still redirected to the login page and local auth state is cleared (unchanged behavior)
5. Check the browser console — a `[auth.store] Failed to notify backend of logout:` error entry with the underlying error should now appear (previously nothing was logged)

## Workspace
`sushigo-a` — `refactor/368-log-logout-catch-error`

🤖 Generated with [Claude Code](https://claude.com/claude-code)