### PR TITLE
🔨 [#376][c] - Remove Type selector from item forms 🎨

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Development is organized into documented sprints — see [`doc/conventions/sprin
 |---|---|---|---|---|---|---:|---|
 | 000 | Introduction | Completed | 2026-07-26 | 2026-07-26 | — | — | [sprint-000-introduction.md](doc/sprints/sprint-000-introduction.md) |
 | 001 | Attendance, Payroll & Quality | Completed | 2026-07-26 | 2026-07-31 (impl. finished 2026-07-30) | 2026-08-09 | 1.40× (51.1h → 36.5h) | [sprint-001-attendance-payroll-quality.md](doc/sprints/sprint-001-attendance-payroll-quality.md) |
-| 002 | Platillos Catalog & Platform Hardening | In Progress | 2026-07-31 | 21.4% (3/14) | — | — | [sprint-002-platillos-catalog-platform-hardening.md](doc/sprints/sprint-002-platillos-catalog-platform-hardening.md) |
+| 002 | Platillos Catalog & Platform Hardening | In Progress | 2026-07-31 | 28.6% (4/14) | — | — | [sprint-002-platillos-catalog-platform-hardening.md](doc/sprints/sprint-002-platillos-catalog-platform-hardening.md) |
 
 ## Development tips
 

--- a/code/webapp/src/components/inventory/__tests__/item-form.test.tsx
+++ b/code/webapp/src/components/inventory/__tests__/item-form.test.tsx
@@ -73,10 +73,9 @@ describe('ItemForm', () => {
             expect(inputs.length).toBeGreaterThan(0)
         })
 
-        it('renders item type select', () => {
-            const { container } = render(<ItemForm {...defaultProps} />)
-            const selects = container.querySelectorAll('select')
-            expect(selects.length).toBeGreaterThan(0)
+        it('does not render a Type selector', () => {
+            const { queryByText } = render(<ItemForm {...defaultProps} />)
+            expect(queryByText('Type')).toBeNull()
         })
 
         it('renders checkboxes for boolean fields', () => {
@@ -144,14 +143,6 @@ describe('ItemForm', () => {
             fireEvent.change(skuInput, { target: { value: 'test-sku' } })
             // The mock setField should be called
             expect(skuInput).toBeDefined()
-        })
-
-        it('allows changing item type', () => {
-            const { container } = render(<ItemForm {...defaultProps} />)
-            const select = container.querySelector('select') as HTMLSelectElement
-
-            fireEvent.change(select, { target: { value: 'PRODUCTO' } })
-            expect(select.value).toBe('PRODUCTO')
         })
 
         it('allows toggling is_stocked checkbox', () => {
@@ -231,6 +222,21 @@ describe('ItemForm', () => {
             await waitFor(() => expect(mockExecute).toHaveBeenCalled())
         })
 
+        it('submits new items with type PRODUCTO without asking the user', async () => {
+            const { getByPlaceholderText, container } = render(<ItemForm {...defaultProps} />)
+
+            fireEvent.change(getByPlaceholderText('e.g., SAL-001'), { target: { value: 'SA-001' } })
+            fireEvent.change(getByPlaceholderText('e.g., Fresh Salmon'), { target: { value: 'Salt Item' } })
+
+            fireEvent.submit(container.querySelector('form')!)
+
+            await waitFor(() =>
+                expect(mockExecute).toHaveBeenCalledWith(
+                    expect.objectContaining({ type: 'PRODUCTO' })
+                )
+            )
+        })
+
         it('calls execute on valid form submission (update)', async () => {
             const item = {
                 id: 1,
@@ -251,6 +257,32 @@ describe('ItemForm', () => {
             fireEvent.submit(container.querySelector('form')!)
 
             await waitFor(() => expect(mockExecute).toHaveBeenCalledTimes(1))
+        })
+
+        it('preserves an existing non-PRODUCTO item type unchanged on update', async () => {
+            const item = {
+                id: 1,
+                sku: 'SAL-001',
+                name: 'Salt Item',
+                description: '',
+                type: 'INSUMO' as const,
+                is_stocked: true,
+                is_perishable: false,
+                is_active: true,
+                is_manufactured: false,
+                created_at: '',
+                updated_at: '',
+            }
+
+            const { container } = render(<ItemForm {...defaultProps} item={item} />)
+
+            fireEvent.submit(container.querySelector('form')!)
+
+            await waitFor(() =>
+                expect(mockExecute).toHaveBeenCalledWith(
+                    expect.objectContaining({ type: 'INSUMO' })
+                )
+            )
         })
     })
 })

--- a/code/webapp/src/components/inventory/__tests__/product-wizard.test.tsx
+++ b/code/webapp/src/components/inventory/__tests__/product-wizard.test.tsx
@@ -69,12 +69,18 @@ describe('ProductWizard', () => {
         fireEvent.change(screen.getByPlaceholderText('ej., ROLL-001'), { target: { value: 'ROLL-001' } })
         fireEvent.change(screen.getByPlaceholderText('ej., California Roll'), { target: { value: 'California Roll' } })
         fireEvent.change(screen.getByPlaceholderText('Descripción detallada del producto'), { target: { value: 'Rico' } })
-        fireEvent.change(screen.getByDisplayValue('Producto Terminado'), { target: { value: 'INSUMO' } })
         const checkboxes = screen.getAllByRole('checkbox')
         fireEvent.click(checkboxes[1]!) // is_perishable
         fireEvent.click(checkboxes[2]!) // is_manufactured
         fireEvent.click(checkboxes[3]!) // is_active
     }
+
+    it('does not render a Type selector in Step 1', async () => {
+        render(<ProductWizard onSuccess={onSuccess} onCancel={onCancel} />, { wrapper: createWrapper() })
+
+        await waitFor(() => expect(apiGet).toHaveBeenCalled())
+        expect(screen.queryByText('Tipo de Producto')).toBeNull()
+    })
 
     it('walks through the full wizard and creates a product with stock', async () => {
         createItem.mockResolvedValue({ data: { data: { id: 100 } } })
@@ -90,6 +96,7 @@ describe('ProductWizard', () => {
             fireEvent.click(screen.getByRole('button', { name: /siguiente/i }))
         })
         await waitFor(() => expect(createItem).toHaveBeenCalled())
+        expect(createItem).toHaveBeenCalledWith(expect.objectContaining({ type: 'PRODUCTO' }))
         expect(showSuccess).toHaveBeenCalledWith('Producto creado exitosamente', 'Paso 1 Completo')
 
         // Step 2: Variant

--- a/code/webapp/src/components/inventory/item-form.tsx
+++ b/code/webapp/src/components/inventory/item-form.tsx
@@ -4,7 +4,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { FormField, Select, Textarea, Checkbox } from '@/components/ui/form-fields'
+import { FormField, Textarea, Checkbox } from '@/components/ui/form-fields'
 import { SlidePanel } from '@/components/ui/slide-panel'
 import { useCreateUpdateMutation } from '@/hooks/use-form-mutation'
 import { itemApi } from '@/services/inventory-api'
@@ -43,7 +43,7 @@ export function ItemForm({ item, onSuccess, onCancel }: Readonly<ItemFormProps>)
       sku: item?.sku || '',
       name: item?.name || '',
       description: item?.description || '',
-      type: item?.type || 'INSUMO',
+      type: item?.type || 'PRODUCTO',
       is_stocked: item?.is_stocked ?? true,
       is_perishable: item?.is_perishable ?? false,
       is_active: item?.is_active ?? true,
@@ -62,7 +62,6 @@ export function ItemForm({ item, onSuccess, onCancel }: Readonly<ItemFormProps>)
   const allErrors = {
     sku: errors.sku?.message || validationErrors.sku,
     name: errors.name?.message || validationErrors.name,
-    type: errors.type?.message || validationErrors.type,
   }
 
   const onSubmit = async (data: ItemFormValues) => {
@@ -75,7 +74,6 @@ export function ItemForm({ item, onSuccess, onCancel }: Readonly<ItemFormProps>)
   const isStocked = watch('is_stocked')
   const isPerishable = watch('is_perishable')
   const isActive = watch('is_active')
-  const formType = watch('type')
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="flex h-full flex-col">
@@ -106,23 +104,6 @@ export function ItemForm({ item, onSuccess, onCancel }: Readonly<ItemFormProps>)
             placeholder="e.g., Fresh Salmon"
             error={!!allErrors.name}
           />
-        </FormField>
-
-        <FormField
-          label="Type"
-          required
-          error={allErrors.type}
-          hint="Classification type for this item"
-        >
-          <Select
-            value={formType}
-            onChange={(e) => setValue('type', e.target.value as ItemFormValues['type'])}
-            error={!!allErrors.type}
-          >
-            <option value="INSUMO">Insumo (Input/Raw Material)</option>
-            <option value="PRODUCTO">Producto (Finished Product)</option>
-            <option value="ACTIVO">Activo (Asset)</option>
-          </Select>
         </FormField>
 
         <FormField label="Description">

--- a/code/webapp/src/components/inventory/product-wizard.tsx
+++ b/code/webapp/src/components/inventory/product-wizard.tsx
@@ -536,17 +536,6 @@ export function ProductWizard({ onSuccess, onCancel }: Readonly<ProductWizardPro
                             />
                         </FormField>
 
-                        <FormField label="Tipo de Producto" required>
-                            <Select
-                                value={wizardData.item.type}
-                                onChange={(e) => updateItemData('type', e.target.value as WizardData['item']['type'])}
-                            >
-                                <option value="INSUMO">Insumo</option>
-                                <option value="PRODUCTO">Producto Terminado</option>
-                                <option value="ACTIVO">Activo</option>
-                            </Select>
-                        </FormField>
-
                         <div className="space-y-3">
                             <Checkbox
                                 checked={wizardData.item.is_stocked}

--- a/doc/sprints/sprint-002-platillos-catalog-platform-hardening.md
+++ b/doc/sprints/sprint-002-platillos-catalog-platform-hardening.md
@@ -37,10 +37,10 @@ public repo), a **High**-value Attendance Today correctness bug (`#358`), and fi
 technical-debt Issues already open on the backlog (`#357`, `#360`, `#365`, `#382`, `#383`) plus
 two small Low-tier cleanups (`#376`, `#385`).
 
-**Progress as of 2026-08-01:** 3 of 14 scoped Issues completed (21.4%) — `#384` (Critical
+**Progress as of 2026-08-04:** 4 of 14 scoped Issues completed (28.6%) — `#384` (Critical
 `APP_KEY` security exposure, PR #393), `#385` (SonarCloud `Readonly` code-smell cleanup, PR
-#391), and `#358` (Attendance Today "Ausentes" correctness bug, PR #395), all open and ready for
-merge.
+#391), `#358` (Attendance Today "Ausentes" correctness bug, PR #395), and `#376` (dead item Type
+selector removal, PR #396), all open and ready for merge.
 
 File-conflict analysis (§9) found **zero shared-file collisions** among all 14 Issues — every
 Issue touches a distinct set of files or a distinct route. The only real ordering constraints are
@@ -97,7 +97,7 @@ between parallel agents.
 | Completed | — |
 | Calendar duration | — |
 | Active workdays | — |
-| Progress (Issues completed) | 3 / 14 (21.4%) as of 2026-08-01 — `#384` (Critical `APP_KEY` exposure, PR #393), `#385` (SonarCloud cleanup, PR #391), and `#358` (Attendance Today "Ausentes" bug, PR #395) implemented; all open, ready for merge |
+| Progress (Issues completed) | 4 / 14 (28.6%) as of 2026-08-04 — `#384` (Critical `APP_KEY` exposure, PR #393), `#385` (SonarCloud cleanup, PR #391), `#358` (Attendance Today "Ausentes" bug, PR #395), and `#376` (dead item Type selector removal, PR #396) implemented; all open, ready for merge |
 
 ## 5. Scope
 
@@ -170,7 +170,7 @@ because every Round 1 Issue is independently assignable to its own agent/workspa
 | ⏳ | #357 | Unify card exit/transition animation across all Attendance Today state changes | Medium | 2h | 4h | — | — | `attendance/index.tsx` + `-use-today-attendance-page.ts`; distinct files from #358 |
 | ⏳ | #365 | [Convention] Run only linters + delivered tests locally; leave full-suite regression check to CI | Medium | 1h | 2h | — | — | Docs only (`doc/conventions/`, `doc/TESTING.md`); no estimate in Issue body — agent-estimated, see §12 |
 | ✅ | #385 | Clear SonarCloud code-smell debt: mark webapp InfoItem/PropertyItem props as Readonly | Low | 0.5h | 1h | 0.2h | PR #391 | `inventory/item-details.tsx`, `location-details.tsx`, `variant-details.tsx`; conflict-free filler; PR ready, merge pending |
-| ⏳ | #376 | Remove Insumo/Activo from item Type selector — Inventory scoped to resale products only | Low | 0.5h | 1h | — | — | `inventory/item-form.tsx`, `product-wizard.tsx`; conflict-free filler |
+| ✅ | #376 | Remove Insumo/Activo from item Type selector — Inventory scoped to resale products only | Low | 0.5h | 1h | 12.7h | PR #396 | Type selector removed from item-form.tsx and product-wizard.tsx; new items default to PRODUCTO, existing item types preserved on edit — PR ready, merge pending |
 |  |  | **Round total** |  | **26h** | **52h** | **—** |  |  |
 
 ### Round 2 — Platillos: seed data and uploader component
@@ -309,7 +309,7 @@ since this document numbers its own §7 as Route A — Execution Rounds instead.
 | ⏳ | #357 | Not started | — | — | — | — |
 | ⏳ | #365 | Not started | — | — | — | — |
 | ✅ | #385 | Wrapped `PropertyItem`/`InfoItem` props in `Readonly<...>` across 3 inventory detail components, clearing all 4 open SonarCloud `typescript:S6759` code smells | PR #391 | — | 0.2h | Pure type-annotation change, no runtime behavior change; 24/24 existing Vitest tests passing, lint + typecheck clean; CI 12/12 green, Copilot 0 comments, Devin/DeepWiki 0 bugs/0 flags on first push; PR ready, merge pending |
-| ⏳ | #376 | Not started | — | — | — | — |
+| ✅ | #376 | Removed the Type (Insumo/Producto/Activo) selector from `item-form.tsx` and `product-wizard.tsx`; new items now default to `type: 'PRODUCTO'` without asking the user, and editing an existing item preserves its current type unchanged — PR open, not yet merged | PR #396 | — | 12.7h | 37 Vitest tests updated/passing (86%+ coverage on touched files), lint + typecheck clean, no backend changes; 1 Copilot review comment addressed (brittle select-count assertion swapped for a label-absence check); Devin/DeepWiki 0 bugs, 3 informational-only flags evaluated and found not applicable; CI 12/12 green — PR ready, merge pending |
 | ⏳ | #378 | Not started | — | — | — | — |
 | ⏳ | #381 | Not started | — | — | — | — |
 | ⏳ | #380 | Not started | — | — | — | — |

--- a/doc/tasks/2026-08/376-remove-type-selector.md
+++ b/doc/tasks/2026-08/376-remove-type-selector.md
@@ -1,0 +1,75 @@
+# 🔨 Remove Insumo/Activo from item Type selector — Inventory scoped to resale products only
+
+## Description
+
+Remove the "Type" (`Insumo`/`Producto`/`Activo`) selector from the item creation/edit forms
+(`code/webapp/src/components/inventory/item-form.tsx:124`,
+`code/webapp/src/components/inventory/product-wizard.tsx:546`). This phase's Inventory module is
+scoped to resale products only — items you buy and resell as-is (e.g. bottled drinks, packaged
+snacks) — tracked via the existing stock/cost machinery.
+
+## Reason
+
+The Type field currently offers `Insumo` and `Activo` as choices, but neither is wired to any
+distinct behavior anywhere in the app — selecting them doesn't change the wizard flow, and no
+backend logic branches on them beyond the `Item` model's own type-check helpers. Leaving them in
+the selector is a confusing dead end for anyone creating an item today. This phase's Inventory
+scope is resale products only, so the selector should reflect that instead of offering choices
+that do nothing.
+
+## Objective
+
+- The Type field is removed from both `item-form.tsx` and `product-wizard.tsx` (or, if a technical
+  reason surfaces to keep the field structurally, it's hidden and hardcoded to `PRODUCTO`, never
+  shown as a user choice)
+- New items are created with `type: 'PRODUCTO'` without asking the user to choose
+- Existing tests referencing the Type selector (`item-form.test.tsx`, `product-wizard.test.tsx`,
+  `item-details.test.tsx`) are updated to match
+- **No backend changes** — `items.type` enum stays `INSUMO`/`PRODUCTO`/`ACTIVO` as-is (no
+  migration), and `CreateItemRequest`/`UpdateItemRequest` keep accepting all three values
+  unchanged. This is a frontend-only restriction; the backend stays flexible for later.
+
+## 🔗 References
+
+- `code/webapp/src/components/inventory/item-form.tsx`
+- `code/webapp/src/components/inventory/product-wizard.tsx`
+- `code/api/app/Models/Item.php` (unchanged, referenced for context — `TYPE_INSUMO`/
+  `TYPE_PRODUCTO`/`TYPE_ACTIVO` stay as they are)
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `0.5h` · **Pessimistic:** `1h` · **Tracked:** `12h42m`
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-08-03", "start": "21:44", "end": "10:26" }
+]
+```
+
+## 📊 Retrospective
+
+**Tracked:** `12h42m` total (1 session: 2026-08-03 21:44 → 2026-08-04 10:26).
+
+**Variance:** far over both the optimistic (`0.5h`) and pessimistic (`1h`) estimates — roughly
+12–25x. The estimate was sized for the actual code change (a small, localized UI removal across
+two files), and the code change itself did land in well under an hour of active edits. The
+overrun is not rework or scope creep: it's wall-clock elapsed across the single Sessions entry,
+which spans the full `/issue` pipeline run end-to-end in one sitting — planning, TDD
+implementation, PR creation, waiting on three separate CI runs (initial push, Copilot-fix push,
+post-squash push) to go green, a Copilot review round-trip, and the Devin/DeepWiki scan — plus a
+conversation-context gap in the middle of that sitting where the session was idle waiting on a
+continuation prompt rather than actively working. The estimate template assumes focused
+implementation time; it doesn't budget for CI queue time or idle gaps inside one continuous
+session, which is most of what this figure reflects.
+
+**Narrative:** Scope matched the issue exactly — no scope changes were requested mid-flight. One
+Copilot review comment came back (a brittle test assertion asserting zero `<select>` elements
+instead of checking for the removed "Type" label) and was addressed in a follow-up commit, which
+triggered a second CI run and a required re-squash. The Devin/DeepWiki scan reported 0 bugs and 3
+informational-only flags, all evaluated and found to be non-issues (by design, already covered by
+a toast, or unaffected by the change) — no code changes resulted from that pass.
+
+
+


### PR DESCRIPTION
## Summary
Closes #376
Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/396

- 🎨 Removed the Type (Insumo/Producto/Activo) selector from `item-form.tsx` and `product-wizard.tsx`
- 🔧 New items are created with `type: 'PRODUCTO'` without asking the user to choose
- 🔧 Editing an existing item preserves its current type unchanged (not user-editable)
- ✅ Updated `item-form.test.tsx` and `product-wizard.test.tsx` to match the new UI; no backend changes

## Manual Testing
1. Start the dev-lab workspace: `./init-agent-workspace.sh`
2. Navigate to https://sushigo.local/inventory/items (or http://localhost:5173/inventory/items) and log in as `admin@sushigo.com`
3. Click "New Item" (simple form): confirm there is no "Type" field in the slide-over panel — only SKU, Item Name, Description, and the three property checkboxes are shown
4. Create a new item; verify it's created successfully and, when opened, its detail view shows the "Producto" type badge
5. Open "New Product" (wizard): confirm Step 1 ("Datos del Producto") has no "Tipo de Producto" field — only SKU, Nombre, Descripción, and the four checkboxes
6. Complete the wizard through Step 4 and confirm the created item ends up typed as `PRODUCTO`
7. Edit an existing item that was seeded as `INSUMO` or `ACTIVO` (e.g. via the Items list "Type" filter) and save it without changing anything else — confirm its type badge stays unchanged (not silently switched to `PRODUCTO`)

## 🤔 Assumptions

- The issue only mandates `type: 'PRODUCTO'` for **new** items ("New items are created with
  `type: 'PRODUCTO'` without asking the user to choose"). It says nothing about existing
  non-`PRODUCTO` items. Since the field is now hidden rather than removed from the schema, I chose
  to preserve an existing item's current `type` unchanged on edit (`item?.type || 'PRODUCTO'`)
  rather than silently coercing legacy `INSUMO`/`ACTIVO` items to `PRODUCTO` the next time someone
  edits them — the issue explicitly keeps the backend enum and existing data untouched ("no
  migration"), so silently mutating legacy data on save would contradict that.

## Test plan
- [x] Vitest: `npx vitest run src/components/inventory/__tests__/item-form.test.tsx src/components/inventory/__tests__/product-wizard.test.tsx`
- [x] Linters: ESLint ✅ · TypeScript ✅
- [ ] Cypress E2E: not applicable — no existing spec covers item-form/product-wizard, and this is a UI-removal refactor, not new functionality

## Workspace
`sushigo-c` — `refactor/376-remove-type-selector`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
