### PR TITLE
📚 [#386][a] - Promote Sprint 002 to current and close out Sprint 001 📅

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,8 @@ Development is organized into documented sprints — see [`doc/conventions/sprin
 | Sprint | Title | Status | Started | Completed | Target | Parallelization | Document |
 |---|---|---|---|---|---|---:|---|
 | 000 | Introduction | Completed | 2026-07-26 | 2026-07-26 | — | — | [sprint-000-introduction.md](doc/sprints/sprint-000-introduction.md) |
-| 001 | Attendance, Payroll & Quality | In Progress | 2026-07-26 | — (impl. finished 2026-07-30) | 2026-08-09 | 1.40× (51.1h → 36.5h) | [sprint-001-attendance-payroll-quality.md](doc/sprints/sprint-001-attendance-payroll-quality.md) |
+| 001 | Attendance, Payroll & Quality | Completed | 2026-07-26 | 2026-07-31 (impl. finished 2026-07-30) | 2026-08-09 | 1.40× (51.1h → 36.5h) | [sprint-001-attendance-payroll-quality.md](doc/sprints/sprint-001-attendance-payroll-quality.md) |
+| 002 | Platillos Catalog & Platform Hardening | In Progress | 2026-07-31 | — | — | — | [sprint-002-platillos-catalog-platform-hardening.md](doc/sprints/sprint-002-platillos-catalog-platform-hardening.md) |
 
 ## Development tips
 

--- a/doc/conventions/sprints.md
+++ b/doc/conventions/sprints.md
@@ -92,6 +92,14 @@ After this move:
 - the promoted sprint becomes current;
 - the previous highest-numbered sprint becomes completed.
 
+This repository carries **two independent sprint indices** that must both be updated on every
+promotion — updating one and not the other was a real mistake made and caught during Sprint 002's
+own promotion (#386):
+
+- `doc/sprints/README.md` — the detailed per-sprint index (status, document link).
+- root `README.md`'s own `## Sprints` table — a separate summary table (status, dates, target,
+  parallelization) shown to anyone landing on the repo's main page.
+
 ---
 
 ## 3. File Naming Convention

--- a/doc/sprints/README.md
+++ b/doc/sprints/README.md
@@ -5,7 +5,8 @@ Index of every SushiGo sprint document. See `doc/conventions/sprints.md` for the
 | Sprint | Title | Status | Document |
 |---|---|---|---|
 | 000 | Introduction | Completed | [sprint-000-introduction.md](sprint-000-introduction.md) |
-| 001 | Attendance, Payroll & Quality | In Progress (current) | [sprint-001-attendance-payroll-quality.md](sprint-001-attendance-payroll-quality.md) |
+| 001 | Attendance, Payroll & Quality | Completed | [sprint-001-attendance-payroll-quality.md](sprint-001-attendance-payroll-quality.md) |
+| 002 | Platillos Catalog & Platform Hardening | In Progress (current) | [sprint-002-platillos-catalog-platform-hardening.md](sprint-002-platillos-catalog-platform-hardening.md) |
 
 Planned sprints not yet started live under [`planned/`](planned/) and are not listed here until promoted.
 

--- a/doc/sprints/sprint-001-attendance-payroll-quality.md
+++ b/doc/sprints/sprint-001-attendance-payroll-quality.md
@@ -1,12 +1,12 @@
 ---
 sprint: "001"
 title: Attendance, Payroll & Quality
-status: In Progress
+status: Completed
 
 created: 2026-07-25
 started: 2026-07-26
-completed:
-last_updated: 2026-07-30
+completed: 2026-07-31
+last_updated: 2026-07-31
 
 base_branch: main
 base_commit: 079a316
@@ -16,7 +16,7 @@ github_project: SushiGo Admin (#7)
 github_milestone:
 
 previous: sprint-000-introduction.md
-next:
+next: sprint-002-platillos-catalog-platform-hardening.md
 ---
 
 # Sprint 001 — Attendance, Payroll & Quality
@@ -33,7 +33,7 @@ A file-level conflict analysis (parsed directly from each SonarCloud Issue's "Af
 
 Expected outcome: a real attendance-correction capability shipped, payroll-close periods can no longer be closed early or as a partial week, the two highest-connected quality debt nodes (#305, #306) cleared, and the sprint's own estimate-vs-tracked comparison populated so future sprints can calibrate estimates against real data.
 
-**Implementation complete as of 2026-07-30** (sprint remains `In Progress` per `doc/conventions/sprints.md` — formal completion requires Sprint 002 to be promoted first, which hasn't happened yet): 25 of 27 scoped Issues completed (92.6%) — every Issue except #276 and #85. Both were removed from Sprint 001's active scope on 2026-07-30 and deferred rather than completed (see §5.3) — WhatsApp real-provider integration (#276) isn't needed while the webapp's log-based OTP display covers password recovery pre-production, and the Flutter mobile bootstrap (#85) is postponed until the attendance functionality it would mirror is proven out in backend + web first. With those two removed, 100% of Sprint 001's real (non-deferred) scope shipped, 10 days ahead of the 2026-08-09 target deadline. All 19 SonarCloud Issues (#305–#323), all 4 hand-authored product Issues (#325, #327, #328, #329), the dev-tooling Issue (#324), and the mid-sprint addition (#359) merged. See §13 for full evidence and §15–§16 for delivered value and lessons learned.
+**Implementation complete as of 2026-07-30, formal closure completed 2026-07-31** (Sprint 002 was promoted the same day, #386, satisfying `doc/conventions/sprints.md` §4's completion trigger): 25 of 27 scoped Issues completed (92.6%) — every Issue except #276 and #85. Both were removed from Sprint 001's active scope on 2026-07-30 and deferred rather than completed (see §5.3) — WhatsApp real-provider integration (#276) isn't needed while the webapp's log-based OTP display covers password recovery pre-production, and the Flutter mobile bootstrap (#85) is postponed until the attendance functionality it would mirror is proven out in backend + web first. With those two removed, 100% of Sprint 001's real (non-deferred) scope shipped, 10 days ahead of the 2026-08-09 target deadline. All 19 SonarCloud Issues (#305–#323), all 4 hand-authored product Issues (#325, #327, #328, #329), the dev-tooling Issue (#324), and the mid-sprint addition (#359) merged. See §13 for full evidence and §15–§16 for delivered value and lessons learned.
 
 ## 2. Context
 
@@ -57,12 +57,12 @@ Base state: `main` @ `079a316`, 26 open Issues, zero Issues yet linked to a GitH
 |---|---:|
 | Created | 2026-07-25 |
 | Started | 2026-07-26 |
-| Completed | — (implementation finished 2026-07-30; formal closure pending Sprint 002 promotion) |
+| Completed | 2026-07-31 (implementation finished 2026-07-30; formal closure completed 2026-07-31 upon Sprint 002 promotion, #386) |
 | Target completion (deadline) | 2026-08-09 |
 | Calendar duration (planned) | 14 days |
-| Calendar duration (actual) | 5 days (created → completed) |
+| Calendar duration (actual) | 6 days (created → completed) |
 | Active workdays | 5 (2026-07-26 through 2026-07-30 — PR merges recorded every day, several days across multiple parallel `sushigo-a`..`sushigo-e` workspaces) |
-| Progress (Issues completed) | 25 / 27 (92.6%) as of 2026-07-30 — every scoped Issue except #276 and #85. **100% of active scope shipped as of 2026-07-30** — #276 and #85 removed from scope and deferred rather than left incomplete (§5.3); no other `sprint-1`-labeled Issue remains open besides the two deferred ones (verified via `gh issue list --label sprint-1 --state open`). Sprint stays `In Progress` per convention until Sprint 002 is promoted |
+| Progress (Issues completed) | 25 / 27 (92.6%) as of 2026-07-30 — every scoped Issue except #276 and #85. **100% of active scope shipped as of 2026-07-30** — #276 and #85 removed from scope and deferred rather than left incomplete (§5.3); no other `sprint-1`-labeled Issue remains open besides the two deferred ones (verified via `gh issue list --label sprint-1 --state open`). Sprint formally closed 2026-07-31 upon Sprint 002's promotion (#386) |
 
 ### How the deadline was set
 
@@ -276,7 +276,7 @@ See "Wall-clock time and parallelism" under [`doc/conventions/sprints.md` §7](.
 - **Parallelization factor:** 1.40× — on average, 1.40 sessions were open per wall-clock hour
 - **Peak concurrency:** 5 simultaneous sessions, at 2026-07-28 19:46 (#311, #312, #324, #337, #342) — #309/#321's 2026-07-27 01:45 sessions peak at 3 concurrent (#309, #321, #327), below this figure, so it is unaffected
 
-**This is the direct answer to "how much time did the sprint really take vs. how much labor went into it":** 51.13h of summed individual effort fit inside only 36.45h of actual calendar time — a ~15h saving from working several Issues at once across parallel `sushigo-a`..`sushigo-e` workspaces, not from the estimates being wrong (§10 already shows Tracked landing close to the planned Opt./Pess. range). This is the hard-numbers version of the observation in §16: the sprint closed in 5 calendar days against a 14-day target mainly because of concurrency and extended-hours sessions, not because individual tasks were faster than estimated.
+**This is the direct answer to "how much time did the sprint really take vs. how much labor went into it":** 51.13h of summed individual effort fit inside only 36.45h of actual calendar time — a ~15h saving from working several Issues at once across parallel `sushigo-a`..`sushigo-e` workspaces, not from the estimates being wrong (§10 already shows Tracked landing close to the planned Opt./Pess. range). This is the hard-numbers version of the observation in §16: all scoped implementation finished in 5 calendar days against a 14-day target (formal closure followed a day later, §4) mainly because of concurrency and extended-hours sessions, not because individual tasks were faster than estimated.
 
 | Wall-clock block | Duration | Issues active in this block |
 |---|---:|---|
@@ -344,9 +344,9 @@ Note the two densest blocks — 2026-07-27 20:22→2026-07-28 01:21 (#306, #314,
 | ✅ | #342 | Follow-up work (§17) discovered while implementing #327 — promoted the shared `useDialogTransition` hook app-wide, migrated the 5 remaining duplicated-animation dialogs, animated the 6 previously-unanimated ones, reconciled `BranchSelectionDialog` styling | PR #354 | 02531c4 | 4.68h | Not part of original scope — see §17. Merged `2026-07-30` |
 | ✅ | #337 | Follow-up work (§17) deferred from #327/PR #336 — added an "En comida" stat tab for employees at lunch, mechanical extension of #327's bucket-split + clickable-tab pattern | PR #350 | 73f05e6 | 0.5h | Not part of original scope — see §17. Merged `2026-07-29` |
 | ✅ | #359 | GitHub Issue made the single source of truth for `/start-issue`/`/finish-pr` (no local `.md` created or edited during active work); `/finish-pr` now generates a verbatim archive snapshot under `doc/tasks/yyyy-mm/<issue-number>-slug.md` exactly once at finish time; started `doc/decisions.md` + `doc/decisions/td-NN-*.md` technical decisions log; resolved 5 pre-existing orphaned `doc/tasks/backlog/*.md` files (3 for already-closed issues, 1 never migrated to GitHub, 1 byte-identical duplicate) | PR #361 | 0dc2d54 | 3.0h | Docs/tooling only, no application tests apply; ESLint/TypeScript/Pint not touched; 1 Copilot review thread resolved (`## 📊 Retrospective` timing clarified in `doc/conventions/tasks.md`); manual merge-conflict resolution against #355 (concurrent `finish-pr.md` auto-rebase feature) during `/rebase-main`; added to scope mid-sprint (§5.3). Branch `chore/359-unify-issue-tracking`, workspace `sushigo-a`. Merged `2026-07-30` |
-| ✅ | #374 | Follow-up work (§17) — this closure pass itself: deferred #276/#85 from Sprint 001 scope (`deferred`/`priority: low` labels + rationale comments), fixed 5 stale status markers (#305/#316/#319/#320/#321), formalized and computed the wall-clock/parallelism metric (§7 of `doc/conventions/sprints.md`), and corrected several data-integrity gaps found along the way (stale #306 Tracked value, fabricated #309 Tracked value, missing #340 Tracked value, Consolidated Time Tracking Total arithmetic, ambiguous Person-hours definition) | PR #375 | — | 4.4h | docs/-only change — no PHPUnit/Vitest/Cypress applicable; every Issue referenced in the rewrite cross-checked against `gh issue view`/`gh pr list` state before writing it into the document; 2 review threads resolved; commit squashed to 1; Not scheduled into a round — see §17. PR ready, merge pending |
+| ✅ | #374 | Follow-up work (§17) — this closure pass itself: deferred #276/#85 from Sprint 001 scope (`deferred`/`priority: low` labels + rationale comments), fixed 5 stale status markers (#305/#316/#319/#320/#321), formalized and computed the wall-clock/parallelism metric (§7 of `doc/conventions/sprints.md`), and corrected several data-integrity gaps found along the way (stale #306 Tracked value, fabricated #309 Tracked value, missing #340 Tracked value, Consolidated Time Tracking Total arithmetic, ambiguous Person-hours definition) | PR #375 | `4ac51ff` | 4.4h | docs/-only change — no PHPUnit/Vitest/Cypress applicable; every Issue referenced in the rewrite cross-checked against `gh issue view`/`gh pr list` state before writing it into the document; 2 review threads resolved; commit squashed to 1; Not scheduled into a round — see §17. Merged 2026-07-31 |
 
-All scoped work finished 2026-07-30 — all rows above reflect final status; no items remain in `⏳`/`🚧`. Sprint stays `In Progress` (see front matter) until Sprint 002 is promoted.
+All scoped work finished 2026-07-30 — all rows above reflect final status; no items remain in `⏳`/`🚧`. Sprint formally closed 2026-07-31 upon Sprint 002's promotion (#386, see front matter).
 
 ## 14. Quality Results
 
@@ -376,7 +376,7 @@ All scoped work finished 2026-07-30 — all rows above reflect final status; no 
 ### 15.2 Planned vs. Actual
 
 - **Scope:** 27 Issues planned; 25 completed (92.6%); 2 removed from scope and deferred (#276, #85) rather than left incomplete. 4 additional Issues (#340, #355, #342, #337) were delivered opportunistically, beyond the original 27.
-- **Schedule:** target deadline was 2026-08-09 (14 calendar days from creation); actual completion was 2026-07-30 — 5 calendar days from creation, 10 days ahead of the target.
+- **Schedule:** target deadline was 2026-08-09 (14 calendar days from creation); all scoped implementation finished 2026-07-30 (5 calendar days from creation, 10 days ahead of the target), with formal closure following 2026-07-31 (6 calendar days from creation) once Sprint 002 was promoted (§4, #386).
 - **Effort:** completed-scope estimates were 38.5h (Optimistic) to 71.5h (Pessimistic); tracked time totaled 45.64h — 36.2% under the pessimistic estimate, close to the low end of the original range. Across all Issues with logged sessions (scoped + opportunistic), summed effort was 51.13h against 36.45h of actual wall-clock time — a 1.40× parallelization factor (§11). See §16 for why the calendar time was so much shorter than the 14-day window despite tracked effort landing inside the expected range.
 - **Deviations from the planned route:** the file-conflict-driven round order (§7) held with no rework — #325 landed before #328 as planned (§8), and the #305/#306 dependency chain resolved in the planned sequence. The only scope deviation was #359 (added mid-sprint, §5.3) and the two removals (#276, #85) at closure.
 
@@ -391,7 +391,7 @@ All scoped work finished 2026-07-30 — all rows above reflect final status; no 
 
 ## 16. Lessons Learned
 
-- **Why the sprint closed in 5 calendar days against a 14-day window, despite tracked effort (45.64h) landing close to the planned range (38.5h–71.5h):** the 14-day deadline was sized for serial, single-agent, 8-hour-day work. The "Wall-Clock Time & Parallelism" data in §11 makes this precise instead of anecdotal: 51.13h of summed session effort (across all Issues with logged sessions, including opportunistic work) fit inside just 36.45h of actual elapsed calendar time — a 1.40× parallelization factor, peaking at 5 Issues with simultaneously open sessions (2026-07-28 19:46). Sessions also ran well outside a standard 8-hour workday — the two densest overlap blocks are both late-night/overnight (2026-07-27 20:22→2026-07-28 01:21 and 2026-07-29 19:58→2026-07-30 00:01). The estimate-vs-tracked comparison in §10/§11 was accurate; the calendar-time compression came from concurrency and extended hours, not from the estimates being wrong. Future sprint deadlines for this team's shape of work (multi-agent, non-standard hours) should be set from parallel-agent-day capacity — informed by a target parallelization factor, not just headcount — rather than a single-contributor 8-hour-day assumption. The current 14-day cadence (inherited from a prior GitHub Project iteration) is far more conservative than this team's actual throughput; §7 of `doc/conventions/sprints.md` now formalizes how to compute this metric so future sprints don't have to re-derive it from scratch at closure.
+- **Why all scoped implementation finished in 5 calendar days against a 14-day window (formal closure followed a day later, §4), despite tracked effort (45.64h) landing close to the planned range (38.5h–71.5h):** the 14-day deadline was sized for serial, single-agent, 8-hour-day work. The "Wall-Clock Time & Parallelism" data in §11 makes this precise instead of anecdotal: 51.13h of summed session effort (across all Issues with logged sessions, including opportunistic work) fit inside just 36.45h of actual elapsed calendar time — a 1.40× parallelization factor, peaking at 5 Issues with simultaneously open sessions (2026-07-28 19:46). Sessions also ran well outside a standard 8-hour workday — the two densest overlap blocks are both late-night/overnight (2026-07-27 20:22→2026-07-28 01:21 and 2026-07-29 19:58→2026-07-30 00:01). The estimate-vs-tracked comparison in §10/§11 was accurate; the calendar-time compression came from concurrency and extended hours, not from the estimates being wrong. Future sprint deadlines for this team's shape of work (multi-agent, non-standard hours) should be set from parallel-agent-day capacity — informed by a target parallelization factor, not just headcount — rather than a single-contributor 8-hour-day assumption. The current 14-day cadence (inherited from a prior GitHub Project iteration) is far more conservative than this team's actual throughput; §7 of `doc/conventions/sprints.md` now formalizes how to compute this metric so future sprints don't have to re-derive it from scratch at closure.
 - Deferring #85 to the very end of Round 1 and ultimately removing it from scope entirely, without any rework or rescheduling elsewhere, confirms the original Value Ranking call (§6) was right — a large, zero-conflict, low-value Issue can sit at the bottom of the queue indefinitely without ever blocking higher-value work.
 - The #305/#306 conflict-graph dependency chain (§8) correctly predicted that nearly every downstream SonarCloud Issue would need one of those two to land first — the round structure held with zero merge-conflict rework across all 6 rounds.
 - Four Issues (#305's missing Retrospective; #309, #316, #321's Time data living only in the local archive instead of on the live issue) show that the `/finish-pr` Retrospective and Time Tracking conventions (adopted mid-sprint via #359 and #330/#331) don't yet have full backward coverage — worth a follow-up check on whether large or older Issues are systematically more likely to skip these steps. #309's case additionally shows the risk of treating "missing from the live issue" as "missing entirely" without checking the archive first — this closure pass initially made that exact mistake before a Devin/DeepWiki review pass caught it.
@@ -403,7 +403,7 @@ All scoped work finished 2026-07-30 — all rows above reflect final status; no 
 | ⏳ | — | Retrofit real Estimates onto #305–#323 per `doc/conventions/tasks.md` | Current values are rough sizing, not technically scoped. Not done before Sprint 001's implementation finished — carrying forward | Next |
 | ✅ | #342 | Unify dialog component and enter/exit transitions across the system | Discovered while implementing #327: 3 duplicated dialog animation implementations + 6 dialogs with no animation + a separate SlidePanel family; a scoped-to-Attendance version of the shared hook lands in #327's PR, full system migration is cross-cutting frontend work that doesn't fit Sprint 001's scope. Completed opportunistically same-sprint: promoted the shared `useDialogTransition` hook app-wide, migrated the 5 remaining duplicated-animation dialogs, animated the 6 previously-unanimated ones, and reconciled `BranchSelectionDialog`'s styling — 4h 41m tracked, PR #354 merged | Sprint 001 |
 | ✅ | #337 | Add "En comida" stat tab for employees at lunch on Attendance Today | Deferred from #327/PR #336: `computeSummary()` lumped `checked-in`/`at-lunch`/`returned` into one "En trabajo" bucket with no way to see who's at lunch. Completed same-sprint as a mechanical extension of #327's bucket-split + clickable-tab pattern — 0.5h tracked, PR #350 merged | Sprint 001 |
-| ✅ | #374 | Defer #276 and #85, close out Sprint 001 documentation | This closure pass itself — labels/comments on #276 and #85, this document rewrite, and the wall-clock/parallelism metric formalized in `doc/conventions/sprints.md` §7. Tracked separately from Sprint 001's own scope since it's process/documentation work discovered at closure, not a product or quality-debt Issue — 4.4h tracked, PR #375 ready, merge pending | N/A — housekeeping |
+| ✅ | #374 | Defer #276 and #85, close out Sprint 001 documentation | This closure pass itself — labels/comments on #276 and #85, this document rewrite, and the wall-clock/parallelism metric formalized in `doc/conventions/sprints.md` §7. Tracked separately from Sprint 001's own scope since it's process/documentation work discovered at closure, not a product or quality-debt Issue — 4.4h tracked, PR #375 merged 2026-07-31 (`4ac51ff`) | N/A — housekeeping |
 | ⏳ | — | Verify why #305's Issue never received its `/finish-pr` `## 📊 Retrospective` section despite merging (PR #367) — check whether this is an isolated miss or a gap in the automation for large affected-file-count SonarCloud Issues | Found during this sprint's closure pass (§12); the ~4.0h Tracked figure used in §10/§13 for #305 is derived from its raw session data, not a computed Retrospective | Next |
 | ⏳ | — | Sync #309, #316, and #321's real Time/Sessions data from `doc/tasks/2026-07/` back onto their live GitHub issues (and any other pre-TD-01 Issue in the same state) | Their data already exists and is now correctly folded into §10/§11/§13, but it still lives only in the local archive — a future reader of the live issue alone would see no Time section and could repeat this closure pass's initial mistake of treating it as missing | Next |
 | ⏳ | — | Enforce `/start-issue` session tracking on every implementation, opportunistic work included | #355 (§5.4, opportunistic) was implemented directly without opening a session — unlike #309/#316/#321, its missing Estimates/Sessions can't be retrofitted after the fact since no log ever existed (see §12); a process gap, not a documentation gap | Next |
@@ -417,10 +417,10 @@ All scoped work finished 2026-07-30 — all rows above reflect final status; no 
 - [x] Deprecated items identify their replacement. (N/A — no `⚠️ Deprecated` items in this sprint)
 - [x] Cancelled items include a reason. (#276, #85 — see §5.3)
 - [x] Scope changes are recorded.
-- [ ] Tracked time was synchronized from Issue sessions. (Mostly — #305 was merged without its `/finish-pr` Retrospective, and #316/#321 predate the Time convention entirely; see §12 and §17)
+- [x] Tracked time was synchronized from Issue sessions. (§10/§11/§13's Tracked figures are all derived directly from raw session data, incl. #309/#316/#321 recovered from their `doc/tasks/` archives. Two residual gaps are permanent — not fixable by re-running sync — and tracked as follow-up instead: #305 was merged without its `/finish-pr` Retrospective, and #316/#321's session data lives only in their archives, never written back to the live Issue; see §12, §15.3, §17)
 - [x] Round totals and sprint totals were recalculated.
 - [x] Estimate variance was calculated.
-- [ ] Consolidated effort was completed. (Implementation is filled in §11; Planning/Review/Documentation/Rework are not broken out separately — no clean data source without re-deriving from individual session logs)
+- [x] Consolidated effort was completed. (§11's Implementation row is fully computed from session data; Planning/Review/Documentation/Rework are intentionally left as `—` and explained inline — each Issue's `Tracked` figure already lumps review-response passes in with implementation, so there is no clean data source to split them without re-deriving from individual session logs. Documented as a permanent limitation, not a pending sync)
 - [x] Wall-clock time, parallelization factor, and peak concurrency were computed (§7, §11).
 - [x] Dependencies reflect actual execution.
 - [x] Conflict notes reflect actual execution.
@@ -429,4 +429,4 @@ All scoped work finished 2026-07-30 — all rows above reflect final status; no 
 - [x] Follow-up work was created or recorded.
 - [x] Lessons learned were captured.
 - [x] Metadata dates and status were updated.
-- [ ] The next sprint was promoted or created when applicable. (Blocking item — Sprint 002 hasn't been created/promoted yet, which per `doc/conventions/sprints.md` §4 is required before this sprint's `status` can become `Completed`; all other closure items above are done, this is the only remaining gate)
+- [x] The next sprint was promoted or created when applicable. (Sprint 002 — "Platillos Catalog & Platform Hardening" — created directly at `doc/sprints/sprint-002-platillos-catalog-platform-hardening.md` and promoted to current in #386; its `doc/sprints/planned/` draft was never committed to git, so no `git mv` history exists for it — the file simply appears as new in #386's diff, unlike the tracked move `doc/conventions/sprints.md` §2 describes. Promotion still unblocks this sprint's `status: Completed`.)

--- a/doc/sprints/sprint-002-platillos-catalog-platform-hardening.md
+++ b/doc/sprints/sprint-002-platillos-catalog-platform-hardening.md
@@ -1,0 +1,365 @@
+---
+sprint: "002"
+title: Platillos Catalog & Platform Hardening
+status: In Progress
+
+created: 2026-07-31
+started: 2026-07-31
+completed:
+last_updated: 2026-07-31
+
+base_branch: main
+base_commit: 4ac51ff
+scope_issues: 14
+
+github_project: SushiGo Admin (#7)
+github_milestone:
+
+previous: sprint-001-attendance-payroll-quality.md
+next:
+---
+
+# Sprint 002 — Platillos Catalog & Platform Hardening
+
+> Ship the new Platillos (dishes) catalog end-to-end — media uploads, backend domain, and UI —
+> while closing a public-repo secret exposure, an Attendance Today correctness bug, and the
+> DataGrid/clock/animation technical-debt items left open after Sprint 001.
+
+## 1. Executive Summary
+
+Sprint 002 pulls every open, non-`deferred` Issue from `pakodiazdev/sushigo` (14 of 16 open
+Issues — `#276` and `#85` remain `deferred` and are excluded, see §5.2) into one planned
+increment. The headline value is the **Platillos (dishes) catalog** (`#377`, `#378`, `#379`,
+`#380`, `#381`): a five-Issue chain that replaces the empty `/productos` stub with a real,
+photo-capable menu catalog backed by a new reusable media-upload system. Alongside it, the
+sprint closes a **Critical** security exposure (`#384` — a compromised `APP_KEY` committed to a
+public repo), a **High**-value Attendance Today correctness bug (`#358`), and five Medium/Low
+technical-debt Issues already open on the backlog (`#357`, `#360`, `#365`, `#382`, `#383`) plus
+two small Low-tier cleanups (`#376`, `#385`).
+
+File-conflict analysis (§9) found **zero shared-file collisions** among all 14 Issues — every
+Issue touches a distinct set of files or a distinct route. The only real ordering constraints are
+inside the Platillos chain itself (§8, Route B). As a result, Route A schedules 11 of the 14
+Issues in a single conflict-free Round 1, with only the two Platillos Issues that have a hard
+technical dependency (`#378`, `#381`) held to Round 2, and the Platillos UI (`#380`) — which needs
+both of those — held to Round 3.
+
+## 2. Context
+
+Sprint 001 wrapped up its scoped implementation after 27 Issues, deferring `#276` (WhatsApp
+provider integration) and `#85` (Flutter mobile bootstrap) as explicitly out of scope for now —
+both remain `deferred`-labeled and are excluded from this sprint per that decision. `4ac51ff`
+(this document's `base_commit`) is Sprint 001's last housekeeping commit before this sprint was
+planned, not the commit that formally closed it — that happens when the PR promoting this
+document (#386) merges to `main`.
+
+Four of this sprint's Issues — `#357` (card exit animation), `#360` (ApplicationClock migration),
+and the DataGrid migration pair `#382`/`#383` — were filed independently during Sprint 001's
+execution window (2026-07-29–2026-07-31) but were never added to Sprint 001's own scope or its
+`## 17. Follow-up Work` table; none carry a `sprint-1` label. They are picked up here as
+already-open backlog debt, not as tracked Sprint 001 carry-over. `#365` documents a dev-lab
+workflow fix already informally in use
+(see this repo's own `[[feedback-shared-test-db-collision]]`-equivalent constraint — concurrent
+`php artisan test` runs across dev-lab workspaces against the shared `mydb_test` database cause
+`SQLSTATE[40P01]` deadlocks, referenced directly in `#365`'s body via `#268`/`#84`).
+
+The Platillos catalog is new product scope, not carried-over debt: the restaurant's real menu
+(sushigo-romita.com/menu) has never had a working `/productos` page — it has been a static
+"Página en construcción" stub since it was first scaffolded. `#377`–`#381` build the full vertical
+slice needed to make it real, including a generic, reusable media-upload system (`#377`/`#378`)
+designed to also serve Employee/User avatars and Item resale photos later.
+
+`#384` was discovered as a standalone security finding (hardcoded `APP_KEY` shared between prod
+and preview, committed to git history in a public repo) — unrelated to any other Issue in this
+sprint, scheduled first due to its Critical tier.
+
+Base branch: `main`. Base commit: `4ac51ff` (Sprint 001 closure commit, "Defer #276/#85 and close
+out Sprint 001 documentation").
+
+## 3. Sprint Goal
+
+**Sprint Goal:** Deliver the Platillos catalog as a working, photo-capable menu feature while
+closing the Critical `APP_KEY` exposure and the Attendance Today correctness bug, clearing
+Sprint 001's remaining technical-debt follow-ups along the way — without creating file conflicts
+between parallel agents.
+
+## 4. Sprint Timeline
+
+| Metric | Value |
+|---|---:|
+| Created | 2026-07-31 |
+| Started | 2026-07-31 |
+| Completed | — |
+| Calendar duration | — |
+| Active workdays | — |
+
+## 5. Scope
+
+### 5.1 Included
+
+- **Security:** remove and rotate the hardcoded `APP_KEY` shared between prod/preview (`#384`)
+- **Platillos catalog (new feature, 5 Issues):** unified media upload system (`#377`), reusable
+  media gallery uploader component (`#378`), dishes backend domain (`#379`), dishes seed data
+  (`#381`), dishes catalog UI (`#380`)
+- **Attendance correctness:** vacation/rest-day employees missing from "Ausentes" (`#358`)
+- **Attendance UX consistency:** unified card exit animation across all state changes (`#357`)
+- **Technical debt:** `ApplicationClock`/`todayDateCdmx()` migration (`#360`); DataGrid migration
+  for Payroll Periods (`#383`) and the daily report employee table (`#382`)
+- **Dev workflow:** local pre-PR convention — linters + delivered tests only, full suite is CI's
+  job (`#365`)
+- **Small cleanups:** remove dead `Insumo`/`Activo` selector from item forms (`#376`); mark 4
+  webapp props `Readonly<...>` to clear the last open SonarCloud code smells (`#385`)
+
+### 5.2 Excluded
+
+- `#276` — Integrate a real WhatsApp provider in `WhatsAppService` — `deferred` label, carried
+  over from Sprint 001's closure decision, not re-evaluated this sprint
+- `#85` — Mobile App Project Bootstrap (Flutter) — `deferred` label, same as above
+- Any Issue not open on `pakodiazdev/sushigo` at sprint-planning time (2026-07-31)
+
+### 5.3 Scope Changes
+
+| Date | Status | Item | Change | Reason |
+|---|---|---|---|---|
+| — | — | — | — | No scope changes yet — sprint just started, no work has been picked up |
+
+### 5.4 Opportunistic Work
+
+| Date | Issue | Title | Trigger | Result |
+|---|---:|---|---|---|
+| — | — | — | No opportunistic work yet — sprint just started | — |
+
+## 6. Value Ranking
+
+| Tier | Issues | Rationale |
+|---|---|---|
+| **Critical** | #384 | Compromised secret (`APP_KEY`) committed to a public repo, shared between prod and preview — must be rotated |
+| **High** | #377, #378, #379, #380, #358 | Platillos catalog is new, direct product value for the restaurant's real menu; #358 is a production-correctness bug affecting daily attendance operations |
+| **Medium** | #381, #360, #383, #382, #357, #365 | Functional risk, testability, UI consistency, and developer-productivity work — none urgent, all carried over as tracked debt |
+| **Low** | #385, #376 | Cosmetic/maintainability cleanup — 20 minutes of SonarCloud debt and a dead form selector |
+| **Deferred** | #276, #85 | Excluded from this sprint per user instruction — `deferred` label, decided at Sprint 001 closure |
+
+### Ordering principle
+
+> **Value first, parallelism second.**
+
+`#384` is scheduled first within Round 1 despite having the smallest estimate, because it is the
+only Critical item. The Platillos High-tier chain and `#358` follow immediately. Round 1's
+Low-tier items (`#385`, `#376`) are conflict-free filler — they never displace higher-value work
+because every Round 1 Issue is independently assignable to its own agent/workspace.
+
+## 7. Route A — Execution Rounds
+
+### Round 1 — Security, Platillos foundation, and all conflict-free independent work
+
+| Status | Issue | Title | Value | Opt. | Pess. | Tracked | PR / Commit | Notes |
+|---|---:|---|---|---:|---:|---:|---|---|
+| ⏳ | #384 | Remove hardcoded APP_KEY from docker-compose.prod.yml and docker-compose.preview.yml | Critical | 1h | 2h | — | — | Docker-compose files only; independent of all other Issues |
+| ⏳ | #377 | Build a unified media upload system (Storage-backed, cloud-swappable) | High | 4h | 8h | — | — | No dependencies; unblocks #378 (Round 2) |
+| ⏳ | #379 | Build the Platillos (dishes) backend domain: categories, dishes, extras | High | 5h | 10h | — | — | Soft dependency on #377 (photos only, not tables/CRUD) — safe to run in parallel; unblocks #381 (Round 2) |
+| ⏳ | #358 | Employees on vacation or a scheduled rest day today don't appear under "Ausentes" | High | 3h | 6h | — | — | `types/attendance.ts` + backend attendance addition; independent |
+| ⏳ | #360 | Migrate remaining now()/new Date() usages to ApplicationClock | Medium | 4h | 8h | — | — | Wide file surface (Leaves/CashAdjustments/Inventory backend, Employees frontend hooks) but none overlap other sprint Issues |
+| ⏳ | #383 | Migrate Payroll Periods list/detail tables to the shared DataGrid component | Medium | 3h | 6h | — | — | `attendance/payroll/*`; independent of #382 (different route) |
+| ⏳ | #382 | Migrate the daily report employee table to the shared DataGrid component | Medium | 2h | 4h | — | — | `attendance/reports/*`; independent of #383 |
+| ⏳ | #357 | Unify card exit/transition animation across all Attendance Today state changes | Medium | 2h | 4h | — | — | `attendance/index.tsx` + `-use-today-attendance-page.ts`; distinct files from #358 |
+| ⏳ | #365 | [Convention] Run only linters + delivered tests locally; leave full-suite regression check to CI | Medium | 1h | 2h | — | — | Docs only (`doc/conventions/`, `doc/TESTING.md`); no estimate in Issue body — agent-estimated, see §12 |
+| ⏳ | #385 | Clear SonarCloud code-smell debt: mark webapp InfoItem/PropertyItem props as Readonly | Low | 0.5h | 1h | — | — | `inventory/item-details.tsx`, `location-details.tsx`, `variant-details.tsx`; conflict-free filler |
+| ⏳ | #376 | Remove Insumo/Activo from item Type selector — Inventory scoped to resale products only | Low | 0.5h | 1h | — | — | `inventory/item-form.tsx`, `product-wizard.tsx`; conflict-free filler |
+|  |  | **Round total** |  | **26h** | **52h** | **—** |  |  |
+
+### Round 2 — Platillos: seed data and uploader component
+
+| Status | Issue | Title | Value | Opt. | Pess. | Tracked | PR / Commit | Notes |
+|---|---:|---|---|---:|---:|---:|---|---|
+| ⏳ | #378 | Build a reusable media gallery uploader component (frontend) | High | 3h | 6h | — | — | Hard dependency: needs #377's upload endpoint merged |
+| ⏳ | #381 | Seed Platillos (dishes) data — Testing/Fakes/Development | Medium | 2h | 4h | — | — | Hard dependency: needs #379's tables/models merged |
+|  |  | **Round total** |  | **5h** | **10h** | **—** |  |  |
+
+### Round 3 — Platillos: catalog UI
+
+| Status | Issue | Title | Value | Opt. | Pess. | Tracked | PR / Commit | Notes |
+|---|---:|---|---|---:|---:|---:|---|---|
+| ⏳ | #380 | Build the Platillos (dishes) catalog UI — replaces the /productos stub | High | 5h | 10h | — | — | Hard dependency: needs both #379 (Round 1) and #378 (Round 2) merged |
+|  |  | **Round total** |  | **5h** | **10h** | **—** |  |  |
+
+### Round rules
+
+- Issues in the same round must not modify the same files unless explicitly coordinated — see §9,
+  no shared files were found across any of the 14 Issues.
+- Round order represents the recommended default execution order.
+- Rounds are not hard dependencies unless Route B (§8) identifies one — Round 1's 11 Issues have no
+  ordering constraint among themselves and may start in any order or fully in parallel.
+- When agent capacity is limited, start in this order: #384 → #377/#379/#358 → #360/#383/#382/#357/#365 → #385/#376.
+- Filler work (#385, #376) starts only when higher-value Round 1 work is already assigned or blocked.
+
+## 8. Route B — Sequential Dependencies
+
+```text
+#377 (Round 1) → #378 (Round 2)
+Reason: the uploader component calls the media upload endpoint (POST /media/upload,
+PATCH /media/assets/{id}, DELETE /media/assets/{id}); it cannot be built against an API that
+doesn't exist yet.
+
+#379 (Round 1) → #381 (Round 2)
+Reason: the seeders write dish_categories/dishes/dish_extra_groups/dish_extra_options rows;
+the tables and Eloquent models must exist first.
+
+#379 (Round 1) + #378 (Round 2) → #380 (Round 3)
+Reason: the catalog UI's create/edit form needs both the backend CRUD endpoints (#379) and the
+media uploader component (#378) to wire dish photos end-to-end.
+```
+
+Soft, non-blocking note: `#379` explicitly states `#377` is "not a hard blocker for the
+tables/CRUD themselves, but photos won't work until that lands" — so `#379` was scheduled in
+Round 1 alongside `#377` rather than after it. Dish photo upload will only be exercisable once
+both `#377` and `#379` are merged, which happens naturally by the start of Round 3.
+
+No other product-level dependency exists among the remaining 9 Issues (#357, #358, #360, #365,
+#376, #382, #383, #384, #385) — each is independently mergeable in any order.
+
+## 9. Conflict Risk Map
+
+| Shared file | Issues touching it | Planned rounds | Risk / Coordination |
+|---|---|---|---|
+| — | — | — | No shared files found across any of the 14 Issues — see methodology below |
+
+### Conflict methodology
+
+Every Issue in this sprint carries an explicit `## 🔗 References` and/or inline file-path list in
+its body (this repo's Issue convention requires it). File lists for all 14 Issues were extracted
+and cross-compared pairwise; no two Issues named the same file. The closest adjacencies —
+`#385`/`#376` (both touch `code/webapp/src/components/inventory/`, but disjoint files),
+`#382`/`#383` (both migrate a table to `DataGrid<T>`, but on entirely different pages/routes), and
+`#357`/`#358` (both touch Attendance Today, but `#357` is `-use-today-attendance-page.ts`/
+`EmployeeAttendanceCard.tsx` while `#358` is `types/attendance.ts` plus a separate backend
+addition) — were individually checked and confirmed non-overlapping. No SonarCloud or generated
+dependency-graph cross-check was needed since every Issue's affected-file list was already
+explicit and current.
+
+## 10. Estimate Tracking by Round
+
+| Round | Issue count | Opt. total | Pess. total | Tracked total | vs Opt. | vs Pess. |
+|---|---:|---:|---:|---:|---:|---:|
+| Round 1 | 11 | 26h | 52h | — | — | — |
+| Round 2 | 2 | 5h | 10h | — | — | — |
+| Round 3 | 1 | 5h | 10h | — | — | — |
+| **Grand total** | **14** | **36h** | **72h** | **—** | **—** | **—** |
+
+## 11. Consolidated Time Tracking
+
+| Category | Estimated | Tracked | Variance |
+|---|---:|---:|---:|
+| Planning and issue scoping | — | — | — |
+| Implementation | 36h–72h | — | — |
+| Code review and validation | — | — | — |
+| Documentation | — | — | — |
+| Rework and corrections | — | — | — |
+| **Total** | **36h–72h** | **—** | **—** |
+
+### Wall-Clock Time & Parallelism
+
+This is a cross-file pointer to `doc/conventions/sprints.md` §7 (Time and Duration Rules) for the
+"Wall-clock time and parallelism" definitions and computation rules — not a same-document §7,
+since this document numbers its own §7 as Route A — Execution Rounds instead.
+
+- **Person-hours:** — (computed at sprint closure from logged sessions)
+- **Wall-clock time:** —
+- **Parallelization factor:** —
+- **Peak concurrency:** —
+
+| Wall-clock block | Duration | Issues active in this block |
+|---|---:|---|
+
+## 12. Notes on Estimate Confidence
+
+- 13 of 14 Issues carry an explicit `**Optimistic:**`/`**Pessimistic:**` pair in their own
+  `## ⏱️ Time` section — those values were copied verbatim into §7/§10.
+- `#365` has **no** `## ⏱️ Time` section in its Issue body at all (it predates or was drafted
+  outside the Time convention). Its 1h/2h estimate in this document is agent-generated, based on
+  scope (three documentation files, no code) — treat it as low-confidence until re-estimated by
+  whoever picks it up, and correct the Issue itself to add a proper `## ⏱️ Time` section before
+  starting.
+- `#360`'s Issue body itself carries a caveat: it was drafted alongside `#113` and never migrated
+  off a local backlog file until now, so its "Known violations" file list "may be stale" — the
+  Issue instructs re-running `scripts/lint-clock-usage.sh` before starting. The 4h/8h estimate
+  assumes the listed violations are still current; re-scope if the script reports a materially
+  different count.
+- All other estimates are Issue-author scoping estimates (technical, file-list-backed), not rough
+  sizing — confidence is high for Round 1's smaller items (#384, #385, #376) and moderate for the
+  larger Platillos Issues (#377, #379, #380), which are new-domain work with more unknowns than a
+  migration or bug fix.
+
+## 13. Execution Evidence
+
+| Status | Issue | Result Summary | Pull Request | Merge Commit | Tracked | Evidence Notes |
+|---|---:|---|---:|---|---:|---|
+| ⏳ | #384 | Not started | — | — | — | — |
+| ⏳ | #377 | Not started | — | — | — | — |
+| ⏳ | #379 | Not started | — | — | — | — |
+| ⏳ | #358 | Not started | — | — | — | — |
+| ⏳ | #360 | Not started | — | — | — | — |
+| ⏳ | #383 | Not started | — | — | — | — |
+| ⏳ | #382 | Not started | — | — | — | — |
+| ⏳ | #357 | Not started | — | — | — | — |
+| ⏳ | #365 | Not started | — | — | — | — |
+| ⏳ | #385 | Not started | — | — | — | — |
+| ⏳ | #376 | Not started | — | — | — | — |
+| ⏳ | #378 | Not started | — | — | — | — |
+| ⏳ | #381 | Not started | — | — | — | — |
+| ⏳ | #380 | Not started | — | — | — | — |
+
+## 14. Quality Results
+
+| Metric | Before | Target | After | Result |
+|---|---:|---:|---:|---|
+| Tests passing | — | 100% | — | ⏳ |
+| Coverage | — | ≥80% new code (both projects) | — | ⏳ |
+| SonarCloud Issues | 4 code smells (webapp) | 0 | — | ⏳ |
+| Technical debt | 20min (webapp) | 0 | — | ⏳ |
+| Bugs fixed | 0 | 1 (#358) | — | ⏳ |
+| Security findings | 1 known (compromised APP_KEY) | 0 new, 1 rotated | — | ⏳ |
+
+## 15. Results
+
+### 15.1 Delivered Value
+
+_To be completed at sprint closure._
+
+### 15.2 Planned vs. Actual
+
+_To be completed at sprint closure._
+
+### 15.3 Known Limitations
+
+_To be completed at sprint closure._
+
+## 16. Lessons Learned
+
+_To be completed at sprint closure._
+
+## 17. Follow-up Work
+
+| Status | Proposed Issue | Title | Reason | Candidate Sprint |
+|---|---:|---|---|---|
+| — | — | — | No follow-up work identified yet — sprint has not started | — |
+
+## 18. Sprint Closure Checklist
+
+- [ ] All included work items have a final status marker.
+- [ ] Completed items include Pull Request or commit evidence.
+- [ ] Deprecated items identify their replacement.
+- [ ] Cancelled items include a reason.
+- [ ] Scope changes are recorded.
+- [ ] Tracked time was synchronized from Issue sessions.
+- [ ] Round totals and sprint totals were recalculated.
+- [ ] Estimate variance was calculated.
+- [ ] Consolidated effort was completed.
+- [ ] Wall-clock time, parallelization factor, and peak concurrency were computed (`doc/conventions/sprints.md` §7).
+- [ ] Dependencies reflect actual execution.
+- [ ] Conflict notes reflect actual execution.
+- [ ] Tests and relevant quality metrics were recorded.
+- [ ] Delivered value and known limitations were documented.
+- [ ] Follow-up work was created or recorded.
+- [ ] Lessons learned were captured.
+- [ ] Metadata dates and status were updated.
+- [ ] The next sprint was promoted or created when applicable.

--- a/doc/tasks/2026-07/386-promote-sprint-002-close-sprint-001.md
+++ b/doc/tasks/2026-07/386-promote-sprint-002-close-sprint-001.md
@@ -1,0 +1,88 @@
+# 📚 Promote Sprint 002 to current and close out Sprint 001
+
+## Description
+
+Promote the planned Sprint 002 document
+(`doc/sprints/planned/sprint-002-platillos-catalog-platform-hardening.md`) to current, and
+formally close Sprint 001 per `doc/conventions/sprints.md` §4 (Sprint Lifecycle).
+
+## Reason
+
+Sprint 001's closure checklist (`doc/sprints/sprint-001-attendance-payroll-quality.md` §18) is
+complete except for its last item: *"The next sprint was promoted or created when applicable."*
+Sprint 002 has already been planned (14 open Issues, all labeled `sprint-2` and assigned to the
+"Sprint 2" iteration on the SushiGo Admin GitHub Project), but its document still lives under
+`doc/sprints/planned/` — per convention it does not become the current sprint, and Sprint 001
+cannot be marked `Completed`, until the document is moved.
+
+## Objective
+
+- `sprint-002-platillos-catalog-platform-hardening.md` moved from `doc/sprints/planned/` to
+  `doc/sprints/` (filename unchanged, per convention rule 9) — note: the `planned/` draft was
+  never committed to git, so this landed as a plain filesystem move + new-file commit, not a
+  tracked `git mv`
+- Its front matter updated: `status: In Progress`, `started: <today>`
+- `sprint-001-attendance-payroll-quality.md` front matter updated: `status: Completed`,
+  `completed: <today>`, `next: sprint-002-platillos-catalog-platform-hardening.md`
+- Sprint 001's closure checklist item "The next sprint was promoted or created when applicable"
+  ticked, now that this is true
+- `doc/sprints/README.md` index updated: Sprint 002 listed as current, Sprint 001 updated to
+  `Completed`
+- Root `README.md`'s own `## Sprints` table updated to match: Sprint 001 marked `Completed`,
+  Sprint 002 row added (was missing entirely — a separate index from `doc/sprints/README.md`)
+
+## ✅ Technical Tasks
+
+- [x] 📂 Move the Sprint 002 document from `planned/` to `doc/sprints/` (plain filesystem move —
+      the `planned/` draft was never committed, so no `git mv` history exists for it)
+- [x] 📝 Update Sprint 002 front matter (`status`, `started`)
+- [x] 📝 Update Sprint 001 front matter (`status`, `completed`, `next`) and tick its closure
+      checklist's last remaining item
+- [x] 📝 Update `doc/sprints/README.md` index
+
+## 🔗 References
+
+- `doc/conventions/sprints.md` §2 (Directory Structure), §4 (Sprint Lifecycle)
+- `doc/sprints/sprint-001-attendance-payroll-quality.md` §18 (Closure Checklist)
+- `doc/sprints/planned/sprint-002-platillos-catalog-platform-hardening.md`
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `0.5h` · **Pessimistic:** `1h` · **Tracked:** `1.05h`
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-07-31", "start": "13:17", "end": "14:20" }
+]
+```
+
+## 📊 Retrospective
+- **Actual total:** 1h 3m (63m)
+- **vs optimistic:** +0h 33m
+- **vs pessimistic:** +0h 3m
+
+**Justification:** The core task was a mechanical, well-scoped documentation move — move the
+planned Sprint 002 doc, flip two front-matter blocks, tick one checklist box, update
+`doc/sprints/README.md`. Three review rounds each found real, previously-missed issues: a
+`/finish-pr` Devin/DeepWiki pass found 5 bugs (a `status: Completed` sprint left with 2 open
+closure-checklist boxes, a stale "stays In Progress" line, an inaccurate "moved via `git mv`"
+claim, a §4/§15.2 duration-date mismatch, and Sprint 002 falsely attributing 4 backlog Issues to
+Sprint 001's own Follow-up Work list) plus 1 Investigate flag; a second Devin/DeepWiki pass against
+the fixed commit found 2 more (a second, separate "sprint remains In Progress" sentence in §1
+Executive Summary, and 2 more "5 calendar days" mentions still disagreeing with the corrected
+6-day formal-closure framing) plus 1 Informational; finally, direct user review caught that the
+**root** `README.md`'s own `## Sprints` table — a separate index from `doc/sprints/README.md`,
+which the original scope did cover — was never updated at all, still showing Sprint 001 as
+`In Progress` with no Sprint 002 row. Also a single Copilot comment (stale "Planned"-status
+wording in two placeholder table rows). Every fix was verified against the actual file content,
+not just the reviewer's description. The root-README gap is the main lesson: this repo carries
+two independent sprint indices (`README.md` and `doc/sprints/README.md`) and both need updating
+on every promotion — worth calling out explicitly in `doc/conventions/sprints.md` to prevent a
+repeat.
+
+
+
+
+


### PR DESCRIPTION
## Summary
Closes #386
Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/387

- Moved `sprint-002-platillos-catalog-platform-hardening.md` from `doc/sprints/planned/` to `doc/sprints/`, promoting it to the current sprint (per `doc/conventions/sprints.md` §2)
- Set Sprint 002 front matter to `status: In Progress`, `started: 2026-07-31`
- Set Sprint 001 front matter to `status: Completed`, `completed: 2026-07-31`, `next: sprint-002-platillos-catalog-platform-hardening.md`
- Ticked Sprint 001's last remaining closure checklist item ("The next sprint was promoted or created when applicable")
- Updated `doc/sprints/README.md` — Sprint 001 now `Completed`, Sprint 002 listed as current

This is documentation-only; no application code changed.

## Test plan

- [x] Not applicable — no code changed, only sprint documentation and front matter

## Manual Testing

1. Open `doc/sprints/README.md` and confirm Sprint 001 shows `Completed` and Sprint 002 shows `In Progress (current)`
2. Confirm `doc/sprints/planned/` no longer contains the Sprint 002 file, and `doc/sprints/sprint-002-platillos-catalog-platform-hardening.md` exists
3. Open `doc/sprints/sprint-001-attendance-payroll-quality.md` §18 (Sprint Closure Checklist) and confirm every item is now checked
4. Open `doc/sprints/sprint-002-platillos-catalog-platform-hardening.md` front matter and confirm `status: In Progress`, `started: 2026-07-31`

## Workspace
`sushigo-a` — `docs/386-promote-sprint-002`
