### PR TITLE
🔨 [#383][e] - Migrate Payroll Periods tables to the shared DataGrid component 🎨

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Development is organized into documented sprints — see [`doc/conventions/sprin
 |---|---|---|---|---|---|---:|---|
 | 000 | Introduction | Completed | 2026-07-26 | 2026-07-26 | — | — | [sprint-000-introduction.md](doc/sprints/sprint-000-introduction.md) |
 | 001 | Attendance, Payroll & Quality | Completed | 2026-07-26 | 2026-07-31 (impl. finished 2026-07-30) | 2026-08-09 | 1.40× (51.1h → 36.5h) | [sprint-001-attendance-payroll-quality.md](doc/sprints/sprint-001-attendance-payroll-quality.md) |
-| 002 | Platillos Catalog & Platform Hardening | In Progress | 2026-07-31 | 28.6% (4/14) | — | — | [sprint-002-platillos-catalog-platform-hardening.md](doc/sprints/sprint-002-platillos-catalog-platform-hardening.md) |
+| 002 | Platillos Catalog & Platform Hardening | In Progress | 2026-07-31 | 35.7% (5/14) | — | — | [sprint-002-platillos-catalog-platform-hardening.md](doc/sprints/sprint-002-platillos-catalog-platform-hardening.md) |
 
 ## Development tips
 

--- a/code/webapp/cypress/e2e/closed-period-detail.cy.ts
+++ b/code/webapp/cypress/e2e/closed-period-detail.cy.ts
@@ -35,8 +35,8 @@ describe('Closed Period Detail — happy path', () => {
     cy.visitWithAuth('/attendance/payroll')
     cy.wait('@list')
 
-    cy.get('[data-testid="pay-period-row"]').should('have.length.gte', 1)
-    cy.contains('[data-testid="pay-period-row"]', `${PERIOD_START} — ${PERIOD_END}`).within(() => {
+    cy.get('table tbody tr').should('have.length.gte', 1)
+    cy.contains('table tbody tr', `${PERIOD_START} — ${PERIOD_END}`).within(() => {
       cy.contains('Cerrado').should('be.visible')
       cy.contains(`${PERIOD_START} — ${PERIOD_END}`).click()
     })
@@ -51,7 +51,7 @@ describe('Closed Period Detail — happy path', () => {
     cy.visitWithAuth('/attendance/payroll')
     cy.wait('@list')
 
-    cy.contains('[data-testid="pay-period-row"]', `${PERIOD_START} — ${PERIOD_END}`)
+    cy.contains('table tbody tr', `${PERIOD_START} — ${PERIOD_END}`)
       .contains(`${PERIOD_START} — ${PERIOD_END}`)
       .click()
     cy.wait('@detail')
@@ -68,7 +68,7 @@ describe('Closed Period Detail — happy path', () => {
     cy.visitWithAuth('/attendance/payroll')
     cy.wait('@list')
 
-    cy.contains('[data-testid="pay-period-row"]', `${PERIOD_START} — ${PERIOD_END}`)
+    cy.contains('table tbody tr', `${PERIOD_START} — ${PERIOD_END}`)
       .contains(`${PERIOD_START} — ${PERIOD_END}`)
       .click()
     cy.wait('@detail')

--- a/code/webapp/cypress/e2e/payroll-export-csv.cy.ts
+++ b/code/webapp/cypress/e2e/payroll-export-csv.cy.ts
@@ -26,10 +26,10 @@ describe('Payroll Export CSV — happy path', () => {
     cy.loginByApi('admin@sushigo.com', 'admin123456')
     cy.visitWithAuth('/attendance/payroll')
 
-    cy.contains('[data-testid="pay-period-row"]', `${PERIOD_START} — ${PERIOD_END}`).should('be.visible')
+    cy.contains('table tbody tr', `${PERIOD_START} — ${PERIOD_END}`).should('be.visible')
     cy.closeDevDebugger()
 
-    cy.contains('[data-testid="pay-period-row"]', `${PERIOD_START} — ${PERIOD_END}`)
+    cy.contains('table tbody tr', `${PERIOD_START} — ${PERIOD_END}`)
       .contains('a', `${PERIOD_START} — ${PERIOD_END}`)
       .click()
 

--- a/code/webapp/cypress/e2e/payroll-period-history.cy.ts
+++ b/code/webapp/cypress/e2e/payroll-period-history.cy.ts
@@ -31,8 +31,8 @@ describe('Payroll Period History — happy path', () => {
     cy.wait('@list')
     cy.closeDevDebugger()
 
-    cy.get('[data-testid="pay-period-row"]').should('have.length', 9)
-    cy.get('[data-testid="pay-period-row"]').first().contains(LATEST_WEEK)
+    cy.get('table tbody tr').should('have.length', 9)
+    cy.get('table tbody tr').first().contains(LATEST_WEEK)
   })
 
   it('filters the history down to a date range', () => {
@@ -46,9 +46,9 @@ describe('Payroll Period History — happy path', () => {
     cy.get('input#pay-period-end').clear({ force: true }).type('2026-05-17', { force: true })
     cy.wait('@filtered')
 
-    cy.get('[data-testid="pay-period-row"]').should('have.length', 2)
-    cy.contains('[data-testid="pay-period-row"]', '2026-05-04 — 2026-05-10').should('be.visible')
-    cy.contains('[data-testid="pay-period-row"]', '2026-05-11 — 2026-05-17').should('be.visible')
+    cy.get('table tbody tr').should('have.length', 2)
+    cy.contains('table tbody tr', '2026-05-04 — 2026-05-10').should('be.visible')
+    cy.contains('table tbody tr', '2026-05-11 — 2026-05-17').should('be.visible')
   })
 
   it('opens a backfilled historical week and shows its frozen breakdown', () => {
@@ -61,7 +61,7 @@ describe('Payroll Period History — happy path', () => {
     cy.wait('@list')
     cy.closeDevDebugger()
 
-    cy.contains('[data-testid="pay-period-row"]', periodLabel)
+    cy.contains('table tbody tr', periodLabel)
       .contains('a', periodLabel)
       .click()
     cy.wait('@detail')

--- a/code/webapp/cypress/e2e/reopen-reclose-period.cy.ts
+++ b/code/webapp/cypress/e2e/reopen-reclose-period.cy.ts
@@ -31,7 +31,7 @@ describe('Reopen / Reclose Pay Period — happy path', () => {
     cy.wait('@list')
 
     cy.intercept('GET', '**/pay-periods/*').as('detail')
-    cy.contains('[data-testid="pay-period-row"]', `${PERIOD_START} — ${PERIOD_END}`)
+    cy.contains('table tbody tr', `${PERIOD_START} — ${PERIOD_END}`)
       .contains(`${PERIOD_START} — ${PERIOD_END}`)
       .click()
     cy.wait('@detail')

--- a/code/webapp/src/components/ui/data-grid.tsx
+++ b/code/webapp/src/components/ui/data-grid.tsx
@@ -163,11 +163,12 @@ export function DataGrid<T extends { id: string | number }>({
     )
   }
 
-  function renderEdgeButton(Icon: LucideIcon, iconCls: string, onClick: () => void, disabled: boolean, roundedCls: string | undefined, key: string) {
+  function renderEdgeButton(Icon: LucideIcon, iconCls: string, onClick: () => void, disabled: boolean, roundedCls: string | undefined, key: string, label: string) {
     return (
       <button
         key={key}
         type="button"
+        aria-label={label}
         onClick={onClick}
         disabled={disabled}
         className={roundedCls ? cn(NAV_BTN, roundedCls) : NAV_BTN}
@@ -179,15 +180,15 @@ export function DataGrid<T extends { id: string | number }>({
 
   function renderLeadingEdges(pag: NonNullable<DataGridProps<T>['pagination']>, iconCls: string) {
     return [
-      renderEdgeButton(ChevronsLeft, iconCls, () => pag.onPageChange(1), pag.currentPage === 1, 'rounded-l-md', 'first'),
-      renderEdgeButton(ChevronLeft, iconCls, () => pag.onPageChange(pag.currentPage - 1), pag.currentPage === 1, undefined, 'prev'),
+      renderEdgeButton(ChevronsLeft, iconCls, () => pag.onPageChange(1), pag.currentPage === 1, 'rounded-l-md', 'first', 'Primera página'),
+      renderEdgeButton(ChevronLeft, iconCls, () => pag.onPageChange(pag.currentPage - 1), pag.currentPage === 1, undefined, 'prev', 'Página anterior'),
     ]
   }
 
   function renderTrailingEdges(pag: NonNullable<DataGridProps<T>['pagination']>, iconCls: string) {
     return [
-      renderEdgeButton(ChevronRight, iconCls, () => pag.onPageChange(pag.currentPage + 1), pag.currentPage === pag.totalPages, undefined, 'next'),
-      renderEdgeButton(ChevronsRight, iconCls, () => pag.onPageChange(pag.totalPages), pag.currentPage === pag.totalPages, 'rounded-r-md', 'last'),
+      renderEdgeButton(ChevronRight, iconCls, () => pag.onPageChange(pag.currentPage + 1), pag.currentPage === pag.totalPages, undefined, 'next', 'Página siguiente'),
+      renderEdgeButton(ChevronsRight, iconCls, () => pag.onPageChange(pag.totalPages), pag.currentPage === pag.totalPages, 'rounded-r-md', 'last', 'Última página'),
     ]
   }
 

--- a/code/webapp/src/pages/attendance/payroll/-employee-pay-row.tsx
+++ b/code/webapp/src/pages/attendance/payroll/-employee-pay-row.tsx
@@ -18,40 +18,40 @@ export function EmployeePayRow({ row, testId }: Readonly<EmployeePayRowProps>) {
   const totalExtras = row.overtime_pay + row.extra_day_pay + row.punctuality_bonus + row.holiday_pay
 
   return (
-    <div data-testid={testId} className="rounded-lg border border-gray-200 bg-white shadow-sm">
+    <div data-testid={testId} className="rounded-lg border border-border bg-card shadow-sm">
       <button
         type="button"
         aria-expanded={expanded}
         className="flex w-full items-center justify-between px-4 py-3 text-left"
         onClick={() => setExpanded(prev => !prev)}
       >
-        <span className="font-medium text-gray-900">{name}</span>
+        <span className="font-medium text-foreground">{name}</span>
         <div className="flex items-center gap-6 text-sm">
-          <span className="text-gray-600">
+          <span className="text-muted-foreground">
             Base: <span className="font-mono">${row.base_pay.toFixed(2)}</span>
           </span>
           {totalDeductions > 0 && (
-            <span className="text-red-600">
+            <span className="text-destructive">
               −<span className="font-mono">${totalDeductions.toFixed(2)}</span>
             </span>
           )}
           {totalExtras > 0 && (
-            <span className="text-green-600">
+            <span className="text-green-600 dark:text-green-400">
               +<span className="font-mono">${totalExtras.toFixed(2)}</span>
             </span>
           )}
-          <span className="rounded bg-indigo-100 px-2 py-0.5 font-semibold text-indigo-800">
+          <span className="rounded bg-primary/10 px-2 py-0.5 font-semibold text-primary">
             Total: ${row.total_pay.toFixed(2)}
           </span>
-          <span className="text-gray-400">{expanded ? '▲' : '▼'}</span>
+          <span className="text-muted-foreground">{expanded ? '▲' : '▼'}</span>
         </div>
       </button>
 
       {expanded && (
-        <div className="border-t border-gray-100 px-4 py-3">
+        <div className="border-t border-border px-4 py-3">
           <table className="w-full text-sm">
             <thead>
-              <tr className="text-left text-xs font-medium uppercase text-gray-500">
+              <tr className="text-left text-xs font-medium uppercase text-muted-foreground">
                 <th className="pb-2 pr-2 w-6">Día</th>
                 <th className="pb-2 pr-4">Fecha</th>
                 <th className="pb-2 pr-4">Concepto</th>
@@ -59,7 +59,7 @@ export function EmployeePayRow({ row, testId }: Readonly<EmployeePayRowProps>) {
                 <th className="pb-2 text-right">Monto</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-50">
+            <tbody className="divide-y divide-border">
               {sortLines(row.pay_period_lines).map((line, i) => (
                 <LineRow key={`${line.concept}-${line.date ?? 'none'}-${i}`} line={line} />
               ))}
@@ -95,15 +95,15 @@ function LineRow({ line }: { readonly line: PayPeriodLine }) {
   const initial = dayInitial(line.date)
   return (
     <tr>
-      <td className="py-1 pr-2 font-semibold text-gray-400 w-6">{initial}</td>
-      <td className="py-1 pr-4 text-gray-500">{line.date ?? '—'}</td>
+      <td className="py-1 pr-2 font-semibold text-muted-foreground w-6">{initial}</td>
+      <td className="py-1 pr-4 text-muted-foreground">{line.date ?? '—'}</td>
       <td className="py-1 pr-4">
-        <span className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs text-gray-600">
+        <span className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
           {line.concept}
         </span>
       </td>
-      <td className="py-1 pr-4 text-gray-700">{line.description}</td>
-      <td className={`py-1 text-right font-mono ${isDeduction ? 'text-red-600' : 'text-gray-900'}`}>
+      <td className="py-1 pr-4 text-foreground">{line.description}</td>
+      <td className={`py-1 text-right font-mono ${isDeduction ? 'text-destructive' : 'text-foreground'}`}>
         ${Math.abs(line.amount).toFixed(2)}
       </td>
     </tr>
@@ -114,7 +114,7 @@ export function PayRowSkeleton() {
   return (
     <div className="space-y-2">
       {[1, 2, 3].map(i => (
-        <div key={i} className="h-14 animate-pulse rounded-lg bg-gray-100" />
+        <div key={i} className="h-14 animate-pulse rounded-lg bg-muted" />
       ))}
     </div>
   )

--- a/code/webapp/src/pages/attendance/payroll/__tests__/employee-pay-row.test.tsx
+++ b/code/webapp/src/pages/attendance/payroll/__tests__/employee-pay-row.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { EmployeePayRow } from '../-employee-pay-row'
+import type { PayPeriodEmployeePreview } from '@/types/attendance-payroll'
+
+afterEach(() => {
+  cleanup()
+})
+
+function buildRow(overrides: Partial<PayPeriodEmployeePreview> = {}): PayPeriodEmployeePreview {
+  return {
+    employee: { id: 'EMP-001', first_name: 'Ana', last_name: 'Payroll', code: 'EMP-001' },
+    base_pay: 1900,
+    late_deductions: 50,
+    unpaid_leave_deductions: 0,
+    overtime_pay: 150,
+    extra_day_pay: 0,
+    punctuality_bonus: 0,
+    holiday_pay: 0,
+    other_adjustments: 0,
+    total_pay: 2000,
+    free_hours_earned: 0,
+    pay_period_lines: [
+      { date: '2026-06-23', concept: 'BASE_PAY', description: 'Salario base', amount: 1900, minutes: null },
+      { date: '2026-06-24', concept: 'LATE_DEDUCTION', description: 'Retardo', amount: -50, minutes: 15 },
+      { date: '2026-06-25', concept: 'OVERTIME', description: 'Hora extra', amount: 150, minutes: 60 },
+    ],
+    ...overrides,
+  }
+}
+
+describe('EmployeePayRow', () => {
+  it('renders the employee name, base pay, deductions, extras, and total collapsed by default', () => {
+    const { container } = render(<EmployeePayRow row={buildRow()} testId="employee-detail-row" />)
+
+    expect(screen.getByText('Ana Payroll')).toBeDefined()
+    expect(screen.getByText(/Base:/)).toBeDefined()
+    expect(container.textContent).toContain('−$50.00')
+    expect(container.textContent).toContain('+$150.00')
+    expect(container.textContent).toContain('Total: $2000.00')
+
+    const toggle = screen.getByRole('button', { expanded: false })
+    expect(toggle).toBeDefined()
+    expect(screen.queryByText('BASE_PAY')).toBeNull()
+  })
+
+  it('expands to show the sorted line-item breakdown when clicked', () => {
+    render(<EmployeePayRow row={buildRow()} testId="employee-detail-row" />)
+
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(screen.getByRole('button', { expanded: true })).toBeDefined()
+    expect(screen.getByText('BASE_PAY')).toBeDefined()
+    expect(screen.getByText('LATE_DEDUCTION')).toBeDefined()
+    expect(screen.getByText('OVERTIME')).toBeDefined()
+    expect(screen.getByText('Salario base')).toBeDefined()
+  })
+
+  it('omits the deductions/extras chips when their totals are zero', () => {
+    const row = buildRow({ late_deductions: 0, unpaid_leave_deductions: 0, overtime_pay: 0 })
+    const { container } = render(<EmployeePayRow row={row} testId="employee-detail-row" />)
+
+    expect(container.textContent).not.toContain('−$')
+    expect(container.textContent).not.toContain('+$')
+  })
+})

--- a/code/webapp/src/pages/attendance/payroll/__tests__/index.test.tsx
+++ b/code/webapp/src/pages/attendance/payroll/__tests__/index.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { render, screen, cleanup, within, fireEvent } from '@testing-library/react'
+import type { PayPeriodListItem, PayPeriodListMeta } from '@/types/attendance-payroll'
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => () => ({ component: null }),
+  Link: ({ children, ...props }: Record<string, unknown>) => {
+    const { to, params, className } = props as { to: string; params: Record<string, string>; className: string }
+    const href = Object.entries(params ?? {}).reduce((acc, [key, value]) => acc.replace(`$${key}`, value), to)
+    return <a href={href} className={className}>{children as React.ReactNode}</a>
+  },
+}))
+
+vi.mock('@/lib/route-guards', () => ({
+  requirePermission: () => () => undefined,
+}))
+
+const mockUsePayPeriodsListPage = vi.fn()
+
+vi.mock('../use-pay-periods-list', () => ({
+  usePayPeriodsListPage: () => mockUsePayPeriodsListPage(),
+}))
+
+import { PayPeriodsListPage } from '../index'
+
+const PERIODS: PayPeriodListItem[] = [
+  {
+    id: 'PERIOD-1',
+    branch_id: 1,
+    period_start: '2026-06-22',
+    period_end: '2026-06-28',
+    status: 'CLOSED',
+    closed_by: 'admin@sushigo.com',
+    closed_at: '2026-06-29T01:00:00Z',
+    reopened_by: null,
+    reopened_at: null,
+    reopen_reason: null,
+    total_employees: 2,
+  },
+  {
+    id: 'PERIOD-2',
+    branch_id: 1,
+    period_start: '2026-06-15',
+    period_end: '2026-06-21',
+    status: 'REOPENED',
+    closed_by: null,
+    closed_at: null,
+    reopened_by: null,
+    reopened_at: null,
+    reopen_reason: null,
+    total_employees: 3,
+  },
+]
+
+const META: PayPeriodListMeta = { current_page: 1, last_page: 3, per_page: 15, total: 32 }
+
+function baseHookReturn(overrides: Partial<ReturnType<typeof buildDefaultHookReturn>> = {}) {
+  return { ...buildDefaultHookReturn(), ...overrides }
+}
+
+function buildDefaultHookReturn() {
+  return {
+    hasBranch: true,
+    status: '' as const,
+    setStatus: vi.fn(),
+    periodStart: '',
+    setPeriodStart: vi.fn(),
+    periodEnd: '',
+    setPeriodEnd: vi.fn(),
+    periods: PERIODS,
+    meta: META,
+    setPage: vi.fn(),
+    isLoading: false,
+    errorMessage: null as string | null,
+  }
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+beforeEach(() => {
+  mockUsePayPeriodsListPage.mockReturnValue(baseHookReturn())
+})
+
+describe('PayPeriodsListPage', () => {
+  it('shows the no-branch state when there is no current branch', () => {
+    mockUsePayPeriodsListPage.mockReturnValue(baseHookReturn({ hasBranch: false }))
+    render(<PayPeriodsListPage />)
+
+    expect(screen.getByText('Sin sucursal seleccionada')).toBeDefined()
+    expect(screen.queryByText('2026-06-22 — 2026-06-28')).toBeNull()
+  })
+
+  it('renders each period through the shared DataGrid with its status, closer, and employee count', () => {
+    render(<PayPeriodsListPage />)
+
+    const row = screen.getByText('2026-06-22 — 2026-06-28').closest('tr')
+    expect(row).not.toBeNull()
+    const utils = within(row as HTMLElement)
+
+    expect(utils.getByText('Cerrado')).toBeDefined()
+    expect(utils.getByText('admin@sushigo.com')).toBeDefined()
+    expect(utils.getByText('2')).toBeDefined()
+
+    const openRow = screen.getByText('2026-06-15 — 2026-06-21').closest('tr')
+    expect(within(openRow as HTMLElement).getAllByText('—')).toHaveLength(2)
+  })
+
+  it('shows the empty message when there are no periods and no error', () => {
+    mockUsePayPeriodsListPage.mockReturnValue(baseHookReturn({ periods: [], meta: { ...META, total: 0, last_page: 1 } }))
+    render(<PayPeriodsListPage />)
+
+    expect(screen.getByText('No hay periodos que coincidan con los filtros.')).toBeDefined()
+  })
+
+  it('shows the error message and does not render the grid when the query fails', () => {
+    mockUsePayPeriodsListPage.mockReturnValue(baseHookReturn({ errorMessage: 'No se pudieron cargar los periodos de nómina.' }))
+    render(<PayPeriodsListPage />)
+
+    expect(screen.getByText('No se pudieron cargar los periodos de nómina.')).toBeDefined()
+    expect(screen.queryByText('2026-06-22 — 2026-06-28')).toBeNull()
+  })
+
+  it('advances the page through DataGrid pagination', () => {
+    const setPage = vi.fn()
+    mockUsePayPeriodsListPage.mockReturnValue(baseHookReturn({ setPage }))
+    render(<PayPeriodsListPage />)
+
+    // DataGrid renders one pagination <nav> per responsive breakpoint (all present in the
+    // DOM at once — jsdom doesn't evaluate the Tailwind media queries that hide the others).
+    // Every copy wires to the same onPageChange, so clicking any "2" button proves the wiring
+    // without depending on which nav a real browser would actually show.
+    const pageTwoButtons = screen.getAllByRole('button', { name: '2' })
+    expect(pageTwoButtons.length).toBeGreaterThan(0)
+
+    fireEvent.click(pageTwoButtons[0]!)
+
+    expect(setPage).toHaveBeenCalledWith(2)
+  })
+})

--- a/code/webapp/src/pages/attendance/payroll/index.tsx
+++ b/code/webapp/src/pages/attendance/payroll/index.tsx
@@ -1,12 +1,11 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
-import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { requirePermission } from '@/lib/route-guards'
 import { PageContainer } from '@/components/ui/page-container'
 import { PageHeader } from '@/components/ui/page-header'
-import { Button } from '@/components/ui/button'
+import { DataGrid, type Column } from '@/components/ui/data-grid'
 import { NoBranchState, PayPeriodStatusBadge } from '@/components/attendance'
 import { usePayPeriodsListPage } from './use-pay-periods-list'
-import type { PayPeriodStatus } from '@/types/attendance-payroll'
+import type { PayPeriodListItem, PayPeriodStatus } from '@/types/attendance-payroll'
 
 // ── Route ─────────────────────────────────────────────────────────────────────
 
@@ -20,6 +19,46 @@ const STATUS_OPTIONS: { value: PayPeriodStatus | ''; label: string }[] = [
   { value: 'OPEN', label: 'Abierto' },
   { value: 'CLOSED', label: 'Cerrado' },
   { value: 'REOPENED', label: 'Reabierto' },
+]
+
+const columns: Column<PayPeriodListItem>[] = [
+  {
+    key: 'period',
+    header: 'Periodo',
+    render: (period) => (
+      <Link
+        to="/attendance/payroll/$periodId"
+        params={{ periodId: period.id }}
+        className="font-medium text-primary hover:underline"
+      >
+        {period.period_start} — {period.period_end}
+      </Link>
+    ),
+  },
+  {
+    key: 'status',
+    header: 'Estatus',
+    render: (period) => <PayPeriodStatusBadge status={period.status} />,
+  },
+  {
+    key: 'closed_by',
+    header: 'Cerrado por',
+    render: (period) => period.closed_by ?? '—',
+  },
+  {
+    key: 'closed_at',
+    header: 'Cerrado el',
+    render: (period) =>
+      period.closed_at
+        ? new Date(period.closed_at).toLocaleString('es-MX', { dateStyle: 'medium', timeStyle: 'short' })
+        : '—',
+  },
+  {
+    key: 'total_employees',
+    header: 'Empleados',
+    align: 'right',
+    render: (period) => period.total_employees,
+  },
 ]
 
 // ── Page ──────────────────────────────────────────────────────────────────────
@@ -105,92 +144,18 @@ export function PayPeriodsListPage() {
         </p>
       )}
 
-      {isLoading && <ListSkeleton />}
-
-      {!isLoading && periods.length === 0 && !errorMessage && (
-        <p className="text-sm text-gray-500">No hay periodos que coincidan con los filtros.</p>
-      )}
-
-      {!isLoading && periods.length > 0 && (
-        <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white shadow-sm">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b text-left text-xs font-medium uppercase text-gray-500">
-                <th className="px-4 py-2">Periodo</th>
-                <th className="px-4 py-2">Estatus</th>
-                <th className="px-4 py-2">Cerrado por</th>
-                <th className="px-4 py-2">Cerrado el</th>
-                <th className="px-4 py-2 text-right">Empleados</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-100">
-              {periods.map(period => (
-                <tr key={period.id} data-testid="pay-period-row">
-                  <td className="px-4 py-2">
-                    <Link
-                      to="/attendance/payroll/$periodId"
-                      params={{ periodId: period.id }}
-                      className="font-medium text-indigo-600 hover:underline"
-                    >
-                      {period.period_start} — {period.period_end}
-                    </Link>
-                  </td>
-                  <td className="px-4 py-2">
-                    <PayPeriodStatusBadge status={period.status} />
-                  </td>
-                  <td className="px-4 py-2 text-gray-700">{period.closed_by ?? '—'}</td>
-                  <td className="px-4 py-2 text-gray-500">
-                    {period.closed_at
-                      ? new Date(period.closed_at).toLocaleString('es-MX', { dateStyle: 'medium', timeStyle: 'short' })
-                      : '—'}
-                  </td>
-                  <td className="px-4 py-2 text-right">{period.total_employees}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-
-      {meta && meta.last_page > 1 && (
-        <div className="flex items-center justify-between text-sm text-muted-foreground">
-          <span>
-            Página {meta.current_page} de {meta.last_page} · {meta.total} periodos
-          </span>
-          <div className="flex items-center gap-1.5">
-            <Button
-              size="sm"
-              variant="outline"
-              className="h-8 w-8 p-0"
-              aria-label="Página anterior"
-              disabled={meta.current_page <= 1}
-              onClick={() => setPage(p => p - 1)}
-            >
-              <ChevronLeft className="h-4 w-4" />
-            </Button>
-            <Button
-              size="sm"
-              variant="outline"
-              className="h-8 w-8 p-0"
-              aria-label="Página siguiente"
-              disabled={meta.current_page >= meta.last_page}
-              onClick={() => setPage(p => p + 1)}
-            >
-              <ChevronRight className="h-4 w-4" />
-            </Button>
-          </div>
-        </div>
+      {!errorMessage && (
+        <DataGrid
+          data={periods}
+          columns={columns}
+          loading={isLoading}
+          emptyMessage="No hay periodos que coincidan con los filtros."
+          getRowId={(period) => period.id}
+          pagination={meta ? { currentPage: meta.current_page, totalPages: meta.last_page, onPageChange: setPage } : undefined}
+          perPage={meta?.per_page}
+          totalResults={meta?.total}
+        />
       )}
     </PageContainer>
-  )
-}
-
-function ListSkeleton() {
-  return (
-    <div className="space-y-2">
-      {[1, 2, 3].map(i => (
-        <div key={i} className="h-14 animate-pulse rounded-lg bg-gray-100" />
-      ))}
-    </div>
   )
 }

--- a/doc/sprints/sprint-002-platillos-catalog-platform-hardening.md
+++ b/doc/sprints/sprint-002-platillos-catalog-platform-hardening.md
@@ -37,10 +37,11 @@ public repo), a **High**-value Attendance Today correctness bug (`#358`), and fi
 technical-debt Issues already open on the backlog (`#357`, `#360`, `#365`, `#382`, `#383`) plus
 two small Low-tier cleanups (`#376`, `#385`).
 
-**Progress as of 2026-08-04:** 4 of 14 scoped Issues completed (28.6%) — `#384` (Critical
+**Progress as of 2026-08-04:** 5 of 14 scoped Issues completed (35.7%) — `#384` (Critical
 `APP_KEY` security exposure, PR #393), `#385` (SonarCloud `Readonly` code-smell cleanup, PR
-#391), `#358` (Attendance Today "Ausentes" correctness bug, PR #395), and `#376` (dead item Type
-selector removal, PR #396), all open and ready for merge.
+#391), `#358` (Attendance Today "Ausentes" correctness bug, PR #395), `#376` (dead item Type
+selector removal, PR #396), and `#383` (Payroll Periods `DataGrid` migration, PR #398), all open
+and ready for merge.
 
 File-conflict analysis (§9) found **zero shared-file collisions** among all 14 Issues — every
 Issue touches a distinct set of files or a distinct route. The only real ordering constraints are
@@ -97,7 +98,7 @@ between parallel agents.
 | Completed | — |
 | Calendar duration | — |
 | Active workdays | — |
-| Progress (Issues completed) | 4 / 14 (28.6%) as of 2026-08-04 — `#384` (Critical `APP_KEY` exposure, PR #393), `#385` (SonarCloud cleanup, PR #391), `#358` (Attendance Today "Ausentes" bug, PR #395), and `#376` (dead item Type selector removal, PR #396) implemented; all open, ready for merge |
+| Progress (Issues completed) | 5 / 14 (35.7%) as of 2026-08-04 — `#384` (Critical `APP_KEY` exposure, PR #393), `#385` (SonarCloud cleanup, PR #391), `#358` (Attendance Today "Ausentes" bug, PR #395), `#376` (dead item Type selector removal, PR #396), and `#383` (Payroll Periods `DataGrid` migration, PR #398) implemented; all open, ready for merge |
 
 ## 5. Scope
 
@@ -165,7 +166,7 @@ because every Round 1 Issue is independently assignable to its own agent/workspa
 | ⏳ | #379 | Build the Platillos (dishes) backend domain: categories, dishes, extras | High | 5h | 10h | — | — | Soft dependency on #377 (photos only, not tables/CRUD) — safe to run in parallel; unblocks #381 (Round 2) |
 | ✅ | #358 | Employees on vacation or a scheduled rest day today don't appear under "Ausentes" | High | 3h | 6h | 5.2h | PR #395 | `today_vacation` backend field + `isAbsentRow`/`isHiddenFromGrid` frontend fallback; PR ready, merge pending |
 | ⏳ | #360 | Migrate remaining now()/new Date() usages to ApplicationClock | Medium | 4h | 8h | — | — | Wide file surface (Leaves/CashAdjustments/Inventory backend, Employees frontend hooks) but none overlap other sprint Issues |
-| ⏳ | #383 | Migrate Payroll Periods list/detail tables to the shared DataGrid component | Medium | 3h | 6h | — | — | `attendance/payroll/*`; independent of #382 (different route) |
+| ✅ | #383 | Migrate Payroll Periods list/detail tables to the shared DataGrid component | Medium | 3h | 6h | 12.1h | PR #398 | List page migrated to `DataGrid<T>`; detail page's employee list kept as cards (expand/collapse can't map to `DataGrid`'s row model) and restyled to semantic tokens; PR ready, merge pending |
 | ⏳ | #382 | Migrate the daily report employee table to the shared DataGrid component | Medium | 2h | 4h | — | — | `attendance/reports/*`; independent of #383 |
 | ⏳ | #357 | Unify card exit/transition animation across all Attendance Today state changes | Medium | 2h | 4h | — | — | `attendance/index.tsx` + `-use-today-attendance-page.ts`; distinct files from #358 |
 | ⏳ | #365 | [Convention] Run only linters + delivered tests locally; leave full-suite regression check to CI | Medium | 1h | 2h | — | — | Docs only (`doc/conventions/`, `doc/TESTING.md`); no estimate in Issue body — agent-estimated, see §12 |
@@ -304,7 +305,7 @@ since this document numbers its own §7 as Route A — Execution Rounds instead.
 | ⏳ | #379 | Not started | — | — | — | — |
 | ✅ | #358 | Added `today_vacation` to `TodayAttendanceController`'s response and updated `isAbsentRow`/`isHiddenFromGrid` so vacation/scheduled-rest-day employees classify as "Ausente" from the start of the day without an Attendance record — PR open, not yet merged | PR #395 | — | 5.2h | 25 new/updated PHPUnit assertions, 248 Vitest passing, 5/5 new + 15/15 regression Cypress specs (dev-lab E2E stack); Copilot review fixed 1 real defect (fallback misclassifying an actively-working employee); Devin/DeepWiki review surfaced 1 legitimate UX tradeoff (rest-day visibility in default grid), resolved via a user decision rather than a silent code change; CI 13/13 green — PR ready, merge pending |
 | ⏳ | #360 | Not started | — | — | — | — |
-| ⏳ | #383 | Not started | — | — | — | — |
+| ✅ | #383 | Migrated the Payroll Periods list page to `DataGrid<T>` (built-in pagination replacing the manual prev/next pager) and restyled `-employee-pay-row.tsx` to semantic tokens; the detail page's expand/collapse employee list stayed as cards since it can't map onto `DataGrid`'s one-row-per-item model — PR open, not yet merged | PR #398 | — | 12.1h | 52 Vitest tests (2 new component test files) + 20 Cypress tests across 6 specs (dev-lab E2E stack) passing; Copilot review fixed 1 real defect (test relying on DataGrid's nav DOM order); Devin/DeepWiki 0 bugs across 2 scan rounds, 1 flag fixed (English pagination-footer fallback), 3 flags evaluated as out-of-scope/matching established convention; CI 12/12 green — PR ready, merge pending |
 | ⏳ | #382 | Not started | — | — | — | — |
 | ⏳ | #357 | Not started | — | — | — | — |
 | ⏳ | #365 | Not started | — | — | — | — |

--- a/doc/tasks/2026-08/383-migrate-payroll-datagrid.md
+++ b/doc/tasks/2026-08/383-migrate-payroll-datagrid.md
@@ -1,0 +1,85 @@
+# 🔨 Migrate Payroll Periods list/detail tables to the shared DataGrid component
+
+## Description
+
+Migrate the Payroll Periods list and detail tables from three separately hand-rolled
+implementations to the shared `DataGrid<T>` component at
+`code/webapp/src/components/ui/data-grid.tsx`.
+
+Current implementation (three different styles across two pages):
+- List page — `code/webapp/src/pages/attendance/payroll/index.tsx:115-153`: raw HTML `<table>`
+  styled with a hardcoded gray/indigo palette (`border-gray-200`, `text-gray-500`,
+  `divide-gray-100`, `text-indigo-600`) instead of the app's semantic tokens, plus manual prev/next
+  pagination buttons built inline (lines 155-183) instead of a shared pager
+- Detail page — `code/webapp/src/pages/attendance/payroll/$periodId.tsx:112-116`: doesn't use a
+  table for the employee list at all; each employee renders as a collapsible `<div>` card
+  (`EmployeePayRow`)
+- `code/webapp/src/pages/attendance/payroll/-employee-pay-row.tsx:20-72,93-111`: a third distinct
+  visual style — white cards (`bg-white`, `shadow-sm`, `rounded-lg border-gray-200`) with amounts
+  colored via hardcoded `text-red-600`/`text-green-600`/`text-indigo-800`, with a nested `<table>`
+  only for the expanded line-item breakdown
+
+## Reason
+
+`DataGrid<T>` is the app's standard table component (used by `employees.tsx`,
+`cash-register-list.tsx`, `stock-dashboard.tsx`, `attendance/config/holidays.tsx`, and others),
+wired to the app's semantic Tailwind tokens (`bg-muted/50`, `divide-border`,
+`text-muted-foreground`, `bg-primary/10`) with built-in sorting, pagination, and skeleton loading.
+Payroll Periods uses none of it — worse, its list and detail pages don't even agree with each
+other (semantic-free gray/indigo table vs. white shadow cards), and neither matches the rest of
+the app. This is the same underlying gap as #382 (daily report employee table), but more visually
+divergent since it also reinvents pagination instead of just table markup.
+
+## Objective
+
+- The Payroll Periods list page (`index.tsx`) renders through `DataGrid<T>` with a `Column<T>[]`
+  definition and uses `DataGrid`'s built-in pagination instead of the inline prev/next buttons
+- The Payroll Period detail page's employee list uses `DataGrid<T>` (or, if the expand/collapse
+  interaction for line-item breakdown genuinely can't map to `DataGrid`'s row model, at minimum
+  restyle it to use the app's semantic tokens instead of hardcoded gray/indigo/red/green classes)
+- `-employee-pay-row.tsx` no longer uses hardcoded color classes for amounts — swaps to the
+  semantic tokens (`text-muted-foreground`, `bg-primary/10`, etc.) already used elsewhere
+- Any tests covering these pages are updated to match the new markup
+
+## 🔗 References
+
+- Related: #382 (same DataGrid-migration gap, daily report employee table)
+- `code/webapp/src/pages/attendance/payroll/index.tsx`
+- `code/webapp/src/pages/attendance/payroll/$periodId.tsx`
+- `code/webapp/src/pages/attendance/payroll/-employee-pay-row.tsx`
+- `code/webapp/src/components/ui/data-grid.tsx` (target shared component)
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `3h` · **Pessimistic:** `6h` · **Tracked:** `12h 5m`
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-08-03", "start": "22:57", "end": "23:59" },
+  { "date": "2026-08-04", "start": "00:00", "end": "11:03" }
+]
+```
+
+## 📊 Retrospective
+- **Actual total:** 12h 5m (62m + 663m)
+- **vs optimistic:** +9h 5m
+- **vs pessimistic:** +6h 5m
+
+**Justification:**
+The implementation itself (migrating `index.tsx` to `DataGrid<T>`, restyling `-employee-pay-row.tsx`
+to semantic tokens, writing 2 new Vitest component test files, and updating 4 Cypress specs) landed
+comfortably inside the 3–6h estimate. The overrun is almost entirely autonomous end-to-end pipeline
+overhead the estimate didn't anticipate: this issue was delivered via `/issue`, which runs the full
+CI → Copilot review → squash → Devin/DeepWiki review → close-out loop unattended, including several
+multi-minute waits (CI runs re-triggered after each push, a mandated ~10-minute poll window for a
+possible new Copilot review after the squash, starting and stopping a full local E2E Docker stack to
+run 6 Cypress specs / 20 tests against the new markup, and two full DeepWiki scan cycles). None of
+that wall-clock time reflects rework or scope creep — one real Copilot comment (a test-selector
+robustness issue) and one real Devin flag (a stale-code English-text fallback) were found and fixed,
+each in a single round-trip.
+
+
+
+


### PR DESCRIPTION
## Summary
Closes #383
Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/398

- Migrated the Payroll Periods list page (`index.tsx`) to the shared `DataGrid<T>` component — replaces the raw hardcoded gray/indigo `<table>` and manual prev/next pagination buttons with `DataGrid`'s built-in pagination and semantic tokens
- Restyled `-employee-pay-row.tsx` (shared by the detail page and the close-preview page) from hardcoded gray/indigo/red/green classes to the app's semantic tokens (`bg-primary/10`, `text-primary`, `text-destructive`, `text-muted-foreground`, `text-foreground`, `border-border`, `bg-card`, `bg-muted`)
- Kept the detail page's employee list as its existing expand/collapse card structure rather than forcing it into `DataGrid` — its per-row expandable line-item breakdown doesn't map onto `DataGrid`'s fixed one-row-per-item model, which is the explicit fallback this issue anticipates
- Updated 4 existing Cypress specs whose selectors depended on the `pay-period-row` testid dropped by the `DataGrid` migration
- Added Vitest component tests for both materially-changed components

## 🤔 Assumptions

- **Detail-page employee list stays out of `DataGrid`.** Checked all 8 other `DataGrid` consumers in the app (`employees.tsx`, `cash-register-list.tsx`, `stock-dashboard.tsx`, `holidays.tsx`, etc.) — none implement expandable/nested rows, and `DataGrid`'s renderer (`components/ui/data-grid.tsx`) is a strict one-`<tr>`-per-item model with no per-row detail slot. This confirms the issue's own fallback applies: restyle `-employee-pay-row.tsx` to semantic tokens instead of forcing the expand/collapse interaction into `DataGrid`.
- **Color tokens for amounts.** Deductions use `text-destructive` (a real theme-aware semantic token already used app-wide for negative/error states). Positive/extra amounts use `text-green-600 dark:text-green-400` since no semantic "success" token exists in `tailwind.config`/`index.css` — this matches the closest established convention for wage-related positive amounts elsewhere in the codebase (`components/employees/wage-summary.tsx`).
- **Cypress selector migration instead of extending `DataGrid`.** Migrating the list page drops the `data-testid="pay-period-row"` attribute — `DataGrid` has no per-row testid hook and no other consumer uses one. Rather than adding a one-off prop to the shared component, updated the 4 affected specs to select rows structurally (`table tbody tr` / `cy.contains('tr', ...)`), the same pattern already used for other `DataGrid`-backed tables (`employees.cy.ts`).

## Manual Testing

1. Run `./init-agent-workspace.sh` (or confirm it's already running) and log in as `admin@sushigo.com` at https://sushigo.local (or http://localhost:5173).
2. Visit **Nómina → Periodos de Nómina** (`/attendance/payroll`). Confirm the list renders through the shared `DataGrid` look (rounded card, `bg-muted/50` header, no more hardcoded gray table) and that filtering by status/date range still works.
3. If there is more than one page of periods, confirm `DataGrid`'s built-in pagination controls (page numbers + prev/next chevrons) navigate correctly and show the "Mostrando X-Y de Z resultados" footer.
4. Click into a closed period's detail page. Confirm the employee cards render with the new semantic colors — red deductions now use the app's destructive red, the "Total" badge uses the primary-tinted pill, and the card matches the app's `bg-card`/`border-border` chrome.
5. Click an employee card to expand it and confirm the line-item breakdown (day initial, date, concept pill, description, amount) still renders and colors correctly.
6. Visit **Nómina → Cierre de Nómina** (`/attendance/payroll/close`) and confirm the (shared) employee preview cards also reflect the new colors, since `-employee-pay-row.tsx` is used by both pages.

## Test plan
- [x] Vitest: `npx vitest run src/pages/attendance/payroll` (52 tests passing, including 2 new component test files)
- [x] Cypress E2E: `payroll-period-history.cy.ts`, `closed-period-detail.cy.ts`, `reopen-reclose-period.cy.ts`, `payroll-export-csv.cy.ts`, `payroll-close-preview.cy.ts`, `payroll-close-confirm.cy.ts` — all 20 tests passing against the new markup
- [x] Linters: Pint N/A (no backend changes) · ESLint ✅ (0 errors) · TypeScript ✅

## Workspace
`sushigo-e` — `refactor/383-migrate-payroll-datagrid`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
