### PR TITLE
🐛 [#400][a] - Enforce real permission checks in inventory policies 🔒

### DIFF
--- a/code/api/app/Models/Item.php
+++ b/code/api/app/Models/Item.php
@@ -116,8 +116,9 @@ class Item extends Model implements AuthorizesMediaOwnership
      * PUT /item-variants/{id}, which accept name, sale_price, min_stock,
      * etc. Reusing it here would let anyone granted "manage this item's
      * photos" also silently edit catalog data and pricing. Not
-     * ItemPolicy::update() either, which is currently a stub that returns
-     * true unconditionally (see #400).
+     * ItemPolicy::update() either — even now that it enforces items.update
+     * (see #400) — since that permission is still the catalog/pricing one,
+     * not this narrower media-only permission.
      */
     public function userCanManageMedia(User $user): bool
     {

--- a/code/api/app/Policies/InventoryLocationPolicy.php
+++ b/code/api/app/Policies/InventoryLocationPolicy.php
@@ -2,6 +2,7 @@
 
 namespace App\Policies;
 
+use App\Models\InventoryLocation;
 use App\Models\User;
 
 class InventoryLocationPolicy
@@ -9,61 +10,56 @@ class InventoryLocationPolicy
     /**
      * Determine whether the user can view any models.
      */
-    public function viewAny(?User $user): bool // NOSONAR - $user kept nullable so Gate::methodAllowsGuests() permits guest access
+    public function viewAny(?User $user): bool
     {
-        // Public endpoint - anyone can list inventory locations
-        return true;
+        return $user !== null && $user->can('inventory_locations.view');
     }
 
     /**
      * Determine whether the user can view the model.
      */
-    public function view(?User $user): bool // NOSONAR - $user kept nullable so Gate::methodAllowsGuests() permits guest access
+    public function view(?User $user, ?InventoryLocation $inventoryLocation = null): bool // NOSONAR - $inventoryLocation required by Laravel's policy contract; unused because authorization here is permission-only, no per-instance check; nullable so a class-string Gate check (no instance) is denied instead of crashing
     {
-        // Public endpoint - anyone can view inventory locations
-        return true;
+        return $user !== null && $user->can('inventory_locations.view');
     }
 
     /**
      * Determine whether the user can create models.
      */
-    public function create(): bool
+    public function create(?User $user): bool
     {
-        // Any authenticated user can create inventory locations
-        return true;
+        return $user !== null && $user->can('inventory_locations.manage');
     }
 
     /**
      * Determine whether the user can update the model.
      */
-    public function update(): bool
+    public function update(?User $user, ?InventoryLocation $inventoryLocation = null): bool // NOSONAR - $inventoryLocation required by Laravel's policy contract; unused because authorization here is permission-only, no per-instance check; nullable so a class-string Gate check (no instance) is denied instead of crashing
     {
-        // Any authenticated user can update inventory locations
-        return true;
+        return $user !== null && $user->can('inventory_locations.manage');
     }
 
     /**
      * Determine whether the user can delete the model.
      */
-    public function delete(): bool
+    public function delete(?User $user, ?InventoryLocation $inventoryLocation = null): bool // NOSONAR - $inventoryLocation required by Laravel's policy contract; unused because authorization here is permission-only, no per-instance check; nullable so a class-string Gate check (no instance) is denied instead of crashing
     {
-        // Any authenticated user can delete inventory locations
-        return true;
+        return $user !== null && $user->can('inventory_locations.manage');
     }
 
     /**
      * Determine whether the user can restore the model.
      */
-    public function restore(): bool
+    public function restore(?User $user, ?InventoryLocation $inventoryLocation = null): bool // NOSONAR - $inventoryLocation required by Laravel's policy contract; unused because authorization here is permission-only, no per-instance check; nullable so a class-string Gate check (no instance) is denied instead of crashing
     {
-        return true;
+        return $user !== null && $user->can('inventory_locations.manage');
     }
 
     /**
      * Determine whether the user can permanently delete the model.
      */
-    public function forceDelete(): bool
+    public function forceDelete(?User $user, ?InventoryLocation $inventoryLocation = null): bool // NOSONAR - $inventoryLocation required by Laravel's policy contract; unused because authorization here is permission-only, no per-instance check; nullable so a class-string Gate check (no instance) is denied instead of crashing
     {
-        return true;
+        return $user !== null && $user->can('inventory_locations.manage');
     }
 }

--- a/code/api/app/Policies/ItemPolicy.php
+++ b/code/api/app/Policies/ItemPolicy.php
@@ -2,6 +2,7 @@
 
 namespace App\Policies;
 
+use App\Models\Item;
 use App\Models\User;
 
 class ItemPolicy
@@ -9,64 +10,56 @@ class ItemPolicy
     /**
      * Determine whether the user can view any models.
      */
-    public function viewAny(?User $user): bool // NOSONAR - $user kept nullable so Gate::methodAllowsGuests() permits guest access
+    public function viewAny(?User $user): bool
     {
-        // Public endpoint - anyone can list items
-        return true;
+        return $user !== null && $user->can('items.view');
     }
 
     /**
      * Determine whether the user can view the model.
      */
-    public function view(?User $user): bool // NOSONAR - $user kept nullable so Gate::methodAllowsGuests() permits guest access
+    public function view(?User $user, ?Item $item = null): bool // NOSONAR - $item required by Laravel's policy contract; unused because authorization here is permission-only, no per-instance check; nullable so a class-string Gate check (no instance) is denied instead of crashing
     {
-        // Public endpoint - anyone can view items
-        return true;
+        return $user !== null && $user->can('items.view');
     }
 
     /**
      * Determine whether the user can create models.
      */
-    public function create(): bool
+    public function create(?User $user): bool
     {
-        // Any authenticated user can create items
-        // In production, you might want to check for specific roles/permissions
-        return true;
+        return $user !== null && $user->can('items.create');
     }
 
     /**
      * Determine whether the user can update the model.
      */
-    public function update(): bool
+    public function update(?User $user, ?Item $item = null): bool // NOSONAR - $item required by Laravel's policy contract; unused because authorization here is permission-only, no per-instance check; nullable so a class-string Gate check (no instance) is denied instead of crashing
     {
-        // Any authenticated user can update items
-        // In production, you might want to check for specific roles/permissions
-        return true;
+        return $user !== null && $user->can('items.update');
     }
 
     /**
      * Determine whether the user can delete the model.
      */
-    public function delete(): bool
+    public function delete(?User $user, ?Item $item = null): bool // NOSONAR - $item required by Laravel's policy contract; unused because authorization here is permission-only, no per-instance check; nullable so a class-string Gate check (no instance) is denied instead of crashing
     {
-        // Any authenticated user can delete items
-        // In production, you might want to check for specific roles/permissions
-        return true;
+        return $user !== null && $user->can('items.delete');
     }
 
     /**
      * Determine whether the user can restore the model.
      */
-    public function restore(): bool
+    public function restore(?User $user, ?Item $item = null): bool // NOSONAR - $item required by Laravel's policy contract; unused because authorization here is permission-only, no per-instance check; nullable so a class-string Gate check (no instance) is denied instead of crashing
     {
-        return true;
+        return $user !== null && $user->can('items.delete');
     }
 
     /**
      * Determine whether the user can permanently delete the model.
      */
-    public function forceDelete(): bool
+    public function forceDelete(?User $user, ?Item $item = null): bool // NOSONAR - $item required by Laravel's policy contract; unused because authorization here is permission-only, no per-instance check; nullable so a class-string Gate check (no instance) is denied instead of crashing
     {
-        return true;
+        return $user !== null && $user->can('items.delete');
     }
 }

--- a/code/api/app/Policies/ItemVariantPolicy.php
+++ b/code/api/app/Policies/ItemVariantPolicy.php
@@ -2,6 +2,7 @@
 
 namespace App\Policies;
 
+use App\Models\ItemVariant;
 use App\Models\User;
 
 class ItemVariantPolicy
@@ -9,61 +10,56 @@ class ItemVariantPolicy
     /**
      * Determine whether the user can view any models.
      */
-    public function viewAny(?User $user): bool // NOSONAR - $user kept nullable so Gate::methodAllowsGuests() permits guest access
+    public function viewAny(?User $user): bool
     {
-        // Public endpoint - anyone can list item variants
-        return true;
+        return $user !== null && $user->can('items.view');
     }
 
     /**
      * Determine whether the user can view the model.
      */
-    public function view(?User $user): bool // NOSONAR - $user kept nullable so Gate::methodAllowsGuests() permits guest access
+    public function view(?User $user, ?ItemVariant $itemVariant = null): bool // NOSONAR - $itemVariant required by Laravel's policy contract; unused because authorization here is permission-only, no per-instance check; nullable so a class-string Gate check (no instance) is denied instead of crashing
     {
-        // Public endpoint - anyone can view item variants
-        return true;
+        return $user !== null && $user->can('items.view');
     }
 
     /**
      * Determine whether the user can create models.
      */
-    public function create(): bool
+    public function create(?User $user): bool
     {
-        // Any authenticated user can create item variants
-        return true;
+        return $user !== null && $user->can('items.create');
     }
 
     /**
      * Determine whether the user can update the model.
      */
-    public function update(): bool
+    public function update(?User $user, ?ItemVariant $itemVariant = null): bool // NOSONAR - $itemVariant required by Laravel's policy contract; unused because authorization here is permission-only, no per-instance check; nullable so a class-string Gate check (no instance) is denied instead of crashing
     {
-        // Any authenticated user can update item variants
-        return true;
+        return $user !== null && $user->can('items.update');
     }
 
     /**
      * Determine whether the user can delete the model.
      */
-    public function delete(): bool
+    public function delete(?User $user, ?ItemVariant $itemVariant = null): bool // NOSONAR - $itemVariant required by Laravel's policy contract; unused because authorization here is permission-only, no per-instance check; nullable so a class-string Gate check (no instance) is denied instead of crashing
     {
-        // Any authenticated user can delete item variants
-        return true;
+        return $user !== null && $user->can('items.delete');
     }
 
     /**
      * Determine whether the user can restore the model.
      */
-    public function restore(): bool
+    public function restore(?User $user, ?ItemVariant $itemVariant = null): bool // NOSONAR - $itemVariant required by Laravel's policy contract; unused because authorization here is permission-only, no per-instance check; nullable so a class-string Gate check (no instance) is denied instead of crashing
     {
-        return true;
+        return $user !== null && $user->can('items.delete');
     }
 
     /**
      * Determine whether the user can permanently delete the model.
      */
-    public function forceDelete(): bool
+    public function forceDelete(?User $user, ?ItemVariant $itemVariant = null): bool // NOSONAR - $itemVariant required by Laravel's policy contract; unused because authorization here is permission-only, no per-instance check; nullable so a class-string Gate check (no instance) is denied instead of crashing
     {
-        return true;
+        return $user !== null && $user->can('items.delete');
     }
 }

--- a/code/api/tests/Unit/Policies/InventoryLocationPolicyTest.php
+++ b/code/api/tests/Unit/Policies/InventoryLocationPolicyTest.php
@@ -2,51 +2,211 @@
 
 namespace Tests\Unit\Policies;
 
+use App\Models\Branch;
+use App\Models\InventoryLocation;
+use App\Models\OperatingUnit;
+use App\Models\User;
 use App\Policies\InventoryLocationPolicy;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Test;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\PermissionRegistrar;
 use Tests\TestCase;
 
 class InventoryLocationPolicyTest extends TestCase
 {
-    #[Test]
-    public function it_allows_guests_to_view_any(): void
+    use RefreshDatabase;
+
+    private InventoryLocationPolicy $policy;
+
+    private OperatingUnit $operatingUnit;
+
+    protected function setUp(): void
     {
-        $this->assertTrue((new InventoryLocationPolicy)->viewAny(null));
+        parent::setUp();
+
+        $this->policy = new InventoryLocationPolicy;
+
+        foreach (['inventory_locations.view', 'inventory_locations.manage'] as $name) {
+            Permission::create(['name' => $name, 'guard_name' => 'api']);
+        }
+
+        $branch = Branch::create([
+            'code' => 'TEST',
+            'name' => 'Test Branch',
+            'address' => '123 Test St',
+            'city' => 'Test City',
+            'state' => 'TS',
+            'country' => 'MX',
+            'postal_code' => '12345',
+            'is_active' => true,
+        ]);
+
+        $this->operatingUnit = OperatingUnit::create([
+            'branch_id' => $branch->id,
+            'type' => OperatingUnit::TYPE_BRANCH_MAIN,
+            'name' => 'Test Main Inventory',
+            'is_active' => true,
+        ]);
+    }
+
+    private function userWith(string ...$permissions): User
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo($permissions);
+        app()[PermissionRegistrar::class]->forgetCachedPermissions();
+
+        return $user;
+    }
+
+    private function location(): InventoryLocation
+    {
+        return InventoryLocation::factory()->create([
+            'operating_unit_id' => $this->operatingUnit->id,
+        ]);
     }
 
     #[Test]
-    public function it_allows_guests_to_view(): void
+    public function guest_cannot_view_any(): void
     {
-        $this->assertTrue((new InventoryLocationPolicy)->view(null));
+        $this->assertFalse($this->policy->viewAny(null));
     }
 
     #[Test]
-    public function it_allows_create(): void
+    public function user_without_view_permission_cannot_view_any(): void
     {
-        $this->assertTrue((new InventoryLocationPolicy)->create());
+        $this->assertFalse($this->policy->viewAny($this->userWith()));
     }
 
     #[Test]
-    public function it_allows_update(): void
+    public function user_with_view_permission_can_view_any(): void
     {
-        $this->assertTrue((new InventoryLocationPolicy)->update());
+        $this->assertTrue($this->policy->viewAny($this->userWith('inventory_locations.view')));
     }
 
     #[Test]
-    public function it_allows_delete(): void
+    public function guest_cannot_view(): void
     {
-        $this->assertTrue((new InventoryLocationPolicy)->delete());
+        $this->assertFalse($this->policy->view(null, $this->location()));
     }
 
     #[Test]
-    public function it_allows_restore(): void
+    public function user_without_view_permission_cannot_view(): void
     {
-        $this->assertTrue((new InventoryLocationPolicy)->restore());
+        $this->assertFalse($this->policy->view($this->userWith(), $this->location()));
     }
 
     #[Test]
-    public function it_allows_force_delete(): void
+    public function user_with_view_permission_can_view(): void
     {
-        $this->assertTrue((new InventoryLocationPolicy)->forceDelete());
+        $this->assertTrue($this->policy->view($this->userWith('inventory_locations.view'), $this->location()));
+    }
+
+    #[Test]
+    public function guest_cannot_create(): void
+    {
+        $this->assertFalse($this->policy->create(null));
+    }
+
+    #[Test]
+    public function user_without_manage_permission_cannot_create(): void
+    {
+        $this->assertFalse($this->policy->create($this->userWith()));
+    }
+
+    #[Test]
+    public function user_with_neighboring_view_permission_cannot_create(): void
+    {
+        $this->assertFalse($this->policy->create($this->userWith('inventory_locations.view')));
+    }
+
+    #[Test]
+    public function user_with_manage_permission_can_create(): void
+    {
+        $this->assertTrue($this->policy->create($this->userWith('inventory_locations.manage')));
+    }
+
+    #[Test]
+    public function guest_cannot_update(): void
+    {
+        $this->assertFalse($this->policy->update(null, $this->location()));
+    }
+
+    #[Test]
+    public function user_without_manage_permission_cannot_update(): void
+    {
+        $this->assertFalse($this->policy->update($this->userWith(), $this->location()));
+    }
+
+    #[Test]
+    public function user_with_neighboring_view_permission_cannot_update(): void
+    {
+        $this->assertFalse($this->policy->update($this->userWith('inventory_locations.view'), $this->location()));
+    }
+
+    #[Test]
+    public function user_with_manage_permission_can_update(): void
+    {
+        $this->assertTrue($this->policy->update($this->userWith('inventory_locations.manage'), $this->location()));
+    }
+
+    #[Test]
+    public function guest_cannot_delete(): void
+    {
+        $this->assertFalse($this->policy->delete(null, $this->location()));
+    }
+
+    #[Test]
+    public function user_without_manage_permission_cannot_delete(): void
+    {
+        $this->assertFalse($this->policy->delete($this->userWith(), $this->location()));
+    }
+
+    #[Test]
+    public function user_with_neighboring_view_permission_cannot_delete(): void
+    {
+        $this->assertFalse($this->policy->delete($this->userWith('inventory_locations.view'), $this->location()));
+    }
+
+    #[Test]
+    public function user_with_manage_permission_can_delete(): void
+    {
+        $this->assertTrue($this->policy->delete($this->userWith('inventory_locations.manage'), $this->location()));
+    }
+
+    #[Test]
+    public function guest_cannot_restore(): void
+    {
+        $this->assertFalse($this->policy->restore(null, $this->location()));
+    }
+
+    #[Test]
+    public function user_without_manage_permission_cannot_restore(): void
+    {
+        $this->assertFalse($this->policy->restore($this->userWith(), $this->location()));
+    }
+
+    #[Test]
+    public function user_with_manage_permission_can_restore(): void
+    {
+        $this->assertTrue($this->policy->restore($this->userWith('inventory_locations.manage'), $this->location()));
+    }
+
+    #[Test]
+    public function guest_cannot_force_delete(): void
+    {
+        $this->assertFalse($this->policy->forceDelete(null, $this->location()));
+    }
+
+    #[Test]
+    public function user_without_manage_permission_cannot_force_delete(): void
+    {
+        $this->assertFalse($this->policy->forceDelete($this->userWith(), $this->location()));
+    }
+
+    #[Test]
+    public function user_with_manage_permission_can_force_delete(): void
+    {
+        $this->assertTrue($this->policy->forceDelete($this->userWith('inventory_locations.manage'), $this->location()));
     }
 }

