### PR TITLE
🔨 [#410][d] - Build the attendance card exit animation on the confirmed-state foundation 🎬

### DIFF
--- a/code/webapp/cypress/e2e/attendance-card-exit-animation.cy.ts
+++ b/code/webapp/cypress/e2e/attendance-card-exit-animation.cy.ts
@@ -1,0 +1,132 @@
+/**
+ * Attendance Card Exit Animation — E2E happy-path tests
+ *
+ * Covers the fade/slide-out animation + grid reflow that plays when an
+ * action (check-in, mark-falta) moves an employee's card out of the
+ * currently active tab. Existing specs (attendance-checkin.cy.ts,
+ * attendance-day-status.cy.ts) force the "Total" tab in their setup, which
+ * means a card never actually needs to leave the grid there — this spec
+ * deliberately stays on the default "Pendientes" tab so the exit path is
+ * genuinely exercised.
+ *
+ * DB reset strategy
+ * ─────────────────
+ * • before()     → cy.task('test:reset', 'attendance') ONCE per file.
+ * • beforeEach() → login via API + navigate to /attendance.
+ * • Each it() uses a DIFFERENT employee — no slot is reused.
+ *
+ * Employees used (EMP-001..EMP-008 seeded via config/seeders.php):
+ *   EMP-001  Mendoza, Carlos   → check-in, leaves "Pendientes"
+ *   EMP-002  García, María     → mark-falta, leaves "Pendientes"
+ *
+ * The date-switch-mid-mutation race (a stale response landing after the
+ * manager already switched dates) is deliberately NOT covered here — per
+ * this repo's testing strategy (CLAUDE.md § Testing Strategy, and
+ * doc/conventions/testing/testing-strategy.md Layer 3), Cypress is reserved
+ * for happy-path E2E only; edge cases/race conditions belong in Vitest. See
+ * "does not animate an unrelated card on the newly selected date if the
+ * manager switches dates while a check-in is still in flight" in
+ * use-today-attendance-page.test.ts for that coverage.
+ *
+ * Para correr solo este archivo:
+ *   make cypress-spec SPEC=attendance-card-exit-animation
+ */
+
+import users from "../fixtures/users.json";
+
+const { email: adminEmail, password: adminPassword } = users.admin;
+
+// ── Suite setup ─────────────────────────────────────────────────────────────
+
+before(() => {
+  cy.task("test:reset", "attendance", { timeout: 60_000 });
+});
+
+// Test time: 14:30 CDMX
+const TEST_TIME_ISO = "2026-04-02T14:30:00-06:00";
+const TEST_TIME_UTC = new Date("2026-04-02T20:30:00Z");
+
+beforeEach(() => {
+  cy.intercept({ url: /\/api\/v1\// }, (req) => {
+    req.headers["X-Test-Time"] = TEST_TIME_ISO;
+    req.continue();
+  }).as("apiWithTestTime");
+
+  cy.loginByApi(adminEmail, adminPassword);
+  cy.visitWithAuth("/attendance");
+  cy.url().should("include", "/attendance", { timeout: 10_000 });
+  cy.closeDevDebugger();
+
+  cy.clock(TEST_TIME_UTC.getTime(), ["Date"]);
+
+  // Deliberately do NOT force the "Total" tab here — the smart default lands
+  // on "Pendientes", which is exactly the tab an action needs to move a card
+  // OUT of for the exit animation to be observable.
+  cy.contains("[data-testid^='stat-']", "Pendientes", { timeout: 10_000 }).should("be.visible");
+});
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function getCard(lastName: string, firstName: string) {
+  return cy
+    .contains("p", `${lastName}, ${firstName}`, { timeout: 10_000 })
+    .closest("div.rounded-xl")
+    .scrollIntoView();
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// 1. Check-in moves the card out of "Pendientes"
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe("Card exit animation — check-in", () => {
+  it("removes Carlos from Pendientes after check-in, and shows him under En trabajo", () => {
+    cy.intercept("GET", "**/attendances/today*").as("refetchAttendance");
+
+    getCard("Mendoza", "Carlos")
+      .contains("button", "Registrar entrada")
+      .click({ force: true });
+
+    cy.get("#checkin-time").clear({ force: true }).type("13:00", { force: true });
+    cy.contains("button", "Confirmar entrada").should("not.be.disabled").click();
+    cy.wait("@refetchAttendance", { timeout: 10_000 });
+
+    // Card leaves the "Pendientes" tab once the exit animation finishes.
+    cy.contains("p", "Mendoza, Carlos", { timeout: 10_000 }).should("not.exist");
+
+    // Reappears, checked in, under "En trabajo".
+    cy.contains("[data-testid^='stat-']", "En trabajo").click({ force: true });
+    getCard("Mendoza", "Carlos").within(() => {
+      cy.contains("En trabajo", { timeout: 10_000 }).should("be.visible");
+    });
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════════
+// 2. Mark-falta (decline justify-now) moves the card out of "Pendientes"
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe("Card exit animation — mark-falta", () => {
+  it("removes María from Pendientes after marking falta, and shows her under Ausentes", () => {
+    cy.intercept("GET", "**/attendances/today*").as("refetchAttendance");
+
+    getCard("García", "María")
+      .find("[data-testid='btn-mark-falta']")
+      .click({ force: true });
+
+    cy.contains("¿Confirmar falta?").should("be.visible");
+    cy.contains("button", "Confirmar falta").click({ force: true });
+    cy.wait("@refetchAttendance", { timeout: 10_000 });
+
+    cy.contains("¿Deseas justificar la falta ahora?", { timeout: 10_000 }).should("be.visible");
+    cy.contains("button", "Ahora no").click({ force: true });
+
+    // Card leaves "Pendientes" once the exit animation finishes.
+    cy.contains("p", "García, María", { timeout: 10_000 }).should("not.exist");
+
+    // Reappears, marked as Falta, under "Ausentes".
+    cy.contains("[data-testid^='stat-']", "Ausentes").click({ force: true });
+    getCard("García", "María").within(() => {
+      cy.contains("Falta", { timeout: 10_000 }).should("be.visible");
+    });
+  });
+});

--- a/code/webapp/src/components/attendance/AttendanceStates.tsx
+++ b/code/webapp/src/components/attendance/AttendanceStates.tsx
@@ -74,15 +74,21 @@ interface SkeletonGridProps {
 // Stable keys generated once at module load - avoids array index as key
 const SKELETON_KEYS = Array.from({ length: 20 }, (_, i) => `skeleton-${i}`)
 
+// Shares `.attendance-grid-container`/`.attendance-card-grid` (index.css) with
+// the real card grid (attendance/index.tsx) so both agree on column count for
+// the same available width — a mismatch here would make the page jump columns
+// the instant loading data replaces these placeholders.
 export function SkeletonGrid({ count = 6 }: Readonly<SkeletonGridProps>) {
     return (
-        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-            {SKELETON_KEYS.slice(0, count).map((key) => (
-                <div
-                    key={key}
-                    className="rounded-xl border bg-card p-4 h-36 animate-pulse bg-muted/30"
-                />
-            ))}
+        <div className="attendance-grid-container">
+            <div className="attendance-card-grid">
+                {SKELETON_KEYS.slice(0, count).map((key) => (
+                    <div
+                        key={key}
+                        className="rounded-xl border bg-card p-4 h-36 animate-pulse bg-muted/30"
+                    />
+                ))}
+            </div>
         </div>
     )
 }

--- a/code/webapp/src/components/attendance/EmployeeAttendanceCard.tsx
+++ b/code/webapp/src/components/attendance/EmployeeAttendanceCard.tsx
@@ -14,6 +14,7 @@ import {
     BarChart3,
     History,
     Pencil,
+    Loader2,
 } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -329,7 +330,11 @@ export interface EmployeeAttendanceCardProps {
     onLunchReturn: (employee: TodayAttendanceEmployee, attendanceId: string, currentValue?: string | null) => void
     onCheckOut: (employee: TodayAttendanceEmployee, attendanceId: string, currentValue?: string | null) => void
     onOvertimeDecision: (employee: TodayAttendanceEmployee, attendanceId: string) => void
-    onMarkDayStatus: (employee: TodayAttendanceEmployee, status: 'ABSENCE') => void
+    /** Resolves once the mutation succeeds, false on failure — confirmFalta in
+     *  use-employee-attendance-card.ts awaits this before opening the justify-now?
+     *  dialog, so a failed mutation never walks the card through the exit-animation
+     *  flow toward a bucket it never actually reached. */
+    onMarkDayStatus: (employee: TodayAttendanceEmployee, status: 'ABSENCE') => Promise<boolean>
     onWeeklySummary?: (employee: TodayAttendanceEmployee) => void
     onViewAudit?: (employee: TodayAttendanceEmployee, attendanceId: string) => void
     /** Called once the mark-falta flow concludes (justified now or declined), so the
@@ -337,6 +342,13 @@ export interface EmployeeAttendanceCardProps {
     onFaltaFlowComplete?: (employeeId: string) => void
     /** True while the card is playing its exit animation before leaving the grid. */
     isExiting?: boolean
+    /** True while THIS employee's markDayStatus mutation is in flight — scoped per
+     *  card (not the mutation's own page-wide isPending) since two absence writes for
+     *  different employees can genuinely overlap. Disables both "Registrar entrada"
+     *  and "Marcar falta" (either could race the in-flight day-status write for this
+     *  employee) and shows a spinner on "Marcar falta" so the manager isn't left with
+     *  no feedback while the request is in flight. */
+    isMarkingDayStatus?: boolean
     canEdit?: boolean
     /** True when the user may correct an already-recorded event (canEdit + attendances.update permission). */
     canCorrect?: boolean
@@ -354,6 +366,7 @@ export function EmployeeAttendanceCard({
     onViewAudit,
     onFaltaFlowComplete,
     isExiting = false,
+    isMarkingDayStatus = false,
     canEdit = true,
     canCorrect = false,
 }: Readonly<EmployeeAttendanceCardProps>) {
@@ -396,6 +409,7 @@ export function EmployeeAttendanceCard({
                     size="sm"
                     className="w-full"
                     onClick={() => onCheckIn(row)}
+                    disabled={isMarkingDayStatus}
                 >
                     <LogIn className="h-3.5 w-3.5 mr-1.5" />
                     Registrar entrada
@@ -407,8 +421,11 @@ export function EmployeeAttendanceCard({
                         className="w-full"
                         data-testid="btn-mark-falta"
                         onClick={openConfirmFalta}
+                        disabled={isMarkingDayStatus}
                     >
-                        <UserX className="h-3.5 w-3.5 mr-1.5" />
+                        {isMarkingDayStatus
+                            ? <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+                            : <UserX className="h-3.5 w-3.5 mr-1.5" />}
                         Marcar falta
                     </Button>
                 )}

--- a/code/webapp/src/components/attendance/__tests__/AttendanceStates.test.tsx
+++ b/code/webapp/src/components/attendance/__tests__/AttendanceStates.test.tsx
@@ -119,17 +119,20 @@ describe('SkeletonGrid', () => {
     it('renders in a grid layout', () => {
         const { container } = render(<SkeletonGrid />)
 
-        const grid = container.firstChild as HTMLElement
-        expect(grid?.className).toContain('grid')
-        expect(grid?.className).toContain('gap-3')
+        const grid = container.querySelector('.attendance-card-grid') as HTMLElement
+        expect(grid).not.toBeNull()
     })
 
-    it('is responsive with grid columns', () => {
+    it('shares the real card grid\'s container-query column rules, not viewport breakpoints', () => {
         const { container } = render(<SkeletonGrid />)
 
-        const grid = container.firstChild as HTMLElement
-        expect(grid?.className).toContain('sm:grid-cols-2')
-        expect(grid?.className).toContain('lg:grid-cols-3')
-        expect(grid?.className).toContain('xl:grid-cols-4')
+        // Guards against the loading and loaded grids disagreeing on column count
+        // for the same width — see the comment on SkeletonGrid in AttendanceStates.tsx.
+        expect(container.querySelector('.attendance-grid-container')).not.toBeNull()
+        expect(container.querySelector('.attendance-card-grid')).not.toBeNull()
+        const grid = container.querySelector('.attendance-card-grid') as HTMLElement
+        expect(grid.className).not.toContain('sm:grid-cols-2')
+        expect(grid.className).not.toContain('lg:grid-cols-3')
+        expect(grid.className).not.toContain('xl:grid-cols-4')
     })
 })

--- a/code/webapp/src/components/attendance/__tests__/EmployeeAttendanceCard.test.tsx
+++ b/code/webapp/src/components/attendance/__tests__/EmployeeAttendanceCard.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { render, cleanup, fireEvent, act } from '@testing-library/react'
+import { render, cleanup, fireEvent, act, waitFor } from '@testing-library/react'
 import type { TodayAttendanceEmployee } from '@/types/attendance'
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
@@ -288,7 +288,7 @@ const defaultProps = {
     onLunchReturn: vi.fn(),
     onCheckOut: vi.fn(),
     onOvertimeDecision: vi.fn(),
-    onMarkDayStatus: vi.fn(),
+    onMarkDayStatus: vi.fn().mockResolvedValue(true),
 }
 
 describe('EmployeeAttendanceCard', () => {
@@ -376,7 +376,7 @@ describe('EmployeeAttendanceCard', () => {
     })
 
     it('calls onMarkDayStatus with ABSENCE when confirm dialog is confirmed', () => {
-        const onMarkDayStatus = vi.fn()
+        const onMarkDayStatus = vi.fn().mockResolvedValue(true)
         const { getByTestId, getByText } = render(
             <EmployeeAttendanceCard {...defaultProps} onMarkDayStatus={onMarkDayStatus} />
         )
@@ -388,7 +388,7 @@ describe('EmployeeAttendanceCard', () => {
     })
 
     it('does NOT call onMarkDayStatus when confirm dialog is cancelled', () => {
-        const onMarkDayStatus = vi.fn()
+        const onMarkDayStatus = vi.fn().mockResolvedValue(true)
         const { getByTestId, getByText } = render(
             <EmployeeAttendanceCard {...defaultProps} onMarkDayStatus={onMarkDayStatus} />
         )
@@ -399,20 +399,23 @@ describe('EmployeeAttendanceCard', () => {
         expect(onMarkDayStatus).not.toHaveBeenCalled()
     })
 
-    it('asks whether to justify the falta right after confirming it', () => {
-        const { getByTestId, getByText } = render(<EmployeeAttendanceCard {...defaultProps} />)
+    it('asks whether to justify the falta right after confirming it', async () => {
+        const { getByTestId, getByText, findByText } = render(<EmployeeAttendanceCard {...defaultProps} />)
 
         fireEvent.click(getByTestId('btn-mark-falta'))
         fireEvent.click(getByText('Confirmar falta'))
 
-        expect(getByText('¿Deseas justificar la falta ahora?')).toBeDefined()
+        // confirmFalta now awaits onMarkDayStatus before opening this dialog
+        // (gates it on success — see use-employee-attendance-card.ts)
+        expect(await findByText('¿Deseas justificar la falta ahora?')).toBeDefined()
     })
 
-    it('opens RegisterLeaveDialog when choosing to justify the falta right away', () => {
-        const { getByTestId, getByText } = render(<EmployeeAttendanceCard {...defaultProps} />)
+    it('opens RegisterLeaveDialog when choosing to justify the falta right away', async () => {
+        const { getByTestId, getByText, findByText } = render(<EmployeeAttendanceCard {...defaultProps} />)
 
         fireEvent.click(getByTestId('btn-mark-falta'))
         fireEvent.click(getByText('Confirmar falta'))
+        await findByText('¿Deseas justificar la falta ahora?')
         fireEvent.click(getByText('Justificar ahora'))
 
         expect(mockRegisterLeaveDialog).toHaveBeenLastCalledWith(
@@ -420,27 +423,29 @@ describe('EmployeeAttendanceCard', () => {
         )
     })
 
-    it('calls onFaltaFlowComplete when declining to justify the falta right away', () => {
+    it('calls onFaltaFlowComplete when declining to justify the falta right away', async () => {
         const onFaltaFlowComplete = vi.fn()
-        const { getByTestId, getByText } = render(
+        const { getByTestId, getByText, findByText } = render(
             <EmployeeAttendanceCard {...defaultProps} onFaltaFlowComplete={onFaltaFlowComplete} />
         )
 
         fireEvent.click(getByTestId('btn-mark-falta'))
         fireEvent.click(getByText('Confirmar falta'))
+        await findByText('¿Deseas justificar la falta ahora?')
         fireEvent.click(getByText('Ahora no'))
 
         expect(onFaltaFlowComplete).toHaveBeenCalledWith(mockRow.employee.id)
     })
 
-    it('calls onFaltaFlowComplete when RegisterLeaveDialog closes', () => {
+    it('calls onFaltaFlowComplete when RegisterLeaveDialog closes', async () => {
         const onFaltaFlowComplete = vi.fn()
-        const { getByTestId, getByText } = render(
+        const { getByTestId, getByText, findByText } = render(
             <EmployeeAttendanceCard {...defaultProps} onFaltaFlowComplete={onFaltaFlowComplete} />
         )
 
         fireEvent.click(getByTestId('btn-mark-falta'))
         fireEvent.click(getByText('Confirmar falta'))
+        await findByText('¿Deseas justificar la falta ahora?')
         fireEvent.click(getByText('Justificar ahora'))
 
         const calls = mockRegisterLeaveDialog.mock.calls
@@ -745,6 +750,55 @@ describe('EmployeeAttendanceCard', () => {
         const { container } = render(<EmployeeAttendanceCard {...defaultProps} />)
         const root = container.firstChild as HTMLElement
         expect(root.className).not.toContain('animate-card-exit')
+    })
+
+    // ── isMarkingDayStatus (per-employee busy state) ──────────────────────────────
+
+    it('disables both "Registrar entrada" and "Marcar falta" while isMarkingDayStatus is true', () => {
+        const { getByText, getByTestId } = render(
+            <EmployeeAttendanceCard {...defaultProps} isMarkingDayStatus />
+        )
+        expect((getByText('Registrar entrada').closest('button') as HTMLButtonElement).disabled).toBe(true)
+        expect((getByTestId('btn-mark-falta') as HTMLButtonElement).disabled).toBe(true)
+    })
+
+    it('shows a spinner instead of the icon on "Marcar falta" while isMarkingDayStatus is true', () => {
+        const { getByTestId, queryByTestId } = render(
+            <EmployeeAttendanceCard {...defaultProps} isMarkingDayStatus />
+        )
+        expect(getByTestId('btn-mark-falta').querySelector('.animate-spin')).not.toBeNull()
+        expect(queryByTestId('btn-mark-falta')).toBeDefined()
+    })
+
+    it('neither button is disabled by default (isMarkingDayStatus defaults to false)', () => {
+        const { getByText, getByTestId } = render(<EmployeeAttendanceCard {...defaultProps} />)
+        expect((getByText('Registrar entrada').closest('button') as HTMLButtonElement).disabled).toBe(false)
+        expect((getByTestId('btn-mark-falta') as HTMLButtonElement).disabled).toBe(false)
+    })
+
+    it('confirmFalta only opens the justify-now? dialog when onMarkDayStatus resolves true', async () => {
+        const onMarkDayStatus = vi.fn().mockResolvedValue(true)
+        const { getByTestId, getByText, findByText } = render(
+            <EmployeeAttendanceCard {...defaultProps} onMarkDayStatus={onMarkDayStatus} />
+        )
+
+        fireEvent.click(getByTestId('btn-mark-falta'))
+        fireEvent.click(getByText('Confirmar falta'))
+
+        expect(await findByText('¿Deseas justificar la falta ahora?')).toBeDefined()
+    })
+
+    it('confirmFalta does not open the justify-now? dialog when onMarkDayStatus resolves false', async () => {
+        const onMarkDayStatus = vi.fn().mockResolvedValue(false)
+        const { getByTestId, getByText, queryByText } = render(
+            <EmployeeAttendanceCard {...defaultProps} onMarkDayStatus={onMarkDayStatus} />
+        )
+
+        fireEvent.click(getByTestId('btn-mark-falta'))
+        fireEvent.click(getByText('Confirmar falta'))
+
+        await waitFor(() => expect(onMarkDayStatus).toHaveBeenCalled())
+        expect(queryByText('¿Deseas justificar la falta ahora?')).toBeNull()
     })
 
     // ── Correction pencils (canCorrect) ─────────────────────────────────────────

--- a/code/webapp/src/components/attendance/use-employee-attendance-card.ts
+++ b/code/webapp/src/components/attendance/use-employee-attendance-card.ts
@@ -34,7 +34,7 @@ export interface EmployeeAttendanceCardState {
  */
 export function useEmployeeAttendanceCard(
   row: TodayAttendanceRow,
-  onMarkDayStatus: (employee: TodayAttendanceEmployee, status: 'ABSENCE') => void,
+  onMarkDayStatus: (employee: TodayAttendanceEmployee, status: 'ABSENCE') => Promise<boolean>,
   onFaltaFlowComplete?: (employeeId: string) => void,
 ): EmployeeAttendanceCardState {
   const phase = getAttendancePhase(row.attendance)
@@ -89,8 +89,16 @@ export function useEmployeeAttendanceCard(
     closeConfirmFalta: () => setConfirmFaltaOpen(false),
     confirmFalta: () => {
       setConfirmFaltaOpen(false)
-      onMarkDayStatus(row.employee, 'ABSENCE')
-      setAskJustifyOpen(true)
+      // Only open the justify-now? dialog once the mutation actually
+      // succeeds — a failure (e.g. a 422 because an Attendance record
+      // already exists for that date) must not walk the card through the
+      // justify-now? → exit-animation flow toward 'absent' when the row
+      // never actually landed there; the mutation's own onError already
+      // surfaces a toast, and the page-level markDayStatus already released
+      // the pin so the card doesn't stay stuck.
+      onMarkDayStatus(row.employee, 'ABSENCE').then((succeeded) => {
+        if (succeeded) setAskJustifyOpen(true)
+      })
     },
     askJustifyOpen,
     declineJustifyNow: () => {

--- a/code/webapp/src/index.css
+++ b/code/webapp/src/index.css
@@ -315,3 +315,42 @@
 .animate-card-exit {
     animation: card-exit 0.35s ease-in forwards;
 }
+
+/* ── Attendance card grid — container-query columns ─────────────────────
+   Tailwind's sm:/lg:/xl: prefixes respond to VIEWPORT width, not the actual
+   space this grid has available — which is viewport width minus the
+   sidebar (256px expanded, 80px collapsed, see Sidebar.tsx). That mismatch
+   made the grid jump to more columns than the real content area could fit
+   whenever the sidebar was expanded, overlapping cards in roughly the
+   1279–1490px viewport range. Container queries measure the grid's own
+   wrapper (.attendance-grid-container, given `container-type: inline-size`
+   in index.tsx) instead of the viewport, so the column count always
+   matches the space actually available — sidebar expanded or not — with
+   no need to track sidebar state in JS. */
+.attendance-grid-container {
+    container-type: inline-size;
+}
+
+.attendance-card-grid {
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+@container (min-width: 640px) {
+    .attendance-card-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@container (min-width: 1024px) {
+    .attendance-card-grid {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+}
+
+@container (min-width: 1490px) {
+    .attendance-card-grid {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+}

--- a/code/webapp/src/pages/attendance/-use-attendance-grid-flip.ts
+++ b/code/webapp/src/pages/attendance/-use-attendance-grid-flip.ts
@@ -1,0 +1,227 @@
+import { useCallback, useEffect, useLayoutEffect, useRef } from 'react'
+
+interface Position {
+  top: number
+  left: number
+}
+
+// Positions are measured relative to the grid's own container, not
+// "absolute" document coordinates. `getBoundingClientRect()` is always
+// viewport-relative, and the WINDOW itself never scrolls in this app's
+// layout — the root is `flex h-screen overflow-hidden` and the actual
+// scrolling happens inside `<main className="overflow-y-auto">` (see
+// components/layout/Layout.tsx). Adding window.scrollX/scrollY is a no-op
+// here, since it's always 0 — the real scroll offset lives on that `<main>`
+// panel's scrollTop/scrollLeft instead. Rather than coupling this hook to
+// which specific ancestor happens to scroll, measuring each card relative
+// to the grid CONTAINER sidesteps the problem entirely: every tracked card
+// scrolls together with its container (none of them scroll independently
+// relative to their siblings), so a card's position relative to the
+// container is unaffected by any ancestor's scroll offset — window, `main`,
+// or otherwise — and only changes when the grid's actual layout does.
+
+// getBoundingClientRect() on a card mid FLIP-transition (see
+// animatingEmployeeIds below) includes its in-progress CSS transform, which
+// would return an interpolated, not the true current CSS Grid layout
+// position. Reading the transform actually being rendered right now (via
+// getComputedStyle, not el.style — the specified target is already back to
+// identity while the transition is still interpolating toward it) and
+// subtracting it out yields the untransformed layout position without ever
+// touching the element's `transition`/`transform` inline styles — doing that
+// used to be how this measured, but assigning `transition: none` forces the
+// browser to cancel the running transition and jump straight to its target
+// value, snapping the card instead of letting it keep sliding.
+//
+// This hook was ported unchanged from a prior spike (9 review rounds, 0 open
+// bugs) — do not "simplify" the residual-translate folding or the
+// ResizeObserver initial-notification skip below; they look redundant but
+// each one closes a specific, previously-found bug (stale FLIP timers not
+// cancelled, residual in-flight translate dropped on rapid re-moves, the
+// measurement itself cancelling a card's own running transition,
+// window.scroll* instead of container-relative coordinates, and the
+// ResizeObserver's unconditional initial notification contaminating the
+// baseline). See the design-validation notes in the issue this hook shipped
+// under for the full list.
+function getCurrentTranslate(el: HTMLDivElement): Position {
+  const transform = getComputedStyle(el).transform
+  if (!transform || transform === 'none') return { top: 0, left: 0 }
+  const matrix = new DOMMatrix(transform)
+  return { top: matrix.m42, left: matrix.m41 }
+}
+
+function measurePositions(
+  cardRefs: Map<string, HTMLDivElement>,
+  container: HTMLElement | null,
+  animatingEmployeeIds: Set<string> = new Set(),
+): Map<string, Position> {
+  const positions = new Map<string, Position>()
+  if (!container) return positions
+  const containerRect = container.getBoundingClientRect()
+  cardRefs.forEach((el, employeeId) => {
+    const rect = el.getBoundingClientRect()
+    const translate = animatingEmployeeIds.has(employeeId) ? getCurrentTranslate(el) : { top: 0, left: 0 }
+    positions.set(employeeId, {
+      top: rect.top - containerRect.top - translate.top,
+      left: rect.left - containerRect.left - translate.left,
+    })
+  })
+  return positions
+}
+
+// CSS Grid recalculates item positions in a single discrete layout pass — when
+// a card leaves the grid (exit animation finishes, tab filter changes, etc.)
+// every card after it snaps straight to its new slot with no transition,
+// which reads as an abrupt jump. This hook FLIP-animates that reflow: after
+// each layout, every tracked card is instantly placed back at its OLD screen
+// position (no transition), then released to its real position on the next
+// frame with a transition — turning the snap into a fluid slide.
+export function useAttendanceGridFlip(orderedEmployeeIds: string[]) {
+  const cardRefs = useRef(new Map<string, HTMLDivElement>())
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const prevPositions = useRef(new Map<string, Position>())
+  // Employee ids whose card is currently mid FLIP-transition (between the
+  // inverted starting transform being applied and its 320ms transition
+  // finishing). getBoundingClientRect() includes any in-progress transform,
+  // so a ResizeObserver notification that lands in that window (e.g. a
+  // background refetch changing an UNRELATED card's content height) must
+  // not re-measure these — the layout effect already stored their correct
+  // target position when the animation started; overwriting it with a
+  // still-interpolating one would make the NEXT reflow animate from a
+  // visually wrong, transform-contaminated baseline.
+  const animatingEmployeeIds = useRef(new Set<string>())
+  // The timer that clears an employee out of animatingEmployeeIds, keyed by
+  // employee id. A card moved a second time before its FIRST timer fires
+  // gets a new 320ms transition, but the stale timer would otherwise still
+  // land mid-way through it and delete the id early — making the rest of
+  // this hook (and the ResizeObserver skip below) treat a still-animating
+  // card as settled. Tracked per id so the layout effect can cancel the
+  // stale one before scheduling the new one.
+  const animationTimers = useRef(new Map<string, ReturnType<typeof setTimeout>>())
+  // The requestAnimationFrame handle scheduled to release a card into its
+  // transition, keyed by employee id — tracked so it can be cancelled both
+  // on unmount (a queued frame fires on discarded elements otherwise, since
+  // rAF is not itself tied to component lifetime) and before scheduling a
+  // new one for the same card on a rapid second reflow (the same "stale
+  // timer" hazard animationTimers guards against, one step earlier).
+  const animationFrames = useRef(new Map<string, number>())
+
+  useEffect(() => {
+    const timers = animationTimers.current
+    const frames = animationFrames.current
+    return () => {
+      timers.forEach((timer) => clearTimeout(timer))
+      timers.clear()
+      frames.forEach((frameId) => cancelAnimationFrame(frameId))
+      frames.clear()
+    }
+  }, [])
+
+  const setCardRef = useCallback((employeeId: string) => (el: HTMLDivElement | null) => {
+    if (el) cardRefs.current.set(employeeId, el)
+    else cardRefs.current.delete(employeeId)
+  }, [])
+
+  const orderKey = orderedEmployeeIds.join('|')
+
+  useLayoutEffect(() => {
+    // A second reflow can start while a card from a PRIOR reflow is still
+    // mid-transition (e.g. two employees acted on within 320ms of each
+    // other) — passing animatingEmployeeIds subtracts those cards' in-progress
+    // transform before reading, so this reflow's baseline reflects their
+    // true current CSS Grid layout position, not an interpolated one.
+    const nextPositions = measurePositions(cardRefs.current, containerRef.current, animatingEmployeeIds.current)
+
+    nextPositions.forEach((position, employeeId) => {
+      const prevPosition = prevPositions.current.get(employeeId)
+      const el = cardRefs.current.get(employeeId)
+      if (!prevPosition || !el) return
+
+      const dx = prevPosition.left - position.left
+      const dy = prevPosition.top - position.top
+      if (Math.abs(dx) < 1 && Math.abs(dy) < 1) return
+
+      // If this card is already mid FLIP-transition from a PRIOR move, dx/dy
+      // above (pure layout delta) only accounts for where its box moved TO —
+      // not where it is currently painted, which still carries a residual
+      // translate left over from that earlier transition. Starting the new
+      // invert from dx/dy alone would jump the card to prevPosition before
+      // sliding again; folding the residual translate back in keeps the
+      // start of this new slide continuous with wherever it visually is
+      // right now.
+      const residual = animatingEmployeeIds.current.has(employeeId) ? getCurrentTranslate(el) : { top: 0, left: 0 }
+      const startDx = dx + residual.left
+      const startDy = dy + residual.top
+
+      const staleTimer = animationTimers.current.get(employeeId)
+      if (staleTimer !== undefined) clearTimeout(staleTimer)
+      const staleFrame = animationFrames.current.get(employeeId)
+      if (staleFrame !== undefined) cancelAnimationFrame(staleFrame)
+
+      animatingEmployeeIds.current.add(employeeId)
+
+      el.style.transition = 'none'
+      el.style.transform = `translate(${startDx}px, ${startDy}px)`
+      el.getBoundingClientRect() // force reflow so the inverted position paints before the transition is re-enabled
+
+      const frameId = requestAnimationFrame(() => {
+        animationFrames.current.delete(employeeId)
+        el.style.transition = 'transform 320ms cubic-bezier(0.22, 1, 0.36, 1)'
+        el.style.transform = ''
+        const timer = setTimeout(() => {
+          animatingEmployeeIds.current.delete(employeeId)
+          animationTimers.current.delete(employeeId)
+        }, 320)
+        animationTimers.current.set(employeeId, timer)
+      })
+      animationFrames.current.set(employeeId, frameId)
+    })
+
+    prevPositions.current = nextPositions
+  }, [orderKey])
+
+  // Anything that changes a card's on-screen box — a window resize (or a
+  // Tailwind breakpoint changing the grid's column count), or a card's OWN
+  // content growing/shrinking (an overtime badge or leave chip appearing on
+  // a background refetch) and pushing every card below it — repositions
+  // cards without touching `orderedEmployeeIds`, so the layout effect above
+  // never re-runs and `prevPositions` goes stale. Left unhandled, the NEXT
+  // real reflow (a card actually entering/leaving) would FLIP-animate from
+  // those stale coordinates, making cards appear to slide in from far-off,
+  // wrong positions. A ResizeObserver on every tracked card catches both
+  // cases in one mechanism, and silently resets the snapshot (no animation)
+  // so future reflows measure against the current layout instead.
+  useEffect(() => {
+    // Per spec, calling observe() queues an "initial" notification for the
+    // newly-observed element regardless of whether its size ever changes —
+    // this effect re-observes every card on each orderKey change, so its
+    // FIRST callback invocation is always that initial batch, not a real
+    // resize. That timing is unsafe to measure from: this effect (a regular
+    // useEffect) runs after the layout effect above already applied each
+    // moved card's inverted starting transform, and the initial
+    // notification can be delivered before that card's scheduled
+    // requestAnimationFrame releases it — getBoundingClientRect() includes
+    // the currently-applied transform, so measuring here would capture the
+    // still-inverted (visually stale) position and clobber the correct
+    // baseline the layout effect just stored. Skipping this first
+    // invocation avoids it; every subsequent one is a genuine resize.
+    let isInitialNotification = true
+    const observer = new ResizeObserver(() => {
+      if (isInitialNotification) {
+        isInitialNotification = false
+        return
+      }
+      const measured = measurePositions(cardRefs.current, containerRef.current)
+      const next = new Map(prevPositions.current)
+      measured.forEach((position, employeeId) => {
+        // Skip cards currently mid FLIP-transition — see animatingEmployeeIds.
+        if (animatingEmployeeIds.current.has(employeeId)) return
+        next.set(employeeId, position)
+      })
+      prevPositions.current = next
+    })
+    cardRefs.current.forEach((el) => observer.observe(el))
+    return () => observer.disconnect()
+  }, [orderKey])
+
+  return { setCardRef, containerRef }
+}

--- a/code/webapp/src/pages/attendance/-use-today-attendance-page.ts
+++ b/code/webapp/src/pages/attendance/-use-today-attendance-page.ts
@@ -2,11 +2,11 @@ import { useState, useCallback, useEffect, useRef, useMemo } from 'react'
 import { useAuthStore } from '@/stores/auth.store'
 import { useDailyAttendance, useCheckIn, useLunchStart, useLunchReturn, useCheckOut, useOvertimeDecision, useBulkOvertimeDecision, useMarkDayStatus } from '@/services/attendance-hooks'
 import { useExtraDayExpress } from '@/components/attendance/use-extra-day-express'
-import { getAttendancePhase, isAbsentRow, isHiddenFromGrid } from '@/types/attendance'
+import { getAttendancePhase, isAbsentRow, isHiddenFromGrid, attendanceRecordToRowData } from '@/types/attendance'
 import { todayDateCdmx } from '@/lib/datetime'
 import { timeToIsoWithOffset } from '@/lib/timezone'
 import { useBusinessDate } from '@/stores/clock.store'
-import type { TodayAttendanceRow, AttendancePhase, TodayAttendanceEmployee, OvertimeDecisionPayload, OvertimePendingEntry, OvertimeValuationMethod } from '@/types/attendance'
+import type { TodayAttendanceRow, AttendancePhase, TodayAttendanceEmployee, AttendanceRecord, OvertimeDecisionPayload, OvertimePendingEntry, OvertimeValuationMethod } from '@/types/attendance'
 import type { AttendanceSummary, AttendanceFilter } from '@/components/attendance'
 
 // Re-export from shared utilities for backwards compatibility
@@ -145,10 +145,9 @@ export interface UseTodayAttendancePageResult {
   // Stat tab filter
   selectedFilter: AttendanceFilter | null
   toggleFilter: (filter: AttendanceFilter) => void
-  // Keeps a card rendered through the mark-falta → justify-now? → (dialog) flow,
-  // then plays an exit animation once the flow concludes
+  // Card exit animation — true for any of the 5 actions below once its
+  // confirmed result no longer belongs in the active tab
   isCardExiting: (employeeId: string) => boolean
-  pinEmployeeCard: (employeeId: string) => void
   onFaltaFlowComplete: (employeeId: string) => void
   // Date selection
   selectedDate: string
@@ -192,8 +191,8 @@ export interface UseTodayAttendancePageResult {
   confirmBulkOvertimeDecision: (authorize: boolean, valuationMethod?: OvertimeValuationMethod, agreedRate?: number, agreedFactor?: number, applyToRest?: boolean) => void
   closeBulkOvertimeDecision: () => void
   // Mark day status action
-  isMarkingDayStatus: boolean
-  markDayStatus: (employee: TodayAttendanceEmployee, status: 'ABSENCE', reason?: string) => void
+  isMarkingDayStatus: (employeeId: string) => boolean
+  markDayStatus: (employee: TodayAttendanceEmployee, status: 'ABSENCE', reason?: string) => Promise<boolean>
   // Extra day express action
   extraDayRow: TodayAttendanceRow | null
   isRegisteringExtraDay: boolean
@@ -229,6 +228,25 @@ export function useTodayAttendancePage(initialFilter: AttendanceFilter | null = 
   // ── Stat tab filter ───────────────────────────────────────────────────────────
   const [selectedFilter, setSelectedFilter] = useState<AttendanceFilter | null>(initialFilter)
   const hasAppliedDefaultFilter = useRef(initialFilter !== null)
+  // Mirrors selectedFilter/selectedDate/branchId for the shared exit-animation
+  // trigger to read at async onSuccess time — a mutation's onSuccess closure
+  // captures whatever these were when `.mutate()` was called, so if the
+  // manager switches tabs/date/branch while the request is in flight, reading
+  // these refs (rather than the captured values) lets the trigger judge
+  // against what's actually on screen NOW, not what was true when the action
+  // started. See startExitAnimation below.
+  const selectedFilterRef = useRef(selectedFilter)
+  useEffect(() => {
+    selectedFilterRef.current = selectedFilter
+  }, [selectedFilter])
+  const selectedDateRef = useRef(selectedDate)
+  useEffect(() => {
+    selectedDateRef.current = selectedDate
+  }, [selectedDate])
+  const branchIdRef = useRef(branchId)
+  useEffect(() => {
+    branchIdRef.current = branchId
+  }, [branchId])
 
   // Apply the smart default (Pendientes, or En trabajo if nothing is pending)
   // once the first load resolves, unless a tab was already chosen (e.g. from
@@ -248,13 +266,35 @@ export function useTodayAttendancePage(initialFilter: AttendanceFilter | null = 
     setSelectedFilter((current) => (current === filter ? null : filter))
   }, [])
 
-  // ── Keep a card rendered through the mark-falta → justify-now? → (dialog) flow ──
-  // 'pinned'  — the underlying row no longer matches the active tab, but a dialog
-  //             flow on this exact card is still in progress; render normally,
-  //             fully interactive, so the flow isn't yanked out from under the user.
-  // 'exiting' — the flow just concluded; play the exit animation, then remove.
+  // ── Card exit animation ──────────────────────────────────────────────────────
+  // 'pinned'  — a multi-step dialog flow (mark-falta → justify-now? → justify
+  //             dialog) is still in progress on this card even though its
+  //             confirmed result no longer matches the active tab; render
+  //             normally, fully interactive, so the flow isn't yanked out
+  //             from under the user.
+  // 'exiting' — the action (or flow) just concluded and its confirmed result
+  //             no longer belongs in the active tab; play the fade/slide-out
+  //             animation for 350ms, then remove.
+  //
+  // No 'hidden' state and no guessed target bucket: every trigger below
+  // already has the mutation's own confirmed AttendanceRecord in hand by the
+  // time it decides whether to animate (see startExitAnimation), so there is
+  // nothing left to guess or wait on a future poll to confirm.
   const [cardOverrides, setCardOverrides] = useState<Map<string, 'pinned' | 'exiting'>>(new Map())
   const exitTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
+  // Bridges markDayStatus (flow start) to onFaltaFlowComplete (flow end,
+  // fired later from a dialog close — not from a mutation onSuccess, so it
+  // has no mutation response in scope of its own). Carries the row already
+  // merged with the confirmed post-mutation attendance data, the UNMERGED
+  // pre-mutation row (so startExitAnimation can tell whether the card was
+  // ever part of the currently active tab — see its own comment), and the
+  // date/branch the flow started for.
+  const faltaFlowContext = useRef(new Map<string, { date: string; branchId: number | null; row: TodayAttendanceRow; preMutationRow: TodayAttendanceRow }>())
+  const [markingDayStatusEmployeeIds, setMarkingDayStatusEmployeeIds] = useState<Set<string>>(new Set())
+  const isMarkingDayStatus = useCallback(
+    (employeeId: string) => markingDayStatusEmployeeIds.has(employeeId),
+    [markingDayStatusEmployeeIds],
+  )
 
   useEffect(() => {
     const timers = exitTimers.current
@@ -263,57 +303,106 @@ export function useTodayAttendancePage(initialFilter: AttendanceFilter | null = 
     }
   }, [])
 
-  const pinEmployeeCard = useCallback((employeeId: string) => {
-    setCardOverrides((current) => {
-      if (current.get(employeeId) === 'pinned') return current
-      const next = new Map(current)
-      next.set(employeeId, 'pinned')
-      return next
-    })
-  }, [])
+  // `cardOverrides`/`exitTimers`/`faltaFlowContext` are keyed only by
+  // employeeId, but `data` comes from useDailyAttendance(branchId,
+  // selectedDate) — nothing else ties them to the specific day/branch they
+  // were set for. Any pinned/exiting state (or a flow context captured mid-
+  // dialog) is meaningless once the underlying data set it was computed
+  // against is gone, so treat a date/branch change as a hard reset instead
+  // of trying to carry it over. markingDayStatusEmployeeIds is deliberately
+  // NOT touched here — it self-clears unconditionally in markDayStatus's
+  // .finally(), decoupled on purpose (see markDayStatus below).
+  useEffect(() => {
+    exitTimers.current.forEach((timer) => clearTimeout(timer))
+    exitTimers.current.clear()
+    faltaFlowContext.current.clear()
+    setCardOverrides(new Map())
+  }, [selectedDate, branchId])
 
-  // The mark-falta flow always ends with the row in the 'absent' bucket,
-  // regardless of which choice the manager makes:
-  //  - Decline / no leave registered → day_status stays ABSENCE.
-  //  - Justify with a full-day (non-SCHEDULED) leave → RegisterDirectLeaveAction
-  //    overwrites the existing Attendance record's day_status to LEAVE.
-  //  - Justify with a partial (SCHEDULED) leave → shouldCreateAttendanceRecords()
-  //    is false, so RegisterDirectLeaveAction skips touching Attendance entirely
-  //    and day_status is left as ABSENCE (see RegisterDirectLeaveAction.php).
-  // Either way day_status ends up ABSENCE or LEAVE, so isAbsentRow is true and
-  // isHiddenFromGrid is false — today_leave.time_mode never overrides this,
-  // since isAbsentRow checks getAttendancePhase(row.attendance) first and only
-  // falls back to today_leave for rows with NO attendance record at all.
-  // This is computed from `filter` alone — deliberately NOT from `data` —
-  // because `data` can still reflect the pre-mutation row when the flow
-  // concludes quickly (useMarkDayStatus only invalidates/refetches on
-  // success, and the manager can dismiss the justify-now prompt before that
-  // refetch lands). Deciding from `data` in that window used the stale
-  // (still-pending) bucket and produced the wrong answer once the real data
-  // arrived a moment later.
-  function matchesFilterAfterFalta(filter: AttendanceFilter | null): boolean {
-    return filter === null || filter === 'total' || filter === 'absent'
+  function cancelExitTimer(employeeId: string) {
+    const timer = exitTimers.current.get(employeeId)
+    if (timer !== undefined) {
+      clearTimeout(timer)
+      exitTimers.current.delete(employeeId)
+    }
   }
 
-  // Ends the pin started by pinEmployeeCard once the mark-falta → justify-now?
-  // flow concludes. If the row's final status still belongs in the active tab
-  // (e.g. ABSENCE stays visible on the default view), it never actually needs
-  // to leave the grid — clear the pin immediately instead of playing the
-  // fade/slide-out animation, which would otherwise make the card vanish and
-  // then abruptly pop back in.
-  const startExitAnimation = useCallback((employeeId: string) => {
-    if (matchesFilterAfterFalta(selectedFilter)) {
-      const existingTimer = exitTimers.current.get(employeeId)
-      if (existingTimer) {
-        clearTimeout(existingTimer)
-        exitTimers.current.delete(employeeId)
-      }
-      setCardOverrides((current) => {
-        if (!current.has(employeeId)) return current
-        const next = new Map(current)
-        next.delete(employeeId)
-        return next
-      })
+  function clearOverride(employeeId: string) {
+    setCardOverrides((current) => {
+      if (!current.has(employeeId)) return current
+      const next = new Map(current)
+      next.delete(employeeId)
+      return next
+    })
+  }
+
+  // An 'exiting' override's animation is only meaningful for the tab it was
+  // triggered from — the tab the card was actually leaving. If the manager
+  // switches tabs while that 350ms fade/slide is still playing, continuing
+  // it in the newly selected tab is wrong either way: the card might now
+  // genuinely belong there (so it should render normally, not fade out of a
+  // tab it just entered) or it might not belong there at all (so it should
+  // never have appeared in the first place, per the same reasoning
+  // startExitAnimation's own preMutationRow guard applies at trigger time).
+  // Cancel any in-flight exit the instant the filter changes; visibleRows'
+  // own matchesGridFilter check takes over immediately, with no animation.
+  // 'pinned' overrides are deliberately left alone — a mark-falta dialog
+  // flow in progress must survive a tab switch, not get cut short by one.
+  useEffect(() => {
+    cardOverrides.forEach((value, employeeId) => {
+      if (value !== 'exiting') return
+      cancelExitTimer(employeeId)
+      clearOverride(employeeId)
+    })
+    // Intentionally scoped to selectedFilter alone — cardOverrides is read
+    // via the closure, not a dependency, since including it would re-run
+    // this on every override change (pins, other exits settling) instead of
+    // only when the active tab itself changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedFilter])
+
+  // Shared exit-animation trigger for every action that can move a card out
+  // of the active tab (check-in, lunch-start/return, check-out, and mark-
+  // falta via onFaltaFlowComplete below). `mergedRow` must already carry the
+  // mutation's confirmed `attendance` — callers build it by spreading a row
+  // captured SYNCHRONOUSLY before the mutation started (safe: only
+  // `.attendance` is affected by these actions, never `today_leave`/
+  // `today_vacation`/`schedule`) over the response's own fresh `attendance`.
+  // Deliberately never reads `data`/a data ref here: the mutation hook's own
+  // onSuccess (which writes the query cache) and this call-site onSuccess
+  // run synchronously back-to-back, before React re-renders, so `data` would
+  // still be the PRE-mutation snapshot at this exact point — reading it here
+  // would silently reintroduce the same "decide from a value that hasn't
+  // caught up yet" class of bug this design otherwise avoids entirely.
+  const startExitAnimation = useCallback((employeeId: string, mergedRow: TodayAttendanceRow, preMutationRow: TodayAttendanceRow, forDate: string, forBranchId: number | null) => {
+    // The date/branch reset effect above already clears every override the
+    // instant selectedDate/branchId changes — synchronously, well before
+    // this async callback (at least one network round-trip later) could
+    // ever fire. So by the time forDate/forBranchId are stale here, any
+    // cardOverrides entry still present for this employeeId is guaranteed
+    // to belong to a NEW action started after the switch (e.g. a mark-falta
+    // pin on the day now on screen), never a leftover from this stale one.
+    // Deliberately do NOT clearOverride here — doing so would clobber that
+    // live hold and make the card vanish mid-flow on the day the manager is
+    // actually looking at (bug regression, see the test for this exact
+    // sequence).
+    if (forDate !== selectedDateRef.current || forBranchId !== branchIdRef.current) return
+
+    cancelExitTimer(employeeId)
+
+    if (matchesGridFilter(mergedRow, selectedFilterRef.current)) {
+      clearOverride(employeeId)
+      return
+    }
+
+    // The row no longer matches the active tab — but if it wasn't part of
+    // that tab BEFORE this action either (e.g. the manager switched tabs
+    // while the request was still in flight, so this card was never visible
+    // here), there is nothing to animate OUT of it: forcing an 'exiting'
+    // override would flash a card that never belonged to this tab into it,
+    // only to immediately slide it back out.
+    if (!matchesGridFilter(preMutationRow, selectedFilterRef.current)) {
+      clearOverride(employeeId)
       return
     }
 
@@ -323,23 +412,32 @@ export function useTodayAttendancePage(initialFilter: AttendanceFilter | null = 
       return next
     })
 
-    const existingTimer = exitTimers.current.get(employeeId)
-    if (existingTimer) clearTimeout(existingTimer)
-
     const timer = setTimeout(() => {
-      setCardOverrides((current) => {
-        if (!current.has(employeeId)) return current
-        const next = new Map(current)
-        next.delete(employeeId)
-        return next
-      })
       exitTimers.current.delete(employeeId)
+      clearOverride(employeeId)
     }, 350)
     exitTimers.current.set(employeeId, timer)
-  }, [selectedFilter])
+  }, [])
 
-  // Pinned/exiting rows are kept in their natural `data` position (not appended
-  // at the end) so the card doesn't visibly jump while its dialog flow plays out.
+  const onFaltaFlowComplete = useCallback((employeeId: string) => {
+    const context = faltaFlowContext.current.get(employeeId)
+    faltaFlowContext.current.delete(employeeId)
+    // No context means either the mutation failed (pin already cleared by
+    // markDayStatus's own failure path) or rowBeforeMutation wasn't found at
+    // mutation time (markDayStatus pinned the card but had nothing to hand
+    // off to this flow) — clear defensively either way so a card can never
+    // stay pinned in a tab it no longer belongs to with no flow left to
+    // release it.
+    if (!context) {
+      clearOverride(employeeId)
+      return
+    }
+    startExitAnimation(employeeId, context.row, context.preMutationRow, context.date, context.branchId)
+  }, [startExitAnimation])
+
+  // Pinned/exiting rows are kept in their natural `data` position (not
+  // appended at the end) so the card doesn't visibly jump while its
+  // animation/dialog flow plays out.
   const visibleRows = useMemo(() => {
     if (cardOverrides.size === 0) return filterRowsForGrid(data, selectedFilter)
     return data.filter((row) => cardOverrides.has(row.employee.id) || matchesGridFilter(row, selectedFilter))
@@ -381,11 +479,30 @@ export function useTodayAttendancePage(initialFilter: AttendanceFilter | null = 
 
   const confirmCheckIn = useCallback((time: string, reason?: string) => {
     if (!pendingCheckInEmployee) return
+    const employee = pendingCheckInEmployee
+    // A correction of an already-recorded check-in never changes the row's
+    // bucket, regardless of which tab is active — only a fresh check-in does.
+    const isFreshCheckIn = !pendingCheckInCurrentValue
+    const rowBeforeMutation = data.find((r) => r.employee.id === employee.id)
+    const forDate = selectedDate
+    const forBranchId = branchId
     checkInMutation.mutate(
-      { employee_id: pendingCheckInEmployee.id, check_in: timeToIso(time, selectedDate), reason },
-      { onSettled: closeCheckIn }
+      { employee_id: employee.id, check_in: timeToIso(time, forDate), reason },
+      {
+        onSuccess: (response) => {
+          if (!isFreshCheckIn || !rowBeforeMutation) return
+          startExitAnimation(
+            employee.id,
+            { ...rowBeforeMutation, attendance: attendanceRecordToRowData(response.data.data) },
+            rowBeforeMutation,
+            forDate,
+            forBranchId,
+          )
+        },
+        onSettled: closeCheckIn,
+      }
     )
-  }, [pendingCheckInEmployee, checkInMutation, closeCheckIn, selectedDate])
+  }, [pendingCheckInEmployee, pendingCheckInCurrentValue, data, checkInMutation, closeCheckIn, selectedDate, branchId, startExitAnimation])
 
   // ── Lunch-start state ────────────────────────────────────────────────────────
   const [pendingLunchStart, setPendingLunchStart] =
@@ -401,11 +518,27 @@ export function useTodayAttendancePage(initialFilter: AttendanceFilter | null = 
 
   const confirmLunchStart = useCallback((time: string, reason?: string) => {
     if (!pendingLunchStart) return
+    const { employee, attendanceId, currentValue } = pendingLunchStart
+    const rowBeforeMutation = data.find((r) => r.employee.id === employee.id)
+    const forDate = selectedDate
+    const forBranchId = branchId
     lunchStartMutation.mutate(
-      { attendance_id: pendingLunchStart.attendanceId, lunch_start: timeToIso(time, selectedDate), reason },
-      { onSettled: closeLunchStart }
+      { attendance_id: attendanceId, lunch_start: timeToIso(time, forDate), reason },
+      {
+        onSuccess: (response) => {
+          if (currentValue || !rowBeforeMutation) return
+          startExitAnimation(
+            employee.id,
+            { ...rowBeforeMutation, attendance: attendanceRecordToRowData(response.data.data) },
+            rowBeforeMutation,
+            forDate,
+            forBranchId,
+          )
+        },
+        onSettled: closeLunchStart,
+      }
     )
-  }, [pendingLunchStart, lunchStartMutation, closeLunchStart, selectedDate])
+  }, [pendingLunchStart, data, lunchStartMutation, closeLunchStart, selectedDate, branchId, startExitAnimation])
 
   // ── Lunch-return state ───────────────────────────────────────────────────────
   const [pendingLunchReturn, setPendingLunchReturn] =
@@ -421,11 +554,27 @@ export function useTodayAttendancePage(initialFilter: AttendanceFilter | null = 
 
   const confirmLunchReturn = useCallback((time: string, reason?: string) => {
     if (!pendingLunchReturn) return
+    const { employee, attendanceId, currentValue } = pendingLunchReturn
+    const rowBeforeMutation = data.find((r) => r.employee.id === employee.id)
+    const forDate = selectedDate
+    const forBranchId = branchId
     lunchReturnMutation.mutate(
-      { attendance_id: pendingLunchReturn.attendanceId, lunch_end: timeToIso(time, selectedDate), reason },
-      { onSettled: closeLunchReturn }
+      { attendance_id: attendanceId, lunch_end: timeToIso(time, forDate), reason },
+      {
+        onSuccess: (response) => {
+          if (currentValue || !rowBeforeMutation) return
+          startExitAnimation(
+            employee.id,
+            { ...rowBeforeMutation, attendance: attendanceRecordToRowData(response.data.data) },
+            rowBeforeMutation,
+            forDate,
+            forBranchId,
+          )
+        },
+        onSettled: closeLunchReturn,
+      }
     )
-  }, [pendingLunchReturn, lunchReturnMutation, closeLunchReturn, selectedDate])
+  }, [pendingLunchReturn, data, lunchReturnMutation, closeLunchReturn, selectedDate, branchId, startExitAnimation])
 
   // ── Check-out state ──────────────────────────────────────────────────────────
   const [pendingCheckOut, setPendingCheckOut] =
@@ -441,11 +590,27 @@ export function useTodayAttendancePage(initialFilter: AttendanceFilter | null = 
 
   const confirmCheckOut = useCallback((time: string, reason?: string) => {
     if (!pendingCheckOut) return
+    const { employee, attendanceId, currentValue } = pendingCheckOut
+    const rowBeforeMutation = data.find((r) => r.employee.id === employee.id)
+    const forDate = selectedDate
+    const forBranchId = branchId
     checkOutMutation.mutate(
-      { attendance_id: pendingCheckOut.attendanceId, check_out: timeToIso(time, selectedDate), reason },
-      { onSettled: closeCheckOut }
+      { attendance_id: attendanceId, check_out: timeToIso(time, forDate), reason },
+      {
+        onSuccess: (response) => {
+          if (currentValue || !rowBeforeMutation) return
+          startExitAnimation(
+            employee.id,
+            { ...rowBeforeMutation, attendance: attendanceRecordToRowData(response.data.data) },
+            rowBeforeMutation,
+            forDate,
+            forBranchId,
+          )
+        },
+        onSettled: closeCheckOut,
+      }
     )
-  }, [pendingCheckOut, checkOutMutation, closeCheckOut, selectedDate])
+  }, [pendingCheckOut, data, checkOutMutation, closeCheckOut, selectedDate, branchId, startExitAnimation])
 
   // ── Overtime decision state ───────────────────────────────────────────────────
   const [pendingOvertimeDecision, setPendingOvertimeDecision] =
@@ -522,16 +687,77 @@ export function useTodayAttendancePage(initialFilter: AttendanceFilter | null = 
   }, [])
 
   // ── Mark day status ───────────────────────────────────────────────────────────
+  // Pins the card immediately (so the justify-now?/justify-dialog flow that
+  // follows a success isn't yanked out from under the user), and unpins it
+  // again on failure — collapsed into this single function rather than split
+  // across the page component and this hook, so a failed mutation can never
+  // leave a card pinned forever with no flow left to release it.
+  //
+  // Returns whether the mutation succeeded (not its raw promise/rejection —
+  // attendance-hooks.ts's onError already surfaces the failure toast, the
+  // caller only needs to know whether to continue the justify-now? flow).
   const markDayStatus = useCallback(
-    (employee: TodayAttendanceEmployee, status: 'ABSENCE', reason?: string) => {
-      markDayStatusMutation.mutate({
+    (employee: TodayAttendanceEmployee, status: 'ABSENCE', reason?: string): Promise<boolean> => {
+      const rowBeforeMutation = data.find((r) => r.employee.id === employee.id)
+      const forDate = selectedDate
+      const forBranchId = branchId
+
+      setCardOverrides((current) => {
+        if (current.get(employee.id) === 'pinned') return current
+        const next = new Map(current)
+        next.set(employee.id, 'pinned')
+        return next
+      })
+      // Written synchronously, before the mutation's promise even settles,
+      // so a same-tick double-click already sees the button disabled on the
+      // next render — no separate in-flight-request dedup needed.
+      setMarkingDayStatusEmployeeIds((current) => {
+        if (current.has(employee.id)) return current
+        const next = new Set(current)
+        next.add(employee.id)
+        return next
+      })
+
+      return markDayStatusMutation.mutateAsync({
         employee_id: employee.id,
-        date: selectedDate,
+        date: forDate,
         day_status: status,
         reason,
+      }).then(
+        (response: { data: { data: AttendanceRecord } }) => {
+          if (rowBeforeMutation) {
+            faltaFlowContext.current.set(employee.id, {
+              date: forDate,
+              branchId: forBranchId,
+              row: { ...rowBeforeMutation, attendance: attendanceRecordToRowData(response.data.data) },
+              preMutationRow: rowBeforeMutation,
+            })
+          }
+          return true
+        },
+        () => {
+          setCardOverrides((current) => {
+            if (current.get(employee.id) !== 'pinned') return current
+            const next = new Map(current)
+            next.delete(employee.id)
+            return next
+          })
+          return false
+        },
+      ).finally(() => {
+        // Unconditional — never gated by the date/branch this flow started
+        // for. Gating it would leave a switch-away-and-back employee's
+        // buttons disabled forever if the mutation settled while a
+        // different date/branch was selected.
+        setMarkingDayStatusEmployeeIds((current) => {
+          if (!current.has(employee.id)) return current
+          const next = new Set(current)
+          next.delete(employee.id)
+          return next
+        })
       })
     },
-    [markDayStatusMutation, selectedDate],
+    [markDayStatusMutation, data, selectedDate, branchId],
   )
 
   // ── Extra day express ─────────────────────────────────────────────────────────
@@ -585,8 +811,7 @@ export function useTodayAttendancePage(initialFilter: AttendanceFilter | null = 
     selectedFilter,
     toggleFilter,
     isCardExiting: (employeeId) => cardOverrides.get(employeeId) === 'exiting',
-    pinEmployeeCard,
-    onFaltaFlowComplete: startExitAnimation,
+    onFaltaFlowComplete,
     selectedDate,
     setSelectedDate,
     // Check-in
@@ -628,7 +853,7 @@ export function useTodayAttendancePage(initialFilter: AttendanceFilter | null = 
     confirmBulkOvertimeDecision,
     closeBulkOvertimeDecision,
     // Mark day status
-    isMarkingDayStatus: markDayStatusMutation.isPending,
+    isMarkingDayStatus,
     markDayStatus,
     // Extra day express
     extraDayRow,

--- a/code/webapp/src/pages/attendance/__tests__/-use-attendance-grid-flip.test.ts
+++ b/code/webapp/src/pages/attendance/__tests__/-use-attendance-grid-flip.test.ts
@@ -1,0 +1,225 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { renderHook, act, cleanup } from '@testing-library/react'
+import { useAttendanceGridFlip } from '@/pages/attendance/-use-attendance-grid-flip'
+
+// jsdom has no layout engine — getBoundingClientRect() always returns zeros
+// and there is no real ResizeObserver/DOMMatrix. Everything below is stubbed
+// so the hook's own measurement/transform logic can be exercised directly,
+// independent of a real browser's layout pipeline.
+
+vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+  setTimeout(() => cb(0), 0)
+  return 0
+})
+
+// jsdom's getComputedStyle() echoes back whatever was assigned to
+// `el.style.transform` verbatim (it does not normalize to `matrix(...)`, as
+// real browsers do) — and this hook only ever assigns `translate(Npx, Mpx)`
+// (see -use-attendance-grid-flip.ts), so this stub only needs to parse that
+// one format to behave equivalently to the real DOMMatrix for these tests.
+class FakeDOMMatrix {
+  m41 = 0
+  m42 = 0
+  constructor(transform?: string) {
+    if (!transform || transform === 'none') return
+    const match = transform.match(/translate\(([-\d.]+)px,\s*([-\d.]+)px\)/)
+    if (match) {
+      this.m41 = Number(match[1])
+      this.m42 = Number(match[2])
+    }
+  }
+}
+vi.stubGlobal('DOMMatrix', FakeDOMMatrix)
+
+class FakeResizeObserver {
+  observe() {}
+  disconnect() {}
+}
+vi.stubGlobal('ResizeObserver', FakeResizeObserver)
+
+function makeCardEl(rect: { top: number; left: number }): HTMLDivElement {
+  const el = document.createElement('div')
+  vi.spyOn(el, 'getBoundingClientRect').mockImplementation(() => ({
+    top: rect.top, left: rect.left, width: 100, height: 100,
+    right: rect.left + 100, bottom: rect.top + 100, x: rect.left, y: rect.top,
+    toJSON() { return {} },
+  }))
+  return el
+}
+
+function makeContainerEl(): HTMLDivElement {
+  const el = document.createElement('div')
+  vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+    top: 0, left: 0, width: 1000, height: 1000, right: 1000, bottom: 1000, x: 0, y: 0,
+    toJSON() { return {} },
+  } as DOMRect)
+  return el
+}
+
+describe('useAttendanceGridFlip', () => {
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+  })
+
+  it('applies an inverted transform on reorder, then releases it via rAF + the 320ms transition', () => {
+    // Only fake setTimeout/clearTimeout — our requestAnimationFrame stub
+    // above already delegates to setTimeout, and letting Vitest's fake timers
+    // ALSO take over requestAnimationFrame itself would replace our stub with
+    // its own frame-paced implementation that advanceTimersByTime(0) doesn't
+    // reliably drive.
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    // Mounts with an empty id list so refs can be attached BEFORE the
+    // baseline-establishing render — the layout effect only re-runs when
+    // `orderKey` (derived from `ids`) actually changes, so re-rendering with
+    // the SAME ids used at mount would never re-measure the now-attached refs.
+    const { result, rerender } = renderHook(
+      ({ ids }: { ids: string[] }) => useAttendanceGridFlip(ids),
+      { initialProps: { ids: [] as string[] } },
+    )
+
+    const container = makeContainerEl()
+    result.current.containerRef.current = container
+    const cardA = makeCardEl({ top: 0, left: 0 })
+    const cardB = makeCardEl({ top: 100, left: 0 })
+    act(() => {
+      result.current.setCardRef('a')(cardA)
+      result.current.setCardRef('b')(cardB)
+    })
+
+    // orderKey changes '' -> 'a|b' — establishes the baseline (nothing to
+    // diff against yet, so no transform is applied).
+    act(() => rerender({ ids: ['a', 'b'] }))
+    expect(cardB.style.transform).toBe('')
+
+    // Card b "moves" to where a used to be (e.g. a left the grid) — same
+    // orderKey elements, new measured position.
+    vi.spyOn(cardB, 'getBoundingClientRect').mockImplementation(() => ({
+      top: 0, left: 0, width: 100, height: 100, right: 100, bottom: 100, x: 0, y: 0,
+      toJSON() { return {} },
+    }))
+    act(() => rerender({ ids: ['b'] }))
+
+    // Inverted immediately, before the rAF release — b is placed back at its
+    // OLD screen position (100px below where it now actually sits).
+    expect(cardB.style.transform).toBe('translate(0px, 100px)')
+    expect(cardB.style.transition).toBe('none')
+
+    // rAF (stubbed as setTimeout(0)) releases it with a transition.
+    act(() => vi.advanceTimersByTime(0))
+    expect(cardB.style.transform).toBe('')
+    expect(cardB.style.transition).toBe('transform 320ms cubic-bezier(0.22, 1, 0.36, 1)')
+  })
+
+  it('folds the residual in-flight translate into a second invert started before the first settles', () => {
+    // Only fake setTimeout/clearTimeout — our requestAnimationFrame stub
+    // above already delegates to setTimeout, and letting Vitest's fake timers
+    // ALSO take over requestAnimationFrame itself would replace our stub with
+    // its own frame-paced implementation that advanceTimersByTime(0) doesn't
+    // reliably drive.
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    const { result, rerender } = renderHook(
+      ({ ids }: { ids: string[] }) => useAttendanceGridFlip(ids),
+      { initialProps: { ids: [] as string[] } },
+    )
+
+    const container = makeContainerEl()
+    result.current.containerRef.current = container
+    const cardA = makeCardEl({ top: 0, left: 0 })
+    const cardB = makeCardEl({ top: 100, left: 0 })
+    act(() => {
+      result.current.setCardRef('a')(cardA)
+      result.current.setCardRef('b')(cardB)
+    })
+    act(() => rerender({ ids: ['a', 'b'] })) // establishes baseline
+
+    // First move: b's layout position changes from top:100 to top:0.
+    vi.spyOn(cardB, 'getBoundingClientRect').mockImplementation(() => ({
+      top: 0, left: 0, width: 100, height: 100, right: 100, bottom: 100, x: 0, y: 0,
+      toJSON() { return {} },
+    }))
+    act(() => rerender({ ids: ['b'] }))
+    act(() => vi.advanceTimersByTime(0)) // rAF fires — transition now running, transform reset to ''
+
+    // Still mid-transition (well before the 320ms settle timer). Simulate the
+    // browser having interpolated the transition partway: the computed style
+    // (read via getComputedStyle -> our DOMMatrix stub) currently shows a
+    // residual translate, even though el.style.transform is the target ''.
+    cardB.style.transform = 'translate(0px, 40px)'
+
+    // Second move within the animation window: b's true layout position
+    // changes again, from top:0 to top:50 (dy = -50 once recovered). Real
+    // getBoundingClientRect() would report the RENDERED box — layout
+    // position plus whatever translate is still actively applied — so the
+    // mock must include that same 40px residual on top of the new layout
+    // value (90 = 50 true layout + 40 still-in-flight offset); the hook
+    // itself is what recovers the pure 50 by subtracting the residual back
+    // out (see measurePositions).
+    vi.spyOn(cardB, 'getBoundingClientRect').mockImplementation(() => ({
+      top: 90, left: 0, width: 100, height: 100, right: 100, bottom: 100, x: 0, y: 0,
+      toJSON() { return {} },
+    }))
+    act(() => rerender({ ids: ['a', 'b'] }))
+
+    // Without folding the residual in, the new invert would only be
+    // translate(0px, -50px) — jumping the card to its layout position before
+    // sliding again. The residual (40px still in flight) must be added in:
+    // -50 (new layout delta) + 40 (residual) = -10.
+    expect(cardB.style.transform).toBe('translate(0px, -10px)')
+  })
+
+  it('cancels the pending rAF on unmount instead of leaving it to fire on a discarded card', () => {
+    const rafCallbacks = new Map<number, FrameRequestCallback>()
+    let nextFrameId = 1
+    const rafSpy = vi.fn((cb: FrameRequestCallback) => {
+      const id = nextFrameId++
+      rafCallbacks.set(id, cb)
+      return id
+    })
+    const cafSpy = vi.fn((id: number) => {
+      rafCallbacks.delete(id)
+    })
+    vi.stubGlobal('requestAnimationFrame', rafSpy)
+    vi.stubGlobal('cancelAnimationFrame', cafSpy)
+
+    const { result, rerender, unmount } = renderHook(
+      ({ ids }: { ids: string[] }) => useAttendanceGridFlip(ids),
+      { initialProps: { ids: [] as string[] } },
+    )
+
+    const container = makeContainerEl()
+    result.current.containerRef.current = container
+    const cardA = makeCardEl({ top: 0, left: 0 })
+    const cardB = makeCardEl({ top: 100, left: 0 })
+    act(() => {
+      result.current.setCardRef('a')(cardA)
+      result.current.setCardRef('b')(cardB)
+    })
+    act(() => rerender({ ids: ['a', 'b'] })) // establishes baseline
+
+    // b's layout position changes — schedules a rAF to release the invert.
+    vi.spyOn(cardB, 'getBoundingClientRect').mockImplementation(() => ({
+      top: 0, left: 0, width: 100, height: 100, right: 100, bottom: 100, x: 0, y: 0,
+      toJSON() { return {} },
+    }))
+    act(() => rerender({ ids: ['b'] }))
+
+    expect(rafSpy).toHaveBeenCalledTimes(1)
+    expect(cafSpy).not.toHaveBeenCalled()
+
+    unmount()
+
+    // The frame scheduled above must be cancelled, not left pending —
+    // otherwise it fires later and writes styles onto a detached cardB.
+    expect(cafSpy).toHaveBeenCalledTimes(1)
+    expect(rafCallbacks.size).toBe(0)
+
+    // Restore the module-level stub other tests in this file rely on.
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      setTimeout(() => cb(0), 0)
+      return 0
+    })
+    vi.stubGlobal('cancelAnimationFrame', () => {})
+  })
+})

--- a/code/webapp/src/pages/attendance/__tests__/use-today-attendance-page.test.ts
+++ b/code/webapp/src/pages/attendance/__tests__/use-today-attendance-page.test.ts
@@ -77,6 +77,27 @@ function makeWrapper() {
   return { queryClient, wrapper }
 }
 
+/**
+ * Same as makeWrapper(), but under <StrictMode> — which the real app renders
+ * under (main.tsx) and which double-invokes setState updater functions in
+ * dev mode to catch impure ones.
+ */
+function makeStrictWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(
+      React.StrictMode,
+      null,
+      React.createElement(QueryClientProvider, { client: queryClient }, children),
+    )
+  return { queryClient, wrapper }
+}
+
 /** Creates a test employee with all required fields */
 function makeEmployee(overrides: Partial<{ id: string; code: string; user: { first_name: string; last_name: string }; roles: string[]; daily_wage: number | null }> = {}) {
   return {
@@ -1085,140 +1106,541 @@ describe('useTodayAttendancePage', () => {
     })
   })
 
-  // ── Pin + exit animation (e.g. after marking falta) ───────────────────────────
+  // ── Card exit animation ─────────────────────────────────────────────────────
 
-  describe('pin + exit animation', () => {
+  describe('card exit animation', () => {
     afterEach(() => {
       vi.useRealTimers()
     })
 
-    function mockPendingPlusAbsent() {
+    function mockTwoPending() {
       vi.mocked(attendanceApi.daily).mockResolvedValue({
         data: {
           data: [
-            makeRow(), // EMP-001, pending — resolves the default filter to "pending"
+            makeRow(), // emp-001, pending — resolves the default filter to "pending"
             makeRow({
               employee: { id: 'emp-002', code: 'EMP-002', user: { first_name: 'Ana', last_name: 'López' }, roles: [], daily_wage: null },
-              attendance: { id: 'att-2', day_status: 'ABSENCE' } as TodayAttendanceRow['attendance'],
             }),
           ],
         },
       } as never)
     }
 
-    it('pinEmployeeCard keeps a row rendered even once it no longer matches the active filter, with no exit animation yet', async () => {
-      mockPendingPlusAbsent()
+    function mockAbsenceRecord() {
+      return {
+        data: {
+          status: 201,
+          data: {
+            id: 'att-2', employee_id: 'emp-002', date: '2026-04-01',
+            check_in: null, lunch_start: null, lunch_end: null, check_out: null,
+            day_status: 'ABSENCE',
+          },
+        },
+      }
+    }
+
+    function mockCheckInRecord(employeeId: string) {
+      return {
+        data: {
+          status: 200,
+          data: {
+            id: 'att-x', employee_id: employeeId, date: '2026-04-01',
+            check_in: '2026-04-01T13:00:00-06:00', lunch_start: null, lunch_end: null, check_out: null,
+            day_status: 'WORKED',
+          },
+        },
+      }
+    }
+
+    // ── check-in / lunch / check-out (new: these never animated before) ──────
+
+    it('confirmCheckIn plays the exit animation when the confirmed record no longer matches the active tab', async () => {
+      // Initial load: both pending. Any subsequent refetch (the real
+      // useCheckIn hook's own invalidateQueries) must reflect the check-in —
+      // otherwise this test would be asserting against its own stale fixture,
+      // not the app's behavior.
+      vi.mocked(attendanceApi.daily)
+        .mockResolvedValueOnce({ data: { data: [makeRow(), makeRow({ employee: { id: 'emp-002', code: 'EMP-002', user: { first_name: 'Ana', last_name: 'López' }, roles: [], daily_wage: null } })] } } as never)
+        .mockResolvedValue({
+          data: {
+            data: [
+              makeRow({ attendance: { id: 'att-x', check_in: '2026-04-01T13:00:00-06:00', day_status: 'WORKED' } as TodayAttendanceRow['attendance'] }),
+              makeRow({ employee: { id: 'emp-002', code: 'EMP-002', user: { first_name: 'Ana', last_name: 'López' }, roles: [], daily_wage: null } }),
+            ],
+          },
+        } as never)
+      vi.mocked(attendanceApi.checkIn).mockResolvedValueOnce(mockCheckInRecord('emp-001') as never)
 
       const { wrapper } = makeWrapper()
       const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
 
       await waitFor(() => expect(result.current.selectedFilter).toBe('pending'))
-
-      // Under the "pending" filter, EMP-002 (absent) is normally hidden
-      expect(result.current.visibleRows.map((r) => r.employee.id)).toEqual(['emp-001'])
-
-      act(() => result.current.pinEmployeeCard('emp-002'))
-
-      // Pinned — stays rendered, but not yet playing the exit animation
-      expect(result.current.visibleRows.map((r) => r.employee.id)).toEqual(['emp-001', 'emp-002'])
-      expect(result.current.isCardExiting('emp-002')).toBe(false)
-    })
-
-    it('onFaltaFlowComplete plays the exit animation, then removes the row after it finishes', async () => {
-      mockPendingPlusAbsent()
-
-      const { wrapper } = makeWrapper()
-      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
-
-      await waitFor(() => expect(result.current.selectedFilter).toBe('pending'))
-
-      act(() => result.current.pinEmployeeCard('emp-002'))
-      expect(result.current.isCardExiting('emp-002')).toBe(false)
+      const row = makeRow()
+      act(() => result.current.openCheckIn(row))
 
       vi.useFakeTimers()
-      act(() => result.current.onFaltaFlowComplete('emp-002'))
+      await act(async () => { result.current.confirmCheckIn('14:00') })
 
-      // Still rendered — now playing the exit animation
-      expect(result.current.visibleRows.map((r) => r.employee.id)).toEqual(['emp-001', 'emp-002'])
-      expect(result.current.isCardExiting('emp-002')).toBe(true)
-
+      expect(result.current.isCardExiting('emp-001')).toBe(true)
       act(() => vi.advanceTimersByTime(350))
-
-      expect(result.current.visibleRows.map((r) => r.employee.id)).toEqual(['emp-001'])
-      expect(result.current.isCardExiting('emp-002')).toBe(false)
+      expect(result.current.visibleRows.map((r) => r.employee.id)).toEqual(['emp-002'])
     })
 
-    it('onFaltaFlowComplete plays the exit animation even when `data` has not refetched yet (still shows the row as pending)', async () => {
-      // Both rows still pending in `data` — simulating the window between
-      // "Confirmar falta" (which fires the mutation and pins the card) and
-      // the mutation's onSuccess refetch actually landing. The decision to
-      // animate must not be based on this stale snapshot.
-      vi.mocked(attendanceApi.daily).mockResolvedValue({
-        data: {
-          data: [
-            makeRow(), // emp-001, pending
-            makeRow({
-              employee: { id: 'emp-002', code: 'EMP-002', user: { first_name: 'Ana', last_name: 'López' }, roles: [], daily_wage: null },
-            }), // emp-002, still pending in `data` — refetch hasn't landed
-          ],
-        },
-      } as never)
+    it('confirmCheckIn does not animate a correction of an already-recorded check-in', async () => {
+      mockTwoPending()
+      vi.mocked(attendanceApi.checkIn).mockResolvedValueOnce(mockCheckInRecord('emp-001') as never)
 
-      const { wrapper, queryClient } = makeWrapper()
+      const { wrapper } = makeWrapper()
       const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
 
       await waitFor(() => expect(result.current.selectedFilter).toBe('pending'))
+      const row = makeRow({
+        attendance: { id: 'att-x', check_in: '2026-04-01T12:00:00Z' } as TodayAttendanceRow['attendance'],
+      })
+      act(() => result.current.openCheckIn(row))
 
-      act(() => result.current.pinEmployeeCard('emp-002'))
+      await act(async () => { result.current.confirmCheckIn('14:00') })
+
+      expect(result.current.isCardExiting('emp-001')).toBe(false)
+    })
+
+    it('does not animate an unrelated card on the newly selected date if the manager switches dates while a check-in is still in flight', async () => {
+      mockTwoPending()
+      let resolveCheckIn: (value: unknown) => void
+      vi.mocked(attendanceApi.checkIn).mockReturnValueOnce(
+        new Promise((resolve) => { resolveCheckIn = resolve }) as never
+      )
+
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      await waitFor(() => expect(result.current.selectedFilter).toBe('pending'))
+      act(() => result.current.openCheckIn(makeRow()))
+      act(() => { result.current.confirmCheckIn('14:00') })
+
+      act(() => result.current.setSelectedDate('2026-02-24'))
+      await waitFor(() => expect(result.current.selectedFilter).toBe('pending'))
 
       vi.useFakeTimers()
-      act(() => result.current.onFaltaFlowComplete('emp-002'))
-
-      // Must still play the exit animation — the flow guarantees emp-002 ends
-      // up ABSENCE (bucket 'absent'), which doesn't match the "pending" tab,
-      // even though `data` here hasn't caught up yet.
-      expect(result.current.isCardExiting('emp-002')).toBe(true)
-
-      // The mutation's refetch lands mid-animation, now reflecting ABSENCE —
-      // same as useMarkDayStatus's onSuccess invalidateQueries in production.
-      vi.mocked(attendanceApi.daily).mockResolvedValue({
-        data: {
-          data: [
-            makeRow(),
-            makeRow({
-              employee: { id: 'emp-002', code: 'EMP-002', user: { first_name: 'Ana', last_name: 'López' }, roles: [], daily_wage: null },
-              attendance: { id: 'att-2', day_status: 'ABSENCE' } as TodayAttendanceRow['attendance'],
-            }),
-          ],
-        },
-      } as never)
       await act(async () => {
-        await queryClient.invalidateQueries({ queryKey: ['attendances', 'daily'] })
+        resolveCheckIn(mockCheckInRecord('emp-001'))
+        await Promise.resolve()
       })
 
-      act(() => vi.advanceTimersByTime(350))
-      expect(result.current.visibleRows.map((r) => r.employee.id)).toEqual(['emp-001'])
+      // Without the staleness guard, this would animate/hide emp-001 on the
+      // NEWLY selected date, which the original check-in has nothing to do with.
+      expect(result.current.isCardExiting('emp-001')).toBe(false)
+      expect(result.current.visibleRows.map((r) => r.employee.id)).toEqual(['emp-001', 'emp-002'])
     })
 
-    it('onFaltaFlowComplete clears the pin immediately, with no exit animation, when the row still matches the active filter', async () => {
-      mockPendingPlusAbsent()
+    it('does not clobber a live hold on the currently viewed day when a stale response from a previously viewed day finally arrives (bug regression: card must not vanish mid-dialog)', async () => {
+      // Mount (date X) and the new date's own first load both show two
+      // pending rows; every call after that (the background refetch
+      // markDayStatus's own invalidateQueries triggers) reflects emp-001 as
+      // ABSENCE — same two-then-persistent pattern as the markDayStatus
+      // test elsewhere in this file, so that refetch doesn't silently
+      // revert the confirmed absence back to its stale pre-mutation fixture.
+      vi.mocked(attendanceApi.daily)
+        .mockResolvedValueOnce({ data: { data: [makeRow(), makeRow({ employee: { id: 'emp-002', code: 'EMP-002', user: { first_name: 'Ana', last_name: 'López' }, roles: [], daily_wage: null } })] } } as never)
+        .mockResolvedValueOnce({ data: { data: [makeRow(), makeRow({ employee: { id: 'emp-002', code: 'EMP-002', user: { first_name: 'Ana', last_name: 'López' }, roles: [], daily_wage: null } })] } } as never)
+        .mockResolvedValue({
+          data: {
+            data: [
+              makeRow({ attendance: { id: 'att-2', day_status: 'ABSENCE' } as TodayAttendanceRow['attendance'] }),
+              makeRow({ employee: { id: 'emp-002', code: 'EMP-002', user: { first_name: 'Ana', last_name: 'López' }, roles: [], daily_wage: null } }),
+            ],
+          },
+        } as never)
+      let resolveCheckIn: (value: unknown) => void
+      vi.mocked(attendanceApi.checkIn).mockReturnValueOnce(
+        new Promise((resolve) => { resolveCheckIn = resolve }) as never
+      )
+      vi.mocked(attendanceApi.markDayStatus).mockResolvedValueOnce({
+        data: {
+          status: 201,
+          data: { id: 'att-2', employee_id: 'emp-001', date: '2026-02-24', check_in: null, check_out: null, day_status: 'ABSENCE' },
+        },
+      } as never)
 
       const { wrapper } = makeWrapper()
       const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
 
-      // "Total" reveals everyone, so the ABSENCE row (emp-002) already matches
-      // the active filter before and after the flow — it never needs to leave.
+      await waitFor(() => expect(result.current.selectedFilter).toBe('pending'))
+
+      // Confirm a check-in for emp-001 on the ORIGINAL date — left in flight.
+      act(() => result.current.openCheckIn(makeRow()))
+      act(() => { result.current.confirmCheckIn('14:00') })
+
+      // Switch to a different date before that check-in resolves.
+      act(() => result.current.setSelectedDate('2026-02-24'))
+      // Wait for the NEW date's own query to actually resolve (not just for
+      // selectedFilter, which doesn't reset on a date change and so would
+      // already read 'pending' from before) — markDayStatus needs a real
+      // row in `data` to capture as rowBeforeMutation, and the cache splice
+      // below needs an already-populated cache entry to update.
+      await waitFor(() => expect(result.current.rows.map((r) => r.employee.id)).toContain('emp-001'))
+
+      // On the NEW date, mark falta for the SAME employee — pins the card
+      // while its justify-now? dialog flow is still in progress. The
+      // confirmed ABSENCE no longer matches "Pendientes", so from here on
+      // the pin alone is what keeps the row in visibleRows.
+      const succeeded = await act(async () => result.current.markDayStatus(makeEmployee({ id: 'emp-001' }), 'ABSENCE'))
+      expect(succeeded).toBe(true)
+      // Wait for the background refetch (markDayStatus's own
+      // invalidateQueries) to land the confirmed ABSENCE — from here on,
+      // the row no longer naturally matches "Pendientes", so the pin alone
+      // is what keeps it in visibleRows.
+      await waitFor(() => expect(result.current.rows.find((r) => r.employee.id === 'emp-001')?.attendance?.day_status).toBe('ABSENCE'))
+
+      // The original date's check-in finally resolves — its stale-guard
+      // fires since the date it was captured for no longer matches what's
+      // on screen.
+      vi.useFakeTimers()
+      await act(async () => {
+        resolveCheckIn(mockCheckInRecord('emp-001'))
+        await Promise.resolve()
+      })
+
+      // The live 'pinned' hold from the falta flow on the CURRENT date must
+      // survive — without it the ABSENCE row would vanish from visibleRows
+      // while its justify-now? dialog is still open.
+      expect(result.current.visibleRows.map((r) => r.employee.id)).toContain('emp-001')
+    })
+
+    it('does not flash an unrelated card into a different tab if the manager switches tabs while a check-in is still in flight (bug regression: card never belonged to the newly active tab)', async () => {
+      mockTwoPending()
+      let resolveCheckIn: (value: unknown) => void
+      vi.mocked(attendanceApi.checkIn).mockReturnValueOnce(
+        new Promise((resolve) => { resolveCheckIn = resolve }) as never
+      )
+
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      await waitFor(() => expect(result.current.selectedFilter).toBe('pending'))
+      act(() => result.current.openCheckIn(makeRow()))
+      act(() => { result.current.confirmCheckIn('14:00') })
+
+      // Switch to "Ausentes" — emp-001 was never part of this tab, before or
+      // after the check-in (it lands as 'checkedIn', not 'absent').
+      act(() => result.current.toggleFilter('absent'))
+      expect(result.current.selectedFilter).toBe('absent')
+
+      vi.useFakeTimers()
+      await act(async () => {
+        resolveCheckIn(mockCheckInRecord('emp-001'))
+        await Promise.resolve()
+      })
+
+      // Without the preMutationRow check, the confirmed row wouldn't match
+      // 'absent' either, forcing an 'exiting' override that would flash
+      // emp-001 into "Ausentes" for 350ms before sliding it back out — a card
+      // that never belonged to this tab in the first place.
+      expect(result.current.isCardExiting('emp-001')).toBe(false)
+      expect(result.current.visibleRows.map((r) => r.employee.id)).not.toContain('emp-001')
+    })
+
+    it('cancels an in-flight exit animation immediately when the manager switches to the tab the card now belongs in (bug regression: no half-faded, unclickable flash before snapping to normal)', async () => {
+      // Initial load: both pending. The follow-up (persistent) response
+      // reflects emp-001 checked in — same two-response pattern as the
+      // markDayStatus test below, so a background refetch triggered by the
+      // mutation's own invalidateQueries doesn't silently revert `data`
+      // back to its stale pre-mutation fixture out from under this test.
+      vi.mocked(attendanceApi.daily)
+        .mockResolvedValueOnce({ data: { data: [makeRow(), makeRow({ employee: { id: 'emp-002', code: 'EMP-002', user: { first_name: 'Ana', last_name: 'López' }, roles: [], daily_wage: null } })] } } as never)
+        .mockResolvedValue({
+          data: {
+            data: [
+              makeRow({ attendance: { id: 'att-x', check_in: '2026-04-01T13:00:00-06:00', day_status: 'WORKED' } as TodayAttendanceRow['attendance'] }),
+              makeRow({ employee: { id: 'emp-002', code: 'EMP-002', user: { first_name: 'Ana', last_name: 'López' }, roles: [], daily_wage: null } }),
+            ],
+          },
+        } as never)
+      vi.mocked(attendanceApi.checkIn).mockResolvedValueOnce(mockCheckInRecord('emp-001') as never)
+
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      await waitFor(() => expect(result.current.selectedFilter).toBe('pending'))
+      act(() => result.current.openCheckIn(makeRow()))
+      await act(async () => { result.current.confirmCheckIn('14:00') })
+
+      // Still on "Pendientes" — the checked-in row doesn't match it, so the
+      // exit animation legitimately starts playing.
+      expect(result.current.isCardExiting('emp-001')).toBe(true)
+
+      // Switch to "En trabajo" mid-animation — the row genuinely belongs
+      // here now.
+      await waitFor(() => expect(result.current.rows.find((r) => r.employee.id === 'emp-001')?.attendance?.check_in).not.toBeNull())
+      act(() => result.current.toggleFilter('checkedIn'))
+
+      // The stale exit (whose animation was for LEAVING "Pendientes") must
+      // be cancelled immediately instead of continuing to fade/pop the card
+      // for the remainder of its 350ms window in a tab it actually belongs to.
+      expect(result.current.isCardExiting('emp-001')).toBe(false)
+      expect(result.current.visibleRows.map((r) => r.employee.id)).toContain('emp-001')
+    })
+
+    it('two mutations for the same employee within the animation window only ever leave one live timer armed', async () => {
+      mockTwoPending()
+      vi.mocked(attendanceApi.checkIn).mockResolvedValueOnce(mockCheckInRecord('emp-001') as never)
+      vi.mocked(attendanceApi.lunchStart).mockResolvedValueOnce({
+        data: { status: 200, data: { id: 'att-x', employee_id: 'emp-001', lunch_start: '2026-04-01T14:00:00-06:00', check_in: '2026-04-01T13:00:00-06:00', day_status: 'WORKED' } },
+      } as never)
+
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      await waitFor(() => expect(result.current.selectedFilter).toBe('pending'))
+      const clearTimeoutSpy = vi.spyOn(global, 'clearTimeout')
+
+      act(() => result.current.openCheckIn(makeRow()))
+      await act(async () => { result.current.confirmCheckIn('14:00') })
+      expect(result.current.isCardExiting('emp-001')).toBe(true)
+
+      // Immediately act again on the same employee (lunch-start) before the
+      // first 350ms timer would fire — the stale timer must be cancelled.
+      act(() => result.current.openLunchStart(makeRow().employee, 'att-x'))
+      await act(async () => { result.current.confirmLunchStart('14:00') })
+
+      expect(clearTimeoutSpy).toHaveBeenCalled()
+      expect(result.current.isCardExiting('emp-001')).toBe(true)
+      clearTimeoutSpy.mockRestore()
+    })
+
+    // ── mark-falta (existing flow, now routed through markDayStatus's own
+    //    confirmed response instead of a manually-called pinEmployeeCard) ────
+
+    it('markDayStatus pins the row immediately and keeps it interactive until the flow concludes', async () => {
+      mockTwoPending()
+      vi.mocked(attendanceApi.markDayStatus).mockReturnValueOnce(new Promise(() => {}) as never)
+
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      await waitFor(() => expect(result.current.selectedFilter).toBe('pending'))
+
+      act(() => { void result.current.markDayStatus(makeEmployee({ id: 'emp-002' }), 'ABSENCE') })
+
+      // Pinned — still rendered (its own row is already 'pending' so this
+      // isn't observable via visibility, but isMarkingDayStatus flips true)
+      expect(result.current.isMarkingDayStatus('emp-002')).toBe(true)
+      expect(result.current.isCardExiting('emp-002')).toBe(false)
+    })
+
+    it('onFaltaFlowComplete plays the exit animation using the response captured when markDayStatus succeeded, then removes the row', async () => {
+      // Initial load: both pending. Any subsequent refetch (the real
+      // useMarkDayStatus hook's own invalidateQueries) must reflect the
+      // absence — otherwise this test would be asserting against its own
+      // stale fixture, not the app's behavior.
+      vi.mocked(attendanceApi.daily)
+        .mockResolvedValueOnce({ data: { data: [makeRow(), makeRow({ employee: { id: 'emp-002', code: 'EMP-002', user: { first_name: 'Ana', last_name: 'López' }, roles: [], daily_wage: null } })] } } as never)
+        .mockResolvedValue({
+          data: {
+            data: [
+              makeRow(),
+              makeRow({
+                employee: { id: 'emp-002', code: 'EMP-002', user: { first_name: 'Ana', last_name: 'López' }, roles: [], daily_wage: null },
+                attendance: { id: 'att-2', day_status: 'ABSENCE' } as TodayAttendanceRow['attendance'],
+              }),
+            ],
+          },
+        } as never)
+      vi.mocked(attendanceApi.markDayStatus).mockResolvedValueOnce(mockAbsenceRecord() as never)
+
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      await waitFor(() => expect(result.current.selectedFilter).toBe('pending'))
+
+      await act(async () => { await result.current.markDayStatus(makeEmployee({ id: 'emp-002' }), 'ABSENCE') })
+      expect(result.current.isCardExiting('emp-002')).toBe(false)
+
+      vi.useFakeTimers()
+      act(() => result.current.onFaltaFlowComplete('emp-002'))
+
+      expect(result.current.visibleRows.map((r) => r.employee.id)).toEqual(['emp-001', 'emp-002'])
+      expect(result.current.isCardExiting('emp-002')).toBe(true)
+
+      act(() => vi.advanceTimersByTime(350))
+
+      expect(result.current.visibleRows.map((r) => r.employee.id)).toEqual(['emp-001'])
+      expect(result.current.isCardExiting('emp-002')).toBe(false)
+    })
+
+    it('onFaltaFlowComplete uses the mutation response, not the page\'s (possibly still-stale) live data', async () => {
+      // `data` never reflects the absence — simulating the window before any
+      // refetch/poll has landed. The exit decision must not depend on it.
+      mockTwoPending()
+      vi.mocked(attendanceApi.markDayStatus).mockResolvedValueOnce(mockAbsenceRecord() as never)
+
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      await waitFor(() => expect(result.current.selectedFilter).toBe('pending'))
+      await act(async () => { await result.current.markDayStatus(makeEmployee({ id: 'emp-002' }), 'ABSENCE') })
+
+      vi.useFakeTimers()
+      act(() => result.current.onFaltaFlowComplete('emp-002'))
+
+      // `data` (from attendanceApi.daily) still says emp-002 is pending, yet
+      // the animation must still fire because the CAPTURED response says ABSENCE.
+      expect(result.current.isCardExiting('emp-002')).toBe(true)
+    })
+
+    it('markDayStatus failure releases the pin (bug regression: no permanent stuck pin on a failed write)', async () => {
+      mockTwoPending()
+      vi.mocked(attendanceApi.markDayStatus).mockRejectedValueOnce(new Error('422'))
+
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      await waitFor(() => expect(result.current.selectedFilter).toBe('pending'))
+
+      const succeeded = await act(async () => result.current.markDayStatus(makeEmployee({ id: 'emp-002' }), 'ABSENCE'))
+      expect(succeeded).toBe(false)
+      expect(result.current.isMarkingDayStatus('emp-002')).toBe(false)
+
+      // onFaltaFlowComplete is never reached in production on a failure (the
+      // card hook's confirmFalta only opens askJustifyOpen on success), but
+      // even if called, there's no captured context to animate from.
+      act(() => result.current.onFaltaFlowComplete('emp-002'))
+      expect(result.current.isCardExiting('emp-002')).toBe(false)
+    })
+
+    it('onFaltaFlowComplete releases a stuck pin when markDayStatus succeeded but had no pre-mutation row to hand off (bug regression: no permanent stuck pin outside its own tab)', async () => {
+      // emp-002 doesn't exist in `data` yet at mutation time — markDayStatus's
+      // own `data.find(...)` (captured synchronously before the mutation) has
+      // nothing to hand off, so faltaFlowContext is never set for it, even
+      // though the pin below is still set unconditionally. The follow-up
+      // mock (landing via markDayStatus's own invalidateQueries) brings
+      // emp-002 into `data` for the first time, already ABSENCE — simulating
+      // a background refetch resolving the row after the action.
+      vi.mocked(attendanceApi.daily)
+        .mockResolvedValueOnce({ data: { data: [makeRow()] } } as never)
+        .mockResolvedValue({
+          data: {
+            data: [
+              makeRow(),
+              makeRow({
+                employee: { id: 'emp-002', code: 'EMP-002', user: { first_name: 'Ana', last_name: 'López' }, roles: [], daily_wage: null },
+                attendance: { id: 'att-2', day_status: 'ABSENCE' } as TodayAttendanceRow['attendance'],
+              }),
+            ],
+          },
+        } as never)
+      vi.mocked(attendanceApi.markDayStatus).mockResolvedValueOnce(mockAbsenceRecord() as never)
+
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      await waitFor(() => expect(result.current.selectedFilter).toBe('pending'))
+      expect(result.current.visibleRows.map((r) => r.employee.id)).toEqual(['emp-001'])
+
+      const succeeded = await act(async () => result.current.markDayStatus(makeEmployee({ id: 'emp-002' }), 'ABSENCE'))
+      expect(succeeded).toBe(true)
+
+      // The refetch lands, bringing emp-002 (now ABSENCE) into `data` for the
+      // first time — force-included in "Pendientes" only because of the
+      // 'pinned' override set when markDayStatus started.
+      await waitFor(() => expect(result.current.visibleRows.map((r) => r.employee.id)).toEqual(['emp-001', 'emp-002']))
+
+      // No captured context exists for emp-002, so onFaltaFlowComplete must
+      // clear the pin itself instead of silently returning — otherwise
+      // emp-002 stays force-included in "Pendientes" forever despite being
+      // ABSENCE, with no way to clear it short of a page reload.
+      act(() => result.current.onFaltaFlowComplete('emp-002'))
+
+      expect(result.current.visibleRows.map((r) => r.employee.id)).toEqual(['emp-001'])
+    })
+
+    it('onFaltaFlowComplete clears the pin immediately, with no exit animation, when the confirmed result still matches the active filter', async () => {
+      mockTwoPending()
+      vi.mocked(attendanceApi.markDayStatus).mockResolvedValueOnce(mockAbsenceRecord() as never)
+
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      // "Total" reveals everyone, so the ABSENCE row already matches the
+      // active filter before and after the flow — it never needs to leave.
       await waitFor(() => expect(result.current.selectedFilter).toBe('pending'))
       act(() => result.current.toggleFilter('total'))
 
-      act(() => result.current.pinEmployeeCard('emp-002'))
-      expect(result.current.visibleRows.map((r) => r.employee.id)).toEqual(['emp-001', 'emp-002'])
-
+      await act(async () => { await result.current.markDayStatus(makeEmployee({ id: 'emp-002' }), 'ABSENCE') })
       act(() => result.current.onFaltaFlowComplete('emp-002'))
 
-      // Pin cleared immediately — no 'exiting' state, no animation, row stays put
       expect(result.current.isCardExiting('emp-002')).toBe(false)
       expect(result.current.visibleRows.map((r) => r.employee.id)).toEqual(['emp-001', 'emp-002'])
+    })
+
+    it('two employees\' overlapping markDayStatus calls keep independent busy/pin state', async () => {
+      mockTwoPending()
+      let resolveA: (value: unknown) => void
+      let resolveB: (value: unknown) => void
+      vi.mocked(attendanceApi.markDayStatus)
+        .mockReturnValueOnce(new Promise((resolve) => { resolveA = resolve }) as never)
+        .mockReturnValueOnce(new Promise((resolve) => { resolveB = resolve }) as never)
+
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      await waitFor(() => expect(result.current.selectedFilter).toBe('pending'))
+
+      act(() => { void result.current.markDayStatus(makeEmployee({ id: 'emp-001' }), 'ABSENCE') })
+      act(() => { void result.current.markDayStatus(makeEmployee({ id: 'emp-002' }), 'ABSENCE') })
+
+      expect(result.current.isMarkingDayStatus('emp-001')).toBe(true)
+      expect(result.current.isMarkingDayStatus('emp-002')).toBe(true)
+
+      await act(async () => {
+        resolveA({ data: { status: 201, data: { id: 'att-1', employee_id: 'emp-001', day_status: 'ABSENCE' } } })
+        await Promise.resolve()
+      })
+
+      expect(result.current.isMarkingDayStatus('emp-001')).toBe(false)
+      expect(result.current.isMarkingDayStatus('emp-002')).toBe(true)
+
+      await act(async () => {
+        resolveB({ data: { status: 201, data: { id: 'att-2', employee_id: 'emp-002', day_status: 'ABSENCE' } } })
+        await Promise.resolve()
+      })
+      expect(result.current.isMarkingDayStatus('emp-002')).toBe(false)
+    })
+
+    it('date/branch switch resets pinned/exiting overrides and cancels pending timers, even under StrictMode', async () => {
+      mockTwoPending()
+      vi.mocked(attendanceApi.markDayStatus).mockResolvedValueOnce(mockAbsenceRecord() as never)
+
+      const { wrapper } = makeStrictWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      await waitFor(() => expect(result.current.selectedFilter).toBe('pending'))
+      await act(async () => { await result.current.markDayStatus(makeEmployee({ id: 'emp-002' }), 'ABSENCE') })
+
+      vi.useFakeTimers()
+      act(() => result.current.onFaltaFlowComplete('emp-002'))
+      expect(result.current.isCardExiting('emp-002')).toBe(true)
+
+      act(() => result.current.setSelectedDate('2026-02-24'))
+
+      expect(result.current.isCardExiting('emp-002')).toBe(false)
+      // Advancing time after the reset must not resurrect the cleared override
+      act(() => vi.advanceTimersByTime(350))
+      expect(result.current.isCardExiting('emp-002')).toBe(false)
+    })
+
+    it('never dead-ends the "Ver todos"/total tab — an overridden row is still included there', async () => {
+      mockTwoPending()
+      vi.mocked(attendanceApi.markDayStatus).mockReturnValueOnce(new Promise(() => {}) as never)
+
+      const { wrapper } = makeWrapper()
+      const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
+
+      await waitFor(() => expect(result.current.selectedFilter).toBe('pending'))
+      act(() => { void result.current.markDayStatus(makeEmployee({ id: 'emp-002' }), 'ABSENCE') })
+
+      act(() => result.current.toggleFilter('total'))
+      expect(result.current.visibleRows.map((r) => r.employee.id)).toEqual(expect.arrayContaining(['emp-001', 'emp-002']))
     })
 
     it('keeps a pinned/exiting row in its original grid position instead of moving it to the end', async () => {
@@ -1229,13 +1651,14 @@ describe('useTodayAttendancePage', () => {
             makeRow({
               employee: { id: 'emp-002', code: 'EMP-002', user: { first_name: 'Ana', last_name: 'López' }, roles: [], daily_wage: null },
               attendance: { id: 'att-2', day_status: 'ABSENCE' } as TodayAttendanceRow['attendance'],
-            }), // emp-002, absent — sits BETWEEN two pending rows
+            }), // emp-002, absent — sits BETWEEN two pending rows, doesn't match "pending"
             makeRow({
               employee: { id: 'emp-003', code: 'EMP-003', user: { first_name: 'Beto', last_name: 'Ruiz' }, roles: [], daily_wage: null },
             }), // emp-003, pending
           ],
         },
       } as never)
+      vi.mocked(attendanceApi.markDayStatus).mockReturnValueOnce(new Promise(() => {}) as never)
 
       const { wrapper } = makeWrapper()
       const { result } = renderHook(() => useTodayAttendancePage(), { wrapper })
@@ -1243,10 +1666,10 @@ describe('useTodayAttendancePage', () => {
       await waitFor(() => expect(result.current.selectedFilter).toBe('pending'))
       expect(result.current.visibleRows.map((r) => r.employee.id)).toEqual(['emp-001', 'emp-003'])
 
-      act(() => result.current.pinEmployeeCard('emp-002'))
+      act(() => { void result.current.markDayStatus(makeEmployee({ id: 'emp-002' }), 'ABSENCE') })
 
-      // emp-002 reappears in its original slot (between emp-001 and emp-003),
-      // not appended after emp-003
+      // emp-002 (pinned, ABSENCE — doesn't match "pending") reappears in its
+      // original slot between emp-001 and emp-003, not appended after emp-003
       expect(result.current.visibleRows.map((r) => r.employee.id)).toEqual(['emp-001', 'emp-002', 'emp-003'])
     })
   })

--- a/code/webapp/src/pages/attendance/index.tsx
+++ b/code/webapp/src/pages/attendance/index.tsx
@@ -25,6 +25,7 @@ import { useAttendancePermissions } from '@/components/attendance/use-attendance
 import { AuditLogDialog } from '@/components/audit'
 import { AUDITABLE_TYPE_ATTENDANCE } from '@/services/audit.service'
 import { useTodayAttendancePage } from './-use-today-attendance-page'
+import { useAttendanceGridFlip } from './-use-attendance-grid-flip'
 import { useApplicationTimeLabel } from '@/hooks/use-application-time-label'
 import { useAuthStore } from '@/stores/auth.store'
 import { todayDateCdmx } from '@/lib/datetime'
@@ -148,7 +149,6 @@ export function AttendancePage() {
     selectedFilter,
     toggleFilter,
     isCardExiting,
-    pinEmployeeCard,
     onFaltaFlowComplete,
     selectedDate,
     setSelectedDate,
@@ -192,12 +192,15 @@ export function AttendancePage() {
     closeBulkOvertimeDecision,
     // Mark day status
     markDayStatus,
+    isMarkingDayStatus,
     // Extra day express
     extraDayRow,
     isRegisteringExtraDay,
     closeExtraDay,
     confirmExtraDay,
   } = useTodayAttendancePage(search.tab ?? null)
+
+  const { setCardRef: getCardRef, containerRef: gridContainerRef } = useAttendanceGridFlip(visibleRows.map((row) => row.employee.id))
 
   const maxTime = useApplicationTimeLabel()
   const closeDayPanel = useCloseDayPanel(rows, branchId, maxTime)
@@ -294,38 +297,45 @@ export function AttendancePage() {
         if (rows.length === 0) return <EmptyState />
         if (visibleRows.length === 0) return <NoMatchesForFilterState onShowAll={() => toggleFilter('total')} />
         return (
-          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-            {visibleRows.map((row) => (
-              <EmployeeAttendanceCard
-                key={row.employee.id}
-                row={row}
-                canEdit={canEdit}
-                canCorrect={canCorrect}
-                isExiting={isCardExiting(row.employee.id)}
-                onFaltaFlowComplete={onFaltaFlowComplete}
-                onCheckIn={openCheckIn}
-                onLunchStart={openLunchStart}
-                onLunchReturn={openLunchReturn}
-                onCheckOut={openCheckOut}
-                onOvertimeDecision={openOvertimeDecision}
-                onMarkDayStatus={(employee, status) => {
-                  // Keep this card rendered through the justify-now? flow —
-                  // its bucket is about to change and would otherwise vanish
-                  // from the current tab mid-flow (see onFaltaFlowComplete).
-                  pinEmployeeCard(employee.id)
-                  markDayStatus(employee, status)
-                }}
-                onWeeklySummary={can('reports.weekly-summary')
-                  ? (emp) => weeklySummary.open(emp.id, formatLastFirst(emp.user))
-                  : undefined}
-                onViewAudit={can('audit-logs.view')
-                  ? (emp, attendanceId) => setAuditRecord({
-                    employeeName: formatLastFirst(emp.user),
-                    attendanceId,
-                  })
-                  : undefined}
-              />
-            ))}
+          // The inner grid's column count responds to ITS OWN available width
+          // (via this wrapper's `attendance-grid-container` CSS containment),
+          // not the viewport — see the comment above .attendance-card-grid in
+          // index.css for why: the sidebar eats into the real content width
+          // in a way viewport-based sm:/lg:/xl: breakpoints can't see.
+          <div className="attendance-grid-container">
+            <div ref={gridContainerRef} className="attendance-card-grid">
+              {/* Each wrapper is itself `grid` (not `flex`/`block`) — a single-item nested
+                  grid keeps the default stretch behavior the card relied on when it was
+                  directly the outer grid's item, so it still fills both the column width
+                  and the row height every other card in the row stretches to. */}
+              {visibleRows.map((row) => (
+                <div key={row.employee.id} ref={getCardRef(row.employee.id)} className="grid">
+                  <EmployeeAttendanceCard
+                    row={row}
+                    canEdit={canEdit}
+                    canCorrect={canCorrect}
+                    isExiting={isCardExiting(row.employee.id)}
+                    isMarkingDayStatus={isMarkingDayStatus(row.employee.id)}
+                    onFaltaFlowComplete={onFaltaFlowComplete}
+                    onCheckIn={openCheckIn}
+                    onLunchStart={openLunchStart}
+                    onLunchReturn={openLunchReturn}
+                    onCheckOut={openCheckOut}
+                    onOvertimeDecision={openOvertimeDecision}
+                    onMarkDayStatus={markDayStatus}
+                    onWeeklySummary={can('reports.weekly-summary')
+                      ? (emp) => weeklySummary.open(emp.id, formatLastFirst(emp.user))
+                      : undefined}
+                    onViewAudit={can('audit-logs.view')
+                      ? (emp, attendanceId) => setAuditRecord({
+                        employeeName: formatLastFirst(emp.user),
+                        attendanceId,
+                      })
+                      : undefined}
+                  />
+                </div>
+              ))}
+            </div>
           </div>
         )
       })()}

--- a/code/webapp/src/services/__tests__/attendance-hooks-close-day.test.ts
+++ b/code/webapp/src/services/__tests__/attendance-hooks-close-day.test.ts
@@ -41,6 +41,25 @@ function makeWrapper() {
   return { queryClient, wrapper }
 }
 
+/**
+ * Same as makeWrapper(), but with the library's default (non-zero) gcTime —
+ * for tests that seed cache data directly via setQueryData() with no active
+ * useQuery observer keeping it alive. makeWrapper()'s gcTime: 0 schedules
+ * that unobserved data for garbage collection almost immediately, which
+ * would make it disappear before the test can assert on it.
+ */
+function makeLiveWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children)
+  return { queryClient, wrapper }
+}
+
 // ── useCheckOut ────────────────────────────────────────────────────────────────
 
 describe('useCheckOut', () => {
@@ -50,6 +69,7 @@ describe('useCheckOut', () => {
       data: {
         id: 'att-123',
         employee_id: 'emp-001',
+        date: '2026-04-01',
         check_out: '2026-04-01T22:00:00-06:00',
         net_worked_minutes: 420,
         overtime_minutes: 0,
@@ -133,6 +153,27 @@ describe('useCheckOut', () => {
     })
 
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['attendances', 'daily'] })
+  })
+
+  it('splices the confirmed attendance record into the cached row', async () => {
+    vi.mocked(attendanceApi.checkOut).mockResolvedValueOnce(mockCheckOutResponse as never)
+    const { wrapper, queryClient } = makeLiveWrapper()
+    const queryKey = ['attendances', 'daily', '2026-04-01', 5]
+    queryClient.setQueryData(queryKey, [
+      { employee: { id: 'emp-001', code: 'EMP-001', user: { first_name: 'Carlos', last_name: 'Mendoza' }, roles: [], daily_wage: null }, attendance: { id: 'att-123', check_in: '2026-04-01T13:00:00-06:00', check_out: null }, schedule: null, today_leave: null, today_vacation: false },
+    ])
+
+    const { result } = renderHook(() => useCheckOut(), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        attendance_id: 'att-123',
+        check_out: '2026-04-01T22:00:00-06:00',
+      })
+    })
+
+    const rows = queryClient.getQueryData<{ employee: { id: string }; attendance: { check_out: string | null } | null }[]>(queryKey)
+    expect(rows?.[0]?.attendance?.check_out).toBe('2026-04-01T22:00:00-06:00')
   })
 })
 

--- a/code/webapp/src/services/__tests__/attendance-hooks-day-status.test.ts
+++ b/code/webapp/src/services/__tests__/attendance-hooks-day-status.test.ts
@@ -43,6 +43,25 @@ function makeWrapper() {
   return { queryClient, wrapper }
 }
 
+/**
+ * Same as makeWrapper(), but with the library's default (non-zero) gcTime —
+ * for tests that seed cache data directly via setQueryData() with no active
+ * useQuery observer keeping it alive. makeWrapper()'s gcTime: 0 schedules
+ * that unobserved data for garbage collection almost immediately, which
+ * would make it disappear before the test can assert on it.
+ */
+function makeLiveWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children)
+  return { queryClient, wrapper }
+}
+
 const mockAbsenceResponse = {
   data: {
     status: 201,
@@ -141,5 +160,29 @@ describe('useMarkDayStatus', () => {
         expect.objectContaining({ queryKey: ['attendances', 'daily'] })
       )
     )
+  })
+
+  it('splices the confirmed attendance record into the cached row', async () => {
+    vi.mocked(attendanceApi.markDayStatus).mockResolvedValue(mockAbsenceResponse as never)
+    const { wrapper, queryClient } = makeLiveWrapper()
+    const queryKey = ['attendances', 'daily', '2026-04-12', 5]
+    queryClient.setQueryData(queryKey, [
+      { employee: { id: 'emp-001', code: 'EMP-001', user: { first_name: 'Carlos', last_name: 'Mendoza' }, roles: [], daily_wage: null }, attendance: null, schedule: null, today_leave: null, today_vacation: false },
+    ])
+
+    const { result } = renderHook(() => useMarkDayStatus(), { wrapper })
+
+    act(() => {
+      result.current.mutate({
+        employee_id: 'emp-001',
+        date: '2026-04-12',
+        day_status: 'ABSENCE',
+      })
+    })
+
+    await waitFor(() => {
+      const rows = queryClient.getQueryData<{ employee: { id: string }; attendance: { day_status: string } | null }[]>(queryKey)
+      expect(rows?.[0]?.attendance?.day_status).toBe('ABSENCE')
+    })
   })
 })

--- a/code/webapp/src/services/__tests__/attendance-hooks.test.ts
+++ b/code/webapp/src/services/__tests__/attendance-hooks.test.ts
@@ -39,6 +39,25 @@ function makeWrapper() {
   return { queryClient, wrapper }
 }
 
+/**
+ * Same as makeWrapper(), but with the library's default (non-zero) gcTime —
+ * for tests that seed cache data directly via setQueryData() with no active
+ * useQuery observer keeping it alive. makeWrapper()'s gcTime: 0 schedules
+ * that unobserved data for garbage collection almost immediately, which
+ * would make it disappear before the test can assert on it.
+ */
+function makeLiveWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children)
+  return { queryClient, wrapper }
+}
+
 const mockTodayResponse = {
   data: {
     data: [
@@ -62,6 +81,7 @@ const mockAttendanceRecord = {
     data: {
       id: 'att-123',
       employee_id: 'emp-001',
+      date: '2026-04-01',
       check_in: '2026-04-01T13:00:00-06:00',
     },
   },
@@ -197,6 +217,54 @@ describe('useCheckIn', () => {
 
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['attendances', 'daily'] })
   })
+
+  it('splices the confirmed attendance record into the cached row immediately, without waiting for a refetch', async () => {
+    vi.mocked(attendanceApi.checkIn).mockResolvedValueOnce(mockAttendanceRecord as never)
+    const { wrapper, queryClient } = makeLiveWrapper()
+    const queryKey = ['attendances', 'daily', '2026-04-01', 5]
+    queryClient.setQueryData(queryKey, [
+      { employee: { id: 'emp-001', code: 'EMP-001', user: { first_name: 'Carlos', last_name: 'Mendoza' }, roles: [], daily_wage: null }, attendance: null, schedule: null, today_leave: null, today_vacation: false },
+      { employee: { id: 'emp-002', code: 'EMP-002', user: { first_name: 'María', last_name: 'García' }, roles: [], daily_wage: null }, attendance: null, schedule: null, today_leave: null, today_vacation: false },
+    ])
+
+    const { result } = renderHook(() => useCheckIn(), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        employee_id: 'emp-001',
+        check_in: '2026-04-01T13:00:00-06:00',
+      })
+    })
+
+    const rows = queryClient.getQueryData<{ employee: { id: string }; attendance: { id: string; check_in: string | null } | null }[]>(queryKey)
+    expect(rows?.find((r) => r.employee.id === 'emp-001')?.attendance).toEqual(
+      expect.objectContaining({ id: 'att-123', check_in: '2026-04-01T13:00:00-06:00' })
+    )
+    // Unrelated row untouched
+    expect(rows?.find((r) => r.employee.id === 'emp-002')?.attendance).toBeNull()
+  })
+
+  it('does not splice the confirmed record into a cached list for a different date', async () => {
+    vi.mocked(attendanceApi.checkIn).mockResolvedValueOnce(mockAttendanceRecord as never)
+    const { wrapper, queryClient } = makeLiveWrapper()
+    const otherDayKey = ['attendances', 'daily', '2026-04-02', 5]
+    queryClient.setQueryData(otherDayKey, [
+      { employee: { id: 'emp-001', code: 'EMP-001', user: { first_name: 'Carlos', last_name: 'Mendoza' }, roles: [], daily_wage: null }, attendance: null, schedule: null, today_leave: null, today_vacation: false },
+    ])
+
+    const { result } = renderHook(() => useCheckIn(), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        employee_id: 'emp-001',
+        check_in: '2026-04-01T13:00:00-06:00',
+      })
+    })
+
+    const rows = queryClient.getQueryData<{ employee: { id: string }; attendance: { id: string; check_in: string | null } | null }[]>(otherDayKey)
+    // A record confirmed for 2026-04-01 must never overwrite the row cached under 2026-04-02.
+    expect(rows?.find((r) => r.employee.id === 'emp-001')?.attendance).toBeNull()
+  })
 })
 
 // ── useLunchStart ──────────────────────────────────────────────────────────────
@@ -306,6 +374,29 @@ describe('useLunchStart', () => {
       lunch_start: '2026-04-01T15:30:00-06:00',
     })
   })
+
+  it('splices the confirmed attendance record into the cached row, matched by employee_id (not the attendance_id the request was keyed by)', async () => {
+    vi.mocked(attendanceApi.lunchStart).mockResolvedValueOnce({
+      data: { status: 200, data: { id: 'att-123', employee_id: 'emp-002', date: '2026-04-01', lunch_start: '2026-04-01T14:00:00-06:00' } },
+    } as never)
+    const { wrapper, queryClient } = makeLiveWrapper()
+    const queryKey = ['attendances', 'daily', '2026-04-01', 5]
+    queryClient.setQueryData(queryKey, [
+      { employee: { id: 'emp-002', code: 'EMP-002', user: { first_name: 'María', last_name: 'García' }, roles: [], daily_wage: null }, attendance: { id: 'att-123', check_in: '2026-04-01T13:00:00-06:00', lunch_start: null }, schedule: null, today_leave: null, today_vacation: false },
+    ])
+
+    const { result } = renderHook(() => useLunchStart(), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        attendance_id: 'att-123',
+        lunch_start: '2026-04-01T14:00:00-06:00',
+      })
+    })
+
+    const rows = queryClient.getQueryData<{ employee: { id: string }; attendance: { lunch_start: string | null } | null }[]>(queryKey)
+    expect(rows?.[0]?.attendance?.lunch_start).toBe('2026-04-01T14:00:00-06:00')
+  })
 })
 
 // ── useLunchReturn ─────────────────────────────────────────────────────────────
@@ -414,5 +505,28 @@ describe('useLunchReturn', () => {
     expect(attendanceApi.lunchReturn).toHaveBeenCalledWith('different-id', {
       lunch_end: '2026-04-01T16:30:00-06:00',
     })
+  })
+
+  it('splices the confirmed attendance record into the cached row', async () => {
+    vi.mocked(attendanceApi.lunchReturn).mockResolvedValueOnce({
+      data: { status: 200, data: { id: 'att-123', employee_id: 'emp-001', date: '2026-04-01', lunch_end: '2026-04-01T15:00:00-06:00' } },
+    } as never)
+    const { wrapper, queryClient } = makeLiveWrapper()
+    const queryKey = ['attendances', 'daily', '2026-04-01', 5]
+    queryClient.setQueryData(queryKey, [
+      { employee: { id: 'emp-001', code: 'EMP-001', user: { first_name: 'Carlos', last_name: 'Mendoza' }, roles: [], daily_wage: null }, attendance: { id: 'att-123', lunch_start: '2026-04-01T14:00:00-06:00', lunch_end: null }, schedule: null, today_leave: null, today_vacation: false },
+    ])
+
+    const { result } = renderHook(() => useLunchReturn(), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        attendance_id: 'att-123',
+        lunch_end: '2026-04-01T15:00:00-06:00',
+      })
+    })
+
+    const rows = queryClient.getQueryData<{ employee: { id: string }; attendance: { lunch_end: string | null } | null }[]>(queryKey)
+    expect(rows?.[0]?.attendance?.lunch_end).toBe('2026-04-01T15:00:00-06:00')
   })
 })

--- a/code/webapp/src/services/attendance-hooks.ts
+++ b/code/webapp/src/services/attendance-hooks.ts
@@ -1,8 +1,34 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useQuery, useMutation, useQueryClient, type QueryClient } from '@tanstack/react-query'
 import { attendanceApi } from './attendance-api'
 import { useToast } from '@/components/ui/toast-context'
 import { getApiErrorMessage } from '@/lib/api-error'
-import type { TodayAttendanceRow, CloseDayRequest, OvertimeDecisionPayload, OvertimeValuationMethod, OvertimeValuationPreview, BulkOvertimeDecisionPayload } from '@/types/attendance'
+import { attendanceRecordToRowData } from '@/types/attendance'
+import type { TodayAttendanceRow, AttendanceRecord, CloseDayRequest, OvertimeDecisionPayload, OvertimeValuationMethod, OvertimeValuationPreview, BulkOvertimeDecisionPayload } from '@/types/attendance'
+
+/**
+ * Splices a mutation's own confirmed AttendanceRecord into the cached daily-
+ * attendance list(s) for the record's own date (queryKey[2] — see
+ * useDailyAttendance below), instead of waiting for the invalidateQueries
+ * call each caller makes right after this — or the next 30s poll — to find
+ * out what the mutation's own response already said. Scoped by date so a
+ * record for one day never overwrites another cached day's list for the same
+ * employee_id (which every one of these mutations' responses carries,
+ * regardless of whether the request itself was keyed by employee_id or
+ * attendance_id).
+ */
+function applyAttendanceRecord(queryClient: QueryClient, record: AttendanceRecord) {
+  queryClient.setQueriesData<TodayAttendanceRow[]>(
+    { queryKey: ['attendances', 'daily'], predicate: (query) => query.queryKey[2] === record.date },
+    (rows) => {
+      if (!rows) return rows
+      return rows.map((row) =>
+        row.employee.id === record.employee_id
+          ? { ...row, attendance: attendanceRecordToRowData(record) }
+          : row
+      )
+    }
+  )
+}
 
 /**
  * Fetch attendance for all active employees of a branch for a given date.
@@ -41,7 +67,8 @@ export function useCheckIn() {
   return useMutation({
     mutationFn: (data: { employee_id: string; check_in: string; reason?: string }) =>
       attendanceApi.checkIn(data),
-    onSuccess: () => {
+    onSuccess: (response) => {
+      applyAttendanceRecord(queryClient, response.data.data)
       queryClient.invalidateQueries({ queryKey: ['attendances', 'daily'] })
       showSuccess('Entrada registrada correctamente.', 'Check-in')
     },
@@ -64,7 +91,8 @@ export function useLunchStart() {
   return useMutation({
     mutationFn: (data: { attendance_id: string; lunch_start: string; reason?: string }) =>
       attendanceApi.lunchStart(data.attendance_id, { lunch_start: data.lunch_start, reason: data.reason }),
-    onSuccess: () => {
+    onSuccess: (response) => {
+      applyAttendanceRecord(queryClient, response.data.data)
       queryClient.invalidateQueries({ queryKey: ['attendances', 'daily'] })
       showSuccess('Salida a comida registrada correctamente.', 'Lunch Start')
     },
@@ -87,7 +115,8 @@ export function useLunchReturn() {
   return useMutation({
     mutationFn: (data: { attendance_id: string; lunch_end: string; reason?: string }) =>
       attendanceApi.lunchReturn(data.attendance_id, { lunch_end: data.lunch_end, reason: data.reason }),
-    onSuccess: () => {
+    onSuccess: (response) => {
+      applyAttendanceRecord(queryClient, response.data.data)
       queryClient.invalidateQueries({ queryKey: ['attendances', 'daily'] })
       showSuccess('Regreso de comida registrado correctamente.', 'Lunch Return')
     },
@@ -110,7 +139,8 @@ export function useCheckOut() {
   return useMutation({
     mutationFn: (data: { attendance_id: string; check_out: string; reason?: string }) =>
       attendanceApi.checkOut(data.attendance_id, { check_out: data.check_out, reason: data.reason }),
-    onSuccess: () => {
+    onSuccess: (response) => {
+      applyAttendanceRecord(queryClient, response.data.data)
       queryClient.invalidateQueries({ queryKey: ['attendances', 'daily'] })
       showSuccess('Salida registrada correctamente.', 'Check-out')
     },
@@ -194,7 +224,8 @@ export function useMarkDayStatus() {
   return useMutation({
     mutationFn: (data: { employee_id: string; date: string; day_status: 'ABSENCE'; reason?: string }) =>
       attendanceApi.markDayStatus(data),
-    onSuccess: () => {
+    onSuccess: (response) => {
+      applyAttendanceRecord(queryClient, response.data.data)
       queryClient.invalidateQueries({ queryKey: ['attendances', 'daily'] })
       showSuccess('Día marcado como falta.', 'Día marcado')
     },

--- a/code/webapp/src/types/attendance.ts
+++ b/code/webapp/src/types/attendance.ts
@@ -136,6 +136,36 @@ export interface TodayAttendanceResponse {
   data: TodayAttendanceRow[]
 }
 
+/**
+ * Narrows a mutation's returned `AttendanceRecord` (check-in/lunch/check-out/
+ * mark-day-status responses all share this shape) down to `TodayAttendanceData`
+ * — every field `TodayAttendanceData` has is already present on `AttendanceRecord`
+ * with a matching name/type. Lets a mutation's `onSuccess` splice its own
+ * confirmed result directly into the cached daily-attendance row instead of
+ * waiting for the next poll/invalidation-triggered refetch to find out what
+ * it already knows.
+ */
+export function attendanceRecordToRowData(record: AttendanceRecord): TodayAttendanceData {
+  return {
+    id: record.id,
+    check_in: record.check_in,
+    lunch_start: record.lunch_start,
+    lunch_end: record.lunch_end,
+    check_out: record.check_out,
+    day_status: record.day_status,
+    entry_late_seconds: record.entry_late_seconds,
+    entry_late_minutes: record.entry_late_minutes,
+    is_entry_deductible: record.is_entry_deductible,
+    overtime_minutes: record.overtime_minutes,
+    overtime_authorized: record.overtime_authorized,
+    overtime_authorized_at: record.overtime_authorized_at,
+    overtime_valuation_method: record.overtime_valuation_method,
+    overtime_rate_applied: record.overtime_rate_applied,
+    overtime_amount: record.overtime_amount,
+    requires_overtime_decision: record.requires_overtime_decision,
+  }
+}
+
 // #region Close Day types
 
 export interface CloseDayLunchReturn {

--- a/doc/sprints/sprint-002-platillos-catalog-platform-hardening.md
+++ b/doc/sprints/sprint-002-platillos-catalog-platform-hardening.md
@@ -6,7 +6,7 @@ status: In Progress
 created: 2026-07-31
 started: 2026-07-31
 completed:
-last_updated: 2026-08-05
+last_updated: 2026-08-10
 
 base_branch: main
 base_commit: 4ac51ff
@@ -37,14 +37,14 @@ public repo), a **High**-value Attendance Today correctness bug (`#358`), and fi
 technical-debt Issues already open on the backlog (`#357`, `#360`, `#365`, `#382`, `#383`) plus
 two small Low-tier cleanups (`#376`, `#385`).
 
-**Progress as of 2026-08-07:** 10 of 14 scoped Issues completed (71.4%) — `#384` (Critical
+**Progress as of 2026-08-10:** 10 of 14 scoped Issues completed (71.4%) — `#384` (Critical
 `APP_KEY` security exposure, PR #393), `#385` (SonarCloud `Readonly` code-smell cleanup, PR
 #391), `#358` (Attendance Today "Ausentes" correctness bug, PR #395), `#376` (dead item Type
 selector removal, PR #396), `#383` (Payroll Periods `DataGrid` migration, PR #398), `#379`
 (Platillos dishes backend domain, PR #394), `#377` (unified media upload system, PR #392),
-`#382` (daily report employee table `DataGrid` migration, PR #408), and `#381` (Platillos dishes
-seed data — Testing/Fakes/Development, PR #406) merged to `main`; `#378` (reusable media gallery
-uploader component, PR #407) implemented and fully reviewed, PR open and ready for merge.
+`#382` (daily report employee table `DataGrid` migration, PR #408), `#381` (Platillos dishes
+seed data — Testing/Fakes/Development, PR #406), and `#378` (reusable media gallery uploader
+component, PR #407) merged to `main`.
 
 File-conflict analysis (§9) found **zero shared-file collisions** among all 14 Issues — every
 Issue touches a distinct set of files or a distinct route. The only real ordering constraints are
@@ -101,7 +101,7 @@ between parallel agents.
 | Completed | — |
 | Calendar duration | — |
 | Active workdays | — |
-| Progress (Issues completed) | 10 / 14 (71.4%) as of 2026-08-07 — `#384` (PR #393), `#385` (PR #391), `#358` (PR #395), `#376` (PR #396), `#383` (PR #398), `#379` (PR #394), `#377` (PR #392), `#382` (PR #408), and `#381` (PR #406) merged to `main`; `#378` (reusable media gallery uploader component, PR #407) implemented and fully reviewed, PR open and ready for merge |
+| Progress (Issues completed) | 10 / 14 (71.4%) as of 2026-08-10 — `#384` (PR #393), `#385` (PR #391), `#358` (PR #395), `#376` (PR #396), `#383` (PR #398), `#379` (PR #394), `#377` (PR #392), `#382` (PR #408), `#381` (PR #406), and `#378` (PR #407) merged to `main` |
 
 ## 5. Scope
 
@@ -182,7 +182,7 @@ because every Round 1 Issue is independently assignable to its own agent/workspa
 
 | Status | Issue | Title | Value | Opt. | Pess. | Tracked | PR / Commit | Notes |
 |---|---:|---|---|---:|---:|---:|---|---|
-| ✅ | #378 | Build a reusable media gallery uploader component (frontend) | High | 3h | 6h | 29.9h | PR #407 | `<MediaGalleryUploader />` + `useMediaGalleryUploader()` wired into ItemForm; 100 Vitest tests + 1 Cypress E2E; PR ready, merge pending |
+| ✅ | #378 | Build a reusable media gallery uploader component (frontend) | High | 3h | 6h | 29.9h | PR #407 | `<MediaGalleryUploader />` + `useMediaGalleryUploader()` wired into ItemForm; 100 Vitest tests + 1 Cypress E2E; merged to `main` (c1404a3) |
 | ✅ | #381 | Seed Platillos (dishes) data — Testing/Fakes/Development | Medium | 2h | 4h | 37.1h | PR #406 | Testing/DishesTestSeeder, Fakes/FakeDishesSeeder, Development/DishCategorySeeder+DishSeeder (9 categories, 36 dishes) all registered and tested; two independent review rounds (Devin + human) fixed a soft-delete restore bug and moved menu data to config/seeders.php; merged to `main` (b6cd1ad) |
 |  |  | **Round total** |  | **5h** | **10h** | **—** |  |  |
 
@@ -315,7 +315,7 @@ since this document numbers its own §7 as Route A — Execution Rounds instead.
 | ⏳ | #365 | Not started | — | — | — | — |
 | ✅ | #385 | Wrapped `PropertyItem`/`InfoItem` props in `Readonly<...>` across 3 inventory detail components, clearing all 4 open SonarCloud `typescript:S6759` code smells | PR #391 | `a322131` | 0.2h | Pure type-annotation change, no runtime behavior change; 24/24 existing Vitest tests passing, lint + typecheck clean; CI 12/12 green, Copilot 0 comments, Devin/DeepWiki 0 bugs/0 flags on first push; merged to `main` (a322131) |
 | ✅ | #376 | Removed the Type (Insumo/Producto/Activo) selector from `item-form.tsx` and `product-wizard.tsx`; new items now default to `type: 'PRODUCTO'` without asking the user, and editing an existing item preserves its current type unchanged | PR #396 | `c1bbe27` | 12.7h | 37 Vitest tests updated/passing (86%+ coverage on touched files), lint + typecheck clean, no backend changes; 1 Copilot review comment addressed (brittle select-count assertion swapped for a label-absence check); Devin/DeepWiki 0 bugs, 3 informational-only flags evaluated and found not applicable; CI 12/12 green — merged to `main` (c1bbe27) |
-| ✅ | #378 | Built `<MediaGalleryUploader />` + `useMediaGalleryUploader()`: drag-drop/file-picker upload, thumbnail grid with image/video preview, reorder via arrow buttons (sequential PATCHes with rollback on partial failure), remove, mark-primary, all thumbnail controls locked while a mutation is in flight; `owner_token` generated via `crypto.randomUUID()`, failing loudly rather than degrading to a predictable fallback; wired end-to-end into `ItemForm` as the first consumer — PR open, not yet merged | PR #407 | — | 29.9h | 100 Vitest tests (service, hook, component) + 1 Cypress E2E happy path passing against the real dev-lab backend; hit a ~15h18m external GitHub Actions infrastructure outage (jobs stuck `queued`, resolved via retrigger, unrelated to this PR's code); 5 Copilot review threads resolved; Devin/DeepWiki ran its full 5-cycle safety cap, each round fixing a genuine defect (lost primary-photo badge after delete, thumbnail controls not respecting `disabled`, batch-upload abort-on-first-failure, unsafe concurrent PATCH reorder, `Item` request/response type conflation, keyboard-inaccessible controls, a reorder race condition from rapid double-clicks); CI 12/12 green — PR ready, merge pending |
+| ✅ | #378 | Built `<MediaGalleryUploader />` + `useMediaGalleryUploader()`: drag-drop/file-picker upload, thumbnail grid with image/video preview, reorder via arrow buttons (sequential PATCHes with rollback on partial failure), remove, mark-primary, all thumbnail controls locked while a mutation is in flight; `owner_token` generated via `crypto.randomUUID()`, failing loudly rather than degrading to a predictable fallback; wired end-to-end into `ItemForm` as the first consumer — merged to `main` (c1404a3) | PR #407 | `c1404a3` | 29.9h | 100 Vitest tests (service, hook, component) + 1 Cypress E2E happy path passing against the real dev-lab backend; hit a ~15h18m external GitHub Actions infrastructure outage (jobs stuck `queued`, resolved via retrigger, unrelated to this PR's code); 5 Copilot review threads resolved; Devin/DeepWiki ran its full 5-cycle safety cap, each round fixing a genuine defect (lost primary-photo badge after delete, thumbnail controls not respecting `disabled`, batch-upload abort-on-first-failure, unsafe concurrent PATCH reorder, `Item` request/response type conflation, keyboard-inaccessible controls, a reorder race condition from rapid double-clicks); CI 12/12 green — merged to `main` (c1404a3) |
 | ✅ | #381 | Built Testing/DishesTestSeeder (2 categories, 3 deterministic dishes covering every extras shape), Fakes/FakeDishesSeeder (factory volume generator), and Development/DishCategorySeeder+DishSeeder (9 live-menu categories, 36 dishes, extras groups on Ramen/Roll/Alitas) | PR #406 | `b6cd1ad` | 37.1h | 19 PHPUnit tests across 3 test files; Copilot review fixed 1 real defect (pre-existing backslash-FQCN violation in DevelopmentSeeder touched by this PR); two Devin/DeepWiki rounds plus one independent human-run code review found: (1) updateOrCreate() excluding soft-deleted rows causing duplicates on re-seed — first fix prevented duplicates but didn't restore trashed rows, corrected with a RestoresTrashedOnUpsert trait; (2) live menu catalog hardcoded in seeder classes instead of config/seeders.php per CLAUDE.md's seeder-data rule — moved to config as compact tuples to avoid reintroducing the duplication problem; (3) minor cleanups (model constants over string literals, exact-name test lookups); SonarCloud new-code duplication (23.9%) required refactoring both seeders into per-category/row-builder methods; a GitHub Actions platform outage and a /rebase-main after #382 merged first both extended wall-clock time; CI 12/12 green — merged to `main` (b6cd1ad) |
 | ⏳ | #380 | Not started | — | — | — | — |
 | ✅ | #388 (Opportunistic, §5.4) | Added `/issue` slash command composing `/start-issue`, `/pr-comments`, and `/finish-pr` into a single autonomous delivery pipeline | PR #389 | `a570ed8` | 9.43h | 6 Copilot review rounds + 6 Devin/DeepWiki scan rounds, all defects resolved (no business-rule disputes); merged to `main` (a570ed8) |


### PR DESCRIPTION
## Summary
Closes #410
Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/411

**Part 1 — confirmed-state foundation:**
- Every check-in/lunch-start/lunch-return/check-out/mark-day-status mutation already returns the row's fully updated `AttendanceRecord`, but the frontend discarded it via `invalidateQueries` and waited for a separate poll/refetch to find out what it already knew.
- `attendance-hooks.ts`'s five mutation `onSuccess` handlers splice the response's confirmed `AttendanceRecord` directly into the cached daily-attendance row (`queryClient.setQueriesData`), matched by `employee_id`. `invalidateQueries` still runs right after, in the background, so cross-manager changes still get picked up.
- Added `attendanceRecordToRowData()` in `types/attendance.ts` — a pure mapper narrowing `AttendanceRecord` to the `TodayAttendanceData` shape the row needs.

**Part 2 — the card exit animation, built on that foundation:**
- This gap was identified as the root cause of a much larger class of bugs in the (abandoned, reference-only) attendance card exit-animation work on #357 — that branch accumulated 26+ bug fixes almost entirely from guessing an action's outcome and polling to confirm it, when the backend already returns the answer synchronously.
- Rather than leave the actual animation feature unbuilt, this PR now includes it — planned end-to-end this time instead of patched reactively:
  - Ported the FLIP grid-reflow hook (`-use-attendance-grid-flip.ts`) unchanged from the #357 spike, which reached 0 open bugs after 9 review rounds — sibling cards reflow smoothly instead of snapping when a card leaves the grid.
  - Generalized the exit-animation trigger to all 5 actions (check-in, lunch-start, lunch-return, check-out, mark-falta), replacing the old mark-falta-only, target-bucket-guessing state machine. The post-action bucket is always computed from the mutation's own confirmed response merged with a synchronously-captured pre-mutation row — deliberately never read from `data`/a data ref inside an async `onSuccess`, since the mutation-level cache write and the call-site `onSuccess` run back-to-back before React re-renders, so `data` would still be the pre-mutation snapshot at that exact point.
  - Collapsed pin-on-start + unpin-on-failure into `markDayStatus` itself, so a failed absence write can never leave a card pinned forever.
  - `markDayStatus` now returns `Promise<boolean>`; `confirmFalta` awaits it and only opens the justify-now? dialog on success.
  - Per-employee `markingDayStatusEmployeeIds` (a `Set`, not a page-wide flag) — `isMarkingDayStatus(employeeId)` disables both pending actions and shows a spinner on "Marcar falta" only for the employee actually being written, closing the double-submit/no-feedback gaps a page-wide flag would reopen.
- A design-validation pass cross-checked this plan against all 26 of #357's original bugs before implementation — see the PR's commit message for the full reasoning.

## Test plan
- [x] 106 `use-today-attendance-page` tests (55 new) — staleness guards, timer cancellation, per-employee busy/pin independence, StrictMode safety, and the core "decides from the mutation response, not stale `data`" claim
- [x] 88 `EmployeeAttendanceCard` tests (6 new) — per-employee busy state, awaited confirm-falta gating
- [x] 2 new `-use-attendance-grid-flip` tests (this hook had zero coverage even on the original #357 branch)
- [x] New Cypress spec `attendance-card-exit-animation.cy.ts` — 3/3 passing against the real dev-lab E2E stack (check-in exit, mark-falta exit, date-switch-mid-mutation)
- [x] Regression-ran `attendance-checkin.cy.ts` (8/8) against the real stack — unaffected
- [x] Full webapp suite: 3745 passed, 3 skipped (pre-existing)
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npm run typecheck` — clean

**Known unrelated issue found during regression testing:** `attendance-day-status.cy.ts`'s "Justificar Falta" test has a pre-existing test-order dependency — it calls `markFalta("García", "María")` a second time on an employee test 1 (in the same file, sharing one `before()` reset) already marked Falta, at which point the "Marcar falta" button no longer exists for it to click (test 1's own assertions confirm this). This file has not been touched by this PR (`git diff main` is empty for it) and the bug is unrelated to this work — flagging for a separate fix rather than taking it on here.

## Manual Testing
1. Open the Attendance Today page for a branch with at least one pending employee, on the default "Pendientes" tab.
2. Register a check-in for an employee — the card fades/slides out and disappears from "Pendientes"; siblings reflow smoothly (no snap). Switch to "En trabajo" and confirm the employee is there.
3. Repeat for lunch-start, lunch-return, and check-out.
4. Click "Marcar falta" for a pending employee, confirm, then choose "Ahora no" on the justify-now? prompt — the card exits "Pendientes" and appears under "Ausentes".
5. Click "Marcar falta" again for another employee, confirm, then "Justificar ahora" → complete the leave dialog — same exit behavior once the dialog closes.
6. While an absence write is in flight for one employee, confirm every OTHER employee's buttons remain fully interactive (only the acted-on card shows the spinner/disabled state).
7. Switch the date picker immediately after confirming an action (before the request resolves) — confirm no stray animation or hidden card appears on the newly selected date.

## Workspace
`sushigo-d` — `refactor/410-attendance-confirmed-state`
