### PR TITLE
🔨 [#360][e] - Migrate remaining now()/new Date() usages to ApplicationClock 🕐

### DIFF
--- a/code/api/app/Actions/Employee/CreateManualOvertimeMovementAction.php
+++ b/code/api/app/Actions/Employee/CreateManualOvertimeMovementAction.php
@@ -7,11 +7,14 @@ use App\Enums\OvertimeOrigin;
 use App\Models\Employee;
 use App\Models\OvertimeBankMovement;
 use App\Models\User;
+use App\Support\Clock\ApplicationClock;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 
 class CreateManualOvertimeMovementAction
 {
+    public function __construct(private readonly ApplicationClock $clock) {}
+
     /**
      * @param  array{date: string, movement_type: OvertimeMovementType, minutes: int, reason: string}  $data
      *
@@ -39,7 +42,7 @@ class CreateManualOvertimeMovementAction
                 'origin' => OvertimeOrigin::MANUAL,
                 'minutes' => $data['minutes'],
                 'authorized_by' => $authorizedBy->id,
-                'authorized_at' => now(),
+                'authorized_at' => $this->clock->nowUtc(),
                 'reason' => $data['reason'],
             ]);
 

--- a/code/api/app/Actions/Leaves/Concerns/LeaveGuards.php
+++ b/code/api/app/Actions/Leaves/Concerns/LeaveGuards.php
@@ -123,7 +123,7 @@ trait LeaveGuards
      */
     private function persistLeaveDates(Leave $leave, array $dates): void
     {
-        $now = now();
+        $now = $this->clock->nowUtc();
 
         $leave->dates()->insert(array_map(fn (string $date) => [
             'leave_id' => $leave->id,

--- a/code/api/app/Actions/Leaves/RegisterDirectLeaveAction.php
+++ b/code/api/app/Actions/Leaves/RegisterDirectLeaveAction.php
@@ -5,6 +5,7 @@ namespace App\Actions\Leaves;
 use App\Actions\Leaves\Concerns\LeaveGuards;
 use App\Enums\LeaveStatus;
 use App\Models\Leave;
+use App\Support\Clock\ApplicationClock;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -23,6 +24,8 @@ use Illuminate\Support\Facades\DB;
 class RegisterDirectLeaveAction
 {
     use LeaveGuards;
+
+    public function __construct(private readonly ApplicationClock $clock) {}
 
     /**
      * @param  array<string, mixed>  $data  Must include 'dates' (array of date strings)
@@ -46,7 +49,7 @@ class RegisterDirectLeaveAction
                 $this->guardNoExistingWorkedAttendance($employee->id, $dates);
             }
 
-            $attributes['approved_at'] = now();
+            $attributes['approved_at'] = $this->clock->nowUtc();
             $leave = Leave::create($attributes);
             $this->persistLeaveDates($leave, $dates);
 

--- a/code/api/app/Actions/VacationRequests/ApproveVacationRequestAction.php
+++ b/code/api/app/Actions/VacationRequests/ApproveVacationRequestAction.php
@@ -4,6 +4,7 @@ namespace App\Actions\VacationRequests;
 
 use App\Actions\VacationRequests\Concerns\VacationRequestGuards;
 use App\Models\VacationRequest;
+use App\Support\Clock\ApplicationClock;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 
@@ -20,6 +21,11 @@ use Illuminate\Validation\ValidationException;
 class ApproveVacationRequestAction
 {
     use VacationRequestGuards;
+
+    // $clock is used by VacationRequestGuards::finalizeApproval(), a trait
+    // method defined in a separate file that Sonar's per-file analysis
+    // doesn't resolve as a usage of this property.
+    public function __construct(private readonly ApplicationClock $clock) {} // NOSONAR
 
     /**
      * @throws ValidationException

--- a/code/api/app/Actions/VacationRequests/Concerns/VacationRequestGuards.php
+++ b/code/api/app/Actions/VacationRequests/Concerns/VacationRequestGuards.php
@@ -201,7 +201,7 @@ trait VacationRequestGuards
      */
     private function persistVacationRequestDates(VacationRequest $vacationRequest, array $dates): void
     {
-        $now = now();
+        $now = $this->clock->nowUtc();
 
         $vacationRequest->dates()->insert(array_map(fn (string $date) => [
             'vacation_request_id' => $vacationRequest->id,
@@ -239,7 +239,7 @@ trait VacationRequestGuards
         $vacationRequest->update([
             'status' => VacationRequestStatus::APPROVED,
             'approved_by' => $approvedById,
-            'approved_at' => now(),
+            'approved_at' => $this->clock->nowUtc(),
         ]);
 
         $this->createAttendanceRecords($vacationRequest->employee_id, $dates);
@@ -282,7 +282,7 @@ trait VacationRequestGuards
             'status' => VacationRequestStatus::APPROVED,
             'requested_by' => $requestedById,
             'approved_by' => $approvedById,
-            'approved_at' => $approvedAt ?? now(),
+            'approved_at' => $approvedAt ?? $this->clock->nowUtc(),
             'notes' => $notes,
         ]);
 

--- a/code/api/app/Actions/VacationRequests/RegisterVacationRequestAction.php
+++ b/code/api/app/Actions/VacationRequests/RegisterVacationRequestAction.php
@@ -6,6 +6,7 @@ use App\Actions\VacationRequests\Concerns\VacationRequestGuards;
 use App\Enums\VacationRequestStatus;
 use App\Models\Employee;
 use App\Models\VacationRequest;
+use App\Support\Clock\ApplicationClock;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -23,6 +24,11 @@ use Illuminate\Support\Facades\DB;
 class RegisterVacationRequestAction
 {
     use VacationRequestGuards;
+
+    // $clock is used by VacationRequestGuards::createApprovedVacationRequest()
+    // and ::persistVacationRequestDates(), trait methods defined in a separate
+    // file that Sonar's per-file analysis doesn't resolve as a usage of this property.
+    public function __construct(private readonly ApplicationClock $clock) {} // NOSONAR
 
     /**
      * @param  array<string, mixed>  $data

--- a/code/api/app/Actions/VacationRequests/RejectVacationRequestAction.php
+++ b/code/api/app/Actions/VacationRequests/RejectVacationRequestAction.php
@@ -5,6 +5,7 @@ namespace App\Actions\VacationRequests;
 use App\Actions\VacationRequests\Concerns\VacationRequestGuards;
 use App\Enums\VacationRequestStatus;
 use App\Models\VacationRequest;
+use App\Support\Clock\ApplicationClock;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 
@@ -20,6 +21,8 @@ class RejectVacationRequestAction
 {
     use VacationRequestGuards;
 
+    public function __construct(private readonly ApplicationClock $clock) {}
+
     /**
      * @throws ValidationException
      */
@@ -33,7 +36,7 @@ class RejectVacationRequestAction
             $vacationRequest->update([
                 'status' => VacationRequestStatus::REJECTED,
                 'approved_by' => $rejectedById,
-                'approved_at' => now(),
+                'approved_at' => $this->clock->nowUtc(),
             ]);
 
             return $vacationRequest;

--- a/code/api/app/Http/Controllers/Api/V1/Holidays/CreateHolidayDefinitionController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Holidays/CreateHolidayDefinitionController.php
@@ -10,6 +10,7 @@ use App\Http\Resources\Holiday\HolidayDefinitionResource;
 use App\Models\Holiday;
 use App\Models\HolidayDefinition;
 use App\Services\HolidayGeneratorService;
+use App\Support\Clock\ApplicationClock;
 
 /**
  * @OA\Post(
@@ -45,7 +46,10 @@ use App\Services\HolidayGeneratorService;
  */
 class CreateHolidayDefinitionController extends Controller
 {
-    public function __construct(private readonly HolidayGeneratorService $generator) {}
+    public function __construct(
+        private readonly HolidayGeneratorService $generator,
+        private readonly ApplicationClock $clock,
+    ) {}
 
     public function __invoke(StoreHolidayDefinitionRequest $request): HolidayDefinitionResource
     {
@@ -55,7 +59,7 @@ class CreateHolidayDefinitionController extends Controller
 
         if ($definition->is_annual) {
             // Auto-generate instances for current year via lazy generator
-            $this->generator->generateForYear((int) now()->year);
+            $this->generator->generateForYear((int) $this->clock->nowInBusinessTz()->year);
         } elseif (isset($data['date'])) {
             // One-off holiday: create a single instance from the provided date
             Holiday::create([

--- a/code/api/app/Http/Controllers/Api/V1/Holidays/ListHolidaysController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Holidays/ListHolidaysController.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Resources\Holiday\HolidayResource;
 use App\Models\Holiday;
 use App\Services\HolidayGeneratorService;
+use App\Support\Clock\ApplicationClock;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 
@@ -46,7 +47,10 @@ use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
  */
 class ListHolidaysController extends Controller
 {
-    public function __construct(private readonly HolidayGeneratorService $generator) {}
+    public function __construct(
+        private readonly HolidayGeneratorService $generator,
+        private readonly ApplicationClock $clock,
+    ) {}
 
     public function __invoke(Request $request): AnonymousResourceCollection
     {
@@ -57,7 +61,7 @@ class ListHolidaysController extends Controller
         $year = isset($validated['year']) ? (int) $validated['year'] : null;
 
         // Lazy generation: trigger for the requested year (or current year by default)
-        $generationYear = $year ?? (int) now()->year;
+        $generationYear = $year ?? (int) $this->clock->nowInBusinessTz()->year;
         $result = $this->generator->generateForYear($generationYear);
 
         $query = Holiday::query()->orderBy('date');

--- a/code/api/app/Http/Controllers/Api/V1/Holidays/UpdateHolidayDefinitionController.php
+++ b/code/api/app/Http/Controllers/Api/V1/Holidays/UpdateHolidayDefinitionController.php
@@ -9,6 +9,7 @@ use App\Http\Requests\Holidays\UpdateHolidayDefinitionRequest;
 use App\Http\Resources\Holiday\HolidayDefinitionResource;
 use App\Models\HolidayDefinition;
 use App\Services\HolidayGeneratorService;
+use App\Support\Clock\ApplicationClock;
 
 /**
  * @OA\Put(
@@ -47,7 +48,10 @@ use App\Services\HolidayGeneratorService;
  */
 class UpdateHolidayDefinitionController extends Controller
 {
-    public function __construct(private readonly HolidayGeneratorService $generator) {}
+    public function __construct(
+        private readonly HolidayGeneratorService $generator,
+        private readonly ApplicationClock $clock,
+    ) {}
 
     public function __invoke(
         UpdateHolidayDefinitionRequest $request,
@@ -58,7 +62,7 @@ class UpdateHolidayDefinitionController extends Controller
 
         // Generate current-year instance if now annual (and not already generated)
         if ($holidayDefinition->is_annual) {
-            $this->generator->generateForYear((int) now()->year);
+            $this->generator->generateForYear((int) $this->clock->nowInBusinessTz()->year);
         }
 
         return new HolidayDefinitionResource($holidayDefinition);

--- a/code/api/app/Http/Controllers/Api/V1/PayPeriods/ConfirmCloseController.php
+++ b/code/api/app/Http/Controllers/Api/V1/PayPeriods/ConfirmCloseController.php
@@ -10,6 +10,7 @@ use App\Models\Holiday;
 use App\Models\PayPeriod;
 use App\Models\PunctualityRange;
 use App\Repositories\EmployeeRepository;
+use App\Support\Clock\ApplicationClock;
 use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
@@ -51,6 +52,7 @@ class ConfirmCloseController extends Controller
     public function __construct(
         private RecalculatePayPeriodEmployeesAction $recalculate,
         private EmployeeRepository $employeeRepository,
+        private ApplicationClock $clock,
     ) {}
 
     public function __invoke(ConfirmClosePayPeriodRequest $request): ResponseEntity
@@ -89,7 +91,7 @@ class ConfirmCloseController extends Controller
                     'period_end' => $periodEnd,
                     'status' => PayPeriod::STATUS_CLOSED,
                     'closed_by' => $request->user()->id,
-                    'closed_at' => now(),
+                    'closed_at' => $this->clock->nowUtc(),
                 ]);
 
                 ($this->recalculate)($payPeriod, $employees, $holidays, $punctualityRanges);

--- a/code/api/app/Http/Controllers/Api/V1/PayPeriods/ReclosePayPeriodController.php
+++ b/code/api/app/Http/Controllers/Api/V1/PayPeriods/ReclosePayPeriodController.php
@@ -11,6 +11,7 @@ use App\Models\PayPeriod;
 use App\Models\PayPeriodEmployee;
 use App\Models\PunctualityRange;
 use App\Repositories\EmployeeRepository;
+use App\Support\Clock\ApplicationClock;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 
@@ -50,6 +51,7 @@ class ReclosePayPeriodController extends Controller
     public function __construct(
         private RecalculatePayPeriodEmployeesAction $recalculate,
         private EmployeeRepository $employeeRepository,
+        private ApplicationClock $clock,
     ) {}
 
     public function __invoke(ReclosePayPeriodRequest $request, PayPeriod $payPeriod): PayPeriodResource
@@ -77,7 +79,7 @@ class ReclosePayPeriodController extends Controller
             $payPeriod->update([
                 'status' => PayPeriod::STATUS_CLOSED,
                 'closed_by' => $request->user()->id,
-                'closed_at' => now(),
+                'closed_at' => $this->clock->nowUtc(),
             ]);
         });
 

--- a/code/api/app/Http/Controllers/Api/V1/PayPeriods/ReopenPayPeriodController.php
+++ b/code/api/app/Http/Controllers/Api/V1/PayPeriods/ReopenPayPeriodController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\PayPeriods\ReopenPayPeriodRequest;
 use App\Http\Resources\PayPeriods\PayPeriodResource;
 use App\Models\PayPeriod;
+use App\Support\Clock\ApplicationClock;
 use Illuminate\Validation\ValidationException;
 
 /**
@@ -51,6 +52,8 @@ use Illuminate\Validation\ValidationException;
  */
 class ReopenPayPeriodController extends Controller
 {
+    public function __construct(private readonly ApplicationClock $clock) {}
+
     public function __invoke(ReopenPayPeriodRequest $request, PayPeriod $payPeriod): PayPeriodResource
     {
         if (! $payPeriod->isClosed()) {
@@ -63,7 +66,7 @@ class ReopenPayPeriodController extends Controller
         $payPeriod->update([
             'status' => PayPeriod::STATUS_REOPENED,
             'reopened_by' => $request->user()->id,
-            'reopened_at' => now(),
+            'reopened_at' => $this->clock->nowUtc(),
             'reopen_reason' => $request->reason(),
         ]);
 

--- a/code/api/app/Services/CashAdjustments/CashAdjustmentService.php
+++ b/code/api/app/Services/CashAdjustments/CashAdjustmentService.php
@@ -8,10 +8,13 @@ use App\Models\CashAdjustment;
 use App\Models\CashAdjustmentLine;
 use App\Models\CashSession;
 use App\Models\User;
+use App\Support\Clock\ApplicationClock;
 use Illuminate\Support\Facades\DB;
 
 class CashAdjustmentService
 {
+    public function __construct(private readonly ApplicationClock $clock) {}
+
     /**
      * Create a new adjustment with lines
      *
@@ -119,7 +122,7 @@ class CashAdjustmentService
         }
 
         $adjustment->posted_by = $user->id;
-        $adjustment->posted_at = now();
+        $adjustment->posted_at = $this->clock->nowUtc();
         $adjustment->save();
 
         return $adjustment;

--- a/code/api/app/Services/CashAdjustments/CashExpenseService.php
+++ b/code/api/app/Services/CashAdjustments/CashExpenseService.php
@@ -8,9 +8,12 @@ use App\Exceptions\InvalidCashExpenseException;
 use App\Models\CashExpense;
 use App\Models\CashSession;
 use App\Models\User;
+use App\Support\Clock\ApplicationClock;
 
 class CashExpenseService
 {
+    public function __construct(private readonly ApplicationClock $clock) {}
+
     /**
      * Register a new expense
      *
@@ -35,7 +38,7 @@ class CashExpenseService
             'notes' => $data->notes,
             'card_terminal_id' => $data->cardTerminalId,
             'bank_account_id' => $data->bankAccountId,
-            'incurred_at' => $data->incurredAt ?? now(),
+            'incurred_at' => $data->incurredAt ?? $this->clock->nowUtc(),
             'created_by' => $data->createdBy->id,
             'meta' => $data->meta,
         ]);
@@ -53,7 +56,7 @@ class CashExpenseService
         }
 
         $expense->posted_by = $user->id;
-        $expense->posted_at = now();
+        $expense->posted_at = $this->clock->nowUtc();
         $expense->save();
 
         return $expense;

--- a/code/api/app/Services/EmployeeRequests/EmployeeRequestService.php
+++ b/code/api/app/Services/EmployeeRequests/EmployeeRequestService.php
@@ -7,6 +7,7 @@ use App\Enums\EmployeeRequestType;
 use App\Models\Employee;
 use App\Models\EmployeeRequest;
 use App\Models\User;
+use App\Support\Clock\ApplicationClock;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -18,6 +19,7 @@ class EmployeeRequestService
         private readonly ExtraDayRequestHandler $extraDayRequestHandler,
         private readonly LeaveRequestHandler $leaveRequestHandler,
         private readonly VacationRequestHandler $vacationRequestHandler,
+        private readonly ApplicationClock $clock,
     ) {}
 
     /**
@@ -81,7 +83,7 @@ class EmployeeRequestService
             $updatedFields = [
                 'status' => EmployeeRequestStatus::APPROVED,
                 'approved_by' => $approver->id,
-                'approved_at' => now(),
+                'approved_at' => $this->clock->nowUtc(),
             ];
 
             if (! empty($payloadOverrides)) {
@@ -119,7 +121,7 @@ class EmployeeRequestService
             $employeeRequest->update([
                 'status' => EmployeeRequestStatus::REJECTED,
                 'approved_by' => $approver->id,
-                'approved_at' => now(),
+                'approved_at' => $this->clock->nowUtc(),
                 'rejection_reason' => $reason,
             ]);
 

--- a/code/api/app/Services/EmployeeRequests/LeaveRequestHandler.php
+++ b/code/api/app/Services/EmployeeRequests/LeaveRequestHandler.php
@@ -8,6 +8,7 @@ use App\Enums\LeaveStatus;
 use App\Models\EmployeeRequest;
 use App\Models\Leave;
 use App\Models\LeaveType;
+use App\Support\Clock\ApplicationClock;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Validation\ValidationException;
 
@@ -23,6 +24,8 @@ use Illuminate\Validation\ValidationException;
 class LeaveRequestHandler implements RequestHandler
 {
     use LeaveGuards;
+
+    public function __construct(private readonly ApplicationClock $clock) {}
 
     /**
      * @throws ValidationException
@@ -65,7 +68,7 @@ class LeaveRequestHandler implements RequestHandler
             [
                 'status' => LeaveStatus::APPROVED,
                 'approved_by' => $approvedBy,
-                'approved_at' => $employeeRequest->approved_at ?? now(),
+                'approved_at' => $employeeRequest->approved_at ?? $this->clock->nowUtc(),
                 'notes' => $employeeRequest->notes,
             ]
         );

--- a/code/api/app/Services/EmployeeRequests/VacationRequestHandler.php
+++ b/code/api/app/Services/EmployeeRequests/VacationRequestHandler.php
@@ -5,6 +5,7 @@ namespace App\Services\EmployeeRequests;
 use App\Actions\VacationRequests\Concerns\VacationRequestGuards;
 use App\Enums\EmployeeRequestType;
 use App\Models\EmployeeRequest;
+use App\Support\Clock\ApplicationClock;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Validation\ValidationException;
 
@@ -18,6 +19,11 @@ use Illuminate\Validation\ValidationException;
 class VacationRequestHandler implements RequestHandler
 {
     use VacationRequestGuards;
+
+    // $clock is used by VacationRequestGuards::createApprovedVacationRequest(),
+    // a trait method defined in a separate file that Sonar's per-file analysis
+    // doesn't resolve as a usage of this property.
+    public function __construct(private readonly ApplicationClock $clock) {} // NOSONAR
 
     /**
      * @throws ValidationException

--- a/code/api/app/Services/Inventory/OpeningBalanceService.php
+++ b/code/api/app/Services/Inventory/OpeningBalanceService.php
@@ -11,11 +11,14 @@ use App\Models\StockMovement;
 use App\Models\StockMovementLine;
 use App\Models\UnitOfMeasure;
 use App\Services\Inventory\Concerns\ConvertsUomQuantities;
+use App\Support\Clock\ApplicationClock;
 use Illuminate\Support\Facades\DB;
 
 class OpeningBalanceService
 {
     use ConvertsUomQuantities;
+
+    public function __construct(private readonly ApplicationClock $clock) {}
 
     /**
      * Register opening balance for an item variant at a specific location
@@ -77,7 +80,7 @@ class OpeningBalanceService
                     'unit_cost' => $unitCost,
                     'base_cost' => $baseCost,
                 ],
-                'posted_at' => now(),
+                'posted_at' => $this->clock->nowUtc(),
             ]);
 
             // Create movement line

--- a/code/api/app/Services/Inventory/StockOutService.php
+++ b/code/api/app/Services/Inventory/StockOutService.php
@@ -14,11 +14,14 @@ use App\Models\StockMovement;
 use App\Models\StockMovementLine;
 use App\Models\UnitOfMeasure;
 use App\Services\Inventory\Concerns\ConvertsUomQuantities;
+use App\Support\Clock\ApplicationClock;
 use Illuminate\Support\Facades\DB;
 
 class StockOutService
 {
     use ConvertsUomQuantities;
+
+    public function __construct(private readonly ApplicationClock $clock) {}
 
     /**
      * Register a stock outbound movement (SALE or CONSUMPTION)
@@ -104,7 +107,7 @@ class StockOutService
                     'sale_price' => $salePrice,
                     'profit_margin' => $profitMargin,
                 ],
-                'posted_at' => now(),
+                'posted_at' => $this->clock->nowUtc(),
             ]);
 
             // Create movement line

--- a/code/api/app/Services/PayrollSeedService.php
+++ b/code/api/app/Services/PayrollSeedService.php
@@ -10,13 +10,17 @@ use App\Models\Attendance;
 use App\Models\Employee;
 use App\Models\OvertimeBankMovement;
 use App\Models\PartialLeave;
+use App\Support\Clock\ApplicationClock;
 use Carbon\Carbon;
+use Carbon\CarbonImmutable;
 use Carbon\CarbonPeriod;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
 class PayrollSeedService
 {
+    public function __construct(private readonly ApplicationClock $clock) {}
+
     // Base shift: 08:00–17:00, lunch 13:00–14:00 → 480 min net
     private const SHIFT_START = '08:00:00';
 
@@ -69,7 +73,7 @@ class PayrollSeedService
             ->delete();
 
         $weekdays = $this->weekdaysInRange($periodStart, $periodEnd);
-        $now = now();
+        $now = $this->clock->nowUtc();
         $created = 0;
 
         foreach ($employees as $employeeIndex => $employee) {
@@ -106,7 +110,7 @@ class PayrollSeedService
     /**
      * @return list<array{attendance: array<string, mixed>, partial_leave: array<string, mixed>|null, overtime: array<string, mixed>|null}>
      */
-    private function buildRows(int $employeeId, Collection $weekdays, SeedScenario $scenario, Carbon $now, int $employeeIndex = 0): array
+    private function buildRows(int $employeeId, Collection $weekdays, SeedScenario $scenario, CarbonImmutable $now, int $employeeIndex = 0): array
     {
         $rows = [];
 

--- a/code/api/tests/Unit/Services/CashAdjustmentServiceTest.php
+++ b/code/api/tests/Unit/Services/CashAdjustmentServiceTest.php
@@ -11,6 +11,7 @@ use App\Models\CashRegister;
 use App\Models\CashSession;
 use App\Models\User;
 use App\Services\CashAdjustments\CashAdjustmentService;
+use App\Support\Clock\ApplicationClock;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -28,7 +29,7 @@ class CashAdjustmentServiceTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->service = new CashAdjustmentService;
+        $this->service = new CashAdjustmentService(app(ApplicationClock::class));
 
         $branch = Branch::factory()->create();
         $register = CashRegister::factory()->for($branch)->create();

--- a/code/api/tests/Unit/Services/CashExpenseServiceTest.php
+++ b/code/api/tests/Unit/Services/CashExpenseServiceTest.php
@@ -13,6 +13,7 @@ use App\Models\CashSession;
 use App\Models\CashTerminal;
 use App\Models\User;
 use App\Services\CashAdjustments\CashExpenseService;
+use App\Support\Clock\ApplicationClock;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -32,7 +33,7 @@ class CashExpenseServiceTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->service = new CashExpenseService;
+        $this->service = new CashExpenseService(app(ApplicationClock::class));
 
         $this->branch = Branch::factory()->create();
         $register = CashRegister::factory()->for($this->branch)->create();

--- a/code/webapp/src/components/attendance/EmployeeAttendanceCard.tsx
+++ b/code/webapp/src/components/attendance/EmployeeAttendanceCard.tsx
@@ -30,6 +30,7 @@ import type {
 import { getPhaseCardClass } from './attendance-helpers'
 import { RegisterLeaveDialog } from './RegisterLeaveDialog'
 import { useEmployeeAttendanceCard } from './use-employee-attendance-card'
+import { useApplicationNowMs } from '@/stores/clock.store'
 
 // ── Sub-components ─────────────────────────────────────────────────────���───────
 
@@ -265,10 +266,13 @@ export function RoleBadges({ roles }: Readonly<RoleBadgesProps>) {
 
 interface LeaveChipProps {
     leave: TodayLeave
-    nowMs?: number  // injectable for tests; defaults to Date.now()
+    nowMs?: number  // injectable for tests; defaults to a ticking Application Clock (or Date.now() when unavailable)
 }
 
-export function LeaveChip({ leave, nowMs = Date.now() }: Readonly<LeaveChipProps>) {
+export function LeaveChip({ leave, nowMs }: Readonly<LeaveChipProps>) {
+    const tickingNowMs = useApplicationNowMs()
+    const effectiveNowMs = nowMs ?? tickingNowMs
+
     if (leave.time_mode === 'OPEN_ENDED') {
         return (
             <div
@@ -293,10 +297,10 @@ export function LeaveChip({ leave, nowMs = Date.now() }: Readonly<LeaveChipProps
     let label: string
     if (endsAtMs === null) {
         label = `Permiso ${payLabel} (horario no disponible)`
-    } else if (startsAtMs !== null && startsAtMs > nowMs) {
+    } else if (startsAtMs !== null && startsAtMs > effectiveNowMs) {
         // Leave hasn't started yet — employee will arrive at work when the leave ends
         label = `Llega a las ${formatTime(leave.ends_at)} (permiso ${payLabel})`
-    } else if (endsAtMs < nowMs) {
+    } else if (endsAtMs < effectiveNowMs) {
         // Leave is over — employee left work when the leave started
         label = `Salió a las ${formatTime(leave.starts_at)} (permiso ${payLabel})`
     } else {

--- a/code/webapp/src/components/cash/open-session-dialog.tsx
+++ b/code/webapp/src/components/cash/open-session-dialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { FormField, Select } from '@/components/ui/form-fields'
@@ -6,6 +6,8 @@ import { SlidePanel } from '@/components/ui/slide-panel'
 import { Loader2 } from 'lucide-react'
 import { useCreateCashSession, useCashRegisters } from '@/services/cash-hooks'
 import { getApiErrorMessage, getApiValidationErrors, hasApiValidationErrors } from '@/lib/api-error'
+import { todayDateCdmx } from '@/lib/datetime'
+import { useBusinessDate } from '@/stores/clock.store'
 import { CashRegisterType, type CashSessionFormData } from '@/types/cash'
 
 interface OpenSessionDialogProps {
@@ -35,24 +37,29 @@ export function OpenSessionDialog({
   // Create session mutation
   const createMutation = useCreateCashSession()
 
-  // Get today's date in YYYY-MM-DD format
-  const getTodayDate = () => {
-    const today = new Date()
-    const year = today.getFullYear()
-    const month = String(today.getMonth() + 1).padStart(2, '0')
-    const day = String(today.getDate()).padStart(2, '0')
-    return `${year}-${month}-${day}`
-  }
+  const businessDate = useBusinessDate()
+  const operatingDateTouchedRef = useRef(false)
 
   // Reset form when dialog opens
   useEffect(() => {
     if (isOpen) {
       setCashRegisterId('')
-      setOperatingDate(getTodayDate())
+      setOperatingDate(businessDate ?? todayDateCdmx())
       setOpeningBalance('')
       setErrors({})
+      operatingDateTouchedRef.current = false
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen])
+
+  // businessDate resolves asynchronously and can land after the dialog is
+  // already open with the browser-clock fallback — keep operatingDate in
+  // sync until the user picks a date manually.
+  useEffect(() => {
+    if (isOpen && businessDate && !operatingDateTouchedRef.current) {
+      setOperatingDate(businessDate)
+    }
+  }, [isOpen, businessDate])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -165,7 +172,10 @@ export function OpenSessionDialog({
             name="operating_date"
             type="date"
             value={operatingDate}
-            onChange={(e) => setOperatingDate(e.target.value)}
+            onChange={(e) => {
+              operatingDateTouchedRef.current = true
+              setOperatingDate(e.target.value)
+            }}
             disabled={createMutation.isPending}
           />
         </FormField>

--- a/code/webapp/src/components/employees/__tests__/override-scope-dialog.test.tsx
+++ b/code/webapp/src/components/employees/__tests__/override-scope-dialog.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, fireEvent, act, cleanup } from '@testing-library/react'
 import { nextDateForDow, detectConflicts } from '@/components/employees/use-override-scope-dialog'
 import { OverrideScopeDialog } from '@/components/employees/override-scope-dialog'
@@ -258,6 +258,18 @@ describe('OverrideScopeDialog', () => {
 // ── nextDateForDow ─────────────────────────────────────────────────────────────
 
 describe('nextDateForDow', () => {
+  // Pinned mid-day instant (16:00 CDMX / 22:00 UTC, same calendar day in both)
+  // so these tests don't flake during the ~6h/day window where UTC and CDMX
+  // (or the CI runner's local timezone) disagree on the date.
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-02T22:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('returns a string in YYYY-MM-DD format', () => {
     const result = nextDateForDow(1)
     expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/)

--- a/code/webapp/src/components/employees/__tests__/use-deactivate-form.test.ts
+++ b/code/webapp/src/components/employees/__tests__/use-deactivate-form.test.ts
@@ -1,12 +1,27 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, cleanup, act } from '@testing-library/react'
 import { useDeactivateForm } from '../use-deactivate-form'
 
+const mockUseBusinessDate = vi.fn<() => string | null>(() => null)
+vi.mock('@/stores/clock.store', () => ({
+    useBusinessDate: () => mockUseBusinessDate(),
+}))
+
+// Pinned mid-day instant (16:00 CDMX / 22:00 UTC, same calendar day in both) so
+// "today" is deterministic regardless of when the suite actually runs — avoids
+// flakiness during the ~6h/day window where UTC and CDMX disagree on the date.
+beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-02T22:00:00Z'))
+    mockUseBusinessDate.mockReturnValue(null)
+})
+
 afterEach(() => {
     cleanup()
+    vi.useRealTimers()
     vi.restoreAllMocks()
 })
 
@@ -162,6 +177,35 @@ describe('useDeactivateForm', () => {
             expect(typeof result.current.form.handleSubmit).toBe('function')
             expect(typeof result.current.form.setValue).toBe('function')
             expect(typeof result.current.form.getValues).toBe('function')
+        })
+    })
+
+    describe('syncing end_date when businessDate resolves asynchronously', () => {
+        it('updates the untouched end_date when businessDate arrives after mount', () => {
+            // businessDate starts null (falls back to the pinned 2026-04-02 browser date)
+            const { result, rerender } = renderHook(() => useDeactivateForm())
+            expect(result.current.form.getValues('end_date')).toBe('2026-04-02')
+
+            // businessDate resolves later to an earlier simulated date
+            mockUseBusinessDate.mockReturnValue('2026-03-30')
+            rerender()
+
+            expect(result.current.form.getValues('end_date')).toBe('2026-03-30')
+        })
+
+        it('does not overwrite end_date once the user has edited it', () => {
+            const { result, rerender } = renderHook(() => useDeactivateForm())
+
+            act(() => {
+                result.current.form.setValue('end_date', '2026-03-15', { shouldDirty: true })
+            })
+            expect(result.current.form.getValues('end_date')).toBe('2026-03-15')
+
+            // businessDate resolves after the user has already picked a date
+            mockUseBusinessDate.mockReturnValue('2026-03-30')
+            rerender()
+
+            expect(result.current.form.getValues('end_date')).toBe('2026-03-15')
         })
     })
 })

--- a/code/webapp/src/components/employees/__tests__/use-manual-overtime-movement-dialog.test.ts
+++ b/code/webapp/src/components/employees/__tests__/use-manual-overtime-movement-dialog.test.ts
@@ -31,11 +31,18 @@ describe('useManualOvertimeMovementDialog', () => {
   })
 
   it('defaults date to today', () => {
-    const today = new Date().toISOString().slice(0, 10)
-    const { result } = renderHook(() =>
-      useManualOvertimeMovementDialog({ employee: mockEmployee, onSuccess: vi.fn() })
-    )
-    expect(result.current.form.getValues('date')).toBe(today)
+    // Pinned mid-day instant (16:00 CDMX / 22:00 UTC, same calendar day in both)
+    // so this doesn't flake during the ~6h/day window where UTC and CDMX disagree.
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-02T22:00:00Z'))
+    try {
+      const { result } = renderHook(() =>
+        useManualOvertimeMovementDialog({ employee: mockEmployee, onSuccess: vi.fn() })
+      )
+      expect(result.current.form.getValues('date')).toBe('2026-04-02')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('submits the movement payload and calls onSuccess', async () => {

--- a/code/webapp/src/components/employees/__tests__/use-rehire-form.test.ts
+++ b/code/webapp/src/components/employees/__tests__/use-rehire-form.test.ts
@@ -15,6 +15,11 @@ vi.mock('@/stores/auth.store', () => ({
         }),
 }))
 
+const mockUseBusinessDate = vi.fn<() => string | null>(() => null)
+vi.mock('@/stores/clock.store', () => ({
+    useBusinessDate: () => mockUseBusinessDate(),
+}))
+
 import { useRehireForm } from '../use-rehire-form'
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -25,6 +30,7 @@ describe('useRehireForm', () => {
         vi.setSystemTime(new Date('2026-04-15T12:00:00'))
         mockCurrentBranch.mockReturnValue({ id: 1, name: 'Central' })
         mockAvailableBranches.mockReturnValue([{ id: 1, name: 'Central' }])
+        mockUseBusinessDate.mockReturnValue(null)
     })
 
     afterEach(() => {
@@ -90,5 +96,34 @@ describe('useRehireForm', () => {
         // Current date should be valid
         const isValid = await result.current.form.trigger('start_date')
         expect(isValid).toBe(true)
+    })
+
+    describe('syncing start_date when businessDate resolves asynchronously', () => {
+        it('updates the untouched start_date when businessDate arrives after mount', () => {
+            // businessDate starts null (falls back to the pinned 2026-04-15 browser date)
+            const { result, rerender } = renderHook(() => useRehireForm())
+            expect(result.current.form.getValues('start_date')).toBe('2026-04-15')
+
+            // businessDate resolves later to an earlier simulated date
+            mockUseBusinessDate.mockReturnValue('2026-04-10')
+            rerender()
+
+            expect(result.current.form.getValues('start_date')).toBe('2026-04-10')
+        })
+
+        it('does not overwrite start_date once the user has edited it', () => {
+            const { result, rerender } = renderHook(() => useRehireForm())
+
+            act(() => {
+                result.current.form.setValue('start_date', '2026-04-01', { shouldDirty: true })
+            })
+            expect(result.current.form.getValues('start_date')).toBe('2026-04-01')
+
+            // businessDate resolves after the user has already picked a date
+            mockUseBusinessDate.mockReturnValue('2026-04-10')
+            rerender()
+
+            expect(result.current.form.getValues('start_date')).toBe('2026-04-01')
+        })
     })
 })

--- a/code/webapp/src/components/employees/__tests__/use-wage-form.test.ts
+++ b/code/webapp/src/components/employees/__tests__/use-wage-form.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { renderHook, act, cleanup } from '@testing-library/react'
 import { useWageForm } from '../use-wage-form'
 
@@ -22,9 +22,17 @@ describe('useWageForm', () => {
         })
 
         it('initializes with today date for effective_from', () => {
-            const { result } = renderHook(() => useWageForm())
-            const today = new Date().toISOString().split('T')[0]
-            expect(result.current.formData.effective_from).toBe(today)
+            // Pinned mid-day instant (16:00 CDMX / 22:00 UTC, same calendar day in
+            // both) so this doesn't flake during the ~6h/day window where UTC and
+            // CDMX disagree on the date.
+            vi.useFakeTimers()
+            vi.setSystemTime(new Date('2026-04-02T22:00:00Z'))
+            try {
+                const { result } = renderHook(() => useWageForm())
+                expect(result.current.formData.effective_from).toBe('2026-04-02')
+            } finally {
+                vi.useRealTimers()
+            }
         })
 
         it('initializes with empty notes', () => {

--- a/code/webapp/src/components/employees/employee-edit-create-form.tsx
+++ b/code/webapp/src/components/employees/employee-edit-create-form.tsx
@@ -8,6 +8,8 @@ import { ToggleSwitch } from '@/components/ui/toggle-switch'
 import { EMPLOYEE_POSITION_ROLES } from '@/types/employee'
 import type { Employee, EmployeePositionRole } from '@/types/employee'
 import { Loader2, RefreshCw } from 'lucide-react'
+import { todayDateCdmx } from '@/lib/datetime'
+import { useBusinessDate } from '@/stores/clock.store'
 
 // ─── Schema ────────────────────────────────────────────────────────────────────
 // A single schema shape covers both create and edit modes.
@@ -136,8 +138,9 @@ export function EmployeeEditCreateForm({
 }: Readonly<EmployeeEditCreateFormProps>) {
   const canEditContact = mode === 'create' || isAdmin
 
+  const businessDate = useBusinessDate()
   // Fresh per mount — avoids stale module-level date when the app stays open past midnight.
-  const today = useMemo(() => new Date().toISOString().slice(0, 10), [])
+  const today = useMemo(() => businessDate ?? todayDateCdmx(), [businessDate])
 
   // Rebuild schema whenever assignable roles change (validates role values against server list).
   const schema = useMemo(() => buildSchema(assignableRoles), [assignableRoles])
@@ -190,6 +193,7 @@ export function EmployeeEditCreateForm({
     reset,
     setValue,
     watch,
+    getFieldState,
     formState: { errors },
   } = useForm<EmployeeFormValues>({
     resolver: zodResolver(schema),
@@ -214,6 +218,16 @@ export function EmployeeEditCreateForm({
   useEffect(() => {
     setValue('hasBranch', hasBranch, { shouldValidate: false })
   }, [hasBranch, setValue])
+
+  // businessDate resolves asynchronously, later than the browser-clock
+  // fallback used for baseDefaultValues on first render — keep start_date
+  // in sync while the user hasn't picked a date manually (create mode only).
+  useEffect(() => {
+    if (mode === 'create' && !getFieldState('start_date').isDirty) {
+      setValue('start_date', today, { shouldValidate: false })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode, today])
 
   const emailValue = watch('email')
   const rolesValue = watch('roles')

--- a/code/webapp/src/components/employees/extra-day-section.tsx
+++ b/code/webapp/src/components/employees/extra-day-section.tsx
@@ -12,20 +12,14 @@ import { ExtraDayForm } from './extra-day-form'
 import type { Employee } from '@/types/employee'
 import type { ListExtraDaysFilters, NegotiatedExtraDay } from '@/types/negotiated-extra-day'
 import { useState } from 'react'
+import { todayDateCdmx } from '@/lib/datetime'
+import { useApplicationClockStore } from '@/stores/clock.store'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function todayIso(): string {
-  const d = new Date()
-  return [
-    d.getFullYear(),
-    String(d.getMonth() + 1).padStart(2, '0'),
-    String(d.getDate()).padStart(2, '0'),
-  ].join('-')
-}
-
 function isFuture(dateStr: string): boolean {
-  return dateStr >= todayIso()
+  const businessDate = useApplicationClockStore.getState().clockState?.business_date
+  return dateStr >= (businessDate ?? todayDateCdmx())
 }
 
 function formatDate(dateStr: string): string {

--- a/code/webapp/src/components/employees/leave-summary-section.tsx
+++ b/code/webapp/src/components/employees/leave-summary-section.tsx
@@ -221,7 +221,7 @@ interface LeaveSummarySectionProps {
 
 export function LeaveSummarySection({ employeeId, employee }: LeaveSummarySectionProps) {
     const ctx = useLeaveSummarySection(employeeId, employee)
-    const monthLabel = new Date().toLocaleDateString('es-MX', { month: 'long', year: 'numeric' })
+    const monthLabel = new Date(`${ctx.today}T00:00:00`).toLocaleDateString('es-MX', { month: 'long', year: 'numeric' })
 
     return (
         <>

--- a/code/webapp/src/components/employees/override-scope-dialog.tsx
+++ b/code/webapp/src/components/employees/override-scope-dialog.tsx
@@ -12,6 +12,8 @@ import { useOverrideScopeDialog } from './use-override-scope-dialog'
 import type { OverrideScopeFormValues } from './use-override-scope-dialog'
 import { calcDayHours, formatHours, overrideDateLabel } from './schedule-section-utils'
 import { formatTime } from '@/lib/time-format'
+import { todayDateCdmx } from '@/lib/datetime'
+import { useBusinessDate } from '@/stores/clock.store'
 
 const SCOPE_OPTIONS: { value: OverrideScope; label: string; description: string }[] = [
   {
@@ -46,7 +48,8 @@ interface ScopeFormStepProps {
 }
 
 function ScopeFormStep({ register, errors, scope, effectiveFrom, isError, isPending, isValid, onClose, onPrimaryClick }: ScopeFormStepProps) {
-  const today = new Date().toISOString().slice(0, 10)
+  const businessDate = useBusinessDate()
+  const today = businessDate ?? todayDateCdmx()
   const isIndefinite = scope === 'indefinite'
   const dateLabel = scope === 'single_date' ? 'Fecha' : 'A partir de'
   const submitLabel = isIndefinite ? 'Aplicar cambio permanente' : 'Guardar excepción'

--- a/code/webapp/src/components/employees/schedule-section-utils.ts
+++ b/code/webapp/src/components/employees/schedule-section-utils.ts
@@ -1,5 +1,6 @@
 import { formatTime } from '@/lib/time-format'
 import { useApplicationClockStore } from '@/stores/clock.store'
+import { todayDateCdmx } from '@/lib/datetime'
 import type { ScheduleDay, ScheduleDayOverride } from '@/types/schedule'
 
 // ── Schedule summary helpers ──────────────────────────────────────────────────
@@ -11,9 +12,7 @@ import type { ScheduleDay, ScheduleDayOverride } from '@/types/schedule'
  */
 function getLocalDate(): string {
   const businessDate = useApplicationClockStore.getState().clockState?.business_date
-  if (businessDate) return businessDate
-  const d = new Date()
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+  return businessDate ?? todayDateCdmx()
 }
 
 /** Single-letter abbreviations for ISO DOW 1=Mon…7=Sun (Mexican convention). */

--- a/code/webapp/src/components/employees/use-bonus-config-section.ts
+++ b/code/webapp/src/components/employees/use-bonus-config-section.ts
@@ -3,6 +3,8 @@ import { useForm, type SubmitHandler } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { useBonusGroups, useEmployeeBonusConfig, useAssignBonusConfig } from '@/services/punctuality-config-hooks'
+import { todayDateCdmx } from '@/lib/datetime'
+import { useBusinessDate } from '@/stores/clock.store'
 
 const assignSchema = z.object({
   bonus_group_id: z.string().min(1, 'Selecciona un grupo'),
@@ -23,7 +25,8 @@ export function useBonusConfigSection(employeeId: string) {
     defaultValues: { bonus_group_id: '', effective_from: '' },
   })
 
-  const today = new Date().toISOString().slice(0, 10)
+  const businessDate = useBusinessDate()
+  const today = businessDate ?? todayDateCdmx()
   const current =
     configs?.find(
       (c) => c.effective_from <= today && (c.effective_to === null || c.effective_to >= today),

--- a/code/webapp/src/components/employees/use-create-schedule-inline.ts
+++ b/code/webapp/src/components/employees/use-create-schedule-inline.ts
@@ -7,6 +7,9 @@ import { useToast } from '@/components/ui/toast-context'
 import { scheduleApi } from '@/services/schedule-api'
 import { DAY_LABELS, LUNCH_DURATION_OPTIONS } from '@/types/schedule'
 import type { EmployeeSchedule } from '@/types/schedule'
+import { todayDateCdmx } from '@/lib/datetime'
+import { addDays } from '@/lib/week'
+import { useApplicationClockStore } from '@/stores/clock.store'
 
 // ── Schema ─────────────────────────────────────────────────────────────────────
 
@@ -53,18 +56,14 @@ const DOW_KEYS: DowKey[] = [
  * If today is Monday, returns today.
  */
 export function getNextMonday(): string {
-  const today = new Date()
-  const dayOfWeek = today.getDay() // 0=Sun, 1=Mon, ..., 6=Sat
+  const businessDate = useApplicationClockStore.getState().clockState?.business_date
+  const today = businessDate ?? todayDateCdmx()
+  const dayOfWeek = new Date(today + 'T00:00:00').getDay() // 0=Sun, 1=Mon, ..., 6=Sat
   // If today is Monday (1), daysUntilMonday = 0
   // If today is Sunday (0), daysUntilMonday = 1
   // If today is Tuesday (2), daysUntilMonday = 6
   const daysUntilMonday = dayOfWeek === 1 ? 0 : (8 - dayOfWeek) % 7 || 7
-  const nextMonday = new Date(today)
-  nextMonday.setDate(today.getDate() + daysUntilMonday)
-  const y = nextMonday.getFullYear()
-  const m = String(nextMonday.getMonth() + 1).padStart(2, '0')
-  const d = String(nextMonday.getDate()).padStart(2, '0')
-  return `${y}-${m}-${d}`
+  return addDays(today, daysUntilMonday)
 }
 
 /**

--- a/code/webapp/src/components/employees/use-deactivate-form.ts
+++ b/code/webapp/src/components/employees/use-deactivate-form.ts
@@ -1,7 +1,9 @@
-import { useMemo } from 'react'
+import { useMemo, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
+import { todayDateCdmx } from '@/lib/datetime'
+import { useBusinessDate } from '@/stores/clock.store'
 
 // ─── Schema factory ───────────────────────────────────────────────────────────
 // Built at call time so `today` is always the current date, even if the app
@@ -28,8 +30,9 @@ export type DeactivateFormValues = z.infer<ReturnType<typeof buildDeactivateSche
  * unit-tested without rendering any UI.
  */
 export function useDeactivateForm() {
+  const businessDate = useBusinessDate()
   // Computed at mount time — fresh per form instance, never stale across midnight.
-  const today = useMemo(() => new Date().toISOString().slice(0, 10), [])
+  const today = useMemo(() => businessDate ?? todayDateCdmx(), [businessDate])
   const schema = useMemo(() => buildDeactivateSchema(today), [today])
 
   const form = useForm<DeactivateFormValues>({
@@ -39,6 +42,18 @@ export function useDeactivateForm() {
       termination_reason: '',
     },
   })
+
+  // `today` can change after mount (businessDate resolves asynchronously,
+  // later than the browser-clock fallback used for the initial defaultValues)
+  // — keep end_date in sync while the user hasn't touched it, so an untouched
+  // field never ends up failing the "not in the future" check it was
+  // pre-filled to satisfy.
+  useEffect(() => {
+    if (!form.getFieldState('end_date').isDirty) {
+      form.setValue('end_date', today)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [today])
 
   return { form, today }
 }

--- a/code/webapp/src/components/employees/use-leave-summary-section.ts
+++ b/code/webapp/src/components/employees/use-leave-summary-section.ts
@@ -3,6 +3,8 @@ import { useEmployeeLeaves, useLeaveTypes } from '@/services/leave-hooks'
 import type { LeaveFilters } from '@/services/leave-api'
 import type { Leave } from '@/types/leave'
 import type { TodayAttendanceEmployee } from '@/types/attendance'
+import { todayDateCdmx } from '@/lib/datetime'
+import { useBusinessDate } from '@/stores/clock.store'
 
 export function useLeaveSummarySection(employeeId: string, employee: { id: string; code: string; user: { first_name: string | null; last_name: string | null } } | undefined) {
     const [showFullHistory, setShowFullHistory] = useState(false)
@@ -10,9 +12,11 @@ export function useLeaveSummarySection(employeeId: string, employee: { id: strin
     const [page, setPage] = useState(1)
 
     // Current month range for summary
-    const now = new Date()
-    const monthStart = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-01`
-    const monthEnd = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate()).padStart(2, '0')}`
+    const businessDate = useBusinessDate()
+    const today = businessDate ?? todayDateCdmx()
+    const [y, m] = today.split('-') as [string, string]
+    const monthStart = `${y}-${m}-01`
+    const monthEnd = `${y}-${m}-${String(new Date(Number(y), Number(m), 0).getDate()).padStart(2, '0')}`
 
     // Summary query: current month, all results (overlap semantics for cross-boundary leaves)
     const summaryQuery = useEmployeeLeaves(employeeId, { overlap_from: monthStart, overlap_to: monthEnd, per_page: 100 })
@@ -81,6 +85,7 @@ export function useLeaveSummarySection(employeeId: string, employee: { id: strin
     }
 
     return {
+        today,
         monthlySummary,
         recentLeaves: recentQuery.data?.data ?? [] as Leave[],
         isLoadingSummary: summaryQuery.isLoading || recentQuery.isLoading,

--- a/code/webapp/src/components/employees/use-manual-overtime-movement-dialog.ts
+++ b/code/webapp/src/components/employees/use-manual-overtime-movement-dialog.ts
@@ -1,8 +1,11 @@
+import { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import type { UseFormReturn } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { useCreateManualOvertimeMovement } from '@/services/overtime-bank-hooks'
+import { todayDateCdmx } from '@/lib/datetime'
+import { useBusinessDate } from '@/stores/clock.store'
 
 const schema = z
   .object({
@@ -48,7 +51,8 @@ export function useManualOvertimeMovementDialog({
 }: UseManualOvertimeMovementDialogProps): UseManualOvertimeMovementDialogResult {
   const mutation = useCreateManualOvertimeMovement(employee?.id ?? '')
 
-  const today = new Date().toISOString().slice(0, 10)
+  const businessDate = useBusinessDate()
+  const today = businessDate ?? todayDateCdmx()
 
   const form = useForm<ManualOvertimeMovementFormValues>({
     resolver: zodResolver(schema),
@@ -59,6 +63,16 @@ export function useManualOvertimeMovementDialog({
       reason: '',
     },
   })
+
+  // businessDate resolves asynchronously, later than the browser-clock
+  // fallback used for the initial defaultValues — keep date in sync while
+  // the user hasn't touched it.
+  useEffect(() => {
+    if (!form.getFieldState('date').isDirty) {
+      form.setValue('date', today)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [today])
 
   const handleSubmit = form.handleSubmit((values) => {
     if (!employee) return

--- a/code/webapp/src/components/employees/use-negotiated-extra-days.ts
+++ b/code/webapp/src/components/employees/use-negotiated-extra-days.ts
@@ -2,31 +2,28 @@ import { useMemo, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { negotiatedExtraDayApi } from '@/services/negotiated-extra-day-api'
 import type { ListExtraDaysFilters, NegotiatedExtraDay } from '@/types/negotiated-extra-day'
+import { todayDateCdmx } from '@/lib/datetime'
+import { addDays } from '@/lib/week'
+import { useBusinessDate } from '@/stores/clock.store'
 
-function monthBounds(): { monthStart: string; monthEnd: string } {
-  const now = new Date()
-  const y = now.getFullYear()
-  const m = String(now.getMonth() + 1).padStart(2, '0')
-  const lastDay = new Date(y, now.getMonth() + 1, 0).getDate()
+function monthBounds(today: string): { monthStart: string; monthEnd: string } {
+  const [y, m] = today.split('-') as [string, string]
+  const lastDay = new Date(Number(y), Number(m), 0).getDate()
   return {
     monthStart: `${y}-${m}-01`,
     monthEnd: `${y}-${m}-${String(lastDay).padStart(2, '0')}`,
   }
 }
 
-function tomorrowIso(): string {
-  const d = new Date()
-  d.setDate(d.getDate() + 1)
-  return [
-    d.getFullYear(),
-    String(d.getMonth() + 1).padStart(2, '0'),
-    String(d.getDate()).padStart(2, '0'),
-  ].join('-')
+function tomorrowIso(today: string): string {
+  return addDays(today, 1)
 }
 
 export function useNegotiatedExtraDays(employeeId: string) {
-  const { monthStart, monthEnd } = useMemo(monthBounds, [])
-  const tomorrow = useMemo(tomorrowIso, [])
+  const businessDate = useBusinessDate()
+  const today = businessDate ?? todayDateCdmx()
+  const { monthStart, monthEnd } = useMemo(() => monthBounds(today), [today])
+  const tomorrow = useMemo(() => tomorrowIso(today), [today])
 
   const [showHistory, setShowHistory] = useState(false)
   const [historyFilters, setHistoryFilters] = useState<ListExtraDaysFilters>({})

--- a/code/webapp/src/components/employees/use-override-scope-dialog.ts
+++ b/code/webapp/src/components/employees/use-override-scope-dialog.ts
@@ -4,20 +4,20 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import type { OverrideScope } from './use-create-day-override'
 import type { ScheduleDayOverride } from '@/types/schedule'
+import { todayDateCdmx } from '@/lib/datetime'
+import { addDays } from '@/lib/week'
+import { useApplicationClockStore } from '@/stores/clock.store'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-/** Returns the next calendar date (local) that falls on the given ISO day-of-week (1=Mon … 7=Sun). */
+/** Returns the next calendar date (business tz, honours simulated time) that falls on the given ISO day-of-week (1=Mon … 7=Sun). */
 export function nextDateForDow(dow: number): string {
   const jsTarget = dow === 7 ? 0 : dow
-  const today = new Date()
-  const daysAhead = (jsTarget - today.getDay() + 7) % 7 // 0 = today, >0 = next occurrence
-  const result = new Date(today)
-  result.setDate(today.getDate() + daysAhead)
-  const y = result.getFullYear()
-  const m = String(result.getMonth() + 1).padStart(2, '0')
-  const d = String(result.getDate()).padStart(2, '0')
-  return `${y}-${m}-${d}`
+  const businessDate = useApplicationClockStore.getState().clockState?.business_date
+  const today = businessDate ?? todayDateCdmx()
+  const todayDow = new Date(today + 'T00:00:00').getDay()
+  const daysAhead = (jsTarget - todayDow + 7) % 7 // 0 = today, >0 = next occurrence
+  return addDays(today, daysAhead)
 }
 
 /**

--- a/code/webapp/src/components/employees/use-rehire-form.ts
+++ b/code/webapp/src/components/employees/use-rehire-form.ts
@@ -1,8 +1,10 @@
-import { useMemo } from 'react'
+import { useMemo, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { useAuthStore } from '@/stores/auth.store'
+import { todayDateCdmx } from '@/lib/datetime'
+import { useBusinessDate } from '@/stores/clock.store'
 
 // ─── Schema factory ───────────────────────────────────────────────────────────
 // Built at call time so `today` is always the current date, even if the app
@@ -29,8 +31,9 @@ export type RehireFormValues = z.infer<ReturnType<typeof buildRehireSchema>>
  * in the view so it can be tested independently of the rendering layer.
  */
 export function useRehireForm() {
+  const businessDate = useBusinessDate()
   // Computed at mount time — fresh per form instance, never stale across midnight.
-  const today = useMemo(() => new Date().toISOString().slice(0, 10), [])
+  const today = useMemo(() => businessDate ?? todayDateCdmx(), [businessDate])
   const schema = useMemo(() => buildRehireSchema(today), [today])
 
   // Use currentBranch or fall back to the first (and only) available branch.
@@ -44,6 +47,18 @@ export function useRehireForm() {
       start_date: today,
     },
   })
+
+  // `today` can change after mount (businessDate resolves asynchronously,
+  // later than the browser-clock fallback used for the initial defaultValues)
+  // — keep start_date in sync while the user hasn't touched it, so an
+  // untouched field never ends up failing the "not in the future" check it
+  // was pre-filled to satisfy.
+  useEffect(() => {
+    if (!form.getFieldState('start_date').isDirty) {
+      form.setValue('start_date', today)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [today])
 
   return { form, today, effectiveBranch }
 }

--- a/code/webapp/src/components/employees/use-schedule-content.ts
+++ b/code/webapp/src/components/employees/use-schedule-content.ts
@@ -2,6 +2,8 @@ import type { EmployeeSchedule, ScheduleDayOverride } from '@/types/schedule'
 import { useCreateDayOverride } from './use-create-day-override'
 import { useWeeklyCalendar } from './use-weekly-calendar'
 import { calcDayHours } from './schedule-section-utils'
+import { todayDateCdmx } from '@/lib/datetime'
+import { useBusinessDate } from '@/stores/clock.store'
 
 export function useScheduleContent(
   schedule: EmployeeSchedule,
@@ -19,12 +21,12 @@ export function useScheduleContent(
 
   const sortedDays = [...(schedule.days ?? [])].sort((a, b) => a.day_of_week - b.day_of_week)
 
-  // Use the browser's local date so that late-evening sessions in Mexico don't
-  // accidentally roll over to UTC tomorrow when checking if an override is active.
-  const todayLocal = (() => {
-    const d = new Date()
-    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
-  })()
+  // Prefer the Application Clock store's business_date (honours simulated time,
+  // and avoids late-evening sessions in Mexico rolling over to UTC tomorrow);
+  // fall back to the browser clock (still business-timezone-formatted) only
+  // when the store hasn't loaded.
+  const businessDate = useBusinessDate()
+  const todayLocal = businessDate ?? todayDateCdmx()
 
   // Returns the most-recently-started indefinite override for a day-of-week that
   // has already taken effect. Sorting DESC by effective_from ensures we get the

--- a/code/webapp/src/components/employees/use-wage-form.ts
+++ b/code/webapp/src/components/employees/use-wage-form.ts
@@ -1,6 +1,8 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import type { CreateWageData } from '@/types/wage-history'
 import { calcularNetoDesdebruto, calcularBrutoDesdeNeto } from './use-wage-calculations'
+import { todayDateCdmx } from '@/lib/datetime'
+import { useBusinessDate } from '@/stores/clock.store'
 
 export type ActiveSalaryInput = 'bruto' | 'neto' | 'diario' | null
 
@@ -27,7 +29,8 @@ export interface WageFormActions {
 }
 
 export function useWageForm(): WageFormState & WageFormActions {
-    const today = new Date().toISOString().split('T')[0] ?? ''
+    const businessDate = useBusinessDate()
+    const today = businessDate ?? todayDateCdmx()
 
     const [formData, setFormData] = useState<CreateWageData>({
         hourly_rate: 0,
@@ -42,6 +45,7 @@ export function useWageForm(): WageFormState & WageFormActions {
     const [activeInput, setActiveInput] = useState<ActiveSalaryInput>(null)
     const [errors, setErrors] = useState<Partial<Record<keyof CreateWageData, string>>>({})
     const [weeklySalaryError, setWeeklySalaryError] = useState<string>('')
+    const effectiveFromTouchedRef = useRef(false)
 
     // ─── Handlers Sincronizados ────────────────────────────────────────────────
 
@@ -86,12 +90,22 @@ export function useWageForm(): WageFormState & WageFormActions {
     }, [])
 
     const handleEffectiveFromChange = useCallback((value: string) => {
+        effectiveFromTouchedRef.current = true
         setFormData((prev) => ({ ...prev, effective_from: value }))
     }, [])
 
     const handleNotesChange = useCallback((value: string) => {
         setFormData((prev) => ({ ...prev, notes: value }))
     }, [])
+
+    // businessDate resolves asynchronously, later than the browser-clock
+    // fallback used for the initial state — keep effective_from in sync
+    // while the user hasn't picked a date manually.
+    useEffect(() => {
+        if (!effectiveFromTouchedRef.current) {
+            setFormData((prev) => ({ ...prev, effective_from: today }))
+        }
+    }, [today])
 
     // ─── Actualizar hourly_rate cuando cambia bruto o horas ────────────────────
 

--- a/code/webapp/src/components/solicitudes/extra-day-request/use-extra-day-request-form.ts
+++ b/code/webapp/src/components/solicitudes/extra-day-request/use-extra-day-request-form.ts
@@ -3,15 +3,16 @@ import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useWageHistory } from '@/services/employee-hooks'
 import { useRequestExtraDay } from '@/services/employee-request-hooks'
+import { todayDateCdmx } from '@/lib/datetime'
+import { useApplicationClockStore } from '@/stores/clock.store'
 
 const extraDayRequestSchema = z.object({
   date: z
     .string()
     .min(1, 'La fecha es requerida')
     .refine((d) => {
-      const now = new Date()
-      const localToday = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`
-      return d > localToday
+      const businessDate = useApplicationClockStore.getState().clockState?.business_date
+      return d > (businessDate ?? todayDateCdmx())
     }, 'Solo se permiten fechas futuras'),
   prima_pct: z.number().min(0, 'Mínimo 0%').max(200, 'Máximo 200%'),
   notes: z.string().max(1000).optional(),

--- a/code/webapp/src/components/solicitudes/my-requests/request-status-card.tsx
+++ b/code/webapp/src/components/solicitudes/my-requests/request-status-card.tsx
@@ -4,6 +4,8 @@ import { Button } from '@/components/ui/button'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { cn } from '@/lib/utils'
 import { formatCurrency, formatDatesLabel, formatDayLabel } from '@/lib/format'
+import { todayDateCdmx } from '@/lib/datetime'
+import { useBusinessDate } from '@/stores/clock.store'
 import { useLeaveTypes } from '@/services/leave-hooks'
 import type { EmployeeRequest, ExtraDayPayload, LeavePayload, VacationPayload } from '@/types/employee-request'
 
@@ -35,15 +37,6 @@ const CANCEL_DESCRIPTIONS: Record<EmployeeRequest['type'], { approved: string; p
 function cancelDescription(type: EmployeeRequest['type'], status: EmployeeRequest['status']): string {
   const { approved, pending } = CANCEL_DESCRIPTIONS[type]
   return status === 'APPROVED' ? approved : pending
-}
-
-function todayIso(): string {
-  const d = new Date()
-  return [
-    d.getFullYear(),
-    String(d.getMonth() + 1).padStart(2, '0'),
-    String(d.getDate()).padStart(2, '0'),
-  ].join('-')
 }
 
 const STATUS_CONFIG = {
@@ -153,9 +146,10 @@ export function RequestStatusCard({ request, onCancel, isCancelling }: RequestSt
 
   const config = STATUS_CONFIG[request.status]
 
+  const businessDate = useBusinessDate()
   const cancellable =
     request.status === 'PENDING' ||
-    (request.status === 'APPROVED' && endDate >= todayIso())
+    (request.status === 'APPROVED' && endDate >= (businessDate ?? todayDateCdmx()))
 
   return (
     <>

--- a/code/webapp/src/components/ui/calendar-shared.ts
+++ b/code/webapp/src/components/ui/calendar-shared.ts
@@ -1,3 +1,5 @@
+import { todayDateCdmx } from '@/lib/datetime'
+
 export const MONTH_LABELS_FULL = [
   'Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio',
   'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre',
@@ -14,7 +16,7 @@ export function toIso(date: Date): string {
 }
 
 export function todayIso(): string {
-  return toIso(new Date())
+  return todayDateCdmx()
 }
 
 export function mondayFirstIndex(jsDay: number): number {

--- a/code/webapp/src/lib/week.ts
+++ b/code/webapp/src/lib/week.ts
@@ -18,7 +18,8 @@
  *    next month.
  */
 
-import { getFrontendTimezone } from './timezone'
+import { todayDateCdmx } from './datetime'
+import { useApplicationClockStore } from '@/stores/clock.store'
 
 const WEEK_START_DAY = Number.parseInt(import.meta.env.VITE_WEEK_START_DAY ?? '1', 10)
 
@@ -42,14 +43,14 @@ function toIsoDate(d: Date): string {
   return `${year}-${month}-${day}`
 }
 
-/** Today's date as observed in the business timezone — "YYYY-MM-DD". */
+/**
+ * Today's date as observed in the business timezone — "YYYY-MM-DD".
+ * Prefers the Application Clock store's `business_date` (honours simulated
+ * time) and falls back to the browser clock only when the store hasn't
+ * loaded yet.
+ */
 function todayInBusinessTz(): string {
-  return new Intl.DateTimeFormat('en-CA', {
-    timeZone: getFrontendTimezone(),
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  }).format(new Date())
+  return useApplicationClockStore.getState().clockState?.business_date ?? todayDateCdmx()
 }
 
 /** Shifts a `YYYY-MM-DD` date string by `n` days (negative to go back). */

--- a/code/webapp/src/pages/attendance/config/holidays.tsx
+++ b/code/webapp/src/pages/attendance/config/holidays.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
 import { Pencil, Trash2, Plus, AlertTriangle } from 'lucide-react'
 import { requirePermission } from '@/lib/route-guards'
@@ -16,6 +16,8 @@ import {
   type HolidayFormValues,
 } from './use-holiday-management'
 import type { Holiday, HolidayType } from '@/types/attendance-payroll'
+import { todayDateCdmx } from '@/lib/datetime'
+import { useBusinessDate } from '@/stores/clock.store'
 
 export const Route = createFileRoute('/attendance/config/holidays')({
   beforeLoad: requirePermission('holidays.manage'),
@@ -23,9 +25,6 @@ export const Route = createFileRoute('/attendance/config/holidays')({
 })
 
 // ── Constants ─────────────────────────────────────────────────────────────────
-
-const CURRENT_YEAR = new Date().getFullYear()
-const YEAR_OPTIONS = [CURRENT_YEAR - 1, CURRENT_YEAR, CURRENT_YEAR + 1]
 
 const MONTH_NAMES = [
   'Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio',
@@ -442,7 +441,26 @@ function EditHolidayForm({
 // ── Page ──────────────────────────────────────────────────────────────────────
 
 function HolidaysPage() {
-  const [selectedYear, setSelectedYear] = useState<number>(CURRENT_YEAR)
+  const businessDate = useBusinessDate()
+  const currentYear = Number((businessDate ?? todayDateCdmx()).slice(0, 4))
+  const yearOptions = [currentYear - 1, currentYear, currentYear + 1]
+  const [selectedYear, setSelectedYear] = useState<number>(currentYear)
+
+  // businessDate resolves asynchronously (after login) and can land on a
+  // different year than the browser-clock fallback used for the very first
+  // render, leaving selectedYear pointing outside the recomputed yearOptions.
+  // Re-sync only when selectedYear still equals the last value *we* set it
+  // to — if the user picked a year themselves (via the <select> below) in
+  // the meantime, selectedYear no longer matches and this leaves it alone,
+  // even across later clock changes (e.g. the devtools clock simulator).
+  const lastAutoYearRef = useRef(currentYear)
+  useEffect(() => {
+    if (selectedYear === lastAutoYearRef.current && currentYear !== lastAutoYearRef.current) {
+      setSelectedYear(currentYear)
+    }
+    lastAutoYearRef.current = currentYear
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentYear])
 
   const {
     holidays,
@@ -543,7 +561,7 @@ function HolidaysPage() {
             onChange={(e) => setSelectedYear(Number(e.target.value))}
             className="border rounded px-3 py-1.5 text-sm bg-background"
           >
-            {YEAR_OPTIONS.map((y) => (
+            {yearOptions.map((y) => (
               <option key={y} value={y}>
                 {y}
               </option>

--- a/code/webapp/src/stores/clock.store.ts
+++ b/code/webapp/src/stores/clock.store.ts
@@ -1,3 +1,4 @@
+import { useEffect, useMemo, useState } from 'react';
 import { create } from 'zustand';
 import {
     getClock,
@@ -159,6 +160,35 @@ export const useApplicationClockStore = create<ApplicationClockStore>((set) => (
  */
 export function useApplicationNow(): string | null {
     return useApplicationClockStore(selectApplicationNowUtc);
+}
+
+const APPLICATION_NOW_TICK_MS = 30_000;
+
+/**
+ * Hook to get the current application time as epoch milliseconds, ticking
+ * locally between server refreshes instead of freezing at the snapshot
+ * captured when the clock was last fetched (e.g. right after login).
+ */
+export function useApplicationNowMs(): number {
+    const applicationNowUtc = useApplicationClockStore(selectApplicationNowUtc);
+    const [tick, setTick] = useState(0);
+
+    useEffect(() => {
+        // Ticks unconditionally — including while applicationNowUtc is null
+        // (clock feature disabled / not yet fetched) — so the Date.now()
+        // fallback below keeps advancing instead of freezing at first render.
+        const interval = setInterval(() => setTick((t) => t + 1), APPLICATION_NOW_TICK_MS);
+        return () => clearInterval(interval);
+    }, []);
+
+    return useMemo(() => {
+        if (!applicationNowUtc) return Date.now();
+        const lastFetched = useApplicationClockStore.getState().lastFetched;
+        const snapshotMs = new Date(applicationNowUtc).getTime();
+        const elapsedMs = lastFetched ? Date.now() - lastFetched.getTime() : 0;
+        return snapshotMs + elapsedMs;
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [applicationNowUtc, tick]);
 }
 
 /**

--- a/scripts/lint-clock-usage.sh
+++ b/scripts/lint-clock-usage.sh
@@ -107,9 +107,11 @@ for forbidden in "${FRONTEND_FORBIDDEN_PATTERNS[@]}"; do
     
     if [[ -n "${filtered// }" ]]; then
         echo -e "${YELLOW}⚠️  Found pattern that may need review: $forbidden${NC}"
-        echo "$filtered" | while read -r line; do
-            [[ -n "$line" ]] && echo "   $line"
-        done
+        while IFS= read -r line; do
+            if [[ -n "$line" ]]; then
+                echo "   $line"
+            fi
+        done <<< "$filtered"
         echo "   → If this is for display/formatting, it's OK. If for business logic, use ApplicationClock."
     fi
 done


### PR DESCRIPTION
## Summary
Closes #360
Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/409

- 🕐 Injected `ApplicationClock` into every backend Action/Service/Controller in `app/Actions`, `app/Services` and `app/Http/Controllers` that still called `now()` directly (Leave/Vacation guard traits, Cash Adjustments, Inventory, PayPeriods, Holidays, Employee Requests, manual overtime, payroll seeder)
- 🕐 Routed every frontend business-decision date default (form defaults, "is future/cancellable" checks, schedule override resolution, bonus/wage effective windows, month/day range anchors) through `todayDateCdmx()` or the Application Clock store instead of ad hoc `new Date()` reads
- 🐛 Fixed a pre-existing bug in `scripts/lint-clock-usage.sh` that made it exit early (before printing the `new Date()` section or the final summary) the moment the `Date.now()` pattern had any match — see `## 🤔 Assumptions` below
- ✅ Left the intentional exceptions the issue itself called out untouched (`use-weekly-calendar.ts`, devtools widgets, id generation, the dev-only payroll seeding tool, `isCloseGateOpen`'s store-then-fallback default param)

## Manual Testing

**Lint script:**
```bash
bash scripts/lint-clock-usage.sh
echo $?   # expect 0
```
Expect `✅ No forbidden clock usage patterns found in business code.` — the script now also completes and prints its `new Date()` section instead of aborting after `Date.now()`.

**Backend — simulated clock now flows into business timestamps:**
1. Log in as `admin@sushigo.com`, open the dev-debugger clock panel, set a simulated date.
2. Approve/reject a Vacation request or a direct Leave for an employee.
3. Confirm the persisted `approved_at` reflects the simulated time (not the real system clock) — e.g. via the request's detail view or `GET /api/v1/vacation-requests/{id}`.

**Frontend — business "today" respects the same clock:**
1. With the clock still simulated, open "Solicitudes" → "Mis solicitudes" for an employee with an APPROVED request whose date is right at the simulated-vs-real "today" boundary.
2. Confirm the "Cancelar" button's enabled/disabled state matches the *simulated* date, not the browser's real date.
3. Reset the clock to system mode when done.

## 🤔 Assumptions

- **Script scope vs. Objective wording:** the issue's Acceptance Criteria says "All backend **Actions/Services** inject `ApplicationClock`", but `scripts/lint-clock-usage.sh` also greps `app/Http/Controllers`, and the Objective ties completion to that script reporting zero violations. Took the literal/broader reading (per the zero-interruption rule's fallback) and migrated the 6 Controllers the script flags too, not just Actions/Services.
- **`now()` used for manual `created_at`/`updated_at` bulk inserts:** `doc/conventions/backend/application-clock.md` allows `now()` for "technical timestamps" like `created_at`/`updated_at`, but the lint script doesn't distinguish those from business timestamps — it flags any `now()` in the scanned directories. Since the Objective is explicitly "zero violations reported by `scripts/lint-clock-usage.sh`", migrated these too (`LeaveGuards::persistLeaveDates`, `VacationRequestGuards::persistVacationRequestDates`, `PayrollSeedService::buildRows`). `$clock->nowUtc()` is a safe drop-in for `now()` here (same value in system mode, and arguably more correct under a simulated clock for audit-trail consistency).
- **`scripts/lint-clock-usage.sh` bug fix:** the script's frontend "may need review" printer aborted the whole script (via `set -euo pipefail` + a bare `&&` losing its exit status on a trailing empty line) as soon as the `Date.now()` pattern had any match — which it always does, since several matches in this codebase are legitimate (devtools widgets, id generation). This meant the script could never reach its own "no violations" summary or even print the `new Date()` section. Fixed as a one-line change to the loop's exit-status handling; verified the script exits 0 and shows the intended output.
- **Holidays "current year" defaults (`ListHolidaysController`, `Create`/`UpdateHolidayDefinitionController`):** treated `now()->year` as a business decision (which year's holidays to lazily generate/default to) rather than a technical timestamp, so migrated to `$clock->nowInBusinessTz()->year`.
- **`pages/attendance/config/holidays.tsx`'s `CURRENT_YEAR`:** treated as business logic (mirrors the backend's own "current year" default for the same Holidays feature) and migrated to `todayDateCdmx()`-derived year, even though it wasn't in the issue's original file list.
- **Left untouched as legitimate exceptions:** `use-weekly-calendar.ts` (issue explicitly blessed this one), `components/dev/page-actions/payroll-close-actions.tsx` (dev-only payroll seeding tool default, not a production business decision), `DigitalClock.tsx` / `use-dev-debugger.ts` (devtools widgets that legitimately need real wall-clock elapsed time), `toast-provider.tsx` (`Date.now()` used only for a unique id, not a timestamp decision), and `lib/week.ts`'s `isCloseGateOpen` default param (already an established store-then-fallback pattern, documented as intentionally independent of the simulated clock).

## Test plan
- [x] PHPUnit: full suite — 1511 passed
- [x] Vitest: full suite — 3620 passed (246 files)
- [x] Linters: Pint ✅ · ESLint ✅ (0 errors) · TypeScript ✅
- [x] `scripts/lint-clock-usage.sh` — exits 0, 0 violations

## Workspace
`sushigo-e` — `refactor/360-migrate-clock-usage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