--- a/code/api/tests/Unit/Policies/ItemPolicyTest.php
+++ b/code/api/tests/Unit/Policies/ItemPolicyTest.php
@@ -2,51 +2,182 @@
 
 namespace Tests\Unit\Policies;
 
+use App\Models\Item;
+use App\Models\User;
 use App\Policies\ItemPolicy;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Test;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\PermissionRegistrar;
 use Tests\TestCase;
 
 class ItemPolicyTest extends TestCase
 {
-    #[Test]
-    public function it_allows_guests_to_view_any(): void
+    use RefreshDatabase;
+
+    private ItemPolicy $policy;
+
+    protected function setUp(): void
     {
-        $this->assertTrue((new ItemPolicy)->viewAny(null));
+        parent::setUp();
+
+        $this->policy = new ItemPolicy;
+
+        foreach (['items.view', 'items.create', 'items.update', 'items.delete'] as $name) {
+            Permission::create(['name' => $name, 'guard_name' => 'api']);
+        }
+    }
+
+    private function userWith(string ...$permissions): User
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo($permissions);
+        app()[PermissionRegistrar::class]->forgetCachedPermissions();
+
+        return $user;
     }
 
     #[Test]
-    public function it_allows_guests_to_view(): void
+    public function guest_cannot_view_any(): void
     {
-        $this->assertTrue((new ItemPolicy)->view(null));
+        $this->assertFalse($this->policy->viewAny(null));
     }
 
     #[Test]
