### PR TITLE
🔧 [#385][d] - Mark webapp InfoItem/PropertyItem props as Readonly 🔒

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Development is organized into documented sprints — see [`doc/conventions/sprin
 |---|---|---|---|---|---|---:|---|
 | 000 | Introduction | Completed | 2026-07-26 | 2026-07-26 | — | — | [sprint-000-introduction.md](doc/sprints/sprint-000-introduction.md) |
 | 001 | Attendance, Payroll & Quality | Completed | 2026-07-26 | 2026-07-31 (impl. finished 2026-07-30) | 2026-08-09 | 1.40× (51.1h → 36.5h) | [sprint-001-attendance-payroll-quality.md](doc/sprints/sprint-001-attendance-payroll-quality.md) |
-| 002 | Platillos Catalog & Platform Hardening | In Progress | 2026-07-31 | — | — | — | [sprint-002-platillos-catalog-platform-hardening.md](doc/sprints/sprint-002-platillos-catalog-platform-hardening.md) |
+| 002 | Platillos Catalog & Platform Hardening | In Progress | 2026-07-31 | 7% | — | — | [sprint-002-platillos-catalog-platform-hardening.md](doc/sprints/sprint-002-platillos-catalog-platform-hardening.md) |
 
 ## Development tips
 

--- a/code/webapp/src/components/inventory/item-details.tsx
+++ b/code/webapp/src/components/inventory/item-details.tsx
@@ -238,12 +238,12 @@ function PropertyItem({
   label,
   value,
   description,
-}: {
+}: Readonly<{
   icon: React.ReactNode
   label: string
   value: string
   description: string
-}) {
+}>) {
   return (
     <div className="flex items-start rounded-lg border border-border p-3">
       <div className="flex h-5 w-5 flex-shrink-0 items-center justify-center">
@@ -264,11 +264,11 @@ function InfoItem({
   icon,
   label,
   value,
-}: {
+}: Readonly<{
   icon: React.ReactNode
   label: string
   value: React.ReactNode
-}) {
+}>) {
   return (
     <div className="flex items-start">
       <div className="flex h-5 w-5 flex-shrink-0 items-center justify-center text-muted-foreground">

--- a/code/webapp/src/components/inventory/location-details.tsx
+++ b/code/webapp/src/components/inventory/location-details.tsx
@@ -205,11 +205,11 @@ function InfoItem({
   icon,
   label,
   value,
-}: {
+}: Readonly<{
   icon: React.ReactNode
   label: string
   value: React.ReactNode
-}) {
+}>) {
   return (
     <div className="flex items-start">
       <div className="flex h-5 w-5 flex-shrink-0 items-center justify-center text-gray-400">

--- a/code/webapp/src/components/inventory/variant-details.tsx
+++ b/code/webapp/src/components/inventory/variant-details.tsx
@@ -221,13 +221,13 @@ function InfoItem({
   value,
   hint,
   iconColor = 'text-gray-600',
-}: {
+}: Readonly<{
   icon: React.ElementType
   label: string
   value: string
   hint?: string
   iconColor?: string
-}) {
+}>) {
   return (
     <div className="flex items-start gap-3">
       <Icon className={`h-4 w-4 mt-0.5 ${iconColor}`} />

--- a/doc/sprints/sprint-002-platillos-catalog-platform-hardening.md
+++ b/doc/sprints/sprint-002-platillos-catalog-platform-hardening.md
@@ -44,6 +44,8 @@ Issues in a single conflict-free Round 1, with only the two Platillos Issues tha
 technical dependency (`#378`, `#381`) held to Round 2, and the Platillos UI (`#380`) — which needs
 both of those — held to Round 3.
 
+**Progress as of 2026-08-01:** 1/14 Issues complete (7%) — #385.
+
 ## 2. Context
 
 Sprint 001 wrapped up its scoped implementation after 27 Issues, deferring `#276` (WhatsApp
@@ -92,6 +94,7 @@ between parallel agents.
 | Completed | — |
 | Calendar duration | — |
 | Active workdays | — |
+| Progress (Issues completed) | 1/14 (7%) |
 
 ## 5. Scope
 
@@ -163,7 +166,7 @@ because every Round 1 Issue is independently assignable to its own agent/workspa
 | ⏳ | #382 | Migrate the daily report employee table to the shared DataGrid component | Medium | 2h | 4h | — | — | `attendance/reports/*`; independent of #383 |
 | ⏳ | #357 | Unify card exit/transition animation across all Attendance Today state changes | Medium | 2h | 4h | — | — | `attendance/index.tsx` + `-use-today-attendance-page.ts`; distinct files from #358 |
 | ⏳ | #365 | [Convention] Run only linters + delivered tests locally; leave full-suite regression check to CI | Medium | 1h | 2h | — | — | Docs only (`doc/conventions/`, `doc/TESTING.md`); no estimate in Issue body — agent-estimated, see §12 |
-| ⏳ | #385 | Clear SonarCloud code-smell debt: mark webapp InfoItem/PropertyItem props as Readonly | Low | 0.5h | 1h | — | — | `inventory/item-details.tsx`, `location-details.tsx`, `variant-details.tsx`; conflict-free filler |
+| ✅ | #385 | Clear SonarCloud code-smell debt: mark webapp InfoItem/PropertyItem props as Readonly | Low | 0.5h | 1h | 0.2h | PR #391 | `inventory/item-details.tsx`, `location-details.tsx`, `variant-details.tsx`; conflict-free filler; PR ready, merge pending |
 | ⏳ | #376 | Remove Insumo/Activo from item Type selector — Inventory scoped to resale products only | Low | 0.5h | 1h | — | — | `inventory/item-form.tsx`, `product-wizard.tsx`; conflict-free filler |
 |  |  | **Round total** |  | **26h** | **52h** | **—** |  |  |
 
@@ -302,7 +305,7 @@ since this document numbers its own §7 as Route A — Execution Rounds instead.
 | ⏳ | #382 | Not started | — | — | — | — |
 | ⏳ | #357 | Not started | — | — | — | — |
 | ⏳ | #365 | Not started | — | — | — | — |
-| ⏳ | #385 | Not started | — | — | — | — |
+| ✅ | #385 | Wrapped `PropertyItem`/`InfoItem` props in `Readonly<...>` across 3 inventory detail components, clearing all 4 open SonarCloud `typescript:S6759` code smells | PR #391 | — | 0.2h | Pure type-annotation change, no runtime behavior change; 24/24 existing Vitest tests passing, lint + typecheck clean; CI 12/12 green, Copilot 0 comments, Devin/DeepWiki 0 bugs/0 flags on first push; PR ready, merge pending |
 | ⏳ | #376 | Not started | — | — | — | — |
 | ⏳ | #378 | Not started | — | — | — | — |
 | ⏳ | #381 | Not started | — | — | — | — |

--- a/doc/tasks/2026-08/385-readonly-props.md
+++ b/doc/tasks/2026-08/385-readonly-props.md
@@ -1,0 +1,70 @@
+# 🔨 Clear SonarCloud code-smell debt: mark webapp InfoItem/PropertyItem props as Readonly
+
+## Description
+
+SonarCloud shows 4 open `CODE_SMELL` issues on `pakodiazdev_sushigo-webapp` — all rule
+`typescript:S6759` ("Mark the props of the component as read-only"), open since 2026-01-09
+(~7 months, `sqale_index` = 20min of debt). No bugs, vulnerabilities, or pending security
+hotspots on either project (`pakodiazdev_sushigo-api` is fully clean — 0 code smells).
+
+Affected components — none type their props param as `Readonly<...>`:
+- `code/webapp/src/components/inventory/item-details.tsx:236` — `PropertyItem`
+- `code/webapp/src/components/inventory/item-details.tsx:263` — `InfoItem`
+- `code/webapp/src/components/inventory/location-details.tsx:204` — `InfoItem`
+- `code/webapp/src/components/inventory/variant-details.tsx:218` — `InfoItem`
+
+## Reason
+
+These are the only open issues across both SonarCloud projects — the rest of the codebase is at
+zero debt. Fixing them clears the backlog to a clean 0/0/0 state and prevents `S6759` from being
+copy-pasted into new components (three of the four are the same `InfoItem` pattern duplicated
+across files).
+
+## Objective
+
+- All 4 flagged prop destructuring params are typed as `Readonly<Props>` (or component-local
+  props type wrapped in `Readonly<>`), matching the pattern SonarCloud's `S6759` expects
+- `npm run lint` and `npm run typecheck` pass with no new errors
+- SonarCloud shows 0 open code smells on `pakodiazdev_sushigo-webapp` after the next analysis
+
+## ✅ Technical Tasks
+
+- [x] 🔧 Mark `PropertyItem` props as `Readonly<...>` in `item-details.tsx:236`
+- [x] 🔧 Mark `InfoItem` props as `Readonly<...>` in `item-details.tsx:263`
+- [x] 🔧 Mark `InfoItem` props as `Readonly<...>` in `location-details.tsx:204`
+- [x] 🔧 Mark `InfoItem` props as `Readonly<...>` in `variant-details.tsx:218`
+
+## 🔗 References
+
+- SonarCloud rule: [typescript:S6759](https://rules.sonarsource.com/typescript/RSPEC-6759)
+- Project: https://sonarcloud.io/project/issues?id=pakodiazdev_sushigo-webapp&resolved=false
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `0.5h` · **Pessimistic:** `1h` · **Tracked:** `13m`
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-08-01", "start": "11:38", "end": "11:51" }
+]
+```
+
+## 📊 Retrospective
+- **Actual total:** 0h 13m (13m)
+- **vs optimistic:** −17m
+- **vs pessimistic:** −47m
+
+**Justification:**
+Delivered under both estimates via `/issue`'s autonomous pipeline. The fix was purely mechanical —
+wrapping four existing prop destructuring types in `Readonly<...>` with no behavior change — and
+the issue's own Technical Tasks list already named the exact file/line for every occurrence, so no
+exploration or design work was needed. Existing unit tests (24 across the three affected
+components) covered regression risk with no new tests required. CI, Copilot, and the Devin/DeepWiki
+review all passed clean on the first push — 0 bugs, 0 flags, no review comments — so there were no
+fix/re-validate cycles to inflate the tracked time.
+
+
+
+


### PR DESCRIPTION
## Summary
Closes #385
Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/391

- 🔒 Wrapped `PropertyItem` props in `Readonly<>` in `item-details.tsx:236`
- 🔒 Wrapped `InfoItem` props in `Readonly<>` in `item-details.tsx:263`
- 🔒 Wrapped `InfoItem` props in `Readonly<>` in `location-details.tsx:204`
- 🔒 Wrapped `InfoItem` props in `Readonly<>` in `variant-details.tsx:218`

Clears the last 4 open SonarCloud code smells (`typescript:S6759`) on `pakodiazdev_sushigo-webapp`,
bringing both SonarCloud projects to a clean 0 code smells / 0 vulnerabilities / 0 security
hotspots state. Pure type-annotation change — no runtime behavior change.

## Manual Testing
This is a pure TypeScript type-annotation change with no runtime behavior difference, so there is
no UI flow to exercise. Verify statically instead:

1. `cd code/webapp && npm run typecheck` → passes with 0 errors
2. `cd code/webapp && npm run lint` → passes with 0 errors
3. Open `src/components/inventory/item-details.tsx`, `location-details.tsx`, and
   `variant-details.tsx` and confirm the `PropertyItem`/`InfoItem` prop destructuring types are
   wrapped in `Readonly<...>`
4. Optionally load the Item, Location, or Variant detail slide-panel in the browser
   (`https://sushigo.local` → Inventory → open any item/location/variant) and confirm it renders
   identically to before this change

## Test plan
- [x] Vitest: `npx vitest run src/components/inventory/__tests__/item-details.test.tsx src/components/inventory/__tests__/location-details.test.tsx src/components/inventory/__tests__/variant-details.test.tsx` — 24/24 passing
- [x] Linters: ESLint ✅ · TypeScript ✅

## Workspace
`sushigo-d` — `chore/385-readonly-props`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
