### PR TITLE
🐛 [#377][a] - Fix SonarCloud quality gate findings from the media upload system 🔧

### DIFF
--- a/code/api/app/Http/Requests/Items/CreateItemRequest.php
+++ b/code/api/app/Http/Requests/Items/CreateItemRequest.php
@@ -35,6 +35,17 @@ class CreateItemRequest extends FormRequest
             return false;
         }
 
+        return $this->authorizesMediaGalleryOwnership();
+    }
+
+    /**
+     * Without this, attaching an unattached gallery to a new item never
+     * checked owner_token — a caller who merely learns another user's
+     * in-progress gallery public_id could claim its photos on their own
+     * item, since MediaAttachmentService attaches unconditionally.
+     */
+    private function authorizesMediaGalleryOwnership(): bool
+    {
         // Raw input, not validated('media_gallery_id'): authorize() runs
         // before the validator, so validated() isn't available yet here.
         $publicId = $this->rawStringInput('media_gallery_id');
@@ -49,10 +60,6 @@ class CreateItemRequest extends FormRequest
             return true; // let the `exists` rule produce a clean 422
         }
 
-        // Without this, attaching an unattached gallery to a new item never
-        // checked owner_token — a caller who merely learns another user's
-        // in-progress gallery public_id could claim its photos on their own
-        // item, since MediaAttachmentService attaches unconditionally.
         return $gallery->isManageableBy($this->user(), $this->rawStringInput('owner_token'));
     }
 

--- a/code/api/app/Http/Requests/Items/UpdateItemRequest.php
+++ b/code/api/app/Http/Requests/Items/UpdateItemRequest.php
@@ -33,6 +33,17 @@ class UpdateItemRequest extends FormRequest
             return false;
         }
 
+        return $this->authorizesMediaGalleryOwnership();
+    }
+
+    /**
+     * Without this, attaching an unattached gallery to this item never
+     * checked owner_token — a caller who merely learns another user's
+     * in-progress gallery public_id could claim its photos on their own
+     * item, since MediaAttachmentService attaches unconditionally.
+     */
+    private function authorizesMediaGalleryOwnership(): bool
+    {
         // Raw input, not validated('media_gallery_id'): authorize() runs
         // before the validator, so validated() isn't available yet here.
         $publicId = $this->rawStringInput('media_gallery_id');
@@ -47,10 +58,6 @@ class UpdateItemRequest extends FormRequest
             return true; // let the `exists` rule produce a clean 422
         }
 
-        // Without this, attaching an unattached gallery to this item never
-        // checked owner_token — a caller who merely learns another user's
-        // in-progress gallery public_id could claim its photos on their own
-        // item, since MediaAttachmentService attaches unconditionally.
         return $gallery->isManageableBy($this->user(), $this->rawStringInput('owner_token'));
     }
 

--- a/code/api/database/seeders/Production/PermissionSeeder.php
+++ b/code/api/database/seeders/Production/PermissionSeeder.php
@@ -11,6 +11,8 @@ class PermissionSeeder extends LockedSeeder
 {
     use AssignsBasicRolePermissions;
 
+    private const MEDIA_WILDCARD = 'media.%';
+
     public function run(): void
     {
         $this->upsertPermissions($this->permissionDefinitions());
@@ -204,7 +206,7 @@ class PermissionSeeder extends LockedSeeder
                             ->orWhere('name', 'like', 'employee-requests.%')
                             ->orWhere('name', 'like', 'attendances.%')
                             ->orWhere('name', 'like', 'reports.%')
-                            ->orWhere('name', 'like', 'media.%');
+                            ->orWhere('name', 'like', self::MEDIA_WILDCARD);
                     })
                     ->get()
             );
@@ -230,7 +232,7 @@ class PermissionSeeder extends LockedSeeder
                             ->orWhere('name', 'like', 'inventory_locations.%')
                             ->orWhere('name', 'like', 'stock.%')
                             ->orWhere('name', 'like', 'dishes.%')
-                            ->orWhere('name', 'like', 'media.%')
+                            ->orWhere('name', 'like', self::MEDIA_WILDCARD)
                             ->orWhere('name', 'like', 'audit-logs.%')
                             ->orWhereIn('name', ['units_of_measure.manage', 'punctuality.manage', 'holidays.manage', 'payroll.preview', 'payroll.close', 'payroll.reopen', 'payroll.reclose', 'overtime.manage', 'vacation-policy.manage']);
                     })
@@ -252,7 +254,7 @@ class PermissionSeeder extends LockedSeeder
                         $q->where('name', 'like', 'items.%')
                             ->orWhere('name', 'like', 'inventory_locations.%')
                             ->orWhere('name', 'like', 'stock.%')
-                            ->orWhere('name', 'like', 'media.%')
+                            ->orWhere('name', 'like', self::MEDIA_WILDCARD)
                             ->orWhere('name', 'units_of_measure.manage')
                             ->orWhereIn('name', self::SELF_SERVICE_REQUESTS_PERMISSIONS);
                     })


### PR DESCRIPTION
## Summary
Closes #377
Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/403

Follow-up to #392 (already merged) — addresses the 3 SonarCloud findings from that PR's analysis that were still open after merge (the other 2 findings SonarCloud reported against that PR — a generic-exception code smell on a service class and a missing upload size cap — had already been fixed in later commits before merge and are not present on `main`; verified against current code before touching anything).

- 🔨 `php:S1142` (MAJOR, x2): `CreateItemRequest::authorize()` and `UpdateItemRequest::authorize()` each had 4 `return` statements (limit is 3). Extracted the media-gallery-ownership check into a private `authorizesMediaGalleryOwnership()` helper on each class — same branching, same behavior, just split across two methods so neither exceeds the limit.
- 🔨 `php:S1192` (CRITICAL): the literal `'media.%'` was duplicated 3 times across `PermissionSeeder::assignManagerPermissions()/assignAdminPermissions()/assignInventoryManagerPermissions()`. Added a `private const MEDIA_WILDCARD = 'media.%'` and replaced all three call sites.

No behavior change — pure refactor to satisfy the quality gate. Full Media/Item/Permission test suite (238 assertions across 100+138 tests) passes unchanged.

## Test plan
- [x] `./vendor/bin/pint` — no changes needed on the touched files
- [x] `php artisan test --filter="Media|Item"` — 100 passed (279 assertions)
- [x] `php artisan test --filter="Permission"` — 138 passed (224 assertions)

## Manual Testing
No user-facing behavior changed — this is an internal refactor to satisfy SonarCloud's quality gate. To confirm the refactor didn't change authorization behavior:
1. As `admin@sushigo.com`, create an Item without a `media_gallery_id` → succeeds (unchanged: `authorizesMediaGalleryOwnership()` returns `true` when no gallery is given).
2. Upload a photo via `POST /media/upload` (no `media_gallery_id`, with an `owner_token`), then create an Item passing that `media_gallery_id` but a **wrong** `owner_token` → still rejected with 403 (unchanged: ownership check still runs, just from the extracted helper).
3. As `manager@sushigo.com`, edit an Item's photos (`PATCH /media/assets/{id}`) → still succeeds (unchanged: `manager` role still resolves permissions via the same `media.%` wildcard, now sourced from `PermissionSeeder::MEDIA_WILDCARD` instead of 3 separate literals).

## Workspace
`sushigo-a` — `fix/377-sonar-quality-gate-fixes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)