-    public function it_allows_create(): void
+    public function user_without_items_view_cannot_view_any(): void
     {
-        $this->assertTrue((new ItemPolicy)->create());
+        $this->assertFalse($this->policy->viewAny($this->userWith()));
     }
 
     #[Test]
-    public function it_allows_update(): void
+    public function user_with_items_view_can_view_any(): void
     {
-        $this->assertTrue((new ItemPolicy)->update());
+        $this->assertTrue($this->policy->viewAny($this->userWith('items.view')));
     }
 
     #[Test]
-    public function it_allows_delete(): void
+    public function guest_cannot_view(): void
     {
-        $this->assertTrue((new ItemPolicy)->delete());
+        $this->assertFalse($this->policy->view(null, Item::factory()->create()));
     }
 
     #[Test]
-    public function it_allows_restore(): void
+    public function user_without_items_view_cannot_view(): void
     {
-        $this->assertTrue((new ItemPolicy)->restore());
+        $this->assertFalse($this->policy->view($this->userWith(), Item::factory()->create()));
     }
 
     #[Test]
-    public function it_allows_force_delete(): void
+    public function user_with_items_view_can_view(): void
     {
-        $this->assertTrue((new ItemPolicy)->forceDelete());
+        $this->assertTrue($this->policy->view($this->userWith('items.view'), Item::factory()->create()));
+    }
+
+    #[Test]
+    public function guest_cannot_create(): void
+    {
+        $this->assertFalse($this->policy->create(null));
+    }
+
+    #[Test]
+    public function user_without_items_create_cannot_create(): void
+    {
+        $this->assertFalse($this->policy->create($this->userWith()));
+    }
+
+    #[Test]
+    public function user_with_neighboring_permission_cannot_create(): void
+    {
+        $this->assertFalse($this->policy->create($this->userWith('items.view')));
+    }
+
+    #[Test]
+    public function user_with_items_create_can_create(): void
+    {
+        $this->assertTrue($this->policy->create($this->userWith('items.create')));
+    }
+
+    #[Test]
+    public function guest_cannot_update(): void
+    {
+        $this->assertFalse($this->policy->update(null, Item::factory()->create()));
+    }
+
+    #[Test]
+    public function user_without_items_update_cannot_update(): void
+    {
+        $this->assertFalse($this->policy->update($this->userWith(), Item::factory()->create()));
+    }
+
+    #[Test]
+    public function user_with_neighboring_permission_cannot_update(): void
+    {
+        $this->assertFalse($this->policy->update($this->userWith('items.view'), Item::factory()->create()));
+    }
+
+    #[Test]
+    public function user_with_items_update_can_update(): void
+    {
+        $this->assertTrue($this->policy->update($this->userWith('items.update'), Item::factory()->create()));
+    }
+
+    #[Test]
+    public function guest_cannot_delete(): void
+    {
+        $this->assertFalse($this->policy->delete(null, Item::factory()->create()));
+    }
+
+    #[Test]
+    public function user_without_items_delete_cannot_delete(): void
+    {
+        $this->assertFalse($this->policy->delete($this->userWith(), Item::factory()->create()));
+    }
+
+    #[Test]
+    public function user_with_neighboring_permission_cannot_delete(): void
+    {
+        $this->assertFalse($this->policy->delete($this->userWith('items.update'), Item::factory()->create()));
+    }
+
+    #[Test]
+    public function user_with_items_delete_can_delete(): void
+    {
+        $this->assertTrue($this->policy->delete($this->userWith('items.delete'), Item::factory()->create()));
+    }
+
+    #[Test]
+    public function guest_cannot_restore(): void
+    {
+        $this->assertFalse($this->policy->restore(null, Item::factory()->create()));
+    }
+
+    #[Test]
+    public function user_without_items_delete_cannot_restore(): void
+    {
+        $this->assertFalse($this->policy->restore($this->userWith(), Item::factory()->create()));
+    }
+
+    #[Test]
+    public function user_with_items_delete_can_restore(): void
+    {
+        $this->assertTrue($this->policy->restore($this->userWith('items.delete'), Item::factory()->create()));
+    }
+
+    #[Test]
+    public function guest_cannot_force_delete(): void
+    {
+        $this->assertFalse($this->policy->forceDelete(null, Item::factory()->create()));
+    }
+
+    #[Test]
+    public function user_without_items_delete_cannot_force_delete(): void
+    {
+        $this->assertFalse($this->policy->forceDelete($this->userWith(), Item::factory()->create()));
+    }
+
+    #[Test]
+    public function user_with_items_delete_can_force_delete(): void
+    {
+        $this->assertTrue($this->policy->forceDelete($this->userWith('items.delete'), Item::factory()->create()));
     }
 }

