### PR TITLE
📚 [#443][a] - Close Sprint 002 and promote Sprint 003 🚀

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,8 @@ Development is organized into documented sprints — see [`doc/conventions/sprin
 |---|---|---|---|---|---|---:|---|
 | 000 | Introduction | Completed | 2026-07-26 | 2026-07-26 | — | — | [sprint-000-introduction.md](doc/sprints/sprint-000-introduction.md) |
 | 001 | Attendance, Payroll & Quality | Completed | 2026-07-26 | 2026-07-31 (impl. finished 2026-07-30) | 2026-08-09 | 1.40× (51.1h → 36.5h) | [sprint-001-attendance-payroll-quality.md](doc/sprints/sprint-001-attendance-payroll-quality.md) |
-| 002 | Platillos Catalog & Platform Hardening | In Progress | 2026-07-31 | 100% (14/14) | — | 1.85× (170.8h → 92.5h, scoped + opportunistic issues) | [sprint-002-platillos-catalog-platform-hardening.md](doc/sprints/sprint-002-platillos-catalog-platform-hardening.md) |
+| 002 | Platillos Catalog & Platform Hardening | Completed | 2026-07-31 | 2026-08-12 (impl. finished 2026-08-11) | — | 1.85× (170.8h → 92.5h, scoped + opportunistic issues) | [sprint-002-platillos-catalog-platform-hardening.md](doc/sprints/sprint-002-platillos-catalog-platform-hardening.md) |
+| 003 | Development Platform & Product Reliability | In Progress | 2026-08-12 | — | 2026-09-05 | — | [sprint-003-development-platform-and-product-reliability.md](doc/sprints/sprint-003-development-platform-and-product-reliability.md) |
 
 ## Development tips
 

--- a/doc/conventions/tasks.md
+++ b/doc/conventions/tasks.md
@@ -26,6 +26,87 @@ without the drift cost of editing two copies concurrently.
 
 ---
 
+## Roadmap planning aliases
+
+Large initiatives may use short aliases to group prospective Issues while the roadmap is being
+designed. These aliases are **planning coordinates, not task identifiers**. The GitHub Issue number
+is still the only permanent ID once an Issue exists.
+
+### Format
+
+```text
+<LANE>-<NN>
+```
+
+- `LANE` is an uppercase, documented acronym of 2–5 letters.
+- `NN` is a zero-padded sequence starting at `01` within that lane and roadmap.
+- A roadmap must define its lane glossary before using an alias.
+- Sequence numbers express grouping/order only; they do not imply priority, sprint, or execution
+  status.
+
+Example:
+
+```text
+DES-01  Design the target architecture
+CAT-03  Redesign the Variant contract
+OPS-02  Implement purchase receiving
+STK-01  Harden concurrent Stock mutations
+```
+
+### Standard Inventory roadmap lanes
+
+| Alias | Full name | Scope | Examples |
+|---|---|---|---|
+| `DES` | Design & Discovery | Architecture, domain decisions, contracts, migration and UI-flow design before implementation | ERD, ADR, API outline, migration plan |
+| `CAT` | Catalog | Master/catalog data that defines what is managed, independent of a transaction | Products, Variants, Brands, Categories, Purchase Presentations |
+| `OPS` | Inventory Operations | Business transactions and commercial configuration that operate on catalog data | Suppliers, receipts, acquisition cost, price lists |
+| `STK` | Stock & Integrity | Stock balances, movements, replenishment, authorization scope and structural cleanup | Concurrency, reversals, thresholds, Operating Unit access |
+
+Within an Inventory roadmap, `OPS` always means **Inventory Operations**, never DevOps. Platform or
+developer-experience work uses its existing `dev-tooling`/platform terminology; if it ever needs a
+roadmap alias, define a distinct acronym instead of overloading `OPS`.
+
+### Usage rules
+
+1. Use aliases only in a roadmap/design document or its GitHub roadmap index while work is being
+   decomposed.
+2. Do not place the alias in the GitHub Issue title, branch name, commit, PR title, session record,
+   or archive filename. Those use the real `#<number>` identity and the existing conventions.
+3. When the Issues are created, add one mapping table to the roadmap:
+
+   ```markdown
+   | Planning alias | GitHub Issue |
+   |---|---:|
+   | DES-01 | #421 |
+   | CAT-01 | #422 |
+   ```
+
+4. From that point forward, dependencies and execution evidence must reference `#421`, `#422`,
+   etc., not only `DES-01` or `CAT-01`.
+5. Never maintain a second live Issue body under the alias. The roadmap may retain a frozen summary
+   and mapping, but scope, checklists, estimates, Sessions, and Retrospective live only on GitHub.
+6. An alias is unique only inside its declared roadmap. Cross-roadmap communication must use the
+   GitHub Issue number and title to avoid collisions such as two unrelated `CAT-01` entries.
+7. If a new lane is needed, document its acronym, full name, scope boundary, and examples here or in
+   the domain's convention before using it. Prefer an existing lane when the boundary already fits.
+8. Reclassifying an Issue never changes its GitHub number. Update the roadmap mapping/glossary and
+   dependency explanation; do not rename historical IDs as if they were permanent task numbers.
+
+### What aliases do not encode
+
+Planning aliases never encode:
+
+- GitHub Issue identity.
+- Priority or value tier.
+- GitHub Project Status.
+- Sprint label or Iteration.
+- Backend/frontend ownership.
+- Completion state.
+
+Those remain explicit GitHub fields, labels, Issue references, and sprint evidence.
+
+---
+
 ## Mandatory sections (structure otherwise flexible)
 
 Every issue body must contain, regardless of size or type:

--- a/doc/sprints/README.md
+++ b/doc/sprints/README.md
@@ -6,7 +6,8 @@ Index of every SushiGo sprint document. See `doc/conventions/sprints.md` for the
 |---|---|---|---|
 | 000 | Introduction | Completed | [sprint-000-introduction.md](sprint-000-introduction.md) |
 | 001 | Attendance, Payroll & Quality | Completed | [sprint-001-attendance-payroll-quality.md](sprint-001-attendance-payroll-quality.md) |
-| 002 | Platillos Catalog & Platform Hardening | In Progress (current) | [sprint-002-platillos-catalog-platform-hardening.md](sprint-002-platillos-catalog-platform-hardening.md) |
+| 002 | Platillos Catalog & Platform Hardening | Completed | [sprint-002-platillos-catalog-platform-hardening.md](sprint-002-platillos-catalog-platform-hardening.md) |
+| 003 | Development Platform & Product Reliability | In Progress (current) | [sprint-003-development-platform-and-product-reliability.md](sprint-003-development-platform-and-product-reliability.md) |
 
 Planned sprints not yet started live under [`planned/`](planned/) and are not listed here until promoted.
 

--- a/doc/sprints/planned/sprint-004-product-catalog-reconstruction.md
+++ b/doc/sprints/planned/sprint-004-product-catalog-reconstruction.md
@@ -1,0 +1,337 @@
+---
+sprint: "004"
+title: Product Catalog Reconstruction
+status: Planned
+
+created: 2026-08-12
+started:
+completed:
+last_updated: 2026-08-12
+
+base_branch: main
+base_commit: ace93c8
+scope_issues: 8
+
+github_project: SushiGo Admin (#7)
+github_milestone:
+
+previous: sprint-003-development-platform-and-product-reliability.md
+next:
+---
+
+# Sprint 004 — Product Catalog Reconstruction
+
+> Deliver one usable Product → Variant → Purchase Presentation catalog, seeded with representative
+> SushiGo data, and retire the competing legacy Product wizard.
+
+## 1. Executive Summary
+
+Sprint 004 is projected as a focused application sprint containing eight Issues from
+`pakodiazdev/sushigo`: `#422` through `#429`. Together they deliver a complete catalog vertical
+rather than isolated backend work: Product identity with Brand and Inventory Category, progressive
+Product creation and detail, embedded Variants, reusable Purchase Presentations, realistic seed
+data, and removal of the superseded wizard and catalog paths.
+
+The selected scope represents **32h optimistic / 60h pessimistic** of engineering effort. It is
+organized into five dependency-aware rounds because every later layer builds on the catalog
+contracts established before it. Backend and frontend work run in parallel only where their
+contracts and file ownership make that safe.
+
+This sprint intentionally stops at catalog configuration. Supplier offerings, purchases,
+acquisition cost, Stock balances, branch-aware sale prices, and the remaining Inventory cleanup are
+deferred to later roadmap Issues. Product creation therefore remains free of cost, price, opening
+balance, location, and transactional purchase data.
+
+## 2. Context
+
+The current Inventory catalog couples Product, Variant, price, cost, stock, location, and unit
+conversion in a wizard. That interaction makes a single creation flow responsible for independent
+domains and can leave partial or conceptually incorrect configuration when a later step fails.
+
+The target workflow creates Product identity first. After persistence, the same SlidePanel becomes
+the Product detail and progressively exposes its Variant catalog. Each Variant then owns its
+inventory identity and can be assigned reusable commercial Purchase Presentations such as Unit,
+Pack x6, Box x12, or Box x24. Those presentations normalize packages to the Variant's base
+inventory unit without pretending that every box has a universal physical-UOM conversion.
+
+Sprint 003 Issue `#421` is the mandatory design gate for this implementation. Sprint 004 may start
+only after that Issue produces an approved target architecture, UI/API contract, and incremental
+migration plan. If its decision changes the assumptions in `#422`–`#429`, the affected Issue bodies,
+estimates, dependencies, and this document must be updated before Sprint 004 is promoted.
+
+Sprint 004 is configured in SushiGo Admin for **2026-09-06 through 2026-09-19**. This document
+remains under `doc/sprints/planned/` until Sprint 003 is closed and Sprint 004 is promoted according
+to `doc/conventions/sprints.md`.
+
+## 3. Sprint Goal
+
+**Sprint Goal:** Replace the coupled Inventory catalog wizard with a tested, progressive Product →
+Variant → Purchase Presentation workflow that is usable end to end, includes realistic SushiGo
+seed data, and leaves financial and Stock operations in their correct later domains.
+
+## 4. Sprint Timeline
+
+| Metric | Value |
+|---|---:|
+| Created | 2026-08-12 |
+| Planned start | 2026-09-06 |
+| Planned end | 2026-09-19 |
+| Started | — |
+| Completed | — |
+| Target calendar duration | 14 days |
+| Active workdays | — |
+
+## 5. Scope
+
+### 5.1 Included
+
+- Product, Brand, and Inventory Category backend contracts (`#422`).
+- Progressive Product create/edit/detail SlidePanel replacing the four-step wizard (`#423`).
+- Product-scoped Variant backend around SKU, barcode, base UOM, and active state (`#424`).
+- Embedded Variant catalog and CRUD inside Product detail (`#425`).
+- Reusable Purchase Presentation templates and Variant assignments (`#426`).
+- Purchase Presentation management inside embedded Variant detail (`#427`).
+- Deterministic Testing, volume Fakes, and realistic Development seeders (`#428`).
+- Removal of ProductWizard and superseded catalog UI/contracts (`#429`).
+
+### 5.2 Excluded
+
+- Implementation before Sprint 003 design gate `#421` is approved.
+- Supplier offerings and purchase-contract design (`#431`).
+- Purchase receipts, promotions, acquisition-cost calculation, and receiving UI (`#432`–`#434`).
+- Branch-aware price lists and price-management UI (`#435`–`#437`).
+- Remaining Stock movement, replenishment, authorization, navigation, and schema cleanup
+  (`#438`–`#442`).
+- Writing cost, sale price, Stock, opening balance, location, or supplier data from Product or
+  Variant forms.
+- Adding Insumo or Activo verticals; the shared backend may support them later through adapted UI.
+- Unrelated pending technical debt such as `#399`, `#415`, `#276`, and `#85`.
+
+### 5.3 Scope Changes
+
+| Date | Status | Item | Change | Reason |
+|---|---|---|---|---|
+| — | — | — | None yet | Sprint not started |
+
+### 5.4 Opportunistic Work
+
+| Date | Issue | Title | Trigger | Result |
+|---|---:|---|---|---|
+| — | — | — | None yet | — |
+
+## 6. Value Ranking
+
+| Tier | Issues | Rationale |
+|---|---|---|
+| **Critical** | `#422`, `#424`, `#426` | Establish the canonical Product, Variant, and package-normalization contracts required by every user-facing workflow |
+| **High** | `#423`, `#425`, `#427` | Turn the contracts into a complete progressive catalog operators can actually use |
+| **Medium** | `#428`, `#429` | Make the vertical demonstrable and remove stale paths that could continue writing invalid catalog data |
+| **Deferred** | `#431`–`#442` | Extend the catalog into purchasing, pricing, and final Stock hardening in later sprints |
+
+### Ordering principle
+
+> Approve the design, stabilize each backend contract, expose it through the progressive UI, prove
+> the full catalog with representative data, and only then delete the legacy workflow.
+
+## 7. Route A — Execution Rounds
+
+### Round 1 — Establish Product Identity
+
+| Status | Issue | Title | Value | Opt. | Pess. | Tracked | PR / Commit | Notes |
+|---|---:|---|---|---:|---:|---:|---|---|
+| ⏳ | #422 | Build Product catalog contract with Brands and Inventory Categories | Critical | 5h | 9h | — | — | Starts only after #421 approval |
+|  |  | **Round total** |  | **5h** | **9h** | **—** |  |  |
+
+### Round 2 — Expose Products and Define Variants
+
+| Status | Issue | Title | Value | Opt. | Pess. | Tracked | PR / Commit | Notes |
+|---|---:|---|---|---:|---:|---:|---|---|
+| ⏳ | #423 | Replace Product wizard with progressive create-and-detail SlidePanel | High | 5h | 9h | — | — | Frontend lane; consumes #422 |
+| ⏳ | #424 | Redesign Product Variants around inventory identity | Critical | 3h | 6h | — | — | Backend lane; consumes #422 and coordinates with #399 |
+|  |  | **Round total** |  | **8h** | **15h** | **—** |  |  |
+
+### Round 3 — Embed Variants and Model Purchase Presentations
+
+| Status | Issue | Title | Value | Opt. | Pess. | Tracked | PR / Commit | Notes |
+|---|---:|---|---|---:|---:|---:|---|---|
+| ⏳ | #425 | Add embedded Variant catalog and CRUD to Product detail | High | 4h | 8h | — | — | Requires #423 and #424 |
+| ⏳ | #426 | Model reusable Purchase Presentations and Variant assignments | Critical | 5h | 9h | — | — | Backend lane after #424 |
+|  |  | **Round total** |  | **9h** | **17h** | **—** |  |  |
+
+### Round 4 — Complete the Usable Catalog and Its Data
+
+| Status | Issue | Title | Value | Opt. | Pess. | Tracked | PR / Commit | Notes |
+|---|---:|---|---|---:|---:|---:|---|---|
+| ⏳ | #427 | Add Purchase Presentation management to Variant detail | High | 4h | 7h | — | — | Frontend lane; requires #425 and #426 |
+| ⏳ | #428 | Seed realistic Products, Variants, and Purchase Presentations | Medium | 3h | 6h | — | — | Backend/data lane; requires #422, #424, and #426 |
+|  |  | **Round total** |  | **7h** | **13h** | **—** |  |  |
+
+### Round 5 — Retire the Competing Workflow
+
+| Status | Issue | Title | Value | Opt. | Pess. | Tracked | PR / Commit | Notes |
+|---|---:|---|---|---:|---:|---:|---|---|
+| ⏳ | #429 | Remove legacy Product wizard and superseded catalog UI | Medium | 3h | 6h | — | — | Runs only after replacement UI and seed evidence are green |
+|  |  | **Round total** |  | **3h** | **6h** | **—** |  |  |
+
+## 8. Route B — Sequential Dependencies
+
+```text
+#421 (Sprint 3 design gate)
+  → #422 Product contract
+      → #423 Product UI
+      → #424 Variant contract
+          → #425 embedded Variant UI
+          → #426 Purchase Presentation contract
+              → #427 Presentation UI
+              → #428 catalog seeders
+                  → #429 legacy cleanup
+```
+
+`#423` and `#424` may run in parallel after `#422`; one owns the Product frontend and the other the
+Variant backend. `#425` and `#426` may also run in parallel after the Variant contract is stable.
+`#427` and `#428` form the last safe parallel pair: presentation UI and deterministic backend/data
+fixtures. `#429` is intentionally last because deletion is safe only when the replacement workflow
+and its representative data have passed their gates.
+
+## 9. Conflict Risk Map
+
+| Shared area | Issues | Planned rounds | Risk / Coordination |
+|---|---|---|---|
+| Item/Product schema, models, API resources, permissions | `#422`, `#424`, `#426`, `#428` | 1–4 | Sequence migrations/contracts; later work consumes rather than redefines earlier boundaries |
+| Product page, API client, types, hooks, SlidePanel | `#423`, `#425`, `#427`, `#429` | 2–5 | Sequential frontend ownership avoids competing nested-panel state and cache contracts |
+| Variant schema/API | `#424`, `#426`, `#428` | 2–4 | Establish Variant contract before presentation assignments and seed data |
+| Seed configuration and database seeders | `#428` | 4 | Single owner; must consume canonical APIs/models and remain idempotent |
+| Inventory routes/navigation and old wizard exports | `#423`, `#429` | 2, 5 | Create replacement first; delete redirects and stale entry points last |
+| Public-ID convention | `#424`, backlog `#399` | 2 | Coordinate explicitly; Sprint 4 must not introduce an incompatible convention |
+
+## 10. Estimate Tracking by Round
+
+| Round | Issue count | Opt. total | Pess. total | Tracked total | vs Opt. | vs Pess. |
+|---|---:|---:|---:|---:|---:|---:|
+| Round 1 | 1 | 5h | 9h | — | — | — |
+| Round 2 | 2 | 8h | 15h | — | — | — |
+| Round 3 | 2 | 9h | 17h | — | — | — |
+| Round 4 | 2 | 7h | 13h | — | — | — |
+| Round 5 | 1 | 3h | 6h | — | — | — |
+| **Sprint total** | **8** | **32h** | **60h** | **—** | **—** | **—** |
+
+## 11. Consolidated Time Tracking
+
+| Category | Estimated | Tracked | Variance |
+|---|---:|---:|---:|
+| Product catalog contract and UI (`#422`, `#423`) | 10h–18h | — | — |
+| Variant contract and embedded UI (`#424`, `#425`) | 7h–14h | — | — |
+| Purchase Presentations backend and UI (`#426`, `#427`) | 9h–16h | — | — |
+| Seed data (`#428`) | 3h–6h | — | — |
+| Legacy cleanup (`#429`) | 3h–6h | — | — |
+| **Sprint total** | **32h–60h** | **—** | **—** |
+
+### Wall-Clock Time & Parallelism
+
+Computed at sprint closure from finalized Issue session arrays, following
+`doc/conventions/sprints.md` §7.
+
+- **Person-hours:** —
+- **Wall-clock time:** —
+- **Parallelization factor:** —
+- **Peak concurrency:** —
+
+| Wall-clock block | Duration | Issues active in this block |
+|---|---:|---|
+| — | — | No sessions yet |
+
+## 12. Notes on Estimate Confidence
+
+Confidence is **medium**. Issue boundaries and dependencies are explicit, but `#421` can still
+re-scope schema or migration decisions before Sprint 4 begins. The estimates assume incremental
+migration over the shared Item model, reuse of the media system from `#377`/`#378`, no financial or
+Stock-domain implementation, and no broad delivery of technical-debt Issue `#399`.
+
+The largest uncertainty is the nested Product/Variant/Presentation UI state across `#423`, `#425`,
+and `#427`. The plan sequences those Issues so each can stabilize cache, accessibility, and panel
+behavior before the next layer consumes it. All eight Issue bodies contain optimistic/pessimistic
+estimates and empty Sessions arrays ready for execution tracking.
+
+## 13. Execution Evidence
+
+| Status | Issue | Result Summary | Pull Request | Merge Commit | Tracked | Evidence Notes |
+|---|---:|---|---:|---|---:|---|
+| ⏳ | #422 | Pending | — | — | — | Product/Brand/Category contract after #421 |
+| ⏳ | #423 | Pending | — | — | — | Progressive Product SlidePanel |
+| ⏳ | #424 | Pending | — | — | — | Product-scoped Variant contract |
+| ⏳ | #425 | Pending | — | — | — | Embedded Variant workflow |
+| ⏳ | #426 | Pending | — | — | — | Reusable Purchase Presentation contract |
+| ⏳ | #427 | Pending | — | — | — | Embedded Presentation management |
+| ⏳ | #428 | Pending | — | — | — | Testing/Fakes/Development catalog data |
+| ⏳ | #429 | Pending | — | — | — | Legacy wizard and stale catalog paths removed |
+
+## 14. Quality Results
+
+| Metric | Before | Target | After | Result |
+|---|---:|---:|---:|---|
+| Product creation entry points | Coupled wizard and overlapping catalog paths | One progressive Product catalog entry point | — | ⏳ |
+| Product create payload | Mixes identity with operational/financial fields | Identity, classification, media, and active state only | — | ⏳ |
+| Variant management | Disconnected/global and financially coupled | Product-scoped CRUD inside Product detail | — | ⏳ |
+| Commercial packaging | Ambiguous use of global UOM conversion | Reusable compatible Purchase Presentation templates | — | ⏳ |
+| Representative catalog data | Legacy/incomplete Product story | Deterministic Coca-Cola, Buldak, Peelez, Ramune, and Mochis examples | — | ⏳ |
+| Relevant tests and gates | TBD | 100% relevant API, component, E2E, and quality checks passing | — | ⏳ |
+
+## 15. Results
+
+### 15.1 Delivered Value
+
+Not yet delivered. Expected value is a coherent catalog that operators can use from Product
+creation through Variant and Purchase Presentation configuration without entering transactional
+cost, sale price, Stock, or opening balances.
+
+### 15.2 Planned vs. Actual
+
+- **Planned Issues:** 8.
+- **Estimate:** 32h optimistic / 60h pessimistic.
+- **Completed:** 0.
+- **Deprecated or cancelled:** 0.
+- **Tracked:** no sessions yet.
+
+### 15.3 Known Limitations
+
+- Sprint 004 cannot start until `#421` is approved and Sprint 003 is closed.
+- The completed catalog will not yet receive purchases or resolve acquisition cost/sale price.
+- Seeders demonstrate reusable catalog definitions only; operational suppliers, receipts, costs,
+  Stock, and branch prices belong to later Issues.
+- The estimate is engineering effort, not elapsed time; five dependency rounds constrain the
+  maximum useful parallelism.
+
+## 16. Lessons Learned
+
+Planning lesson: catalog identity, operational packaging, transaction cost, sale price, and Stock
+are related but distinct lifecycle boundaries. Delivering them as separate verticals avoids another
+wizard that creates partial state and gives each sprint an independently testable outcome.
+
+Additional lessons will be added from execution evidence.
+
+## 17. Follow-up Work
+
+| Status | Proposed Issue | Title | Reason | Candidate Sprint |
+|---|---:|---|---|---|
+| ⏳ | #431–#434 | Supplier offerings, Purchase Receipts, receiving UI, and acquisition cost | Consume the stable Purchase Presentation and Stock mutation contracts | Sprint 005+ |
+| ⏳ | #435–#437 | Branch-aware price lists, UI, and operational seed data | Sale price belongs outside Product/Variant catalog identity | Future |
+| ⏳ | #438–#442 | Stock movement, replenishment, access, navigation, and final schema cleanup | Finish Inventory hardening after replacement domains exist | Future |
+
+## 18. Sprint Closure Checklist
+
+- [x] Eight Issues selected as one end-to-end catalog vertical.
+- [x] Every included Issue is linked to SushiGo Admin, labeled `sprint-4`, and assigned to the
+      `Sprint 4` iteration.
+- [ ] Sprint 003 design gate `#421` was approved and any resulting re-scope recorded.
+- [ ] All included work items have a final status marker.
+- [ ] Completed items include Pull Request or commit evidence.
+- [ ] Deprecated or cancelled items include replacement/reason.
+- [ ] Scope changes and opportunistic work are recorded.
+- [ ] Tracked time was synchronized from Issue Sessions arrays.
+- [ ] Round totals, sprint totals, and estimate variance were recalculated.
+- [ ] Wall-clock time, parallelization factor, and peak concurrency were computed.
+- [ ] Dependencies and conflict notes reflect actual execution.
+- [ ] Relevant tests, E2E scenarios, and quality metrics were recorded.
+- [ ] Delivered value and known limitations were documented.
+- [ ] Follow-up work and lessons learned were captured.
+- [ ] Metadata dates/status were updated and the next sprint was created when applicable.

--- a/doc/sprints/planned/sprint-004-product-catalog-reconstruction.md
+++ b/doc/sprints/planned/sprint-004-product-catalog-reconstruction.md
@@ -16,7 +16,7 @@ github_project: SushiGo Admin (#7)
 github_milestone:
 
 previous: sprint-003-development-platform-and-product-reliability.md
-next:
+next: sprint-005-purchasing-cost-and-pricing.md
 ---
 
 # Sprint 004 — Product Catalog Reconstruction
@@ -313,9 +313,9 @@ Additional lessons will be added from execution evidence.
 
 | Status | Proposed Issue | Title | Reason | Candidate Sprint |
 |---|---:|---|---|---|
-| ⏳ | #431–#434 | Supplier offerings, Purchase Receipts, receiving UI, and acquisition cost | Consume the stable Purchase Presentation and Stock mutation contracts | Sprint 005+ |
-| ⏳ | #435–#437 | Branch-aware price lists, UI, and operational seed data | Sale price belongs outside Product/Variant catalog identity | Future |
-| ⏳ | #438–#442 | Stock movement, replenishment, access, navigation, and final schema cleanup | Finish Inventory hardening after replacement domains exist | Future |
+| ⏳ | #431–#434 | Supplier offerings, Purchase Receipts, receiving UI, and acquisition cost | Consume the stable Purchase Presentation and Stock mutation contracts | Sprint 005 |
+| ⏳ | #435–#437 | Branch-aware price lists, UI, and operational seed data | Complete the commercial operating story after purchasing | Sprint 005 |
+| ⏳ | #438–#442 | Stock movement, replenishment, access, navigation, and final schema cleanup | Finish Inventory hardening after replacement domains exist | Sprint 006 |
 
 ## 18. Sprint Closure Checklist
 

--- a/doc/sprints/planned/sprint-005-purchasing-cost-and-pricing.md
+++ b/doc/sprints/planned/sprint-005-purchasing-cost-and-pricing.md
@@ -1,0 +1,268 @@
+---
+sprint: "005"
+title: Purchasing, Cost & Pricing
+status: Planned
+
+created: 2026-08-12
+started:
+completed:
+last_updated: 2026-08-12
+
+base_branch: main
+base_commit: 68ee117
+scope_issues: 7
+
+github_project: SushiGo Admin (#7)
+github_milestone:
+
+previous: sprint-004-product-catalog-reconstruction.md
+next: sprint-006-stock-integrity-and-inventory-completion.md
+---
+
+# Sprint 005 — Purchasing, Cost & Pricing
+
+> Turn the Product catalog into an operational commercial flow: configure suppliers, receive
+> packages, calculate effective acquisition cost, and resolve branch-aware sale prices.
+
+## 1. Executive Summary
+
+Sprint 005 contains `#431`–`#437`, a seven-Issue vertical estimated at **36h optimistic / 67h
+pessimistic**. It builds Supplier offerings over the Purchase Presentations delivered in Sprint 4,
+adds immutable Purchase Receipts and receiving UI, unifies weighted-average acquisition cost, adds
+effective branch-aware price lists and UI, and proves the complete story with operational seed data.
+
+The outcome is usable functionality rather than backend scaffolding: operators can record what was
+actually bought, including paid/bonus packages and expenses, inspect the resulting effective unit
+cost, and configure distinct sale prices by branch or approved operating context.
+
+## 2. Context
+
+Sprint 4 deliberately keeps catalog identity free of supplier, cost, price, Stock, and transaction
+data. Sprint 5 consumes that stable Product → Variant → Purchase Presentation model and the
+concurrency-safe Stock mutation contract from `#430` to implement the next lifecycle boundary.
+
+Cost belongs to the purchase evidence that produced it, not the Product form. Sale price belongs to
+an effective operational context, not a global Variant fallback. This sprint groups both domains
+because the final seed and demonstration flow must explain how package, supplier, promotion,
+expense, acquisition cost, and branch price differ without conflating them.
+
+The SushiGo Admin Iteration is scheduled for **2026-09-20 through 2026-10-03**. Promotion requires
+Sprint 4 completion and verified compatibility with its final Presentation contracts.
+
+## 3. Sprint Goal
+
+**Sprint Goal:** Deliver auditable purchase receiving and branch-aware pricing end to end, with one
+authoritative acquisition-cost source and deterministic operational data.
+
+## 4. Sprint Timeline
+
+| Metric | Value |
+|---|---:|
+| Created | 2026-08-12 |
+| Planned start | 2026-09-20 |
+| Planned end | 2026-10-03 |
+| Started | — |
+| Completed | — |
+| Target calendar duration | 14 days |
+| Active workdays | — |
+
+## 5. Scope
+
+### 5.1 Included
+
+- Suppliers and purchasable Variant Presentation offerings (`#431`).
+- Purchase Receipt posting, promotions, expenses, and effective unit cost (`#432`).
+- Purchase receiving UI and canonical cost preview (`#433`).
+- One weighted-average acquisition-cost source across Variant, Stock, and reports (`#434`).
+- Effective branch/operating-context price lists (`#435`).
+- Price-list management UI (`#436`).
+- Deterministic Suppliers, Receipts, costs, and branch-price seed data (`#437`).
+
+### 5.2 Excluded
+
+- Product/Variant/Presentation catalog reconstruction (`#422`–`#429`), completed first in Sprint 4.
+- Stock movement normalization, replenishment policies, horizontal access, navigation, and final
+  legacy cleanup (`#438`–`#442`), assigned to Sprint 6.
+- A Product or Variant form fallback for cost or sale price.
+- Redis-dependent price resolution or speculative promotion/channel engines.
+- Deferred technical debt `#85`, `#276`, `#399`, and `#415`.
+
+### 5.3 Scope Changes
+
+| Date | Status | Item | Change | Reason |
+|---|---|---|---|---|
+| — | — | — | None yet | Sprint not started |
+
+### 5.4 Opportunistic Work
+
+| Date | Issue | Title | Trigger | Result |
+|---|---:|---|---|---|
+| — | — | — | None yet | — |
+
+## 6. Value Ranking
+
+| Tier | Issues | Rationale |
+|---|---|---|
+| **Critical** | `#432`, `#434` | Purchase posting and authoritative acquisition cost directly affect Stock value and margins |
+| **High** | `#431`, `#433`, `#435`, `#436` | Complete supplier, receiving, and branch-price functionality for operators |
+| **Medium** | `#437` | Demonstrate and regression-test the full operational story |
+| **Deferred** | `#438`–`#442` | Final Stock hardening follows in Sprint 6 |
+
+### Ordering principle
+
+> Stabilize supplier offerings, post purchases through atomic Stock mutation, reconcile cost, add
+> pricing, and seed only after every canonical calculation exists.
+
+## 7. Route A — Execution Rounds
+
+### Round 1 — Supplier and Price Foundations
+
+| Status | Issue | Title | Value | Opt. | Pess. | Tracked | PR / Commit | Notes |
+|---|---:|---|---|---:|---:|---:|---|---|
+| ⏳ | #431 | Build Suppliers and purchasable Variant Presentations | High | 5h | 9h | — | — | Requires Sprint 4 presentation contract |
+| ⏳ | #435 | Build effective Product price lists by branch/context | High | 6h | 11h | — | — | Independent pricing lane after Variant contract |
+|  |  | **Round total** |  | **11h** | **20h** | **—** |  |  |
+
+### Round 2 — Post Purchases and Manage Prices
+
+| Status | Issue | Title | Value | Opt. | Pess. | Tracked | PR / Commit | Notes |
+|---|---:|---|---|---:|---:|---:|---|---|
+| ⏳ | #432 | Receive Product Presentations and calculate effective unit cost | Critical | 7h | 13h | — | — | Reuses #430 atomic Stock mutation |
+| ⏳ | #436 | Add branch-aware price-list management UI | High | 5h | 9h | — | — | Consumes #435 |
+|  |  | **Round total** |  | **12h** | **22h** | **—** |  |  |
+
+### Round 3 — Complete Receiving and Reconcile Cost
+
+| Status | Issue | Title | Value | Opt. | Pess. | Tracked | PR / Commit | Notes |
+|---|---:|---|---|---:|---:|---:|---|---|
+| ⏳ | #433 | Add purchase receiving UI and cost preview | High | 6h | 11h | — | — | Consumes #432 |
+| ⏳ | #434 | Unify weighted-average acquisition cost | Critical | 4h | 8h | — | — | Reconcile before final seed evidence |
+|  |  | **Round total** |  | **10h** | **19h** | **—** |  |  |
+
+### Round 4 — Prove the Operational Story
+
+| Status | Issue | Title | Value | Opt. | Pess. | Tracked | PR / Commit | Notes |
+|---|---:|---|---|---:|---:|---:|---|---|
+| ⏳ | #437 | Seed Suppliers, Receipts, costs, and branch prices | Medium | 3h | 6h | — | — | Requires #431–#436 |
+|  |  | **Round total** |  | **3h** | **6h** | **—** |  |  |
+
+## 8. Route B — Sequential Dependencies
+
+```text
+#431 → #432 → #433
+          └→ #434
+#435 → #436
+#431 + #432 + #433 + #434 + #435 + #436 → #437
+```
+
+Supplier and pricing foundations can run in parallel. Purchase posting must precede its UI and cost
+reconciliation. Operational seed data is last because it validates the canonical calculations and
+both visible workflows rather than inventing interim behavior.
+
+## 9. Conflict Risk Map
+
+| Shared area | Issues | Rounds | Coordination |
+|---|---|---|---|
+| Supplier/Presentation API and receipt services | `#431`, `#432`, `#437` | 1, 2, 4 | Sequential contract consumption |
+| Stock cost fields/services/reports | `#432`, `#434`, `#437` | 2–4 | Reconcile one source before seed assertions |
+| Receiving API types and UI | `#432`, `#433` | 2, 3 | Backend contract first |
+| Price-list API/types/UI | `#435`, `#436`, `#437` | 1, 2, 4 | Backend then UI then seed evidence |
+| Seeder configuration | `#437` | 4 | Single final owner |
+
+## 10. Estimate Tracking by Round
+
+| Round | Issues | Opt. | Pess. | Tracked | vs Opt. | vs Pess. |
+|---|---:|---:|---:|---:|---:|---:|
+| 1 | 2 | 11h | 20h | — | — | — |
+| 2 | 2 | 12h | 22h | — | — | — |
+| 3 | 2 | 10h | 19h | — | — | — |
+| 4 | 1 | 3h | 6h | — | — | — |
+| **Total** | **7** | **36h** | **67h** | **—** | **—** | **—** |
+
+## 11. Consolidated Time Tracking
+
+| Category | Estimated | Tracked | Variance |
+|---|---:|---:|---:|
+| Suppliers and purchasing (`#431`–`#433`) | 18h–33h | — | — |
+| Acquisition-cost reconciliation (`#434`) | 4h–8h | — | — |
+| Branch-aware pricing (`#435`, `#436`) | 11h–20h | — | — |
+| Operational seed data (`#437`) | 3h–6h | — | — |
+| **Total** | **36h–67h** | **—** | **—** |
+
+### Wall-Clock Time & Parallelism
+
+- **Person-hours:** —
+- **Wall-clock time:** —
+- **Parallelization factor:** —
+- **Peak concurrency:** —
+
+| Wall-clock block | Duration | Issues active in this block |
+|---|---:|---|
+| — | — | No sessions yet |
+
+## 12. Notes on Estimate Confidence
+
+Confidence is **medium**. Boundaries and formulas are scoped in the Issues, but purchase posting and
+cost migration carry meaningful database/concurrency risk. Estimates assume Sprint 4 contracts and
+`#430` remain stable, exact-decimal money handling is preserved, and no unrelated pricing engine is
+introduced.
+
+## 13. Execution Evidence
+
+| Status | Issue | Result | PR / Commit | Tracked | Notes |
+|---|---:|---|---|---:|---|
+| ⏳ | #431 | Pending | — | — | Supplier offerings |
+| ⏳ | #432 | Pending | — | — | Receipt posting and effective cost |
+| ⏳ | #433 | Pending | — | — | Receiving UI |
+| ⏳ | #434 | Pending | — | — | Cost reconciliation |
+| ⏳ | #435 | Pending | — | — | Price-list backend |
+| ⏳ | #436 | Pending | — | — | Price-list UI |
+| ⏳ | #437 | Pending | — | — | Operational seeds |
+
+## 14. Quality Results
+
+| Metric | Before | Target | After | Result |
+|---|---|---|---|---|
+| Purchase evidence | Manual conversions/no canonical receipt | Immutable posted receipt with exact calculations | — | ⏳ |
+| Acquisition cost | Competing Variant/Stock sources | One reconciled weighted-average source | — | ⏳ |
+| Sale price | Global Variant assumption | Effective deterministic branch/context resolution | — | ⏳ |
+| Operational data | Catalog-only examples | Suppliers, promotion, receipt, cost, and branch-price story | — | ⏳ |
+
+## 15. Results
+
+### 15.1 Delivered Value
+
+Not yet delivered. Expected value is an auditable purchase-to-Stock-cost flow plus locally resolved
+sale prices that operators can configure and inspect.
+
+### 15.2 Planned vs. Actual
+
+- Planned: 7 Issues, 36h–67h.
+- Completed: 0.
+- Tracked: no sessions yet.
+
+### 15.3 Known Limitations
+
+- Sprint 5 depends on Sprints 3–4 and cannot be safely promoted early.
+- Final Stock movement, replenishment, access, navigation, and schema cleanup remains in Sprint 6.
+- Promotion/discount engines beyond receipt evidence are out of scope.
+
+## 16. Lessons Learned
+
+Planning lesson: cost must be derived from immutable purchase evidence, while price must resolve
+from operational context. Keeping them outside the Product catalog prevents competing defaults.
+
+## 17. Follow-up Work
+
+| Status | Issues | Work | Candidate Sprint |
+|---|---:|---|---|
+| ⏳ | #438–#442 | Stock integrity and final Inventory completion | Sprint 006 |
+
+## 18. Sprint Closure Checklist
+
+- [x] All seven Issues are linked, labeled `sprint-5`, and assigned to Sprint 5.
+- [ ] Every Issue has a final status and PR/commit evidence.
+- [ ] Scope changes and tracked Sessions are synchronized.
+- [ ] Estimates, wall-clock time, parallelism, and quality results are finalized.
+- [ ] Dependencies, conflicts, delivered value, limitations, and lessons reflect execution.
+- [ ] Sprint 6 is promoted when applicable.

--- a/doc/sprints/planned/sprint-006-stock-integrity-and-inventory-completion.md
+++ b/doc/sprints/planned/sprint-006-stock-integrity-and-inventory-completion.md
@@ -1,0 +1,255 @@
+---
+sprint: "006"
+title: Stock Integrity & Inventory Completion
+status: Planned
+
+created: 2026-08-12
+started:
+completed:
+last_updated: 2026-08-12
+
+base_branch: main
+base_commit: 68ee117
+scope_issues: 5
+
+github_project: SushiGo Admin (#7)
+github_milestone:
+
+previous: sprint-005-purchasing-cost-and-pricing.md
+next:
+---
+
+# Sprint 006 — Stock Integrity & Inventory Completion
+
+> Complete the Inventory reconstruction by hardening Stock movements, location policy, horizontal
+> authorization, navigation, and evidence-backed removal of legacy contracts.
+
+## 1. Executive Summary
+
+Sprint 006 contains `#438`–`#442`, five Issues estimated at **24h optimistic / 48h pessimistic**.
+It normalizes Stock Movement and immutable reversals, moves replenishment thresholds into the
+Location + Variant context, enforces Operating Unit access, consolidates the final Inventory
+navigation/workflows, and removes legacy fields only after reconciliation evidence exists.
+
+This is the cleanup sprint that finishes functionality and integrity together. It does not delete
+old schema first; it proves each replacement consumer, migrates/reconciles data, and then removes
+the obsolete source of truth.
+
+## 2. Context
+
+Sprints 4 and 5 establish replacement catalog, purchase, cost, and pricing domains. The remaining
+Stock code still contains duplicated movement fields, incomplete reversal semantics, global
+thresholds, insufficient horizontal scope, overlapping navigation, and legacy columns. Those risks
+cannot be removed safely until the replacement verticals exist.
+
+The SushiGo Admin Iteration is scheduled for **2026-10-04 through 2026-10-17**. Sprint 6 is the
+planned completion boundary for the current Product Inventory roadmap, not a generic promise to
+eliminate every unrelated technical-debt Issue.
+
+## 3. Sprint Goal
+
+**Sprint Goal:** Finish Inventory with auditable Stock corrections, location-aware policy,
+Operating Unit isolation, one coherent UI, and reconciled removal of superseded contracts.
+
+## 4. Sprint Timeline
+
+| Metric | Value |
+|---|---:|
+| Created | 2026-08-12 |
+| Planned start | 2026-10-04 |
+| Planned end | 2026-10-17 |
+| Started | — |
+| Completed | — |
+| Target calendar duration | 14 days |
+| Active workdays | — |
+
+## 5. Scope
+
+### 5.1 Included
+
+- Canonical Stock Movement lines and immutable compensating reversals (`#438`).
+- Location + Variant replenishment thresholds (`#439`).
+- Operating Unit access across Inventory data and mutations (`#440`).
+- Consolidated Inventory navigation and workflows (`#441`).
+- Reconciled removal of legacy fields and architecture documentation (`#442`).
+
+### 5.2 Excluded
+
+- Reimplementation of completed Product, purchase, cost, or pricing verticals.
+- Deleting legacy data before parity, reconciliation, and rollback evidence.
+- Unrelated deferred/backlog debt `#85`, `#276`, `#399`, and `#415`.
+- New forecasting, automatic purchase-order, or warehouse-optimization features.
+
+### 5.3 Scope Changes
+
+| Date | Status | Item | Change | Reason |
+|---|---|---|---|---|
+| — | — | — | None yet | Sprint not started |
+
+### 5.4 Opportunistic Work
+
+| Date | Issue | Title | Trigger | Result |
+|---|---:|---|---|---|
+| — | — | — | None yet | — |
+
+## 6. Value Ranking
+
+| Tier | Issues | Rationale |
+|---|---|---|
+| **Critical** | `#438`, `#440` | Preserve immutable Stock evidence and prevent cross-unit access |
+| **High** | `#439`, `#442` | Correct operational replenishment and remove competing sources safely |
+| **Medium** | `#441` | Present the completed domains through one coherent operational UI |
+
+### Ordering principle
+
+> Harden data and access first, expose the final workflow second, and remove legacy contracts only
+> after all replacement consumers and reconciliation checks are green.
+
+## 7. Route A — Execution Rounds
+
+### Round 1 — Stock and Access Foundations
+
+| Status | Issue | Title | Value | Opt. | Pess. | Tracked | PR / Commit | Notes |
+|---|---:|---|---|---:|---:|---:|---|---|
+| ⏳ | #438 | Normalize Stock Movements and immutable reversals | Critical | 6h | 12h | — | — | Depends on #430 |
+| ⏳ | #440 | Enforce Operating Unit access across Inventory | Critical | 5h | 10h | — | — | Cover every replacement domain |
+|  |  | **Round total** |  | **11h** | **22h** | **—** |  |  |
+
+### Round 2 — Location Policy
+
+| Status | Issue | Title | Value | Opt. | Pess. | Tracked | PR / Commit | Notes |
+|---|---:|---|---|---:|---:|---:|---|---|
+| ⏳ | #439 | Configure replenishment thresholds per Location | High | 4h | 8h | — | — | Consume stable Stock/access scopes |
+|  |  | **Round total** |  | **4h** | **8h** | **—** |  |  |
+
+### Round 3 — Consolidate Operational UI
+
+| Status | Issue | Title | Value | Opt. | Pess. | Tracked | PR / Commit | Notes |
+|---|---:|---|---|---:|---:|---:|---|---|
+| ⏳ | #441 | Consolidate Inventory navigation and workflows | Medium | 5h | 10h | — | — | Requires final replacement UIs/contracts |
+|  |  | **Round total** |  | **5h** | **10h** | **—** |  |  |
+
+### Round 4 — Remove Legacy Sources
+
+| Status | Issue | Title | Value | Opt. | Pess. | Tracked | PR / Commit | Notes |
+|---|---:|---|---|---:|---:|---:|---|---|
+| ⏳ | #442 | Remove legacy fields and reconcile documentation | High | 4h | 8h | — | — | Destructive schema cleanup only after evidence |
+|  |  | **Round total** |  | **4h** | **8h** | **—** |  |  |
+
+## 8. Route B — Sequential Dependencies
+
+```text
+#430 (Sprint 3) → #438
+Sprint 4 catalog + Sprint 5 operations → #440
+#438 + #440 → #439 → #441 → #442
+```
+
+`#438` and `#440` may start in parallel. Replenishment consumes their stable Stock/access contract;
+navigation then consolidates the completed workflows. `#442` is last because it removes schema and
+code only after every replacement and migration check exists.
+
+## 9. Conflict Risk Map
+
+| Shared area | Issues | Rounds | Coordination |
+|---|---|---|---|
+| Stock models, services, movement resources | `#438`, `#439`, `#440`, `#442` | 1–4 | Sequence contracts and migration cleanup |
+| Operating Unit/Location scopes | `#439`, `#440`, `#441` | 1–3 | Access scope precedes UI queries |
+| Inventory routes, clients, types, navigation | `#439`, `#441`, `#442` | 2–4 | Replacement UI before deletion |
+| Migrations and architecture docs | `#438`, `#439`, `#442` | 1, 2, 4 | Reconciliation owner is #442 |
+
+## 10. Estimate Tracking by Round
+
+| Round | Issues | Opt. | Pess. | Tracked | vs Opt. | vs Pess. |
+|---|---:|---:|---:|---:|---:|---:|
+| 1 | 2 | 11h | 22h | — | — | — |
+| 2 | 1 | 4h | 8h | — | — | — |
+| 3 | 1 | 5h | 10h | — | — | — |
+| 4 | 1 | 4h | 8h | — | — | — |
+| **Total** | **5** | **24h** | **48h** | **—** | **—** | **—** |
+
+## 11. Consolidated Time Tracking
+
+| Category | Estimated | Tracked | Variance |
+|---|---:|---:|---:|
+| Stock movement and access (`#438`, `#440`) | 11h–22h | — | — |
+| Replenishment (`#439`) | 4h–8h | — | — |
+| Navigation/workflows (`#441`) | 5h–10h | — | — |
+| Reconciliation/cleanup (`#442`) | 4h–8h | — | — |
+| **Total** | **24h–48h** | **—** | **—** |
+
+### Wall-Clock Time & Parallelism
+
+- **Person-hours:** —
+- **Wall-clock time:** —
+- **Parallelization factor:** —
+- **Peak concurrency:** —
+
+| Wall-clock block | Duration | Issues active in this block |
+|---|---:|---|
+| — | — | No sessions yet |
+
+## 12. Notes on Estimate Confidence
+
+Confidence is **medium-low** because migration/reconciliation work depends on the data produced by
+three prior sprints. The range assumes those contracts are stable and all destructive cleanup is
+deferred until evidence exists. Unexpected legacy consumers must expand `#442` transparently rather
+than being silently deleted.
+
+## 13. Execution Evidence
+
+| Status | Issue | Result | PR / Commit | Tracked | Notes |
+|---|---:|---|---|---:|---|
+| ⏳ | #438 | Pending | — | — | Movement/reversal integrity |
+| ⏳ | #439 | Pending | — | — | Location replenishment |
+| ⏳ | #440 | Pending | — | — | Horizontal authorization |
+| ⏳ | #441 | Pending | — | — | Final navigation/workflows |
+| ⏳ | #442 | Pending | — | — | Reconciled legacy removal |
+
+## 14. Quality Results
+
+| Metric | Before | Target | After | Result |
+|---|---:|---:|---:|---|
+| Stock corrections | Duplicated fields/incomplete reversal | Immutable linked compensating movements | — | ⏳ |
+| Replenishment | Global Variant thresholds | Location-specific resolved policy | — | ⏳ |
+| Horizontal access | Capability without complete membership scope | Operating Unit isolation across Inventory | — | ⏳ |
+| Inventory navigation | Overlapping/stale paths | One entry point per operational concept | — | ⏳ |
+| Legacy sources | Multiple active fields/contracts | Reconciled replacement or explicit archive decision | — | ⏳ |
+
+## 15. Results
+
+### 15.1 Delivered Value
+
+Not yet delivered. Expected value is a complete, auditable, location-aware, horizontally authorized
+Inventory module with no competing legacy workflow or source of truth.
+
+### 15.2 Planned vs. Actual
+
+- Planned: 5 Issues, 24h–48h.
+- Completed: 0.
+- Tracked: no sessions yet.
+
+### 15.3 Known Limitations
+
+- Promotion requires completed replacement domains from Sprints 4–5.
+- This sprint closes the current Inventory roadmap, not unrelated deferred project debt.
+- Data reconciliation may reveal follow-ups that must be recorded instead of hidden in cleanup.
+
+## 16. Lessons Learned
+
+Planning lesson: deletion is the final migration operation, not the redesign strategy. Replacement,
+parity, reconciliation, and rollback evidence must exist before removing a legacy source.
+
+## 17. Follow-up Work
+
+| Status | Issue | Work | Candidate Sprint |
+|---|---:|---|---|
+| ⏳ | TBD | Any reconciliation gap discovered during #442 | Backlog / Sprint 007 only if evidence requires it |
+
+## 18. Sprint Closure Checklist
+
+- [x] All five Issues are linked, labeled `sprint-6`, and assigned to Sprint 6.
+- [ ] Every Issue has a final status and PR/commit evidence.
+- [ ] Scope changes and tracked Sessions are synchronized.
+- [ ] Estimates, wall-clock time, parallelism, and quality results are finalized.
+- [ ] Dependencies, conflicts, delivered value, limitations, and lessons reflect execution.
+- [ ] Reconciliation proves safe legacy removal and follow-ups are filed.

--- a/doc/sprints/sprint-002-platillos-catalog-platform-hardening.md
+++ b/doc/sprints/sprint-002-platillos-catalog-platform-hardening.md
@@ -1,12 +1,12 @@
 ---
 sprint: "002"
 title: Platillos Catalog & Platform Hardening
-status: In Progress
+status: Completed
 
 created: 2026-07-31
 started: 2026-07-31
-completed:
-last_updated: 2026-08-11
+completed: 2026-08-12
+last_updated: 2026-08-12
 
 base_branch: main
 base_commit: 4ac51ff
@@ -16,7 +16,7 @@ github_project: SushiGo Admin (#7)
 github_milestone:
 
 previous: sprint-001-attendance-payroll-quality.md
-next:
+next: sprint-003-development-platform-and-product-reliability.md
 ---
 
 # Sprint 002 — Platillos Catalog & Platform Hardening
@@ -110,8 +110,8 @@ between parallel agents.
 |---|---:|
 | Created | 2026-07-31 |
 | Started | 2026-07-31 |
-| Completed | — (all scope delivered 2026-08-11; formal closure per `doc/conventions/sprints.md` §4 is still pending Sprint 003's promotion — see §17/§18) |
-| Calendar duration | 11 days so far (created → 2026-08-11, last scope delivered) |
+| Completed | 2026-08-12 (all scope delivered 2026-08-11; formally closed upon Sprint 003 promotion, #443) |
+| Calendar duration | 13 days (2026-07-31 → 2026-08-12; implementation completed 2026-08-11) |
 | Active workdays | 8 days (2026-07-31, 08-01, 08-03 through 08-07, 08-11 — session data recorded; no sessions logged 08-02, 08-08, 08-09, 08-10) |
 | Progress (Issues completed) | 14 / 14 (100%) — `#384` (PR #393), `#385` (PR #391), `#358` (PR #395), `#376` (PR #396), `#383` (PR #398), `#379` (PR #394), `#377` (PR #392), `#382` (PR #408), `#381` (PR #406), `#378` (PR #407), `#365` (PR #413), `#360` (PR #409), and `#380` (PR #414) merged to `main`; `#357` deprecated in favor of `#410`/PR #411 (§13) |
 
@@ -565,7 +565,7 @@ worked genuinely concurrently — Peak concurrency (5) is roughly in line with S
 | ⏳ | — | Archive `#357` and `#410` to `doc/tasks/2026-08/` and correct `#357`'s live Retrospective total (28h51m → 32h58m, all 6 sessions) | Neither Issue has a local archive snapshot — `#357` because its delivering PR (#411) is filed under `#410`, `#410` because it was never run through `/finish-pr`'s archive step; `#357`'s Retrospective narrative undercounts its own Sessions array (§12) | Next |
 | ⏳ | — | Fix `#381`'s live Issue Sessions entry — its second session's `end` date is one day off (`2026-08-06` instead of `2026-08-07`), contradicted by its own Retrospective arithmetic (§12) | Found during this closure pass; corrected only in this document's §11 computation, not on the live Issue | Next |
 | ⏳ | — | File and fix the pre-existing `attendance-day-status.cy.ts` test-order dependency found (not fixed) during `#410`'s regression testing — its "Justificar Falta" case depends on run order within a shared `before()` reset | Explicitly flagged as out-of-scope in PR #411's own description; unrelated to `#410`'s diff (`git diff main` empty for that file) | Next |
-| ⏳ | — | Plan and promote Sprint 003 | Per `doc/conventions/sprints.md` §4, a sprint is *formally* complete only once its closure checklist is done **and** the next sprint becomes current — no Sprint 003 exists in `doc/sprints/planned/` yet, so Sprint 002 remains the highest-numbered (i.e. "current" by location) sprint even though its own scope is 100% delivered (§18) | Next |
+| ✅ | #443 | Plan and promote Sprint 003 | Sprint 003 was planned, promoted to `doc/sprints/`, and made current; this formally closes Sprint 002 under `doc/conventions/sprints.md` §4 | Completed 2026-08-12 |
 
 ## 18. Sprint Closure Checklist
 
@@ -585,5 +585,7 @@ worked genuinely concurrently — Peak concurrency (5) is roughly in line with S
 - [x] Delivered value and known limitations were documented. (§15)
 - [x] Follow-up work was created or recorded. (§17 — 3 already-filed Issues linked, 6 net-new follow-ups recorded, none yet filed as their own GitHub Issues)
 - [x] Lessons learned were captured. (§16)
-- [x] Metadata dates and status were updated. (front matter `last_updated: 2026-08-11`; `status` deliberately kept `In Progress` and `completed` deliberately left empty — per `doc/conventions/sprints.md` §6, both are only set at *formal* closure, which per §4 requires the next sprint's promotion, not yet done — see next item)
-- [ ] The next sprint was promoted or created when applicable. **Not done** — no Sprint 003 exists yet in `doc/sprints/planned/`. Per `doc/conventions/sprints.md` §4, this is the one checklist item that keeps Sprint 002 from being *formally* complete even though every other item above is done and its own scope is 100% delivered (§1/§4/§7/§13); recorded as the last §17 follow-up item. Until a Sprint 003 is planned and promoted, this document's `status` field correctly stays `In Progress` per the location-based lifecycle rule (§4's own lifecycle table: "highest-numbered sprint in `doc/sprints/`" = current/in progress), even though every Issue in its scope is done.
+- [x] Metadata dates and status were updated. (front matter records `status: Completed`,
+      `completed: 2026-08-12`, and the Sprint 003 successor.)
+- [x] The next sprint was promoted or created when applicable. (Sprint 003 was moved from
+      `doc/sprints/planned/` to `doc/sprints/` and marked `In Progress` by #443 on 2026-08-12.)

--- a/doc/sprints/sprint-003-development-platform-and-product-reliability.md
+++ b/doc/sprints/sprint-003-development-platform-and-product-reliability.md
@@ -409,7 +409,8 @@ Additional lessons will be added from actual execution evidence.
 | Status | Proposed Issue | Title | Reason | Candidate Sprint |
 |---|---:|---|---|---|
 | ⏳ | #422–#429 | Deliver the Product → Variant → Purchase Presentation catalog vertical | Intentionally gated by the reviewed target design from #421 | Sprint 004 |
-| ⏳ | #431–#442 | Deliver purchasing/pricing and complete Stock cleanup/hardening | Later roadmap; must not inflate Sprint 3 after scope lock | Future |
+| ⏳ | #431–#437 | Deliver purchasing, acquisition cost, price lists, and operational seed data | Depends on the Product catalog completed in Sprint 4 | Sprint 005 |
+| ⏳ | #438–#442 | Complete Stock integrity, access, navigation, and legacy cleanup | Requires the replacement operational domains before final cleanup | Sprint 006 |
 | ⏳ | TBD | Reassess dev-lab portability only if Linux support becomes a product need | Explicitly excluded from #64's macOS-focused CI scope | Future |
 
 ## 18. Sprint Closure Checklist

--- a/doc/sprints/sprint-003-development-platform-and-product-reliability.md
+++ b/doc/sprints/sprint-003-development-platform-and-product-reliability.md
@@ -27,7 +27,7 @@ next: sprint-004-product-catalog-reconstruction.md
 
 ## 1. Executive Summary
 
-Sprint 003 is the **current, scope-complete sprint** with five planned Issues from
+Sprint 003 is the **current sprint, with scope selection complete and locked**, and contains five planned Issues from
 `pakodiazdev/sushigo-dev-lab` and five Issues from `pakodiazdev/sushigo`. The dev-lab increment adds
 automated coverage for the shared workspace-bootstrap helpers, a reliable
 workspace-status command, an opt-in pgAdmin database browser, corrected troubleshooting guidance,

--- a/doc/sprints/sprint-003-development-platform-and-product-reliability.md
+++ b/doc/sprints/sprint-003-development-platform-and-product-reliability.md
@@ -1,0 +1,438 @@
+---
+sprint: "003"
+title: Development Platform & Product Reliability
+status: In Progress
+
+created: 2026-08-12
+started: 2026-08-12
+completed:
+last_updated: 2026-08-12
+
+base_branch: main
+base_commit: cfd6cfb
+scope_issues: 10
+
+github_project: SushiGo Admin (#7)
+github_milestone:
+
+previous: sprint-002-platillos-catalog-platform-hardening.md
+next: sprint-004-product-catalog-reconstruction.md
+---
+
+# Sprint 003 — Development Platform & Product Reliability
+
+> Strengthen the lightweight multi-workspace development platform, then use that more reliable
+> foundation to deliver the highest-value SushiGo product and engineering work selected during the
+> remainder of Sprint 003 planning.
+
+## 1. Executive Summary
+
+Sprint 003 is the **current, scope-complete sprint** with five planned Issues from
+`pakodiazdev/sushigo-dev-lab` and five Issues from `pakodiazdev/sushigo`. The dev-lab increment adds
+automated coverage for the shared workspace-bootstrap helpers, a reliable
+workspace-status command, an opt-in pgAdmin database browser, corrected troubleshooting guidance,
+and ADRs for the architectural decisions that now underpin the lab.
+
+The SushiGo increment delivers employee avatars end to end, replaces unconditional Inventory policy
+authorization, prevents concurrent stock overselling, and produces the reviewed architecture and
+migration plan for the next Product-catalog vertical. This gives the sprint visible functionality,
+configuration/tooling, correctness fixes, and forward product design without implementing Product
+contracts before their design gate.
+
+The ten Issues represent an estimated **27h optimistic / 53h pessimistic** of engineering effort.
+They are organized into three conflict-aware rounds: establish testing/runtime visibility, employee
+identity, Inventory authorization/integrity, and Product design in parallel; add pgAdmin after the
+shared Makefile/README surface is clear while completing self-service avatars; then normalize
+documentation and record the final dev-lab architectural decisions.
+
+## 2. Context
+
+Sprint 002 delivered its full planned scope, including the Platillos catalog and platform-hardening
+work. Its execution also reinforced how much the project depends on `sushigo-dev-lab`: multiple
+agents work concurrently in isolated workspaces, run independent databases and E2E stacks, and
+depend on the lab's orchestration scripts to preserve throughput without returning to the heavy
+nine-container development stack.
+
+The dev-lab has accumulated a small but coherent maintenance backlog. Its central bootstrap library
+has no automated coverage; operators cannot see all workspace runtime states in one command;
+database inspection still requires `psql` or a manually configured external client; troubleshooting
+guidance contains stale manual-deletion instructions; and several accepted architectural decisions
+exist only in Issues, Pull Requests, and commit history.
+
+These tasks belong together because they improve the reliability, observability, inspectability,
+and maintainability of the development platform while shipping a complete employee-identity slice
+and reducing two concrete Inventory integrity risks. The Product Inventory design then turns the
+newly analyzed backlog into an implementation-ready vertical for a later sprint.
+
+Planning is based on `pakodiazdev/sushigo` `main` at `cfd6cfb`. Sprint 003 exists in the SushiGo
+Admin project as a 14-day iteration scheduled for **2026-08-23 through 2026-09-05**. Scope selection
+is complete. The sprint was promoted to `doc/sprints/` and officially started on **2026-08-12** by
+`#443`, formally closing Sprint 002. The Project iteration window remains the planning cadence; the
+repository metadata records the actual lifecycle start.
+
+## 3. Sprint Goal
+
+**Sprint Goal:** Improve development-platform reliability and operational visibility, deliver
+employee identity end to end, close Inventory authorization/concurrency risks, and finalize the
+Product Inventory target design with conflict-aware execution and complete time/evidence tracking.
+
+## 4. Sprint Timeline
+
+| Metric | Value |
+|---|---:|
+| Created | 2026-08-12 |
+| Planned iteration start | 2026-08-23 |
+| Planned iteration end | 2026-09-05 |
+| Started | 2026-08-12 |
+| Completed | — |
+| Target calendar duration | 14 days |
+| Active workdays | — |
+
+## 5. Scope
+
+### 5.1 Included
+
+Confirmed `pakodiazdev/sushigo-dev-lab` scope:
+
+- Automated Bats coverage and macOS CI for the workspace-bootstrap configuration helpers
+  (`sushigo-dev-lab#64`).
+- A reliable `make status` runtime overview for every configured workspace
+  (`sushigo-dev-lab#67`).
+- An opt-in, host-only pgAdmin service with a preconfigured shared-PostgreSQL connection
+  (`sushigo-dev-lab#68`).
+- Normalized and corrected troubleshooting guidance, including replacement of stale destructive
+  manual workflows (`sushigo-dev-lab#66`).
+- Backfilled ADRs for shared bootstrap, workspace deletion, per-slot E2E infrastructure, and the
+  final pgAdmin architecture (`sushigo-dev-lab#65`).
+
+Confirmed `pakodiazdev/sushigo` scope:
+
+- Administrator-managed employee avatars on `User`, integrated with the employee administration
+  flow, reusable initials fallback, and initial identity-surface adoption (`sushigo#401`).
+- Self-service avatar editing and completion of the remaining identity-surface rollout
+  (`sushigo#420`).
+- Permission-backed authorization for the Item, ItemVariant, and InventoryLocation policies,
+  replacing unconditional policy stubs while preserving the separate media permission
+  (`sushigo#400`).
+- A reviewed Product Inventory target architecture, UI/API contract, and incremental migration plan
+  that gates later catalog implementation (`sushigo#421`).
+- Concurrency-safe stock mutation and database/application balance invariants that prevent two
+  requests from consuming the same available units (`sushigo#430`).
+
+### 5.2 Excluded
+
+- Any `pakodiazdev/sushigo` Issue not explicitly listed in the confirmed scope.
+- Product catalog implementation (`sushigo#422`–`sushigo#429`); it must follow the reviewed design
+  from `sushigo#421` rather than run concurrently with the design gate.
+- Purchase, pricing, and remaining Stock-hardening roadmap (`sushigo#431`–`sushigo#442`).
+- Automatic assignment of every open SushiGo Issue merely because it exists in the backlog.
+- Unplanned portability work to make the macOS-oriented dev-lab support every Linux distribution.
+- Broad refactors of side-effect-heavy bootstrap operations (`install_deps()` and
+  `bootstrap_laravel()`) solely to make them unit-testable under `sushigo-dev-lab#64`.
+- Rewriting the Project iteration cadence merely because the repository lifecycle started before
+  its scheduled iteration window.
+
+### 5.3 Scope Changes
+
+No planned-scope change occurred during promotion. Issue `#443` is recorded as startup
+documentation under Opportunistic Work rather than silently inflating the ten-Issue implementation
+scope. Changes made after promotion must be recorded here without deleting historical rows.
+
+| Date | Status | Item | Change | Reason |
+|---|---|---|---|---|
+| — | — | — | None yet | No planned-scope change at sprint start |
+
+### 5.4 Opportunistic Work
+
+| Date | Issue | Title | Trigger | Result |
+|---|---:|---|---|---|
+| 2026-08-12 | #443 | Formally close Sprint 002, promote Sprint 003, and record Sprint 004 planning | Sprint lifecycle transition and planning documents were ready for permanent review | Sprint 002 closed; Sprint 003 promoted; Sprint 004 and roadmap convention submitted together |
+
+## 6. Value Ranking
+
+The ranking below covers the final planned scope. Post-start additions require an explicit scope
+change and recalculation rather than automatic backlog intake.
+
+| Tier | Issues | Rationale |
+|---|---|---|
+| **Critical** | `sushigo#430` | Prevent a demonstrated concurrency window from overselling Stock and violating balance integrity |
+| **High** | `sushigo#400`, `sushigo#401`, `sushigo#420`, `dev-lab#64`, `dev-lab#68` | Close a latent authorization gap, deliver complete employee identity value, prevent regressions in shared bootstrap, and remove database-inspection friction |
+| **Medium** | `sushigo#421`, `dev-lab#67`, `dev-lab#66` | Gate the next Product vertical with reviewed design, improve runtime observability, and replace stale operational guidance |
+| **Low** | `dev-lab#65` | Preserve architectural rationale after the behavior has shipped |
+| **Deferred** | — | No confirmed dev-lab Issue is intentionally deferred |
+
+### Ordering principle
+
+> **Value first, parallelism second.** Product security, correctness, and data integrity take
+> precedence. Within the dev-lab lane, testing and observability land before documentation of the
+> final state; Product implementation remains behind its approved design gate.
+
+## 7. Route A — Execution Rounds
+
+These rounds schedule the complete planned dev-lab and SushiGo scope. Any later addition is a scope
+change and must update estimates, dependencies, conflicts, and the scope-change log.
+
+### Round 1 — Establish Safety and Runtime Visibility
+
+| Status | Issue | Repository | Title | Value | Opt. | Pess. | Tracked | PR / Commit | Notes |
+|---|---:|---|---|---|---:|---:|---:|---|---|
+| ⏳ | #64 | `sushigo-dev-lab` | Add Bats coverage and macOS CI for workspace-bootstrap configuration helpers | High | 3h | 6h | — | — | Use `tests/README.md` to avoid a README conflict with #67 |
+| ⏳ | #67 | `sushigo-dev-lab` | Add `make status` for a reliable workspace runtime overview | Medium | 2h | 4h | — | — | Distinguish live, degraded, stopped, stale-socket, and unconfigured states |
+| ⏳ | #401 | `sushigo` | Add administrator-managed employee avatars with reusable initials fallback | High | 4h | 7h | — | — | Foundation required by #420 |
+| ⏳ | #400 | `sushigo` | Enforce permissions in Item, ItemVariant, and InventoryLocation policies | High | 2h | 4h | — | — | Independent authorization lane; keep `items.manage-media` separate |
+| ⏳ | #430 | `sushigo` | Prevent concurrent stock overselling and enforce balance invariants | Critical | 4h | 8h | — | — | Land early; required before future purchase receiving (#432) |
+| ⏳ | #421 | `sushigo` | Design the Product Inventory target architecture and migration plan | Medium | 3h | 6h | — | — | Design-only gate; #422/#423 remain outside Sprint 3 |
+|  |  |  | **Round total** |  | **18h** | **35h** | **—** |  |  |
+
+### Round 2 — Add On-Demand Database Inspection
+
+| Status | Issue | Repository | Title | Value | Opt. | Pess. | Tracked | PR / Commit | Notes |
+|---|---:|---|---|---|---:|---:|---:|---|---|
+| ⏳ | #68 | `sushigo-dev-lab` | Add opt-in pgAdmin service for the shared PostgreSQL instance | High | 2h | 4h | — | — | Runs after #67 because both modify `Makefile` and `README.md` |
+| ⏳ | #420 | `sushigo` | Add self-service avatar editing and complete identity-surface rollout | High | 3h | 6h | — | — | Runs after #401 establishes the shared avatar contract and component |
+|  |  |  | **Round total** |  | **5h** | **10h** | **—** |  |  |
+
+### Round 3 — Correct Guidance and Preserve Decisions
+
+| Status | Issue | Repository | Title | Value | Opt. | Pess. | Tracked | PR / Commit | Notes |
+|---|---:|---|---|---|---:|---:|---:|---|---|
+| ⏳ | #66 | `sushigo-dev-lab` | Normalize and correct troubleshooting guidance | Medium | 2h | 4h | — | — | Replace stale manual deletion/package-lock guidance, not formatting only |
+| ⏳ | #65 | `sushigo-dev-lab` | Backfill ADRs for #010, #011, #016, and #68 | Low | 2h | 4h | — | — | Must describe #68's final implementation, not its pre-implementation proposal |
+|  |  |  | **Round total** |  | **4h** | **8h** | **—** |  |  |
+
+## 8. Route B — Sequential Dependencies
+
+```text
+dev-lab#67 (Round 1) → dev-lab#68 (Round 2)
+Type: file-level sequencing.
+Reason: both modify Makefile targets/help and README operational documentation. Landing #67 first
+lets #68 build on the final command surface instead of resolving avoidable conflicts.
+
+dev-lab#68 (Round 2) → dev-lab#65 (Round 3)
+Type: architectural-evidence dependency.
+Reason: ADR-005 must capture the implementation that actually shipped — optional Compose profile,
+loopback-only exposure, login trade-off, and runtime credential bootstrap — rather than a proposal.
+
+sushigo#401 (Round 1) → sushigo#420 (Round 2)
+Type: product and shared-component dependency.
+Reason: #401 establishes the backend avatar contract, reusable fallback component, and first
+identity surfaces that #420 extends into self-service editing and the remaining application views.
+```
+
+`dev-lab#64` is technically independent of the other confirmed Issues when its test documentation
+lives under `tests/README.md`. `dev-lab#66` can run independently at the code level, but it is placed
+in the final documentation round so its operational guidance reflects the final sprint command
+surface.
+
+`sushigo#401` and `sushigo#420` have no dependency on the confirmed dev-lab work. Their product lane
+depends on the already merged generic media system from `sushigo#377` and is sequenced internally
+to keep the API and reusable frontend component contract stable.
+
+`sushigo#400` is independent of the avatar and dev-lab lanes. Its authorization contract is
+already defined by the route middleware and Form Requests; implementation must preserve the
+dedicated `items.manage-media` boundary introduced by `sushigo#377`.
+
+`sushigo#430` is independent of the current avatar, policy, and dev-lab implementations. It lands
+in Round 1 because the later purchase-receiving backend (`sushigo#432`, outside this sprint) must
+reuse its atomic Stock mutation contract rather than create another unsafe path.
+
+`sushigo#421` is intentionally design-only. It may audit the same Inventory areas as #400/#430 but
+does not edit production code; Product catalog implementation (`sushigo#422` onward) is excluded
+until #421 approves or re-scopes the target contract.
+
+## 9. Conflict Risk Map
+
+| Shared file | Issues touching it | Planned rounds | Risk / Coordination |
+|---|---|---|---|
+| `sushigo-dev-lab/Makefile` | `dev-lab#67`, `dev-lab#68` | 1, 2 | Sequential; both add lifecycle targets and help text |
+| `sushigo-dev-lab/README.md` | `dev-lab#67`, `dev-lab#68` | 1, 2 | Sequential; #67 updates workflow/status, #68 updates shared services |
+| `sushigo-dev-lab/docker-compose.yml` | `dev-lab#68` | 2 | Isolated in confirmed scope |
+| `sushigo-dev-lab/scripts/lib/workspace-bootstrap.sh` | `dev-lab#64` | 1 | Tests should avoid behavioral refactoring unless a real defect is exposed |
+| `sushigo-dev-lab/docs/troubleshooting.md` | `dev-lab#66` | 3 | Isolated documentation ownership |
+| `sushigo-dev-lab/docs/decisions/index.md` | `dev-lab#65` | 3 | Single ADR/index owner |
+| `sushigo/code/api/app/Models/User.php`, employee API, and self-profile API | `sushigo#401`, `sushigo#420` | 1, 2 | Sequential; #401 establishes admin-managed media and #420 adds self-service mutation |
+| Shared avatar component, auth store, employee views, and layout header | `sushigo#401`, `sushigo#420` | 1, 2 | Sequential ownership; #420 reuses and expands the component introduced by #401 |
+| Inventory policy classes and their unit tests | `sushigo#400` | 1 | Isolated ownership; regression-test route permissions and media authorization |
+| `Stock.php`, Stock mutation services/schema, and Inventory stock tests | `sushigo#430` | 1 | Single implementation owner; coordinate test fixtures with #400 but no expected production-file collision |
+| Inventory architecture/API/UI audit surface | `sushigo#421` | 1 | Read-only design work; may cite #400/#430 evidence but must not implement their changes |
+
+### Conflict methodology
+
+Affected files were inferred from each Issue's requested deliverables and confirmed against the
+current repository structure on 2026-08-12. The map intentionally treats shared documentation and
+Makefile command surfaces as conflict nodes even when the underlying services are independent.
+
+The map covers the final planned scope. #421 must produce a deeper conflict/dependency map for the
+future Product roadmap without pulling that implementation into Sprint 3.
+
+## 10. Estimate Tracking by Round
+
+| Round | Issue count | Opt. total | Pess. total | Tracked total | vs Opt. | vs Pess. |
+|---|---:|---:|---:|---:|---:|---:|
+| Round 1 | 6 | 18h | 35h | — | — | — |
+| Round 2 | 2 | 5h | 10h | — | — | — |
+| Round 3 | 2 | 4h | 8h | — | — | — |
+| **Confirmed dev-lab total** | **5** | **11h** | **22h** | **—** | **—** | **—** |
+| Confirmed SushiGo scope | 5 | 16h | 31h | — | — | — |
+| **Confirmed sprint total** | **10** | **27h** | **53h** | **—** | **—** | **—** |
+
+## 11. Consolidated Time Tracking
+
+| Category | Estimated | Tracked | Variance |
+|---|---:|---:|---:|
+| Testing and CI (`dev-lab#64`) | 3h–6h | — | — |
+| Operational tooling (`dev-lab#67`, `dev-lab#68`) | 4h–8h | — | — |
+| Documentation and ADRs (`dev-lab#66`, `dev-lab#65`) | 4h–8h | — | — |
+| Employee identity (`sushigo#401`, `sushigo#420`) | 7h–13h | — | — |
+| Inventory authorization and Stock integrity (`sushigo#400`, `sushigo#430`) | 6h–12h | — | — |
+| Product Inventory design (`sushigo#421`) | 3h–6h | — | — |
+| Code review and validation | Included in Issue estimates | — | — |
+| Rework and corrections | Included in Issue estimates | — | — |
+| **Confirmed dev-lab total** | **11h–22h** | **—** | **—** |
+| **Confirmed sprint total** | **27h–53h** | **—** | **—** |
+
+### Wall-Clock Time & Parallelism
+
+Computed at sprint closure from finalized Issue session arrays, following
+`doc/conventions/sprints.md` §7.
+
+- **Person-hours:** —
+- **Wall-clock time:** —
+- **Parallelization factor:** —
+- **Peak concurrency:** —
+
+| Wall-clock block | Duration | Issues active in this block |
+|---|---:|---|
+| — | — | No sessions yet |
+
+## 12. Notes on Estimate Confidence
+
+The dev-lab estimates were produced after reading the current Issue bodies and auditing the current
+repository files on 2026-08-12. Confidence is **medium**:
+
+- `dev-lab#64` is wider than its original body suggests because no CI workflow exists and the
+  tested scripts deliberately use macOS-specific `sed -i ''`; the estimate assumes a macOS runner
+  instead of an unplanned portability refactor.
+- `dev-lab#67` must validate process liveness instead of treating socket existence as sufficient,
+  and must define degraded/stale states.
+- `dev-lab#68` has the most complete technical scope and acceptance criteria; its main uncertainty
+  is runtime-safe pgAdmin credential provisioning and container validation.
+- `dev-lab#66` includes correctness work because the current document contains stale destructive
+  commands; it is not a formatting-only pass.
+- `dev-lab#65` includes a fourth ADR for #68 and therefore must wait for implementation evidence.
+- `sushigo#401` was reduced from a broad avatar initiative to an administrator-managed first slice;
+  its estimate excludes the self-service profile and broad identity-surface rollout split into
+  `sushigo#420`.
+- `sushigo#420` was estimated independently after the split and assumes #401's API contract and
+  reusable avatar component have landed first.
+- `sushigo#400` covers all three unconditional inventory policies and their tests. Its estimate
+  assumes the existing permission vocabulary remains unchanged and explicitly excludes a broader
+  authorization redesign.
+- `sushigo#430` has high variance because meaningful concurrent-request tests and safe first-row
+  creation may require database-specific coordination beyond the straightforward row lock.
+- `sushigo#421` is capped as design-only. Implementing migrations, APIs, UI, or seeders belongs to
+  #422 onward and would be an unplanned scope expansion.
+
+All ten Issue bodies contain their final planned scope, optimistic/pessimistic estimates, and empty
+Sessions arrays. Estimates remain planning ranges until execution evidence is recorded.
+
+## 13. Execution Evidence
+
+| Status | Issue | Repository | Result Summary | Pull Request | Merge Commit | Tracked | Evidence Notes |
+|---|---:|---|---|---:|---|---:|---|
+| ⏳ | #64 | `sushigo-dev-lab` | Pending | — | — | — | Final Bats/macOS CI scope recorded in Issue body |
+| ⏳ | #67 | `sushigo-dev-lab` | Pending | — | — | — | Final runtime-state semantics recorded in Issue body |
+| ⏳ | #68 | `sushigo-dev-lab` | Pending | — | — | — | Already scoped, project-linked, labeled, and assigned to Sprint 3 |
+| ⏳ | #66 | `sushigo-dev-lab` | Pending | — | — | — | Correctness changes must be recorded, not hidden as formatting |
+| ⏳ | #65 | `sushigo-dev-lab` | Pending | — | — | — | ADR list expands to include #68 |
+| ⏳ | #401 | `sushigo` | Pending | — | — | — | Admin employee-avatar foundation; continuation split to #420 |
+| ⏳ | #420 | `sushigo` | Pending | — | — | — | Self-service editing and remaining identity-surface rollout |
+| ⏳ | #400 | `sushigo` | Pending | — | — | — | Three inventory policies aligned with route/Form Request permissions |
+| ⏳ | #430 | `sushigo` | Pending | — | — | — | Atomic Stock mutation and balance-invariant enforcement |
+| ⏳ | #421 | `sushigo` | Pending | — | — | — | Design/ERD/UI/API/migration gate only; no production implementation |
+| 🚧 | #443 | `sushigo` | Sprint lifecycle and planning documentation | — | — | In progress | Opportunistic startup work; branch and PR carry the session-created documentation |
+
+## 14. Quality Results
+
+| Metric | Before | Target | After | Result |
+|---|---:|---:|---:|---|
+| Dev-lab automated tests | No Bats suite or CI workflow | Bats suite and green macOS CI | — | ⏳ |
+| Workspace runtime visibility | Per-workspace manual checks | One reliable status command | — | ⏳ |
+| Database inspection | `psql` or external manual configuration | Host-only, preconfigured pgAdmin on demand | — | ⏳ |
+| Troubleshooting consistency | Mixed formats and stale commands | Every entry has symptom/Cause/Fix and current safe guidance | — | ⏳ |
+| Recorded dev-lab ADRs | 1 | 5 | — | ⏳ |
+| Inventory authorization stubs | 3 policies authorize unconditionally | Exact permission-backed policies with negative/positive tests | — | ⏳ |
+| Concurrent Stock mutation | Read-then-decrement window can approve the same available units twice | Atomic mutation plus enforced balance invariants | — | ⏳ |
+| Product Inventory target design | Discovery exists only in planning discussion/backlog | Reviewed ERD, UI flow, API outline, migration plan, and dependency map | — | ⏳ |
+| SushiGo tests and quality gates | TBD | 100% relevant checks passing, 0 new security findings | — | ⏳ |
+
+## 15. Results
+
+### 15.1 Delivered Value
+
+Not yet delivered. Expected dev-lab value is a safer, observable, inspectable, and better-documented
+parallel-development environment. Expected SushiGo value is end-to-end employee identity, safer
+Inventory authorization and Stock mutation, and an implementation-ready Product Inventory design.
+
+### 15.2 Planned vs. Actual
+
+- **Confirmed planned Issues:** 5 dev-lab Issues and 5 SushiGo Issues.
+- **Pending planned Issues:** 0; scope selection is complete.
+- **Opportunistic startup Issues:** 1 (`#443`), tracked outside the ten-Issue implementation total.
+- **Confirmed estimate:** 27h optimistic / 53h pessimistic.
+- **Completed:** 0.
+- **Deprecated or cancelled:** 0.
+- **Tracked:** no sessions yet.
+
+### 15.3 Known Limitations
+
+- Sprint 003 officially started on 2026-08-12. Its GitHub Iteration retains the previously agreed
+  2026-08-23 through 2026-09-05 planning window, while repository metadata records actual start.
+- Product catalog implementation remains outside Sprint 3. #421 may change #422 onward before a
+  later sprint selects those implementation Issues.
+- The 27h–53h range assumes conflict-aware parallel execution; it is engineering effort, not
+  elapsed calendar time.
+- Project assignment alone does not imply implementation. The ten planned implementation rows
+  remain pending; only opportunistic startup documentation `#443` is in progress.
+
+## 16. Lessons Learned
+
+Planning lesson recorded before execution: development-platform work must be represented in the
+same sprint evidence as product work when it consumes real agent capacity. Omitting dev-lab Issues
+would understate person-hours, hide dependencies that affect every workspace, and make the
+parallelization metrics incomplete.
+
+Additional lessons will be added from actual execution evidence.
+
+## 17. Follow-up Work
+
+| Status | Proposed Issue | Title | Reason | Candidate Sprint |
+|---|---:|---|---|---|
+| ⏳ | #422–#429 | Deliver the Product → Variant → Purchase Presentation catalog vertical | Intentionally gated by the reviewed target design from #421 | Sprint 004 |
+| ⏳ | #431–#442 | Deliver purchasing/pricing and complete Stock cleanup/hardening | Later roadmap; must not inflate Sprint 3 after scope lock | Future |
+| ⏳ | TBD | Reassess dev-lab portability only if Linux support becomes a product need | Explicitly excluded from #64's macOS-focused CI scope | Future |
+
+## 18. Sprint Closure Checklist
+
+- [x] SushiGo application Issues were selected before sprint promotion.
+- [x] Every included Issue is linked to SushiGo Admin, labeled `sprint-3`, and assigned to the
+      `Sprint 3` iteration.
+- [ ] All included work items have a final status marker.
+- [ ] Completed items include Pull Request or commit evidence.
+- [ ] Deprecated items identify their replacement.
+- [ ] Cancelled items include a reason.
+- [ ] Scope changes are recorded.
+- [ ] Tracked time was synchronized from Issue sessions.
+- [ ] Round totals and sprint totals were recalculated.
+- [ ] Estimate variance was calculated.
+- [ ] Consolidated effort was completed.
+- [ ] Wall-clock time, parallelization factor, and peak concurrency were computed
+      (`doc/conventions/sprints.md` §7).
+- [ ] Dependencies reflect actual execution.
+- [ ] Conflict notes reflect actual execution.
+- [ ] Tests and relevant quality metrics were recorded.
+- [ ] Delivered value and known limitations were documented.
+- [ ] Follow-up work was created or recorded.
+- [ ] Lessons learned were captured.
+- [ ] Metadata dates and status were updated.
+- [ ] The next sprint was promoted or created when applicable.


### PR DESCRIPTION
## Summary

Closes #443
Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/444

Formally closes Sprint 002, promotes Sprint 003 as the current sprint, and records the Product Inventory roadmap as coherent planned Sprints 004–006. It also synchronizes both sprint indexes and documents the DES/CAT/OPS/STK roadmap-alias convention.

---

## 🚀 Commits

1. **fb4e696** 📚 [#443] - Close Sprint 002 and promote Sprint 003 🚀
2. **f2570cc** 📚 [#443] - Plan Sprints 005 and 006 for Inventory completion 🗓️
3. **990faa8** 📚 [#443] - Clarify Sprint 003 scope lock wording 📝

---

## ✅ What's Included

### Sprint lifecycle

- Marks Sprint 002 `Completed` on 2026-08-12 and completes its closure checklist.
- Promotes Sprint 003 from `planned/` to the current `In Progress` sprint.
- Synchronizes the root README and detailed sprint index.

### Inventory roadmap

- Sprint 004: Product Catalog Reconstruction (`#422–#429`, 32–60h).
- Sprint 005: Purchasing, Cost & Pricing (`#431–#437`, 36–67h).
- Sprint 006: Stock Integrity & Inventory Completion (`#438–#442`, 24–48h).
- Links the Sprint 003–006 document chain and records dependencies, rounds, risks, estimates, and closure criteria.

### Conventions

- Documents DES/CAT/OPS/STK as roadmap planning aliases rather than permanent task IDs.
- Defines mapping, uniqueness, lifecycle, and usage rules for future roadmaps.

---

## 🧪 Testing

- [x] YAML frontmatter parses for Sprints 002–006.
- [x] Sprints 003–006 contain all 18 required sections.
- [x] `git diff --check` passes.
- [x] GitHub Project Iterations verified: S1 31, S2 18, S3 11, S4 8, S5 7, S6 5.
- [x] Every Product Inventory roadmap Issue `#421–#442` has an Iteration.
- [x] CI API/frontend tests, lint, Swagger, and Sonar checks pass.

---

## Manual Testing

1. Open `doc/sprints/README.md` and confirm Sprint 002 is Completed and Sprint 003 is the only current sprint.
2. Open the root `README.md` Sprint table and confirm it reports the same lifecycle states and dates.
3. Confirm `doc/sprints/sprint-003-development-platform-and-product-reliability.md` is directly under `doc/sprints/`, while Sprints 004–006 remain under `doc/sprints/planned/`.
4. Follow each document's `previous`/`next` frontmatter from Sprint 002 through Sprint 006 and confirm every link target exists.
5. Run `git diff --check origin/main...HEAD`; expect no output and exit code 0.

---

## 🔗 References

- **Task**: #443
- **Design gate**: #421
- **Product Inventory roadmap**: #422–#442
- **Sprint convention**: `doc/conventions/sprints.md`
- **Task convention**: `doc/conventions/tasks.md`

---

## Workspace

`sushigo-a` — `docs/443-close-sprint-2-promote-sprint-3`
