### PR TITLE
📚 [#418][a] - Refresh RESUME_STATUS.md to reflect Sprint 002 and the cleanup wave 📊

### DIFF
--- a/RESUME_STATUS.md
+++ b/RESUME_STATUS.md
@@ -1,11 +1,13 @@
 # Analisis Integral del Proyecto SushiGo
 
-**Fecha de analisis**: 2026-07-18
-**Version anterior**: 2026-04-08
-**Branch actual**: `main` @ 2f2fdca (post-#075/#076/#131/#214/#247 merges)
+**Fecha de analisis**: 2026-08-11
+**Version anterior**: 2026-07-18
+**Branch actual**: `main` @ ffb1603 (post-#380 merge, cierre de Sprint 002 — ver `doc/sprints/sprint-002-platillos-catalog-platform-hardening.md`)
 
-> Ver `plan/roadmap.md` (en `sushigo-dev-lab`) para el detalle vivo de waves/chains e issue-por-issue;
-> esta seccion resume el mismo estado a un nivel mas alto.
+> `plan/roadmap.md` (en `sushigo-dev-lab`) ya no existe — el proceso de waves/chains ad hoc que
+> documentaba se reemplazo por el proceso formal de sprints (`doc/sprints/`, adoptado en #330/#359,
+> ver §2b). Ver `doc/sprints/sprint-002-platillos-catalog-platform-hardening.md` para el detalle
+> vivo issue-por-issue del sprint actual; esta seccion resume el mismo estado a un nivel mas alto.
 
 ---
 
@@ -17,8 +19,10 @@
 - **Inventarios**: Control de stock por ubicaciones, movimientos de entrada/salida, UoM con conversiones
 - **Caja**: Sesiones de caja, ajustes, gastos, terminales de tarjeta
 - **Asistencia y Nomina** (nuevo desde Feb 2026): Empleados, horarios, check-in/out, comidas, horas extra, cierre semanal
+- **Menu / Platillos** (nuevo desde Ago 2026, Sprint 002): Categorias de menu, platillos con precio base, extras de personalizacion por platillo — catalogo `/productos` que reemplazo el stub estatico
 - **Unidades Operativas**: Sucursales fisicas y eventos temporales
 - **Control de Usuarios**: OAuth, roles y permisos granulares
+- **Sistema de Media** (nuevo desde Ago 2026): Upload/reorder/delete generico, cloud-swappable (storage local hoy), con capa de autorizacion por ownership — usado hoy por Items y Dishes, disenado para extenderse a avatares de Employee/User
 
 ### Stack Tecnologico
 
@@ -29,7 +33,7 @@
 | Base de Datos | PostgreSQL 15 |
 | Infraestructura | Docker Compose, Nginx, Supervisor |
 | Mobile (planificado) | Flutter, Dart, GoRouter, Riverpod |
-| Testing | PHPUnit (442 tests), Vitest (1123 tests), Cypress (21 tests) |
+| Testing | PHPUnit (150 archivos), Vitest (259 archivos), Cypress (54 specs) — ver §4 para metodologia |
 | Calidad | SonarCloud, ESLint, PHP Pint, Branch Protection |
 
 ---
@@ -38,7 +42,8 @@
 
 Desde el analisis de abril, el trabajo se organizo en 3 cadenas secuenciales (Payroll, Overtime,
 Vacaciones) ejecutadas en paralelo a traves de los 5 workspaces del dev-lab. **Las 3 cadenas y las
-5 waves planificadas estan hoy 100% completas** — ver `plan/roadmap.md` para el detalle completo.
+5 waves planificadas estan hoy 100% completas** — en su momento (julio) el detalle vivia en
+`plan/roadmap.md`; esa referencia es historica y ya no es valida — ver la nota del encabezado y §2b.
 
 | Cadena/Area | Issues | Estado |
 |---|---|---|
@@ -56,6 +61,64 @@ Vacaciones) ejecutadas en paralelo a traves de los 5 workspaces del dev-lab. **L
 **Hito clave adicional:** las Policies de autorizacion ya no retornan `true` de forma generica —
 ahora usan `$user->can('recurso.accion')` (ver `app/Policies/*`). El item "Autorizacion Real" que
 la seccion 6 de abril marcaba como pendiente de alta prioridad **ya esta resuelto**.
+
+---
+
+## 2b. Progreso Mas Reciente (2026-07-18 → 2026-08-11)
+
+Las 3 tareas de "Wave 6" que el analisis de julio recomendaba (#251, #249, #248) **se completaron
+las tres entre el 2026-07-19 y el 2026-07-20**, un dia despues de aquel analisis. Desde ahi el
+trabajo se organizo en dos grandes bloques: primero una ola de saneamiento tecnico (SonarCloud +
+autorizacion de CashAdjustments + UX de Attendance), luego el **Sprint 002 completo**
+("Platillos Catalog & Platform Hardening") ya formalmente documentado bajo el nuevo proceso de
+sprints (`doc/sprints/`, adoptado en #330/#359 durante este mismo periodo). ~55 Issues cerrados en
+esta ventana.
+
+### Bloque 1 — Saneamiento tecnico (2026-07-19 → 2026-07-31, pre-Sprint 002)
+
+| Area | Issues | Resultado |
+|---|---|---|
+| **Wave 6 (recomendada en jul)** | #251 Lock periodos cerrados, #249 checkbox masivo overtime, #248 centralizar `Label` | ✅ Las 3 completas |
+| **SonarCloud — Security Hotspots** | #267 | ✅ Revisados y limpiados en `sushigo-api` |
+| **SonarCloud — Maintainability (127 issues abiertos)** | #268, #305–#323 (18 reglas `typescript:S*` distintas: cognitive complexity, PRNGs inseguros, `any` props, claves de array como key, jump statements redundantes, etc.) | ✅ Los 127 issues abiertos resueltos, uno por uno |
+| **SonarCloud — Duplicacion de codigo** | #282 (883 lineas / 42 bloques), #289 (0.3% residual) | ✅ Duplicacion eliminada en `sushigo-api` |
+| **CashAdjustments — Hardening de autorizacion** | #291 (Show/Update/Delete/Post sin autorizacion a nivel de recurso), #293 (ULID `public_id` en vez de id numerico), #295 (List sin autorizacion/branch-scoping), #303 (permisos faltantes en seeders) | ✅ Las 4, mismo patron que luego se replico en #377 (media) y quedo pendiente para Inventory en #399 |
+| **Design system — Unificacion** | #259 (labels), #272 (migrar `<button>` a componente `Button`), #324 (catalogo dev de componentes), #342 (unificar transiciones de dialogo) | ✅ Completo |
+| **Attendance UX** | #325 (overlay de dialogo no cubria pantalla completa), #326/#328 (editar eventos de asistencia ya registrados), #327/#337 (stat cards "Ausentes"/"En comida") | ✅ Completo |
+| **Infra/Proceso** | #264 (nest de datos personales bajo `user` en Employee API), #296 (fix `phpunit.xml` hardcodeaba `DB_DATABASE`, rompia aislamiento por workspace), #275 (permisos granulares de UoM), #340 (versionar `.claude/settings.json`), #351/#355 (mejoras a `/finish-pr`), #368 (catch silencioso en `auth.store.ts`) | ✅ Completo |
+| **Proceso de sprints** | #330 (adoptar documentacion formal de sprints, convertir plan de Sprint 1), #359 (TD-01: unificar tracking de issues/tasks — el GitHub Issue pasa a ser la unica fuente de verdad mientras esta abierto), #374 (cerrar formalmente Sprint 001), #386 (promover Sprint 002 a actual) | ✅ Completo — ver `doc/decisions/td-01-single-source-issue-tracking.md` |
+| **Tooling** | #388 (`/issue`: pipeline autonomo end-to-end — `/start-issue` + `/pr-comments` + `/finish-pr`), #404 (`/issue` sin interrupciones — remueve los 5 `AskUserQuestion`) | ✅ Completo, ambos oportunistas (fuera de scope formal) |
+
+### Bloque 2 — Sprint 002: Platillos Catalog & Platform Hardening (2026-07-31 → 2026-08-11)
+
+**14/14 Issues completados (100%)** — documentacion completa en
+[`doc/sprints/sprint-002-platillos-catalog-platform-hardening.md`](doc/sprints/sprint-002-platillos-catalog-platform-hardening.md).
+Resumen ejecutivo:
+
+| Valor | Issues | Resultado |
+|---|---|---|
+| **Critico — Seguridad** | #384 | `APP_KEY` hardcodeado (compartido prod/preview, expuesto en historial de un repo publico) removido de `docker-compose.*.yml`; rotacion de la key viva en Cloud Run queda pendiente (requiere acceso a GCP fuera del alcance de la automatizacion) |
+| **Alto — Platillos (5 issues, cadena completa)** | #377 (sistema generico de media upload), #378 (componente `<MediaGalleryUploader />` reutilizable), #379 (dominio backend: categorias/platillos/extras), #381 (seed data en 3 niveles), #380 (UI del catalogo `/productos`) | El stub estatico "Pagina en construccion" del menu real (sushigo-romita.com/menu) se reemplazo por un catalogo funcional con fotos, filtros, extras configurables y gestor de categorias |
+| **Alto — Correctness** | #358 | Empleados en vacaciones/dia de descanso programado ya aparecen bajo "Ausentes" desde el inicio del dia |
+| **Medio — Deuda tecnica** | #360 (migrar `now()`/`new Date()` a `ApplicationClock`), #383/#382 (migrar tablas de Payroll Periods y reporte diario al `DataGrid<T>` compartido), #365 (convencion: pruebas locales pre-PR solo linters + tests entregados, suite completa es trabajo de CI) | Completo |
+| **Medio — UX** | #357 → **reemplazado por #410** | Ver nota abajo |
+| **Bajo — Limpieza** | #385 (4 props `Readonly<...>`), #376 (quitar selector Insumo/Activo de items) | Completo |
+
+**Nota sobre #357/#410:** el PR original de #357 (animacion de salida de tarjetas en Attendance
+Today) acumulo 26+ rondas de fixes de revision, casi todas por la misma causa raiz — el codigo
+adivinaba el resultado de una accion y esperaba un poll para confirmarlo, en vez de leer la
+respuesta ya confirmada que el backend devuelve en cada mutacion. Ese analisis se convirtio en un
+Issue nuevo, `#410`, que reconstruyo la funcionalidad sobre esa base corregida y la entrego (PR
+#411) — `#357` quedo `⚠️ Deprecated` en el documento del sprint, no `✅`, pero su valor si se
+entrego.
+
+**Hallazgo colateral durante Sprint 002:** al construir el patron de media upload para Item (#377)
+y replicarlo a Dish (#380), quedo en evidencia que `Item`/`ItemVariant` y el resto de Inventory
+nunca recibieron el mismo endurecimiento de autorizacion/ULID que CashAdjustments ya tiene desde
+julio (#291/#293) — de ahi nacieron los pendientes `#399` y, mas grave, se **descubrio que
+`ItemPolicy` retorna `true` sin condicion en todos sus metodos** (`#400`, ver §6). Esto significa
+que la mejora "Autorizacion Real" que el analisis de julio daba por completamente resuelta
+**tenia un hueco real en el dominio de Inventory** que no se habia detectado hasta ahora.
 
 ---
 
@@ -104,13 +167,15 @@ Se construyo el modulo completo de Asistencia desde cero, abarcando backend y fr
 | Tecnica | Descripcion |
 |---------|-------------|
 | **Single Action Controllers (SAC)** | Cada controlador maneja una sola accion via `__invoke()` |
-| **Actions Pattern** | Logica de negocio encapsulada en `app/Actions/` (15 actions) |
-| **Service Layer** | Servicios para operaciones complejas (9 services) |
-| **Form Request Validation** | Validacion centralizada (49 request validators) |
+| **Actions Pattern** | Logica de negocio encapsulada en `app/Actions/` (34 actions) |
+| **Service Layer** | Servicios para operaciones complejas (33 services) |
+| **Form Request Validation** | Validacion centralizada (110 request validators) |
 | **JsonResource Responses** | BaseResource con envelope `{ data, status, meta }` |
 | **Trackable Seeders** | Sistema con LockedSeeder, OnceSeeder, RepeatableSeeder |
 | **Effective-Dated History** | Patron effective_from/effective_to para configs (wages, schedules) |
-| **HasPublicId Trait** | ULID auto-generado, route binding via `public_id` |
+| **HasPublicId Trait** | ULID auto-generado, route binding via `public_id` — cubre HR/Attendance/Payroll, CashAdjustments (#291/#293) y Media (`#377`); Inventory (Item/ItemVariant/Stock) queda pendiente (`#399`) |
+| **ApplicationClock (inyectado)** | Reloj simulable inyectado en Actions/Services/Controllers en vez de `now()`/`new Date()` directo — permite congelar/adelantar el tiempo en dev y tests (`#360`, `doc/conventions/backend/application-clock.md`) |
+| **Media System (storage-backed)** | Sistema generico de upload/reorder/delete de galerias, cloud-swappable, con capa de autorizacion por ownership (`AuthorizesMediaOwnership`, `owner_token` para formularios en progreso) — usado por Item y Dish, disenado para extenderse a mas entidades (`#377`) |
 | **OpenAPI/Swagger** | Documentacion automatica de API |
 | **Soft Deletes** | Eliminacion logica para integridad de datos |
 | **Test Data Seeders** | Testing/ (deterministic), Fakes/ (volume), Development/ (full dev) |
@@ -128,6 +193,8 @@ Se construyo el modulo completo de Asistencia desde cero, abarcando backend y fr
 | **Composable UI** | Componentes estilo Shadcn/ui |
 | **Strict TypeScript** | No `any`, `unknown` + utilities para errores |
 | **API Error Utilities** | `getApiErrorMessage()`, `getApiValidationErrors()` |
+| **DataGrid\<T\> compartido** | Tabla generica con `Column<T>[]`, paginacion y skeleton loading integrados — reemplazo tablas HTML/estilos ad hoc en Payroll Periods y el reporte diario (`#382`/`#383`) |
+| **MediaGalleryUploader** | Componente reutilizable de drag-drop/upload/reorder/preview + hook `useMediaGalleryUploader()`, primer consumidor de la capa de Media System del backend (`#378`) |
 
 ---
 
@@ -135,63 +202,82 @@ Se construyo el modulo completo de Asistencia desde cero, abarcando backend y fr
 
 ### Backend (Laravel API)
 
-| Metrica | Ene 2026 | Abr 2026 | Jul 2026 | Cambio (Abr→Jul) |
-|---------|----------|----------|----------|--------|
-| Controllers | 73 | 96 | 158 | +62 |
-| Models | 22 | 32 | 55 | +23 |
-| Services | 6 | 9 | 28 | +19 |
-| Actions | 2 | 15 | 31 | +16 |
-| Request Validators | 12 | 49 | 88 | +39 |
-| API Resources | — | 7 | 28 | +21 |
-| PHPUnit tests | ~50 | 442* | 112 | ver nota* |
+| Metrica | Ene 2026 | Abr 2026 | Jul 2026 | Ago 2026 | Cambio (Jul→Ago) |
+|---------|----------|----------|----------|----------|--------|
+| Controllers | 73 | 96 | 158 | 191 | +33 |
+| Models | 22 | 32 | 55 | 60 | +5 |
+| Services | 6 | 9 | 28 | 33 | +5 |
+| Actions | 2 | 15 | 31 | 34 | +3 |
+| Request Validators | 12 | 49 | 88 | 110 | +22 |
+| API Resources | — | 7 | 28 | 32 | +4 |
+| PHPUnit tests | ~50 | 442* | 112 | 150 | +38 (archivos) |
 
-\* El numero de abril (442) conto casos de prueba individuales via `php artisan test`; el de julio
-cuenta **archivos** de test via `git ls-tree` (no se corrio la suite completa esta pasada) — no son
-directamente comparables. Recomendado: correr `php artisan test` en un proximo analisis para tener
-un numero de casos real.
+\* El numero de abril (442) conto casos de prueba individuales via `php artisan test`; julio y
+agosto cuentan **archivos** de test (`find tests -name "*Test.php"`) — no se corrio la suite
+completa esta pasada (ver §4 nota general). No comparar abril directamente contra jul/ago sin
+recorrer la suite; jul→ago si es comparable (misma metodologia).
 
 ### Frontend (React Webapp)
 
-| Metrica | Ene 2026 | Abr 2026 | Jul 2026 | Cambio (Abr→Jul) |
-|---------|----------|----------|----------|--------|
-| Componentes (.tsx) | 38 | 112 | 293 | +181 |
-| Paginas | 18 | 27 | 42 | +15 |
-| Vitest tests | — | 1,123* | 237 | ver nota* |
-| Cypress tests | — | 21* | 45 | ver nota* |
+| Metrica | Ene 2026 | Abr 2026 | Jul 2026 | Ago 2026 | Cambio (Jul→Ago) |
+|---------|----------|----------|----------|----------|--------|
+| Componentes (.tsx, incl. tests) | 38 | 112 | 293 | 314 | +21 |
+| Paginas | 18 | 27 | 42 | 41 | −1 |
+| Vitest tests | — | 1,123* | 237 | 259 | +22 (archivos) |
+| Cypress tests | — | 21* | 45 | 54 | +9 (specs) |
 
-\* Mismo caveat que arriba: abril conto casos de prueba (`it()`/`test()` individuales), julio cuenta
-**archivos** `.test.ts(x)` / `.cy.ts`. No comparar directamente sin recorrer la suite.
+\* Mismo caveat que arriba: abril conto casos de prueba (`it()`/`test()` individuales), jul/ago
+cuentan **archivos** `.test.ts(x)` / `.cy.ts`. No comparar abril directamente sin recorrer la
+suite; jul→ago si es comparable. La baja de 1 en Paginas esta dentro del margen de conteo (no se
+identifico una ruta eliminada; probablemente diferencia de metodologia de conteo entre pasadas).
 
 ### Calidad y Testing
 
-| Metrica | Valor (Abr 2026, casos) | Valor (Jul 2026, archivos) |
-|---------|---|---|
-| PHPUnit | 442 casos | 112 archivos de test |
-| Vitest | 1,123 casos | 237 archivos de test |
-| Cypress | 21 casos (6 specs) | 45 specs (`.cy.ts`) |
-| SonarCloud | Activo, >= 80% coverage en codigo nuevo | Sin cambios, requisito de merge en todos los PRs recientes |
-| Quality gates | Pint + ESLint + TypeScript + Branch Protection | Sin cambios |
+| Metrica | Valor (Abr 2026, casos) | Valor (Jul 2026, archivos) | Valor (Ago 2026, archivos) |
+|---------|---|---|---|
+| PHPUnit | 442 casos | 112 archivos de test | 150 archivos de test |
+| Vitest | 1,123 casos | 237 archivos de test | 259 archivos de test |
+| Cypress | 21 casos (6 specs) | 45 specs (`.cy.ts`) | 54 specs (`.cy.ts`) |
+| SonarCloud | Activo, >= 80% coverage en codigo nuevo | Sin cambios, requisito de merge en todos los PRs recientes | Sin cambios; ademas la deuda de julio (127 issues + 883 lineas duplicadas + security hotspots) quedo en 0 (§2b) |
+| Quality gates | Pint + ESLint + TypeScript + Branch Protection | Sin cambios | Sin cambios |
+
+**Nota:** el badge del `README.md` raiz ("112 / 237 / 45 archivos de test") quedo desactualizado
+tras esta ventana — no se corrigio en esta pasada porque el foco de este documento es el analisis
+integral, no el README; queda como ajuste menor pendiente (no bloqueante).
 
 ---
 
 ## 5. Scorecard de Calidad
 
-| Area | Ene 2026 | Abr 2026 | Tendencia |
-|------|----------|----------|-----------|
-| **Arquitectura API** | 90 (A) | 92 (A) | ↑ Actions pattern maduro |
-| **Modelos y Relaciones** | 92 (A) | 93 (A) | ↑ 10 modelos nuevos, effective-dated |
-| **Validacion de Requests** | 88 (A-) | 90 (A) | ↑ 49 validators, zod en frontend |
-| **Service/Actions Layer** | 90 (A) | 92 (A) | ↑ 15 actions, patron consolidado |
-| **Cobertura de Tests** | 80 (B+) | 90 (A) | ↑↑ 442+1123+21 tests |
-| **Practicas Laravel** | 85 (B+) | 88 (A-) | ↑ Seeders, Resources, Pint |
-| **Organizacion Frontend** | 80 (B) | 88 (A-) | ↑↑ Hooks, componentes, separacion |
-| **TypeScript/Type Safety** | 75 (B-) | 88 (A-) | ↑↑ No-any enforced, zod |
-| **State Management** | 80 (B) | 90 (A) | ↑ Auth consolidado, hooks pattern |
-| **Manejo de Errores** | 65 (C+) | 78 (B) | ↑ API error utilities, toast pattern |
+| Area | Ene 2026 | Abr 2026 | Ago 2026 | Tendencia |
+|------|----------|----------|----------|-----------|
+| **Arquitectura API** | 90 (A) | 92 (A) | 94 (A) | ↑ SAC extendido a Media/Dishes, servicios de media divididos en invokables de responsabilidad unica |
+| **Modelos y Relaciones** | 92 (A) | 93 (A) | 94 (A) | ↑ Dominio Menu/Platillos + Media, cascading soft-deletes transaccionales |
+| **Validacion de Requests** | 88 (A-) | 90 (A) | 91 (A) | ↑ 110 validators, patron `SharesValidationMessages` contra duplicacion |
+| **Service/Actions Layer** | 90 (A) | 92 (A) | 93 (A) | ↑ 34 actions, 33 services |
+| **Cobertura de Tests** | 80 (B+) | 90 (A) | 92 (A) | ↑ Cypress specs +9 (45→54), Vitest +22 archivos, gate de ≥80% en codigo nuevo sostenido en cada PR del Sprint 002 |
+| **Practicas Laravel** | 85 (B+) | 88 (A-) | 90 (A) | ↑ Deuda SonarCloud de julio (127 issues + 883 lineas duplicadas + hotspots) en 0 |
+| **Organizacion Frontend** | 80 (B) | 88 (A-) | 90 (A) | ↑ `DataGrid<T>` y `MediaGalleryUploader` compartidos, catalogo dev de componentes |
+| **TypeScript/Type Safety** | 75 (B-) | 88 (A-) | 89 (A-) | → Estable, sin regresiones de `any` |
+| **State Management** | 80 (B) | 90 (A) | 91 (A) | ↑ #410 elimino una clase entera de bugs de "adivinar y esperar poll" en Attendance Today |
+| **Autorizacion / Seguridad** | — | 85 (B+)* | 82 (B) | ↓ `APP_KEY` estatico removido (#384) pero rotacion viva en Cloud Run pendiente; CashAdjustments endurecido (#291/#293) pero se **redescubrio** que `ItemPolicy` retorna `true` sin condicion (#400) — el "ya resuelto" de julio no cubria Inventory |
+| **Manejo de Errores** | 65 (C+) | 78 (B) | 80 (B+) | ↑ Fix de fault-tolerance en cleanup de media concurrente; sigue sin error boundary global en React (§6) |
 
-### Calificacion Global: 89/100 (A-)
+### Calificacion Global: 90/100 (A-)
 
-**Mejora significativa desde 80/100 (B) en enero.** Las principales mejoras fueron: consolidacion de auth, testing masivo (0 → 1,586 tests), eliminacion de `any`, patron de hooks consistente, y estrategia de testing documentada.
+**Se mantiene en A-, con una base mas amplia de deuda resuelta pero un hallazgo de seguridad real
+que corrige una afirmacion optimista del analisis anterior.** El salto principal desde enero sigue
+siendo el mismo (auth consolidado, testing masivo, eliminacion de `any`, patron de hooks), y esta
+ventana suma: cero deuda de SonarCloud en `sushigo-api` (127 issues + 883 lineas duplicadas + todos
+los security hotspots), el catalogo Platillos como dominio nuevo completo, y un sistema de media
+generico reutilizable. La contraparte honesta: `#400` demuestra que "Autorizacion Real" (marcado
+`✅ Resuelto` en julio) era cierto para HR/Attendance/CashAdjustments pero no para Inventory —
+la calificacion de esa fila baja en vez de subir hasta que `#400` se cierre.
+
+\* La fila "Autorizacion / Seguridad" no existia como fila propia del scorecard en enero/abril —
+se estimo retroactivamente en 85 (B+) para abril usando el mismo hito ("Policies usan
+`$user->can()`") que la seccion 2a de aquel analisis citaba como resuelto, para poder mostrar
+tendencia; no es un numero recalculado desde una pasada anterior real.
 
 ---
 
@@ -203,19 +289,28 @@ un numero de casos real.
 |------|--------|
 | ~~Consolidar Estado de Autenticacion~~ | ✅ Completado (#014) — Todo en Zustand |
 | ~~Uso de `any` en TypeScript~~ | ✅ Resuelto — `no-explicit-any` enforced |
-| ~~Sin tests frontend~~ | ✅ Resuelto — 1,123 Vitest + 21 Cypress (abril); 237 Vitest + 45 Cypress specs (julio) |
+| ~~Sin tests frontend~~ | ✅ Resuelto — 1,123 Vitest + 21 Cypress (abril); 259 Vitest + 54 Cypress specs (agosto) |
 | ~~Respuestas API inconsistentes~~ | ✅ Resuelto — JsonResource con BaseResource |
-| ~~Autorizacion Real~~ | ✅ Resuelto desde abril — Policies usan `$user->can('recurso.accion')`, ya no `return true` generico |
+| ~~Autorizacion Real (parcial)~~ | ⚠️ Resuelto para HR/Attendance/Payroll y CashAdjustments (`$user->can('recurso.accion')`) desde abril, endurecido en julio (#291/#293) — **pero no para Inventory**: `ItemPolicy` retorna `true` sin condicion en todos sus metodos, hallazgo nuevo, ver `#400` en Pendientes |
+| ~~Locking de periodos cerrados~~ | ✅ Resuelto (#251, cerrado 2026-07-19) — attendance/payroll-input de fechas dentro de un periodo `CLOSED` ya no se puede editar sin bloqueo |
+| ~~Deuda SonarCloud (sushigo-api)~~ | ✅ Resuelto (§2b, Bloque 1) — 127 issues de maintainability, 883 lineas duplicadas y todos los security hotspots abiertos en julio quedaron en 0 |
 
 ### Pendientes
 
 | Prioridad | Area | Detalle |
 |-----------|------|---------|
-| Alta | **Locking de periodos cerrados** | Nuevo hallazgo (#251, abierto 2026-07-15): el close/reopen de payroll (#073-#076) existe, pero attendance/payroll-input de fechas dentro de un periodo `CLOSED` aun se puede editar sin bloqueo |
-| Alta | **Excepciones de Dominio** | Aun se usa `Exception` generica en algunos servicios (no re-verificado esta pasada) |
+| **Alta** | **`ItemPolicy` sin autorizacion real** (`#400`) | Descubierto durante Sprint 002 al extender el patron de media/ownership a Dish — cualquier usuario autenticado puede crear/editar/eliminar/restaurar cualquier Item, sin chequear rol ni relacion con el recurso. Mismo tipo de hallazgo que "Autorizacion Real" en enero, pero en un dominio que quedo fuera del barrido de abril |
+| Media | **Rotacion de `APP_KEY` viva en Cloud Run** | El `APP_KEY` hardcodeado se removio del repo y de `docker-compose.*.yml` (#384), pero las keys ya desplegadas en prod/preview no se rotaron — requiere acceso a GCP fuera del alcance de la automatizacion actual |
+| Media | **`Item`/`ItemVariant`/Inventory sin `public_id` ULID** (`#399`) | El resto de la app (HR/Attendance/Payroll, CashAdjustments, Media) ya expone ULID en vez de id numerico secuencial; Inventory quedo fuera de #291/#293 y es la superficie mas grande pendiente |
+| Media | **Overlap de grid en Attendance Today** (`#412`) | Las tarjetas de empleados se superponen en el rango ~1279–1490px de viewport cuando el sidebar esta expandido — bug de breakpoints Tailwind basados en viewport, no en el ancho real disponible |
+| Media | **Avatar de empleado con placeholder de iniciales** (`#401`) | Deliberadamente fuera de alcance de #377 — reutilizaria el sistema de media ya construido, aplicado a `Employee`/`User` |
+| Baja | **Campos monetarios como decimal, no centavos enteros** (`#415`) | Levantado durante la revision de #380 (`Dish.base_price`/`price_delta`); `technical-debt` + `priority: low`, diferido hasta un pivote multi-moneda/SaaS |
+| Baja | **Excepciones de Dominio** | Aun se usa `Exception` generica en algunos servicios (no re-verificado esta pasada) |
 | Media | **Error Boundaries** | No hay manejo global de errores en React (no re-verificado esta pasada) |
 | Media | **Console Logs** | Reducidos pero algunos persisten en produccion (no re-verificado esta pasada) |
 | Baja | **Componentes Grandes** | ProductWizard sigue en 900+ lineas (no re-verificado esta pasada) |
+| Diferida | **Integracion real de WhatsApp** (`#276`) | `deferred`/`priority: low` desde el cierre de Sprint 001 — el OTP por log basta mientras no haya plan concreto de produccion |
+| Diferida | **Bootstrap app movil (Flutter)** (`#85`) | `deferred`/`priority: low` — pospuesto hasta que Attendance este probado en backend+web |
 
 ---
 
@@ -223,74 +318,90 @@ un numero de casos real.
 
 ### Trabajo en Progreso
 
-Ninguno — los 5 workspaces del dev-lab acaban de cerrar sus PRs (#075, #076, #131, #214, #247, todas
-mergeadas entre 2026-07-17 y 2026-07-18). Los 5 estan libres para tomar la siguiente tarea.
+`#416` (resincronizacion del documento de Sprint 002 y del README) ya se mergeo — PR #417 cerrado
+2026-08-12. `#418` (esta misma actualizacion de `RESUME_STATUS.md`) sigue abierto — PR #419 en
+`sushigo-a`, en revision. Es el unico Issue actualmente abierto que no es backlog nuevo: es
+housekeeping, se cerrara solo cuando el PR mergee.
 
-### Backlog Real Pendiente (verificado contra GitHub Issues abiertos, 2026-07-18)
+### Backlog Real Pendiente (verificado contra GitHub Issues abiertos, 2026-08-11)
 
-Todo lo que en la version de abril aparecia como "Grupo 1-6" (32 tareas: #054-058, #061-086) **ya esta
-completo** salvo las 2 excepciones explicitamente diferidas. El backlog real hoy es mucho mas chico:
+Sprint 002 completo (14/14, §2b) mas el bloque de saneamiento tecnico previo cerraron practicamente
+todo lo que el analisis de julio tenia listado como pendiente o como candidato a Wave 6 — incluidas
+las 3 tareas de Wave 6 (#251/#249/#248) y los 3 items de "solo triage" (#153/#168/#170), todas ya
+cerradas. En total hay 8 Issues abiertos en `pakodiazdev/sushigo` a la fecha de este analisis:
+`#418` (esta misma actualizacion, ya cubierta arriba en "Trabajo en Progreso", excluida del conteo
+de abajo) mas los 7 que forman el backlog real, ninguno agrupado en un sprint todavia:
 
-#### Nuevas (sin empezar, sin conflicto entre si — candidatas a Wave 6)
+#### Abiertos, sin sprint asignado
 
-| # | Tarea | Area | Est. | Dependencia |
-|---|-------|------|------|-------------|
-| 251 | Bloquear edicion de attendance/payroll-input en periodos `CLOSED` | Backend, attendance-payroll | ~3-4h | #074/#076 ✅ (ya mergeados) |
-| 249 | Checkbox "aplicar al resto" en el dialogo de decision masiva de overtime | Frontend | ~2h | #228/#229 ✅ (ya mergeados) |
-| 248 | Centralizar componente `Label` de formularios (contraste en `<dialog>`) | Frontend, design system | ~2h | Independiente, mismo patron que #247 ✅ |
+| # | Tarea | Area | Prioridad | Notas |
+|---|-------|------|-----------|-------|
+| 400 | `ItemPolicy` retorna `true` sin condicion en todos sus metodos | Backend, seguridad | **Alta** | Hallazgo real durante Sprint 002 (§2b/§6) — cualquier usuario autenticado puede crear/editar/eliminar/restaurar cualquier Item |
+| 412 | Overlap de grid en Attendance Today (~1279–1490px con sidebar expandido) | Frontend, bug | Media | Breakpoints Tailwind basados en viewport, no en ancho real disponible tras restar el sidebar |
+| 399 | Exponer `public_id` (ULID) para Item/ItemVariant y el resto de Inventory | Backend, tech-debt | Media | Levantado durante la revision de #377; mismo patron ya aplicado a CashAdjustments/Media/HR |
+| 401 | Avatar de empleado con placeholder de iniciales | Frontend/Backend, feature | Media | Reutiliza el sistema de media de #377; deliberadamente fuera de su alcance original |
+| 415 | Campos monetarios como enteros (centavos) en vez de `decimal` | Backend, tech-debt | Baja | `priority: low`, diferido hasta pivote multi-moneda/SaaS |
+| 276 | Integrar un proveedor real de WhatsApp en `WhatsAppService` | Backend | Diferida | `deferred`, decidido al cierre de Sprint 001 |
+| 85 | Bootstrap app movil (Flutter) | Mobile | Diferida | `deferred`, pospuesto hasta que Attendance este probado en backend+web |
 
-#### Diferidas a proposito (sin cambios desde abril)
+> Correccion: una version anterior de este documento listaba `#86` (Unificar `Employee.name` con
+> `User.name`) aqui como "cerrado sin evidencia de PR encontrada" — busqueda incorrecta (`gh pr list
+> --search "86 in:title"` no matchea `#086` con padding de ceros, que es como GitHub tokeniza el
+> titulo). `#86` si se implemento: PR #263 (`🔨 [#086][a] - Unify Employee name with User.name 🔗`),
+> mergeado 2026-07-21T03:52:30Z — migro `first_name`/`last_name` a `users` como fuente unica de
+> verdad, elimino la logica de sincronizacion manual en `UpdateEmployeeController`, mantuvo el
+> contrato de API identico (verificado con 0 cambios de frontend necesarios). Se retira de esta
+> tabla; ver §9 para el requerimiento correspondiente.
 
-| # | Tarea | Motivo |
-|---|-------|--------|
-| 085 | Bootstrap app movil (Flutter) | Bloqueado — requiere repo Flutter separado |
-| 086 | Unificar `Employee.name` con `User.name` | Breaking change, requiere periodo de deprecacion coordinado |
-
-#### Requieren solo triage/verificacion, no codigo nuevo
-
-| # | Tarea | Accion sugerida |
-|---|-------|------------------|
-| 153 | Quitar `--ignore-platform-req=php` | Bloqueado en upstream (soporte PHP 8.5), revisar periodicamente |
-| 168 | `cy.loginByApi` apunta a devtest API en dev-lab | Bug especifico de dev-lab |
-| 170 | Target `cypress-devlab` para E2E interactivo | Mejora especifica de dev-lab |
-
-#### Cerrados 2026-07-18 (bookkeeping obsoleto, trabajo ya entregado)
-
-| # | Tarea | Resuelto por |
-|---|-------|--------------|
-| 216 | Remove explicit `any` / react-refresh warnings | PR #217 (mergeado 2026-07-03) — cerrado con comentario referenciando el PR |
-| 055 | Mark Day Status (redesign) | PR #103 (mergeado 2026-04-13) — checklist del issue nunca se actualizo tras el merge; follow-ups #096/#104/[#098]/#57/#58 tambien ya cerrados — cerrado con comentario referenciando el PR |
-
-> Nota de higiene: `doc/tasks/backlog/066-punctuality-exceptions.md`, `069-overtime-config.md` y
-> `121-indefinite-exception-summary.md` corresponden a issues cerrados hace semanas pero nunca se
-> movieron a `doc/tasks/2026-0X/` segun la convencion. Limpieza pendiente, no bloqueante.
+> Nota de higiene (sigue pendiente desde julio): `doc/tasks/backlog/066-punctuality-exceptions.md`,
+> `069-overtime-config.md` y `121-indefinite-exception-summary.md` corresponden a issues cerrados
+> hace meses pero nunca se movieron a `doc/tasks/2026-0X/` segun la convencion — ahora ademas
+> desactualizado, ya que el propio `doc/tasks/backlog/` quedo retirado por TD-01 (#359, §2b): los
+> issues ya no pasan por un archivo local antes de abrirse en GitHub. Limpieza pendiente, no
+> bloqueante.
 
 ---
 
 ## 8. Recomendacion: Siguiente Tarea
 
-**Todo el plan activo previo (Chains 1-3, Waves 1-5) esta completo.** La decision ya no es "que sigue
-en la cadena" sino "como repartir las 3 tareas nuevas e independientes entre los 5 workspaces libres".
+**Sprint 002 esta 100% entregado (§2b), pero formalmente no cerrado** — `doc/conventions/sprints.md`
+§4 exige promover un Sprint 003 para eso, y todavia no hay ninguno planeado en `doc/sprints/planned/`
+(ver el propio `doc/sprints/sprint-002-platillos-catalog-platform-hardening.md` §17/§18). La decision
+real no es "que sigue en la cadena" sino dos cosas en paralelo: (a) cerrar `#418`/PR #419 (este mismo
+refresh), y (b) decidir si los 7 Issues abiertos del backlog real (§7) justifican ya un Sprint 003,
+o si conviene resolverlos como backlog suelto primero y planear el sprint despues.
 
-### Opcion recomendada (trabajo en paralelo — Wave 6): **#251 + #249 + #248 simultaneas**
+### Opcion recomendada: **`#400` primero, en solitario — es el unico con riesgo real de producto**
 
-Ninguna depende de las otras ni toca los mismos archivos (backend `AttendancePolicy`/`PayPeriod` vs.
-dialogo frontend de overtime vs. componente `Label` global) — mismo perfil de bajo riesgo que la Wave 3.
+`#400` no es deuda tecnica cosmetica: es una brecha de autorizacion viva en produccion (cualquier
+usuario autenticado puede modificar o borrar cualquier Item del catalogo de inventario). Mismo perfil
+de riesgo que tuvo `#251` en julio ("unico con riesgo real de producto") — se recomienda resolverlo
+antes de agrupar el resto en un sprint, no despues.
 
 | Prioridad de arranque | Issue | Por que |
 |---|---|---|
-| 1 | **#251** | Unico con riesgo real de producto: hoy se puede editar en silencio un dia dentro de un periodo de nomina ya cerrado, aunque #073-#076 (close/reopen) ya existan |
-| 2 | **#249** | Pequena, misma familia (overtime), mantiene momentum en attendance-payroll |
-| 3 | **#248** | Limpieza pura de design system, cero urgencia, buen filler |
+| 1 | **#400** | Brecha de autorizacion real y explotable hoy — sin dependencias, cambio acotado a `ItemPolicy` |
+| 2 | **#412** | Bug de UX visible para el usuario final, fix acotado (breakpoints), sin dependencias |
+| 3 | **#399** | Deuda de seguridad menor (ids enumerables) pero superficie mas grande (7 modelos + rutas + frontend) — buen candidato a Sprint 003 en vez de un fix suelto |
+| 4 | **#401** | Feature nueva, no urgente, depende conceptualmente de #377 (ya mergeado, sin bloqueo real) |
+| 5 | **#415** | Ya diferido explicitamente hasta un pivote multi-moneda/SaaS — no tomar todavia |
 
-### Si prefieres trabajar solo en lugar de en paralelo
+### Si se decide agrupar en Sprint 003 en lugar de resolver #400 suelto
 
-Secuencia sugerida: **#251 → #249 → #248**, en ese orden de prioridad de negocio.
+`#400`, `#412`, `#399`, `#401` no comparten archivos entre si (Policy backend vs. CSS de grid vs.
+migraciones de Inventory vs. media de Employee) — mismo perfil de bajo riesgo para paralelizar entre
+workspaces que tuvo Round 1 de Sprint 002. Aun asi, dado que `#400` es una brecha de seguridad activa,
+no esperar a planear el sprint completo para resolverlo — sacarlo primero, como Sprint 001 hizo con
+`#384` en Sprint 002.
 
 ### Quick wins administrativos
 
-~~Cerrar #216 y #055 en GitHub~~ — ✅ hecho el 2026-07-18, ambos cerrados con comentario referenciando
-el PR que los resolvio (#217 y #103 respectivamente).
+- ~~Mergear PR #417 (`#416`)~~ — ✅ hecho, `#416` cerrado 2026-08-12 via PR #417
+- Mergear PR #419 (`#418`, este mismo refresh de `RESUME_STATUS.md`)
+- Cuando se retome el trabajo: archivar `#357`/`#410` en `doc/tasks/2026-08/` y sincronizar el
+  `Tracked` real de `#360` sobre su Issue vivo — ambos gaps quedaron documentados en el Follow-up
+  Work del sprint (`doc/sprints/sprint-002-platillos-catalog-platform-hardening.md` §17) pero sin
+  Issue propio todavia
 
 ---
 
@@ -307,24 +418,34 @@ el PR que los resolvio (#217 y #103 respectivamente).
 | Leave/vacation management | ✅ | #081, #082, #096, #212, #214 |
 | Operational reports | ✅ | #067, #068 |
 | Punctuality configuration | ✅ | #063-#066 |
-| Autorizacion por dominio | ✅ | Policies usan `$user->can()`, ya no `return true` |
 | Audit log viewer | ✅ | #084 |
+| Proteccion de periodos cerrados | ✅ | #251 — attendance/payroll-input de un periodo `CLOSED` ya no se puede editar sin bloqueo |
+| Dialogo masivo de overtime | ✅ | #249 — checkbox "aplicar al resto" agregado |
+| Consistencia visual de formularios (`Label`) | ✅ | #248/#259 |
+| SonarCloud sin deuda abierta (`sushigo-api`) | ✅ | #267/#268/#282/#289 (§2b) |
+| Catalogo de menu / Platillos | ✅ | #377-#381 — reemplaza el stub estatico `/productos`, cadena completa (§2b) |
+| Correccion de "Ausentes" en Attendance Today | ✅ | #358 — empleados en vacaciones/descanso ya aparecen desde el inicio del dia |
+| Migracion a `ApplicationClock` inyectado | ✅ | #360 |
+| Tablas unificadas con `DataGrid<T>` (Payroll Periods, reporte diario) | ✅ | #382, #383 |
+| Animacion de salida de tarjetas en Attendance Today | ✅ | #410 (reemplazo de #357, ver §2b) |
+| `APP_KEY` estatico removido de git/compose | ✅ | #384 (rotacion de la key **viva** en Cloud Run sigue pendiente, ver Parciales) |
+| Unificar `Employee.name` con `User.name` (fuente unica de verdad) | ✅ | #86, PR #263 (mergeado 2026-07-21) — contrato de API se mantuvo identico, 0 cambios de frontend |
 
 ### Requerimientos Parciales
 
 | Requerimiento | Estado | Brecha |
 |---------------|--------|--------|
-| Proteccion de periodos cerrados | ⚠️ | Close/reopen existe pero no bloquea ediciones directas — #251 |
-| Dialogo masivo de overtime | ⚠️ | Falta checkbox "aplicar al resto" — #249 |
-| Consistencia visual de formularios | ⚠️ | `Label` component no centralizado (mismo patron que #247 ya resuelto para `Button`) — #248 |
+| Autorizacion por dominio | ⚠️ | Policies usan `$user->can()` en HR/Attendance/Payroll/CashAdjustments/Media — pero `ItemPolicy` (Inventory) retorna `true` sin condicion — #400 |
+| Rotacion de credenciales expuestas | ⚠️ | Exposicion estatica cerrada (#384), pero las keys ya desplegadas en prod/preview de Cloud Run siguen sin rotar — requiere acceso a GCP fuera de esta automatizacion |
+| ids no enumerables en toda la app | ⚠️ | HR/Attendance/Payroll, CashAdjustments y Media ya exponen ULID `public_id`; Inventory (Item/ItemVariant/Stock/...) sigue exponiendo id numerico secuencial — #399 |
 
 ### No Implementados (diferidos a proposito)
 
 | Requerimiento | Tarea Backlog |
 |---------------|---------------|
 | Mobile app | #085 |
-| Unificacion Employee/User.name | #086 |
+| Integracion real de WhatsApp (`WhatsAppService`) | #276 |
 
 ---
 
-*Documento actualizado el 2026-07-18 por Claude Code*
+*Documento actualizado el 2026-08-11 por Claude Code*


### PR DESCRIPTION
## Summary

Closes #418
Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/419

- Refreshes `RESUME_STATUS.md` (last updated 2026-07-18, PR #253) to reflect everything since:
  the ~55-Issue SonarCloud/CashAdjustments-authorization/design-system cleanup wave, adoption of
  the formal sprint documentation process (TD-01, #359), and Sprint 002 in full (14/14 Issues,
  "Platillos Catalog & Platform Hardening")
- Adds §2b (following the doc's own §2a precedent) summarizing 2026-07-18 → 2026-08-11
- §4/§5 metrics and scorecard get a fresh `Ago 2026` column computed from the actual current
  codebase (`find`/`wc` counts against `code/api`/`code/webapp`), not carried over from July
- §6/§7 backlog sections replaced with the actual currently-open GitHub Issues (`#400`, `#412`,
  `#399`, `#401`, `#415`, `#276`, `#85`) — all of July's Wave 6/triage items are closed
- §8 recommends `#400` (a real, currently-exploitable `ItemPolicy` authorization gap discovered
  during Sprint 002) as the clear next priority, correcting July's "Autorizacion Real: ya
  resuelto" claim, which turned out not to cover the Inventory domain
- Fixed a broken `plan/roadmap.md` pointer in the doc's own header — that file was retired by
  TD-01 (#359) in favor of `doc/sprints/`

No application code changed — this PR only touches `RESUME_STATUS.md`.

## Test plan

- [x] `docs/`-only change — no PHPUnit/Vitest/Cypress applicable
- [x] Every metric in §4 (Controllers/Models/Services/Actions/Request Validators/API
      Resources/PHPUnit test files, and the frontend equivalents) recomputed directly from the
      current codebase via `find`/`wc -l`, not carried over or estimated
- [x] Every Issue referenced in §2b/§6/§7/§9 verified against `gh issue view`/`gh pr list` state
      (open/closed, merge commit) before writing it into the document

## Manual Testing

1. Open `RESUME_STATUS.md` on this branch and confirm:
   - Header: `Fecha de analisis: 2026-08-11`, `Branch actual: main @ ffb1603`
   - §2b exists between §2a and §2, covering the cleanup wave and Sprint 002
   - §6 "Pendientes" lists `#400` as Alta priority, not the old Wave 6 items (now all closed)
   - §7 backlog table lists exactly the issues currently open on GitHub (`gh issue list --repo pakodiazdev/sushigo --state open`)
   - §8 recommends `#400` first, not a Wave-style parallel batch
   - Footer reads `2026-08-11`

## Workspace
`sushigo-a` — `docs/418-refresh-resume-status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