--- a/code/api/tests/Unit/Policies/ItemVariantPolicyTest.php
+++ b/code/api/tests/Unit/Policies/ItemVariantPolicyTest.php
@@ -2,51 +2,192 @@
 
 namespace Tests\Unit\Policies;
 
+use App\Models\Item;
+use App\Models\ItemVariant;
+use App\Models\UnitOfMeasure;
+use App\Models\User;
 use App\Policies\ItemVariantPolicy;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Test;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\PermissionRegistrar;
 use Tests\TestCase;
 
 class ItemVariantPolicyTest extends TestCase
 {
-    #[Test]
-    public function it_allows_guests_to_view_any(): void
+    use RefreshDatabase;
+
+    private ItemVariantPolicy $policy;
+
+    protected function setUp(): void
     {
-        $this->assertTrue((new ItemVariantPolicy)->viewAny(null));
+        parent::setUp();
+
+        $this->policy = new ItemVariantPolicy;
+
+        foreach (['items.view', 'items.create', 'items.update', 'items.delete'] as $name) {
+            Permission::create(['name' => $name, 'guard_name' => 'api']);
+        }
+    }
+
+    private function userWith(string ...$permissions): User
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo($permissions);
+        app()[PermissionRegistrar::class]->forgetCachedPermissions();
+
+        return $user;
+    }
+
+    private function variant(): ItemVariant
+    {
+        return ItemVariant::factory()->create([
+            'item_id' => Item::factory(),
+            'uom_id' => UnitOfMeasure::create(['code' => 'KG', 'name' => 'Kilogramo', 'symbol' => 'kg'])->id,
+        ]);
     }
 
     #[Test]
