### PR TITLE
🐛 [#388][a] - Fix close-out pause and concurrent-run scratch-file collision 🔧

### DIFF
--- a/.claude/commands/finish-pr.md
+++ b/.claude/commands/finish-pr.md
@@ -201,7 +201,7 @@ written **directly to the issue**, not to a local file. There is no separate "sy
 there is nothing else to sync with.
 
 ```bash
-gh issue view <NNN> --repo <owner>/<repo> --json body -q .body > /tmp/finish-pr-issue-body.md
+gh issue view <NNN> --repo <owner>/<repo> --json body -q .body > /tmp/finish-pr-<N>-issue-body.md
 ```
 
 1. In the `## ⏱️ Time` → `Sessions` JSON array, close any session still showing `"end": "?"` with
@@ -219,7 +219,7 @@ gh issue view <NNN> --repo <owner>/<repo> --json body -q .body > /tmp/finish-pr-
 Write the updated body back:
 
 ```bash
-gh issue edit <NNN> --repo <owner>/<repo> --body-file /tmp/finish-pr-issue-body.md
+gh issue edit <NNN> --repo <owner>/<repo> --body-file /tmp/finish-pr-<N>-issue-body.md
 ```
 
 Do **not** close the issue here — merging the PR closes it automatically via `Closes #NNN`.
@@ -397,7 +397,7 @@ housekeeping commit:
 
 ```bash
 git fetch origin <baseRefName>
-git diff origin/<baseRefName> HEAD --name-only | sort > /tmp/finish-pr-files-before.txt
+git diff origin/<baseRefName> HEAD --name-only | sort > /tmp/finish-pr-<N>-files-before.txt
 git reset --soft origin/<baseRefName>
 ```
 
@@ -407,8 +407,8 @@ not just concatenate every intermediate commit message verbatim.
 
 ```bash
 git commit -m "<final consolidated message>"
-git diff origin/<baseRefName> HEAD --name-only | sort > /tmp/finish-pr-files-after.txt
-diff /tmp/finish-pr-files-before.txt /tmp/finish-pr-files-after.txt && echo "MATCH"
+git diff origin/<baseRefName> HEAD --name-only | sort > /tmp/finish-pr-<N>-files-after.txt
+diff /tmp/finish-pr-<N>-files-before.txt /tmp/finish-pr-<N>-files-after.txt && echo "MATCH"
 git push --force-with-lease origin HEAD
 ```
 
@@ -484,12 +484,12 @@ git rebase origin/<baseRefName>
 
 - If it **succeeds**, the branch is already a single commit from Phase 7.5, so the rebase replays
   cleanly as one commit. Re-validate against the file list Phase 7.5 already proved correct
-  (`finish-pr-files-after.txt`, captured post-squash against the *old* base) — preserve it under
-  its own name first, since the next command overwrites `finish-pr-files-after.txt` in place:
+  (`finish-pr-<N>-files-after.txt`, captured post-squash against the *old* base) — preserve it under
+  its own name first, since the next command overwrites `finish-pr-<N>-files-after.txt` in place:
   ```bash
-  cp /tmp/finish-pr-files-after.txt /tmp/finish-pr-files-preverify.txt
-  git diff origin/<baseRefName> HEAD --name-only | sort > /tmp/finish-pr-files-after.txt
-  diff /tmp/finish-pr-files-preverify.txt /tmp/finish-pr-files-after.txt && echo "MATCH"
+  cp /tmp/finish-pr-<N>-files-after.txt /tmp/finish-pr-<N>-files-preverify.txt
+  git diff origin/<baseRefName> HEAD --name-only | sort > /tmp/finish-pr-<N>-files-after.txt
+  diff /tmp/finish-pr-<N>-files-preverify.txt /tmp/finish-pr-<N>-files-after.txt && echo "MATCH"
   ```
   A clean rebase replays the same patch onto a new parent, so this must still match — a mismatch
   means the rebase silently dropped or altered files and should be treated like a failed diff

--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -64,18 +64,20 @@ This exact bar governs Phase 6 (Copilot) and Phase 8 (Devin). Phase 1 has a rela
 escape valve for planning ambiguities — see that phase for its own research-then-ask rule. Phase 10
 has one deliberate ask at the very end of the run (share `/usage`'s output for cost logging) — that
 is a wrap-up request for data this command cannot read itself, not a decision point in the
-pipeline. Phase 8 also has a narrow infrastructure fallback (asking whether to wait for the Chrome
+pipeline. Phase 8 has a narrow infrastructure fallback (asking whether to wait for the Chrome
 extension to connect, or skip that sub-check) — an environment/tooling question, not a decision
-about the feature or the review. Outside those spots — Phase 1's research-then-ask, Phase 6/8's
-business-rule bar, Phase 8's Chrome-extension fallback, and Phase 10's wrap-up ask — nothing else in
-this command pauses for the user.
+about the feature or the review. Phase 9 delegates to `finish-pr.md` verbatim, which has the exact
+same Chrome-extension fallback in its own Phase 7.6b — so that ask can also surface during close-out,
+not just Phase 8. Outside those spots — Phase 1's research-then-ask, Phase 6/8's business-rule bar,
+the Chrome-extension fallback (Phase 8 or, via delegation, Phase 9/finish-pr's 7.6b), and Phase 10's
+wrap-up ask — nothing else in this command pauses for the user.
 
 ---
 
 ## PHASE 0 — Confirm the issue exists
 
 ```bash
-gh issue view $ARGUMENTS --repo pakodiazdev/sushigo --json number,title,body,state,labels
+gh issue view "$ARGUMENTS" --repo pakodiazdev/sushigo --json number,title,body,state,labels
 ```
 
 - **Command fails / issue not found** → stop immediately. Report `❌ Issue #$ARGUMENTS does not
@@ -212,9 +214,9 @@ is the documentation *and* the task, not just the diff.
    re-verifying the same boxes later is harmless — never *un*tick something it finds already
    checked.
    ```bash
-   gh issue view $ARGUMENTS --repo pakodiazdev/sushigo --json body -q .body > /tmp/issue-tasks-body.md
+   gh issue view "$ARGUMENTS" --repo pakodiazdev/sushigo --json body -q .body > "/tmp/issue-$ARGUMENTS-tasks-body.md"
    # tick [ ] → [x] only for items you can verify actually shipped in this PR's diff
-   gh issue edit $ARGUMENTS --repo pakodiazdev/sushigo --body-file /tmp/issue-tasks-body.md
+   gh issue edit "$ARGUMENTS" --repo pakodiazdev/sushigo --body-file "/tmp/issue-$ARGUMENTS-tasks-body.md"
    ```
 
 Fold any doc changes into the same commits as the rest of Phase 3 (or their own doc-scoped commit,
@@ -478,10 +480,10 @@ Append one entry to a `## 💸 Token & Cost` section on the issue — same patte
 first time anything logs against this issue, otherwise append.
 
 ```bash
-gh issue view $ARGUMENTS --repo pakodiazdev/sushigo --json body -q .body > /tmp/issue-cost-body.md
+gh issue view "$ARGUMENTS" --repo pakodiazdev/sushigo --json body -q .body > "/tmp/issue-$ARGUMENTS-cost-body.md"
 ```
 
-Edit `/tmp/issue-cost-body.md`:
+Edit `/tmp/issue-$ARGUMENTS-cost-body.md`:
 - If `## 💸 Token & Cost` doesn't exist yet, add it (with an empty `### 📅 Runs` json array and a
   `### 📊 Totals` line) after `## ⏱️ Time`.
 - Append to `Runs`:
@@ -495,7 +497,7 @@ Edit `/tmp/issue-cost-body.md`:
   later runs it standalone on a different PR that didn't go through `/issue`.
 
 ```bash
-gh issue edit $ARGUMENTS --repo pakodiazdev/sushigo --body-file /tmp/issue-cost-body.md
+gh issue edit "$ARGUMENTS" --repo pakodiazdev/sushigo --body-file "/tmp/issue-$ARGUMENTS-cost-body.md"
 ```
 
 This applies regardless of how the run ended — log what was actually spent even if Phase 6 or 8

--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -18,7 +18,7 @@ local archive is written once, later, by `/finish-pr`.
 ## PHASE 1 — Load the issue
 
 ```bash
-gh issue view $ARGUMENTS --repo pakodiazdev/sushigo --json number,title,body,labels,state
+gh issue view "$ARGUMENTS" --repo pakodiazdev/sushigo --json number,title,body,labels,state
 ```
 
 If the issue is closed, stop and inform the user.
@@ -35,14 +35,14 @@ before continuing — do not silently work around a malformed issue.
 ### 1a. Ensure the issue is linked to the SushiGo Admin project
 
 ```bash
-gh issue view $ARGUMENTS --repo pakodiazdev/sushigo --json projectItems -q '.projectItems[].project.title'
+gh issue view "$ARGUMENTS" --repo pakodiazdev/sushigo --json projectItems -q '.projectItems[].project.title'
 ```
 
 If `"SushiGo Admin"` is not in the list, link it (Status field only — never set the Iteration field,
 that is a sprint-assignment decision the user makes explicitly):
 
 ```bash
-gh project item-add 7 --owner pakodiazdev --url https://github.com/pakodiazdev/sushigo/issues/$ARGUMENTS
+gh project item-add 7 --owner pakodiazdev --url "https://github.com/pakodiazdev/sushigo/issues/$ARGUMENTS"
 ```
 
 ---
@@ -128,9 +128,9 @@ the array as `[]` first if the issue somehow doesn't have one yet — see Phase 
 today's date and the current local time as `start` and `"?"` as `end`:
 
 ```bash
-gh issue view $ARGUMENTS --repo pakodiazdev/sushigo --json body -q .body > /tmp/issue-body.md
-# edit /tmp/issue-body.md: append { "date": "YYYY-MM-DD", "start": "HH:MM", "end": "?" } to Sessions
-gh issue edit $ARGUMENTS --repo pakodiazdev/sushigo --body-file /tmp/issue-body.md
+gh issue view "$ARGUMENTS" --repo pakodiazdev/sushigo --json body -q .body > "/tmp/issue-$ARGUMENTS-body.md"
+# edit /tmp/issue-$ARGUMENTS-body.md: append { "date": "YYYY-MM-DD", "start": "HH:MM", "end": "?" } to Sessions
+gh issue edit "$ARGUMENTS" --repo pakodiazdev/sushigo --body-file "/tmp/issue-$ARGUMENTS-body.md"
 ```
 
 If the file already has previous session entries, append to the array rather than replacing it.
@@ -232,9 +232,9 @@ Fetch the current body, fill the `end` field of the session opened in Phase 5 wi
 local time:
 
 ```bash
-gh issue view $ARGUMENTS --repo pakodiazdev/sushigo --json body -q .body > /tmp/issue-body.md
-# edit /tmp/issue-body.md: set this session's "end" to "HH:MM"
-gh issue edit $ARGUMENTS --repo pakodiazdev/sushigo --body-file /tmp/issue-body.md
+gh issue view "$ARGUMENTS" --repo pakodiazdev/sushigo --json body -q .body > "/tmp/issue-$ARGUMENTS-body.md"
+# edit /tmp/issue-$ARGUMENTS-body.md: set this session's "end" to "HH:MM"
+gh issue edit "$ARGUMENTS" --repo pakodiazdev/sushigo --body-file "/tmp/issue-$ARGUMENTS-body.md"
 ```
 
 `Tracked` stays `_in progress_` — it is only recomputed once, by `/finish-pr`, from the full


### PR DESCRIPTION
## Summary
Closes #388
Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/390

Follow-up fixes to `/issue` and `/start-issue` for two real bugs Devin's DeepWiki scan found after PR #389 merged.

- 🐛 The one-interruption rule's list of every allowed pause point missed that Phase 9 delegates to `finish-pr.md` verbatim, which has its own identical Chrome-extension-fallback ask in Phase 7.6b — a run promising never to pause outside four listed spots could still stall there unlisted
- 🐛 Scoped every issue-body scratch file to the issue number (`$ARGUMENTS`) instead of a fixed filename — `/tmp/issue-tasks-body.md`, `/tmp/issue-cost-body.md` (`issue.md`), and `/tmp/issue-body.md` (`start-issue.md`, both open and close session steps) could all collide across two concurrent runs on the same dev-lab machine and clobber each other's staged issue text

## Manual Testing
1. Read `.claude/commands/issue.md`'s "The one-interruption rule" section — confirm it now explicitly lists the Phase 9/finish-pr Chrome-extension fallback alongside Phase 8's
2. Run `/issue <N>` and `/start-issue <N>` for two different issue numbers concurrently in two dev-lab workspaces — confirm each run's scratch files (`/tmp/issue-<N>-*.md`) are distinct and never overwritten by the other run

## Test plan
- [x] Reviewed the diff against `doc/conventions/git/pull-requests.md` and `CLAUDE.md`'s conventions
- [ ] Run `/issue <N>` end-to-end once more to confirm no regression in the phases touched

## Workspace
`sushigo-a` — `feature/388-add-issue-command`

🤖 Generated with [Claude Code](https://claude.com/claude-code)