-    public function it_allows_guests_to_view(): void
+    public function guest_cannot_view_any(): void
     {
-        $this->assertTrue((new ItemVariantPolicy)->view(null));
+        $this->assertFalse($this->policy->viewAny(null));
     }
 
     #[Test]
-    public function it_allows_create(): void
+    public function user_without_items_view_cannot_view_any(): void
     {
-        $this->assertTrue((new ItemVariantPolicy)->create());
+        $this->assertFalse($this->policy->viewAny($this->userWith()));
     }
 
     #[Test]
-    public function it_allows_update(): void
+    public function user_with_items_view_can_view_any(): void
     {
-        $this->assertTrue((new ItemVariantPolicy)->update());
+        $this->assertTrue($this->policy->viewAny($this->userWith('items.view')));
     }
 
     #[Test]
-    public function it_allows_delete(): void
+    public function guest_cannot_view(): void
     {
-        $this->assertTrue((new ItemVariantPolicy)->delete());
+        $this->assertFalse($this->policy->view(null, $this->variant()));
     }
 
     #[Test]
-    public function it_allows_restore(): void
+    public function user_without_items_view_cannot_view(): void
     {
-        $this->assertTrue((new ItemVariantPolicy)->restore());
+        $this->assertFalse($this->policy->view($this->userWith(), $this->variant()));
     }
 
     #[Test]
-    public function it_allows_force_delete(): void
+    public function user_with_items_view_can_view(): void
     {
-        $this->assertTrue((new ItemVariantPolicy)->forceDelete());
+        $this->assertTrue($this->policy->view($this->userWith('items.view'), $this->variant()));
+    }
+
+    #[Test]
+    public function guest_cannot_create(): void
+    {
+        $this->assertFalse($this->policy->create(null));
+    }
+
+    #[Test]
+    public function user_without_items_create_cannot_create(): void
+    {
+        $this->assertFalse($this->policy->create($this->userWith()));
+    }
+
+    #[Test]
+    public function user_with_neighboring_permission_cannot_create(): void
+    {
+        $this->assertFalse($this->policy->create($this->userWith('items.view')));
+    }
+
+    #[Test]
+    public function user_with_items_create_can_create(): void
+    {
+        $this->assertTrue($this->policy->create($this->userWith('items.create')));
+    }
+
+    #[Test]
+    public function guest_cannot_update(): void
+    {
+        $this->assertFalse($this->policy->update(null, $this->variant()));
+    }
+
+    #[Test]
+    public function user_without_items_update_cannot_update(): void
+    {
+        $this->assertFalse($this->policy->update($this->userWith(), $this->variant()));
+    }
+
+    #[Test]
+    public function user_with_neighboring_permission_cannot_update(): void
+    {
+        $this->assertFalse($this->policy->update($this->userWith('items.view'), $this->variant()));
+    }
+
+    #[Test]
+    public function user_with_items_update_can_update(): void
+    {
+        $this->assertTrue($this->policy->update($this->userWith('items.update'), $this->variant()));
+    }
+
+    #[Test]
+    public function guest_cannot_delete(): void
+    {
+        $this->assertFalse($this->policy->delete(null, $this->variant()));
+    }
+
+    #[Test]
+    public function user_without_items_delete_cannot_delete(): void
+    {
+        $this->assertFalse($this->policy->delete($this->userWith(), $this->variant()));
+    }
+
+    #[Test]
+    public function user_with_neighboring_permission_cannot_delete(): void
+    {
+        $this->assertFalse($this->policy->delete($this->userWith('items.update'), $this->variant()));
+    }
+
+    #[Test]
+    public function user_with_items_delete_can_delete(): void
+    {
+        $this->assertTrue($this->policy->delete($this->userWith('items.delete'), $this->variant()));
+    }
+
+    #[Test]
+    public function guest_cannot_restore(): void
+    {
+        $this->assertFalse($this->policy->restore(null, $this->variant()));
+    }
+
+    #[Test]
+    public function user_without_items_delete_cannot_restore(): void
+    {
+        $this->assertFalse($this->policy->restore($this->userWith(), $this->variant()));
+    }
+
+    #[Test]
+    public function user_with_items_delete_can_restore(): void
+    {
+        $this->assertTrue($this->policy->restore($this->userWith('items.delete'), $this->variant()));
+    }
+
+    #[Test]
+    public function guest_cannot_force_delete(): void
+    {
+        $this->assertFalse($this->policy->forceDelete(null, $this->variant()));
+    }
+
+    #[Test]
+    public function user_without_items_delete_cannot_force_delete(): void
+    {
+        $this->assertFalse($this->policy->forceDelete($this->userWith(), $this->variant()));
+    }
+
+    #[Test]
+    public function user_with_items_delete_can_force_delete(): void
+    {
+        $this->assertTrue($this->policy->forceDelete($this->userWith('items.delete'), $this->variant()));
     }
 }

--- a/doc/sprints/sprint-003-development-platform-and-product-reliability.md
+++ b/doc/sprints/sprint-003-development-platform-and-product-reliability.md
@@ -179,7 +179,7 @@ change and must update estimates, dependencies, conflicts, and the scope-change 
 | ⏳ | #64 | `sushigo-dev-lab` | Add Bats coverage and macOS CI for workspace-bootstrap configuration helpers | High | 3h | 6h | — | — | Use `tests/README.md` to avoid a README conflict with #67 |
 | ⏳ | #67 | `sushigo-dev-lab` | Add `make status` for a reliable workspace runtime overview | Medium | 2h | 4h | — | — | Distinguish live, degraded, stopped, stale-socket, and unconfigured states |
 | ⏳ | #401 | `sushigo` | Add administrator-managed employee avatars with reusable initials fallback | High | 4h | 7h | — | — | Foundation required by #420 |
-| ⏳ | #400 | `sushigo` | Enforce permissions in Item, ItemVariant, and InventoryLocation policies | High | 2h | 4h | — | — | Independent authorization lane; keep `items.manage-media` separate |
+| ✅ | #400 | `sushigo` | Enforce permissions in Item, ItemVariant, and InventoryLocation policies | High | 2h | 4h | 3.2h | PR #445 | PR ready, merge pending |
 | ⏳ | #430 | `sushigo` | Prevent concurrent stock overselling and enforce balance invariants | Critical | 4h | 8h | — | — | Land early; required before future purchase receiving (#432) |
 | ⏳ | #421 | `sushigo` | Design the Product Inventory target architecture and migration plan | Medium | 3h | 6h | — | — | Design-only gate; #422/#423 remain outside Sprint 3 |
 |  |  |  | **Round total** |  | **18h** | **35h** | **—** |  |  |
@@ -347,7 +347,7 @@ Sessions arrays. Estimates remain planning ranges until execution evidence is re
 | ⏳ | #65 | `sushigo-dev-lab` | Pending | — | — | — | ADR list expands to include #68 |
 | ⏳ | #401 | `sushigo` | Pending | — | — | — | Admin employee-avatar foundation; continuation split to #420 |
 | ⏳ | #420 | `sushigo` | Pending | — | — | — | Self-service editing and remaining identity-surface rollout |
-| ⏳ | #400 | `sushigo` | Pending | — | — | — | Three inventory policies aligned with route/Form Request permissions |
+| ✅ | #400 | `sushigo` | Replaced unconditional `return true` stubs in ItemPolicy/ItemVariantPolicy/InventoryLocationPolicy with real Spatie permission checks; 72 new unit assertions | PR #445 | — | 3.2h | 72 policy unit tests + 44 regression tests passing; Pint clean; SonarCloud quality gate passing (100% new coverage); Copilot review clean; Devin/DeepWiki 0 bugs, 2 flags fixed (stale comment, nullable-param footgun), 4 evaluated as false positive/informational |
 | ⏳ | #430 | `sushigo` | Pending | — | — | — | Atomic Stock mutation and balance-invariant enforcement |
 | ⏳ | #421 | `sushigo` | Pending | — | — | — | Design/ERD/UI/API/migration gate only; no production implementation |
 | 🚧 | #443 | `sushigo` | Sprint lifecycle and planning documentation | — | — | In progress | Opportunistic startup work; branch and PR carry the session-created documentation |

--- a/doc/tasks/2026-08/400-enforce-inventory-policies.md
+++ b/doc/tasks/2026-08/400-enforce-inventory-policies.md
@@ -1,0 +1,140 @@
+# 🐛 Inventory policies authorize unconditionally instead of enforcing permissions
+
+## Bug description
+
+Three auto-discovered Laravel policies authorize every ability unconditionally:
+
+- `App\Policies\ItemPolicy`
+- `App\Policies\ItemVariantPolicy`
+- `App\Policies\InventoryLocationPolicy`
+
+Their `viewAny()`, `view()`, `create()`, `update()`, `delete()`, `restore()`, and
+`forceDelete()` methods return `true` without checking the authenticated user's permissions. The
+existing unit tests reinforce the stub behavior by asserting that every mutation ability is
+allowed.
+
+Current HTTP endpoints are still protected by route middleware and Form Request authorization, so
+this is **not evidence of a currently exploitable endpoint**. It is a latent authorization defect:
+any new controller, service, media attachment, Blade directive, or API path that correctly calls
+`$user->can(...)` receives a false authorization result without an error.
+
+## Hypothesis
+
+These three policies were generated from Laravel's default policy stub and never filled in with
+real authorization logic before the corresponding permissions (`items.*`,
+`inventory_locations.*`) existed in the permission seeders. Every ability was left as a hardcoded
+`return true` (some on nullable-`$user` methods to satisfy `Gate::methodAllowsGuests()`, others on
+parameterless methods), with comments claiming the resources are "public" or open to "any
+authenticated user." No caller currently exercises these policies directly — route middleware and
+Form Request `authorize()` checks are what actually gate the HTTP endpoints today — so the stub
+return values have never been observed to produce a wrong HTTP response. The defect is latent: it
+only becomes exploitable the moment new code calls `$user->can(...)` / `$this->authorize(...)`
+against `Item`, `ItemVariant`, or `InventoryLocation` and trusts the result.
+
+## Reproduction guide
+
+1. In `code/api`, open a Tinker shell or a scratch test and construct a user with **no**
+   permissions assigned (e.g. a fresh `User` with no roles).
+2. Call `$user->can('create', \App\Models\Item::class)` (or `view`, `update`, `delete`, `restore`,
+   `forceDelete`, and the same for `ItemVariant::class` / `InventoryLocation::class`).
+3. **Observed:** every call returns `true`, regardless of the user's permissions.
+4. **Expected:** each ability should return `true` only when the user holds the permission listed
+   in the "Verified authorization contract" table below (e.g. `create` on `Item` requires
+   `items.create`), and `false` for a guest/no-permission user.
+5. The existing unit tests under `code/api/tests/Unit/Policies/` for these three policies currently
+   assert the buggy `true`-for-everyone behavior, which is why this has gone unnoticed — they
+   reinforce the stub instead of catching it.
+
+## Verified authorization contract
+
+The policies must match the permissions already enforced by the API:
+
+| Policy abilities | Required permission |
+|---|---|
+| `ItemPolicy::viewAny`, `view` | `items.view` |
+| `ItemPolicy::create` | `items.create` |
+| `ItemPolicy::update` | `items.update` |
+| `ItemPolicy::delete`, `restore`, `forceDelete` | `items.delete` |
+| `ItemVariantPolicy::viewAny`, `view` | `items.view` |
+| `ItemVariantPolicy::create` | `items.create` |
+| `ItemVariantPolicy::update` | `items.update` |
+| `ItemVariantPolicy::delete`, `restore`, `forceDelete` | `items.delete` |
+| `InventoryLocationPolicy::viewAny`, `view` | `inventory_locations.view` |
+| `InventoryLocationPolicy::create`, `update`, `delete`, `restore`, `forceDelete` | `inventory_locations.manage` |
+
+The three resources are protected endpoints, so mutation and view abilities must require a
+non-null authenticated `User`. Method signatures should follow Laravel's expected policy contract
+and accept the model argument where applicable.
+
+## Important media boundary
+
+Do **not** replace `Item::userCanManageMedia()` with `ItemPolicy::update()`. Since #377, media
+management intentionally uses the narrower `items.manage-media` permission. Reusing
+`items.update` would couple photo management to catalog/pricing edit rights and regress that
+least-privilege boundary.
+
+## Objective
+
+- [x] Replace unconditional authorization in all three policies with the verified permission map.
+- [x] Remove outdated comments claiming these resources are public or that any authenticated user
+      may mutate them.
+- [x] Update the three policy unit-test suites to cover an unauthenticated caller, a user without
+      permission, and a user with the exact required permission for every ability.
+- [x] Confirm users with a neighboring permission are denied (for example, `items.view` cannot
+      create/update/delete, and `items.update` cannot manage media).
+- [x] Keep `Item::userCanManageMedia()` and its existing media-ownership tests on
+      `items.manage-media`.
+- [x] Run the relevant policy and inventory permission tests, then the normal API quality gates.
+
+## Acceptance criteria
+
+- [x] No unconditional `return true` remains in the three policies.
+- [x] Policy results and route/Form Request authorization use the same permission vocabulary.
+- [x] Guests and users without the required permission are denied.
+- [x] Users with the exact required permission are allowed.
+- [x] Existing inventory endpoints and item-media authorization continue to pass their regression
+      tests.
+- [x] No unrelated policy or permission redesign is introduced.
+
+## References
+
+- `code/api/app/Policies/ItemPolicy.php`
+- `code/api/app/Policies/ItemVariantPolicy.php`
+- `code/api/app/Policies/InventoryLocationPolicy.php`
+- `code/api/routes/api/items.php`
+- `code/api/routes/api/inventory.php`
+- `code/api/app/Models/Item.php::userCanManageMedia()`
+- Discovered while implementing the generic media system in #377
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `2h`
+- **Pessimistic:** `4h`
+- **Tracked:** `3h10m`
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-08-12", "start": "20:13", "end": "23:23" }
+]
+```
+
+## 📊 Retrospective
+- **Actual total:** 3h 10m (190m)
+- **vs optimistic:** +1h 10m
+- **vs pessimistic:** −50m
+
+**Justification:**
+Landed within the pessimistic estimate but above optimistic, mostly due to review-response
+cycles rather than the core fix itself (which was straightforward once the permission map was
+verified against route middleware). A transient SonarCloud 502 required one CI retry. The
+SonarCloud quality gate then flagged the intentionally-unused model parameters as `S1172`
+unused-parameter code smells, requiring a NOSONAR pass. The Devin/DeepWiki automated review
+surfaced two rounds of legitimate findings after the initial squash: a stale comment in
+`Item.php` still describing `ItemPolicy::update()` as a stub, and a real (if latent) footgun
+where a class-string `Gate::allows('update', Item::class)` call would throw `ArgumentCountError`
+against a required model parameter instead of denying — fixed by making the model parameters
+nullable with a null default. Each of these required its own commit, CI re-run, and Devin
+re-scan round trip, which accounts for the time above the optimistic estimate.
+


### PR DESCRIPTION
## Summary
Closes #400
Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/445

- 🔒 Replaced the unconditional `return true` stubs in `ItemPolicy`, `ItemVariantPolicy`, and
  `InventoryLocationPolicy` with real Spatie permission checks, matching the permission map already
  enforced by route middleware (`items.view/create/update/delete`,
  `inventory_locations.view/manage`)
- 🧹 Removed outdated comments claiming these resources are "public" or open to "any authenticated
  user"
- ✅ Rewrote the three policy unit-test suites (`ItemPolicyTest`, `ItemVariantPolicyTest`,
  `InventoryLocationPolicyTest`) — 72 new assertions covering guest, no-permission,
  neighboring-permission, and exact-permission scenarios for every ability
- 🔐 Left `Item::userCanManageMedia()` and its existing media-ownership tests untouched, still gated
  on `items.manage-media` — not coupled to `items.update`

## Manual Testing

1. `cd code/api && php artisan tinker`
2. Create a user with no roles/permissions:
   `$guest = \App\Models\User::factory()->create();`
3. `$guest->can('create', \App\Models\Item::class)` → now returns `false` (previously `true`).
4. Give the user `items.create` only:
   `$guest->givePermissionTo('items.create');`
5. `$guest->can('create', \App\Models\Item::class)` → returns `true`.
6. `$guest->can('update', \App\Models\Item::class)` → still `false` (neighboring permission
   correctly denied).
7. Confirm no HTTP regression — log in as `inventory@sushigo.com` (inventory-manager role) and hit
   `GET /api/v1/items`, `POST /api/v1/items`, `GET /api/v1/inventory-locations` — all still `200`.
8. Confirm `Item::userCanManageMedia()` is unaffected — a user with only `items.update` (not
   `items.manage-media`) still gets `403` on `PATCH /api/v1/media/{id}`.

## Test plan
- [x] PHPUnit: `php artisan test --filter='Item(Variant)?PolicyTest|InventoryLocationPolicyTest'` — 72 passed
- [x] PHPUnit regression: `php artisan test --filter='InventoryPermissionsTest|ItemMediaAttachmentTest|ItemMediaOwnershipTest|InventoryLocationCrudTest'` — 44 passed
- [x] Linters: Pint ✅

## 🤔 Assumptions

- Kept the policy methods on nullable `?User $user` with an explicit `$user !== null` check
  (matching the codebase's pre-existing pattern for `viewAny()`/`view()`, which used nullable
  `?User` so `Gate::methodAllowsGuests()` invokes the method directly for guests) rather than
  switching to non-nullable `User $user` like `CashRegisterPolicy`. The issue's own text only
  requires that a null user is functionally denied, not a specific type signature; nullable types
  keep every ability directly unit-testable (`$policy->create(null)`) without going through the
  `Gate` facade, consistent with the existing `Unit/Policies/*Test.php` style in this repo.
- Did not add operating-unit/branch scoping to `InventoryLocationPolicy::view/update/delete`
  (unlike `CashRegisterPolicy`'s `ChecksBranchAccess` trait), even though `InventoryLocation` has an
  `operating_unit_id`. The issue's "Verified authorization contract" table only maps ability →
  permission with no scoping requirement, and its Acceptance Criteria explicitly forbids
  "unrelated policy or permission redesign" — adding branch scoping here would be exactly that.

## ⚠️ Needs Human Judgment

_None yet — filled in if Copilot/Devin raise a business-rule dispute during review._

## Workspace
`sushigo-a` — `fix/400-enforce-inventory-policies`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
