### PR TITLE
📚 [#421][c] - Design the Product Inventory target architecture and migration plan 📐

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,12 +243,13 @@ Uses the workspace's own `docker-compose.e2e.yml` with a Cypress container.
 
 ## Architecture & domain documentation
 
-- [Inventory Architecture & Design (modelos, diagramas y flujos)](doc/architecture/inventory-architecture.md)
-- [Security & User System Architecture](doc/architecture/security-and-user-system-architecture.md)
+- [Inventory Architecture & Design](doc/architecture/inventory-architecture.en.md)
+- [Product Catalog Architecture (Product → Variant → Purchase Presentation target design)](doc/architecture/product-catalog/product-catalog-architecture.en.md)
+- [Security & User System Architecture](doc/architecture/security-and-user-system-architecture.en.md)
 - [Media System Architecture (storage-backed, cloud-swappable uploads)](doc/architecture/media/media-architecture.en.md)
 - [Task #004 — Auth + Zustand migration](doc/tasks/2025-11/004-authentication-frontend-zustand.md)
 
-These documents capture the target inventory domain (operating units, stock movements, Hashids exposure) and should guide upcoming modules.
+These documents capture the target inventory domain (operating units, stock movements, `public_id` exposure) and should guide upcoming modules.
 
 ## Sprints
 
@@ -259,7 +260,7 @@ Development is organized into documented sprints — see [`doc/conventions/sprin
 | 000 | Introduction | Completed | 2026-07-26 | 2026-07-26 | — | — | [sprint-000-introduction.md](doc/sprints/sprint-000-introduction.md) |
 | 001 | Attendance, Payroll & Quality | Completed | 2026-07-26 | 2026-07-31 (impl. finished 2026-07-30) | 2026-08-09 | 1.40× (51.1h → 36.5h) | [sprint-001-attendance-payroll-quality.md](doc/sprints/sprint-001-attendance-payroll-quality.md) |
 | 002 | Platillos Catalog & Platform Hardening | Completed | 2026-07-31 | 2026-08-12 (impl. finished 2026-08-11) | — | 1.85× (170.8h → 92.5h, scoped + opportunistic issues) | [sprint-002-platillos-catalog-platform-hardening.md](doc/sprints/sprint-002-platillos-catalog-platform-hardening.md) |
-| 003 | Development Platform & Product Reliability | In Progress | 2026-08-12 | — | 2026-09-05 | — | [sprint-003-development-platform-and-product-reliability.md](doc/sprints/sprint-003-development-platform-and-product-reliability.md) |
+| 003 | Development Platform & Product Reliability | In Progress | 2026-08-12 | 10% (1/10) | 2026-09-05 | — | [sprint-003-development-platform-and-product-reliability.md](doc/sprints/sprint-003-development-platform-and-product-reliability.md) |
 
 ## Development tips
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,9 +1,5 @@
 # 📚 Documentation Structure
 
-This directory contains all project documentation organized by language.
-
-# 📚 Documentation Structure
-
 This directory contains all project documentation with a pragmatic language strategy.
 
 ## Structure
@@ -12,8 +8,7 @@ This directory contains all project documentation with a pragmatic language stra
 doc/
 ├── architecture/          # System architecture and design docs
 │   ├── *.en.md           # English versions
-│   ├── *.es.md           # Spanish versions
-│   └── identifiers-hashids.md
+│   └── *.es.md           # Spanish versions
 │
 ├── conventions/           # Development standards (English only)
 │   ├── backend/          # Laravel standards
@@ -32,8 +27,12 @@ doc/
 Available in **English and Spanish** (`.en.md` and `.es.md` suffixes):
 
 -   **Inventory Architecture**: Complete domain model, ER diagrams, and operational flows for the inventory system
+-   **Product Catalog Architecture** (`architecture/product-catalog/`): Target design for Product → Variant → Purchase Presentation, replacing the legacy `ProductWizard`
 -   **Security & User System**: Authentication, authorization, roles, and permissions design
--   **Hashids Identifiers**: Guidelines for secure ID obfuscation in APIs (English only)
+
+### Decisions (`decisions.md` + `decisions/`)
+
+Index and individual ADRs recording accepted technical decisions — see [Technical Decisions](decisions.md).
 
 ### Conventions (`conventions/`)
 
@@ -78,8 +77,8 @@ For conventions and tasks:
 ### Architecture (Bilingual)
 
 -   [Inventory Architecture](architecture/inventory-architecture.en.md) | [Arquitectura de Inventarios](architecture/inventory-architecture.es.md)
+-   [Product Catalog Architecture](architecture/product-catalog/product-catalog-architecture.en.md) | [Arquitectura del Catálogo de Producto](architecture/product-catalog/product-catalog-architecture.es.md)
 -   [Security Architecture](architecture/security-and-user-system-architecture.en.md) | [Arquitectura de Seguridad](architecture/security-and-user-system-architecture.es.md)
--   [Hashids Identifiers](architecture/identifiers-hashids.md)
 
 ### Conventions (English)
 
@@ -94,62 +93,7 @@ For conventions and tasks:
 -   [#005 - Inventory Design Documentation](tasks/2025-11/005-inventory-product-onboarding.md)
 -   [#006 - Inventory Product Onboarding](tasks/2025-11/006-inventory-product-onboarding.md)
 
-## Content Overview
-
-### Architecture (`architecture/`)
-
--   **Inventory Architecture**: Complete domain model, ER diagrams, and operational flows for the inventory system
--   **Security & User System**: Authentication, authorization, roles, and permissions design
--   **Hashids Identifiers**: Guidelines for secure ID obfuscation in APIs
-
-### Conventions (`conventions/`)
-
--   **Backend**: Laravel standards for controllers, services, actions, repositories, API rules, and seeder system
--   **Frontend**: React/TypeScript routing structure and component organization
--   **Git**: Commit message format and branching strategy
-
-### Tasks (`tasks/`)
-
-Engineering task logs organized by date, documenting:
-
--   Implementation details
--   Technical decisions
--   Progress tracking
--   Code examples and patterns
-
-## Language Strategy
-
--   **English (en/)**: Primary language for code, APIs, and technical documentation
--   **Spanish (es/)**: Secondary language for architecture docs and team collaboration
-
-Both directories maintain identical structure and equivalent content, only differing in language.
-
-## Contributing
-
-When adding new documentation:
-
-1. Create the document in English first (`en/`)
-2. Translate and add to Spanish (`es/`)
-3. Ensure both versions maintain the same structure and content
-4. Update this README if adding new categories
-
-## Quick Links
-
-### English
-
--   [Inventory Architecture](en/architecture/inventory-architecture.md)
--   [Security Architecture](en/architecture/security-and-user-system-architecture.md)
--   [Git Commit Conventions](en/conventions/git/commits.md)
--   [Task Documentation Guide](en/conventions/tasks.md)
-
-### Español
-
--   [Arquitectura de Inventarios](es/architecture/inventory-architecture.md)
--   [Arquitectura de Seguridad](es/architecture/security-and-user-system-architecture.md)
--   [Convenciones de Commits Git](es/conventions/git/commits.md)
--   [Guía de Documentación de Tareas](es/conventions/tasks.md)
-
 ---
 
-**Last Updated**: 2025-11-05
+**Last Updated**: 2026-08-12
 **Maintained by**: SushiGo / ComandaFlow Team

--- a/doc/architecture/inventory-architecture.en.md
+++ b/doc/architecture/inventory-architecture.en.md
@@ -34,13 +34,21 @@ The system must guarantee:
 | **Inventory by Location**      | Stock segregated by `InventoryLocation` (MAIN, KITCHEN, BAR, etc.).         |
 | **Complete Traceability**      | Each movement generates `StockMovement` and detailed lines.                 |
 | **Expandable Architecture**    | Ready for purchases, batches, production, and analytics.                    |
-| **Secure IDs**                 | Internal incremental IDs, external exposed as Hashids.                      |
+| **Secure IDs**                 | Internal incremental IDs, external exposed as `public_id` (ULID).           |
 | **Service-Oriented Layering**  | Thin controllers → Domain services → Models.                                |
 | **Laravel Native**             | Use of Laravel 12 + Spatie Permission native patterns.                      |
 
 ---
 
 ## 3. Domain Model
+
+> **Note (2026-08-12):** the `Item`/`ItemVariant` shapes below (§3.2 ER diagram, §3.7 class diagram)
+> still show today's flat schema, including `sale_price`/`min_stock`/`max_stock`-equivalent fields
+> that the Product vertical is removing from its catalog write path. See
+> [Product Catalog — Target Architecture](product-catalog/product-catalog-architecture.en.md) and
+> [TD-03](../decisions/td-03-product-catalog-separation.md) for the target Product/Variant/Purchase
+> Presentation model and the migration sequence; this document is updated to match once that
+> migration completes (`#442`).
 
 ### 3.1 Main Entities
 
@@ -723,8 +731,18 @@ stateDiagram-v2
 
 ## 5. Obfuscated Identifiers
 
--   No incremental ID is exposed in APIs; we use Hashids to avoid enumeration and information leaks.
--   The complete configuration guide, risks, and helpers are in [Hashids Identifiers](./identifiers-hashids.md).
+> **Stale note (2026-08-12):** this section described a planned Hashids strategy that was never
+> implemented and links to a document that doesn't exist in this repository. The convention actually
+> in use is `public_id` (ULID) via the `HasPublicId`/`SerializesPublicIdAsId` traits — already
+> adopted by `Dish`, `MediaGallery`, `CashAdjustment`, and others. Bringing `Item`/`ItemVariant` (and
+> the rest of this domain) onto that convention is tracked by
+> [#399](https://github.com/pakodiazdev/sushigo/issues/399); the new Product-catalog tables
+> (`Brand`, `InventoryCategory`, `PurchasePresentationTemplate`, `VariantPurchasePresentation`) adopt
+> it from the start — see
+> [Product Catalog — Target Architecture](product-catalog/product-catalog-architecture.en.md) §2.
+
+-   No incremental ID is exposed in APIs; internal auto-increment IDs stay internal, external IDs are
+    ULIDs (`public_id`).
 
 ---
 
@@ -733,10 +751,10 @@ stateDiagram-v2
 | Layer                        | Responsibility                                                    |
 | ---------------------------- | ----------------------------------------------------------------- |
 | **Controllers**              | Receive requests, validate, and delegate to services.             |
-| **FormRequests**             | Validate payloads, decode Hashids, and sanitize data.             |
+| **FormRequests**             | Validate payloads, resolve `public_id` route bindings, and sanitize data. |
 | **Services**                 | Orchestrate business rules (transfers, sales, closures, costing). |
 | **Policies**                 | Authorization per operating unit and role.                        |
-| **Resources / Transformers** | Serialize responses exposing `hashid` and calculated data.        |
+| **Resources / Transformers** | Serialize responses exposing `public_id` (as `id`) and calculated data. |
 
 Main services:
 
@@ -751,7 +769,6 @@ Main services:
 ## 7. References
 
 -   [Tenancy for Laravel](https://tenancyforlaravel.com/docs)
--   [vinkla/hashids](https://github.com/vinkla/hashids)
 -   [Martin Fowler — DDD Aggregates](https://martinfowler.com/bliki/DDD_Aggregate.html)
 -   [Eric Evans — Domain Driven Design](https://domainlanguage.com/ddd/)
 -   [Inventory Management Overview (MS Docs)](https://learn.microsoft.com/en-us/dynamics365/supply-chain/inventory/inventory-overview)

--- a/doc/architecture/inventory-architecture.es.md
+++ b/doc/architecture/inventory-architecture.es.md
@@ -34,13 +34,36 @@ El sistema debe garantizar:
 | **Inventory by Location**      | Stock segregado por `InventoryLocation` (MAIN, KITCHEN, BAR, etc.).                    |
 | **Traceabilidad total**        | Cada movimiento genera `StockMovement` y líneas detalladas.                            |
 | **Expandable Architecture**    | Preparado para compras, lotes, producción y analítica.                                 |
-| **Secure IDs**                 | IDs internos incrementales, externos expuestos como Hashids.                           |
+| **Secure IDs**                 | IDs internos incrementales, externos expuestos como `public_id` (ULID).                |
 | **Service-Oriented Layering**  | Controladores delgados → Servicios de dominio → Modelos.                               |
 | **Laravel Native**             | Uso de patrones propios de Laravel 12 + Spatie Permission.                             |
 
 ---
 
 ## 3. Modelo de dominio
+
+> **Nota (2026-08-12):** las formas de `Item`/`ItemVariant` de abajo (diagrama ER §3.2, diagrama de
+> clases §3.7) todavía muestran el esquema plano actual, incluyendo campos equivalentes a
+> `sale_price`/`min_stock`/`max_stock` que la vertical de Producto está retirando de su ruta de
+> escritura de catálogo. Ver
+> [Product Catalog — Target Architecture](product-catalog/product-catalog-architecture.es.md) y
+> [TD-03](../decisions/td-03-product-catalog-separation.md) para el modelo objetivo de
+> Producto/Variante/Presentación de Compra y la secuencia de migración; este documento se
+> actualizará para coincidir una vez que esa migración concluya (`#442`).
+>
+> **Nota adicional:** esta versión en español anteriormente incluía `Item.is_manufactured` en el
+> diagrama ER, el diagrama de clases y el resumen de clases, con una descripción de negocio que no
+> tiene respaldo real: la migración que debía agregar esa columna
+> (`2025_11_12_092126_add_is_manufactured_to_items_table.php`) quedó vacía (no-op). Se removió de
+> esta versión para que coincida con la versión en inglés (que nunca lo tuvo); el campo muerto en
+> `product-wizard.tsx` que lo leía/escribía sigue señalado para limpieza en
+> [Product Catalog — Target Architecture](product-catalog/product-catalog-architecture.es.md) §9.4
+> (`#429`). Por la misma razón, también se removió del resumen de clases (§3.8) el bloque
+> "Aplicación"/"Casos de uso" de `UomConversion` que daba ejemplos de `PRODUCTO` (bandeja/caja) —
+> contradecía la propia regla de la §3.3 ("Only INSUMO enables multiple conversions; PRODUCTO and
+> ACTIVO operate 1:1") y es exactamente el antipatrón que
+> [Product Catalog — Target Architecture](product-catalog/product-catalog-architecture.es.md) §4 y
+> §9.3 reemplazan con `VariantPurchasePresentation`; la versión en inglés nunca tuvo ese bloque.
 
 ### 3.1 Entidades principales
 
@@ -127,7 +150,6 @@ erDiagram
     enum type "INSUMO|PRODUCTO|ACTIVO"
     boolean is_stocked
     boolean is_perishable
-    boolean is_manufactured
   }
 
   ITEM_VARIANT {
@@ -341,7 +363,6 @@ classDiagram
     +type: ItemType
     +is_stocked: bool
     +is_perishable: bool
-    +is_manufactured: bool
     +registerVariant(data)
   }
 
@@ -595,10 +616,7 @@ classDiagram
     -   Propiedades: `id`, `operating_unit_id`, `name`, `type`, `is_primary`.
     -   Acciones: `markPrimary()` (se usa en ajustes iniciales de la unidad).
 -   **Item**
-    -   Propiedades: `id`, `sku`, `name`, `type`, `is_stocked`, `is_perishable`, `is_manufactured`.
-    -   **`is_manufactured`**: Indica si el item se fabrica/prepara internamente (`true`) o se compra para reventa (`false`). Esto permite diferenciar entre:
-        -   **Productos manufacturados** (`is_manufactured=true`): Platillos del menú que se preparan en cocina usando insumos según recetas.
-        -   **Productos de reventa** (`is_manufactured=false`): Items que se compran ya terminados (ej: dulcería coreana, bebidas embotelladas) y se revenden directamente sin transformación.
+    -   Propiedades: `id`, `sku`, `name`, `type`, `is_stocked`, `is_perishable`.
     -   Acciones: `registerVariant(data)` encapsula la creación de variantes a través de factories/acciones.
 -   **ItemVariant**
     -   Propiedades: `id`, `item_id`, `code`, `name`, `uom_id`, `track_lot`, `track_serial`.
@@ -608,11 +626,6 @@ classDiagram
     -   Usada como catálogo; no expone métodos adicionales.
 -   **UomConversion**
     -   Propiedades: `id`, `from_uom_id`, `to_uom_id`, `factor`, `tolerance`, `is_active`.
-    -   **Aplicación**: Disponible para cualquier item con `is_stocked=true`, no solo INSUMOS.
-    -   **Casos de uso**:
-        -   **INSUMO**: 1 kg = 1000 g (conversión entre escalas de medida)
-        -   **PRODUCTO manufacturado**: 1 bandeja = 8 piezas (presentaciones de venta)
-        -   **PRODUCTO reventa**: 1 caja = 24 unidades (compra mayoreo vs venta individual)
     -   Acción: `convert(qty)` aplica factor y tolerancia (en la práctica se resuelve vía `TransfersService`/`CostingService`).
 -   **Stock**
     -   Propiedades: `id`, `inventory_location_id`, `item_variant_id`, `on_hand`, `reserved`.
@@ -733,8 +746,18 @@ stateDiagram-v2
 
 ## 5. Identificadores ofuscados
 
--   Ningún ID incremental se expone en APIs; utilizamos Hashids para evitar enumeración y fugas de información.
--   La guía completa de configuración, riesgos y helpers está en [Identificadores Hashids](./identifiers-hashids.md).
+> **Nota de obsolescencia (2026-08-12):** esta sección describía una estrategia Hashids planeada que
+> nunca se implementó y enlaza a un documento que no existe en este repositorio. La convención
+> realmente en uso es `public_id` (ULID) mediante los traits `HasPublicId`/`SerializesPublicIdAsId`
+> — ya adoptada por `Dish`, `MediaGallery`, `CashAdjustment`, entre otros. Migrar `Item`/`ItemVariant`
+> (y el resto de este dominio) a esa convención se rastrea en
+> [#399](https://github.com/pakodiazdev/sushigo/issues/399); las nuevas tablas del catálogo de
+> Producto (`Brand`, `InventoryCategory`, `PurchasePresentationTemplate`,
+> `VariantPurchasePresentation`) la adoptan desde el inicio — ver
+> [Product Catalog — Target Architecture](product-catalog/product-catalog-architecture.es.md) §2.
+
+-   Ningún ID incremental se expone en APIs; los IDs internos autoincrementales permanecen internos,
+    los IDs externos son ULIDs (`public_id`).
 
 ---
 
@@ -743,10 +766,10 @@ stateDiagram-v2
 | Capa                         | Responsabilidad                                                         |
 | ---------------------------- | ----------------------------------------------------------------------- |
 | **Controllers**              | Reciben requests, validan y delegan a servicios.                        |
-| **FormRequests**             | Validan payloads, decodifican Hashids y sanitizan datos.                |
+| **FormRequests**             | Validan payloads, resuelven route bindings por `public_id` y sanitizan datos. |
 | **Services**                 | Orquestan reglas de negocio (transferencias, ventas, cierres, costing). |
 | **Policies**                 | Autorización por unidad operativa y rol.                                |
-| **Resources / Transformers** | Serializan respuestas exponiendo `hashid` y datos calculados.           |
+| **Resources / Transformers** | Serializan respuestas exponiendo `public_id` (como `id`) y datos calculados. |
 
 Servicios principales:
 
@@ -761,7 +784,6 @@ Servicios principales:
 ## 7. Referencias
 
 -   [Tenancy for Laravel](https://tenancyforlaravel.com/docs)
--   [vinkla/hashids](https://github.com/vinkla/hashids)
 -   [Martin Fowler — DDD Aggregates](https://martinfowler.com/bliki/DDD_Aggregate.html)
 -   [Eric Evans — Domain Driven Design](https://domainlanguage.com/ddd/)
 -   [Inventory Management Overview (MS Docs)](https://learn.microsoft.com/en-us/dynamics365/supply-chain/inventory/inventory-overview)

--- a/doc/architecture/product-catalog/product-catalog-architecture.en.md
+++ b/doc/architecture/product-catalog/product-catalog-architecture.en.md
@@ -1,0 +1,577 @@
+# 🍱 Product Inventory — Target Architecture & Migration Plan
+
+**Scope**
+Target design for the SushiGo Product inventory vertical: Product (`Item`, `type=PRODUCTO`) →
+Variant → Purchase Presentation, the progressive SlidePanel UI, API contracts, invariants, public
+identifiers, and the incremental migration/removal plan away from the current `ProductWizard`.
+Produced by [issue #421](https://github.com/pakodiazdev/sushigo/issues/421) as a design-only
+deliverable — no migrations, endpoints, production UI, seeders, or legacy deletion happen here.
+
+This document is scoped to **Products only** (Milestone A of the roadmap below). Insumos need a
+later workflow adapted to physical UOM conversions and recipe consumption; Fixed Assets remain a
+separate, deferred domain. It complements, and does not replace,
+[Inventory Architecture & Design](../inventory-architecture.en.md), which still owns
+Branch/OperatingUnit/InventoryLocation/Stock/StockMovement. See that document's §3 (flat
+Item/ItemVariant schema, including the cost/price/stock-threshold fields this design moves out) and
+§5 (Hashids vs. `public_id`) for notes on where its own content is now superseded by this one.
+
+---
+
+## 1. Context
+
+The current Product-creation path is a single four-step `ProductWizard`
+(`code/webapp/src/components/inventory/product-wizard.tsx`) that mixes:
+
+1. Item identity (`sku, name, description, type, is_stocked, is_perishable, is_active`, plus a
+   dead `is_manufactured` field with no backing column — see §9.4).
+2. Variant identity **and** commercial fields in one request (`code, name, uom_id, sale_price,
+   min_stock, max_stock, is_active`).
+3. A write directly to the **global** `uom_conversions` table, framed as if it were a
+   product-specific packaging factor.
+4. Opening balance per location, via a separate `/inventory/opening-balance` endpoint chained
+   client-side.
+
+Building the next increment of the wizard directly would bake these unresolved boundaries into new
+code. This document finalizes the target shape first so the implementation backlog (`#422`–`#442`,
+already filed) can build against a stable contract. `doc/conventions/tasks.md` documents the
+`CAT-01`…`STK-06` planning-alias *convention* itself (lane glossary, format, a two-row illustrative
+example); the actual full alias-to-issue mapping for this roadmap lives in the local, gitignored
+`dev-lab plan/inventory-product-catalog-redesign.md` §11 — not committed to this repo, consistent
+with that convention's own rule that aliases never appear as a second live copy inside a repo file.
+
+---
+
+## 2. Design Principles
+
+| Principle | Description |
+|---|---|
+| **Identity vs. transaction** | Product/Variant capture *what something is*. Cost, price, and stock are *events* recorded elsewhere and never written back onto catalog rows as permanent fields. |
+| **Explicit, reusable packaging** | Commercial packages (`Box x24`, `Pack x6`) are named, admin-managed templates assigned per Variant — never an ambiguous global `UOM_CONVERSION` row reused across unrelated products. |
+| **Deactivate, don't delete** | Every new catalog table follows the existing `is_active` + `SoftDeletes` pattern already used by `Item`/`ItemVariant`. Rows referenced by history are deactivated, never hard-deleted. |
+| **Incremental replacement** | Existing Item/ItemVariant CRUD, media integration, permissions, and test infrastructure are extended, not discarded. Legacy fields/routes/UI are removed only after their replacement has shipped (see §9). |
+| **`items` stays the internal table** | `Item`/`ItemVariant` remain the internal Eloquent models during incremental replacement. "Product" is a UI/API vocabulary scoped to `type = PRODUCTO`, not a new table, to avoid forking the catalog mid-migration. |
+| **Public IDs, one strategy** | Every new table exposes `public_id` (ULID) via the existing `HasPublicId` + `SerializesPublicIdAsId` traits — the same convention already used by `Dish`, `MediaGallery`, `CashAdjustment`, etc. — coordinated with, not duplicating, [#399](https://github.com/pakodiazdev/sushigo/issues/399). |
+
+---
+
+## 3. Domain Model
+
+### 3.1 Entities
+
+- **Brand** — optional catalog of manufacturer/commercial brands (`Coca-Cola`, `Buldak`). Normalized,
+  soft-deletable, independent of Dish categories.
+- **InventoryCategory** — required catalog of inventory taxonomy (`Beverages`, `Instant Noodles`).
+  A **new**, separate taxonomy — not `DishCategory`, which belongs to the unrelated Menu/Dishes
+  domain (`code/webapp/src/pages/productos.tsx`).
+- **Item** (`type = PRODUCTO`) — the Product's catalog identity: name, brand, category, description,
+  media, active state. No cost, price, opening stock, location, or UOM.
+- **ItemVariant** — the concrete inventoried presentation (e.g. *Coca-Cola Original 600 ml*): SKU
+  (`code`), unit barcode, base UOM, lot/serial tracking, active state. No cost, sale price, or stock
+  thresholds.
+- **PurchasePresentationTemplate** — a reusable, admin-managed commercial package definition
+  (`Unit`, `Pack x6`, `Box x24`) with a package type and a base-unit quantity.
+- **VariantPurchasePresentation** — the assignment of a template to a specific Variant, with an
+  optional package barcode and a default flag.
+
+Everything downstream of these six entities — acquisition cost, stock, and branch pricing — is
+explicitly **out of scope** for the catalog write path; see §4.
+
+### 3.2 Domain / ER Diagram
+
+```mermaid
+erDiagram
+  BRAND ||--o{ ITEM : brands
+  INVENTORY_CATEGORY ||--o{ ITEM : categorizes
+  ITEM ||--o{ ITEM_VARIANT : has
+  UNIT_OF_MEASURE ||--o{ ITEM_VARIANT : base_uom
+  ITEM_VARIANT ||--o{ VARIANT_PURCHASE_PRESENTATION : offered_as
+  PURCHASE_PRESENTATION_TEMPLATE ||--o{ VARIANT_PURCHASE_PRESENTATION : instantiates
+  MEDIA_ATTACHMENT }o--|| ITEM : gallery_for
+
+  BRAND {
+    bigint id PK
+    string public_id
+    string name
+    boolean is_active
+  }
+
+  INVENTORY_CATEGORY {
+    bigint id PK
+    string public_id
+    string name
+    integer position
+    boolean is_active
+  }
+
+  ITEM {
+    bigint id PK
+    string public_id
+    bigint brand_id FK "nullable"
+    bigint inventory_category_id FK "required for PRODUCTO"
+    string sku "nullable, deprecated for PRODUCTO"
+    string name
+    text description
+    enum type "INSUMO|PRODUCTO|ACTIVO"
+    boolean is_active
+  }
+
+  ITEM_VARIANT {
+    bigint id PK
+    string public_id
+    bigint item_id FK
+    bigint uom_id FK
+    string code "the SKU"
+    string barcode "nullable, app-validated unique (no DB constraint yet)"
+    string name
+    boolean track_lot
+    boolean track_serial
+    boolean is_active
+  }
+
+  PURCHASE_PRESENTATION_TEMPLATE {
+    bigint id PK
+    string public_id
+    string code
+    string name
+    enum package_type "UNIT|PACK|BOX|TRAY"
+    decimal base_unit_quantity
+    bigint compatible_dimension_uom_id FK
+    boolean is_active
+  }
+
+  VARIANT_PURCHASE_PRESENTATION {
+    bigint id PK
+    string public_id
+    bigint item_variant_id FK
+    bigint template_id FK
+    string package_barcode "nullable, unique"
+    boolean is_default
+    boolean is_active
+    json meta
+  }
+```
+
+### 3.3 Cardinalities and lifecycle rules
+
+| Relationship | Cardinality | Rule |
+|---|---|---|
+| Brand → Item | 1‑to‑many, optional | `Item.brand_id` nullable. Deactivating a Brand does not cascade; it only blocks new assignments (validated in the FormRequest, not a DB trigger). |
+| InventoryCategory → Item | 1‑to‑many, required | `Item.inventory_category_id` NOT NULL for `type = PRODUCTO`. A category cannot be deactivated while active Products reference it — enforced in the deactivate endpoint, not a DB constraint (soft-delete already allows historical FK integrity). |
+| Item → ItemVariant | 1‑to‑many | No DB-level minimum. Business rule (app layer, not schema): a Product needs at least one **active** Variant to be considered sellable/orderable by downstream domains (purchasing, pricing) — the catalog itself allows a Product with zero Variants mid-authoring. |
+| ItemVariant → VariantPurchasePresentation | 1‑to‑many | A Variant may have zero presentations initially (falls back to "no packaging configured" in purchasing UIs, which is a valid state during CAT-04/CAT-05 rollout). |
+| PurchasePresentationTemplate → VariantPurchasePresentation | 1‑to‑many, reusable | The same template (e.g. `BOX_24`) is assigned to many Variants across many Products. Templates used by any assignment (past or present) are deactivated, never deleted. |
+| VariantPurchasePresentation.is_default | exactly one active default per Variant | Enforced with a partial unique index (`item_variant_id` where `is_default = true AND is_active = true`) plus a service-level check on write, mirroring the existing `Stock` unique-location-variant safe-creation pattern. |
+
+### 3.4 SKU and barcode ownership
+
+- **`ItemVariant.code`** is the authoritative SKU. It already exists, is unique today, and needs no
+  rename — only clearer documentation (Swagger description, this doc) that it *is* the SKU. Unlike
+  `barcode` below, `code` already has a real DB-level `unique()` constraint
+  (`create_item_variants_table` migration), so data corruption isn't a risk — but the same
+  create-only gap applies to its *validation*: `CreateItemVariantRequest` validates
+  `unique:item_variants,code`, `UpdateItemVariantRequest` doesn't accept `code` at all today, and
+  §6's PATCH endpoint (which accepts "same shape as create, partial") will need its own
+  `unique:item_variants,code,{id}` rule once it does — without it, a duplicate `code` on PATCH would
+  surface as a raw, unhandled DB constraint violation instead of a clean `422`. Same owner as the
+  barcode gap below: `#424` (`CAT-03`).
+- **`Item.sku`** becomes nullable and deprecated for `type = PRODUCTO`. It is not read or written by
+  the new Product create/edit contract. It is not dropped in this vertical — schema deletion is a
+  Milestone C concern (`#442`, "Remove legacy Inventory fields...") once no consumer reads it.
+- **`ItemVariant.barcode`** is the **unit** barcode (already exists, nullable). Today it is only
+  validated as `unique:item_variants,barcode` on `CreateItemVariantRequest` — there is no
+  database-level unique constraint, only a plain index (`add_barcode_to_item_variants_table`
+  migration), and that create-path check is the *only* place uniqueness is enforced at all:
+  `UpdateItemVariantRequest` doesn't accept `barcode` (or `code`/`uom_id`) as a field today, so under
+  the **current** contract a Variant's barcode can only ever be set once, at creation — there's no
+  live gap yet because there's no update path to race against. That changes with this design's own
+  §6 API contract, which adds `barcode?` to the PATCH endpoint: once that ships, the create-only
+  validation stops being sufficient, and both a DB-level unique constraint *and* an update-path
+  `unique:item_variants,barcode,{id}` rule (excluding the row itself) are needed — flagged here for
+  `#424` (`CAT-03`) to add both together, rather than shipping the new PATCH capability with only
+  half of yesterday's protection.
+- **`VariantPurchasePresentation.package_barcode`** is a **separate** namespace from unit barcode —
+  the barcode printed on a box/pack. Being a new table, it should get a real DB-level unique
+  constraint from the start (unlike the legacy gap above). A package barcode and a unit barcode are
+  allowed to coincide in principle only if they belong to different physical objects; the design does
+  not need a cross-column uniqueness constraint because they are scanned in different operational
+  contexts (receiving a case vs. selling a piece).
+
+### 3.5 Brand / Category requirements and first Variant attributes
+
+Resolved from the plan's own working assumptions (`plan/inventory-product-catalog-redesign.md` §17,
+cited by this issue's `## 🔗 References`), validated against the current schema audit and finalized
+here:
+
+- **Brand is optional.** Not every product line has a distinct brand worth filtering by; forcing one
+  would either invent placeholder brands or block catalog entry. Optional with a nullable FK keeps
+  the filter usable without becoming a data-entry tax.
+- **InventoryCategory is required.** Every Product needs a rubro for navigation/filtering and for
+  future reporting; unlike Brand, there is no meaningful "uncategorized" bucket the UI should have to
+  render around.
+- **First-class Variant attributes** (beyond name/SKU/barcode/base UOM, which are already agreed):
+  `description` (nullable text, free-form flavor/size/content note — e.g. "Original, 600 ml"),
+  `track_lot`/`track_serial` (already exist, kept), `is_active`. A generic configurable-attribute
+  engine (separate `flavor`, `size`, `content` columns or an EAV table) is explicitly **not** built
+  in Milestone A — the current SushiGo catalog (Coca-Cola, Buldak, Peelez, Ramune, Mochis) is fully
+  representable with a free-text `description` plus the Variant's own `name`, and a generic engine
+  without real multi-attribute-filtering demand would be speculative scope. Revisit if a future
+  catalog needs structured attribute filtering (e.g. "show me all 600 ml variants across brands").
+
+---
+
+## 4. Responsibility boundaries
+
+The current wizard's core defect is collapsing five different responsibilities into one write.
+The target design separates them explicitly:
+
+| Responsibility | Owner | Where it lives | Milestone |
+|---|---|---|---|
+| Catalog identity | Product / Variant | `items`, `item_variants` (identity columns only) | A (this doc) |
+| Commercial packaging | Purchase Presentation | `purchase_presentation_templates`, `variant_purchase_presentations` | A (`#426`/`#427`) |
+| Physical UOM conversion | `UnitOfMeasure` / `UomConversion` | Existing global tables — reserved for genuine dimensional equivalences (`kg → g`), **not** product packaging | Unchanged; Insumos-only going forward |
+| Acquisition cost | Purchase Receipt | Future `purchase_receipt_lines`, snapshotting the presentation factor at receipt time | B (`#431`/`#432`) |
+| Stock balance | `Stock` / `StockMovement` | Existing tables, posted by receiving/sale/adjustment services | Unchanged (hardening in `#430`/`#438`) |
+| Branch sale price | Price List | Future `price_lists` + variant price assignment, effective-dated per branch | B (`#435`/`#436`) |
+
+`OpeningBalanceService` (`code/api/app/Services/Inventory/OpeningBalanceService.php`) already writes
+`last_unit_cost`/`avg_unit_cost` transactionally today — confirming cost is *already* treated as a
+transactional side effect in the service layer, even though `CreateItemVariantController` currently
+also lets `sale_price` be set directly on create. The target contract removes that second path: cost
+and price are never accepted by a Product/Variant create-or-update request, full stop.
+
+---
+
+## 5. Product SlidePanel UX flow
+
+### 5.1 Navigation shape
+
+```text
+Products page (/inventory/products)
+└── New Product  ─────────────────────────────┐
+    │                                          │
+    ▼                                          │
+  SlidePanel: create mode                      │
+    ├── Name, Brand (optional), Category*,     │
+    │   Description, Images, Active            │
+    └── [Save] ───────────────────────────────►┤
+                                                 ▼
+                                    SlidePanel: same instance,
+                                    now in saved-detail mode
+                                        ├── General information (edit-in-place)
+                                        ├── Images (existing gallery pattern)
+                                        └── Variant catalog
+                                              ├── [+ New Variant] → nested slide
+                                              │     Variant form: Name, SKU(code),
+                                              │     Barcode, Base UOM, Description,
+                                              │     track_lot/track_serial, Active
+                                              │     [Save] → nested detail mode
+                                              └── Variant card → nested slide
+                                                    Variant detail
+                                                      └── Purchase presentations
+                                                            ├── [+ Assign template]
+                                                            │     (existing Unit/Pack/Box
+                                                            │     templates, admin can also
+                                                            │     open template manager)
+                                                            └── list: template name,
+                                                                  package type, factor,
+                                                                  package barcode, default,
+                                                                  active
+```
+
+`*` Category is required at save time; the form allows leaving it unselected while drafting only if
+the SlidePanel defers validation to submit (standard `react-hook-form` + `zod` behavior — no special
+casing needed).
+
+### 5.2 State diagram
+
+```mermaid
+stateDiagram-v2
+  [*] --> Closed
+  Closed --> CreateMode: New Product
+  CreateMode --> Closed: Cancel / Esc
+  CreateMode --> DetailMode: Save succeeds (same panel instance)
+  DetailMode --> Closed: Close
+
+  state DetailMode {
+    [*] --> GeneralInfo
+    GeneralInfo --> VariantList
+    VariantList --> VariantCreate: + New Variant
+    VariantCreate --> VariantDetail: Save succeeds
+    VariantList --> VariantDetail: Select existing Variant
+    VariantDetail --> VariantList: Back
+    VariantDetail --> PresentationList: Purchase presentations
+    PresentationList --> PresentationAssign: + Assign template
+    PresentationAssign --> PresentationList: Save succeeds / Cancel
+    PresentationList --> VariantDetail: Back
+  }
+```
+
+This is a genuinely new interaction for this codebase: today's `SlidePanel`
+(`code/webapp/src/components/ui/slide-panel.tsx`) is a generic single-panel primitive, and every
+existing usage (e.g. Dishes) swaps between two separate panel instances (a details panel and a form
+panel) rather than one panel transitioning its own content in place. `CAT-02` (`#423`) is the first
+consumer of the create→detail transition; `CAT-04`/`CAT-06` (`#425`/`#427`) extend the same panel
+instance with nested Variant/Presentation levels rather than opening new top-level panels, so the
+user never loses the Product they were editing.
+
+### 5.3 States to design for (per CAT-02/CAT-04/CAT-06 acceptance criteria)
+
+Loading, empty (no Variants yet / no presentations yet), validation error (inline, per field),
+submit error (toast + field errors via `getApiValidationErrors`), keyboard/focus (focus returns to
+the triggering row on close, nested slides trap focus), responsive (mobile: full-screen slide), and
+dark mode (existing `dark:` token conventions — no new Button/Label primitives invented ahead of
+[[project_button_centralization]]/[[project_label_centralization]] if those land first).
+
+---
+
+## 6. API contract outline
+
+All endpoints versioned under `/api/v1`, all use the existing `SingleActionController` (`__invoke`)
+pattern. Route-model-binding via `HasPublicId` (`{item:public_id}` style) and
+`SerializesPublicIdAsId` responses are an **existing convention elsewhere** in the codebase (`Dish`,
+`MediaGallery`, `CashAdjustment`) — `Item`/`ItemVariant` don't have it yet, since `#399` ("Expose
+public_id (ULID) for Item/ItemVariant...") is still open. This design's endpoints assume `#399`
+lands as a prerequisite, not a parallel option: every path below (`{product}`, `{variant}`, etc.)
+is written as a `public_id`, so `#422`/`#424` need `#399`'s migration and trait adoption in place
+(or bundled into the same PR) before these routes can bind on anything but the internal numeric ID.
+Permissions follow the existing granular `resource.action` convention rather than the coarser
+per-domain style used by Dishes, to stay consistent with the current `items.*` mapping `#400`
+already codifies.
+
+| Method | Path | Request (create/update) | Permission | Notes |
+|---|---|---|---|---|
+| GET | `/inventory/products` | — (query: `search, brand_id, inventory_category_id, is_active, page`) | `items.view` | Filters to `type = PRODUCTO` server-side; returns variant count per row for the list. |
+| POST | `/inventory/products` | `name, brand_id?, inventory_category_id, description?, media_gallery_id?, owner_token?, is_active?` | `items.create` | No `sku` accepted from this contract (kept nullable/legacy). No cost/price/stock fields. |
+| GET | `/inventory/products/{product}` | — | `items.view` | Includes brand, category, media gallery, variant summary. |
+| PATCH | `/inventory/products/{product}` | Same shape as create, partial | `items.update` | |
+| DELETE | `/inventory/products/{product}` | — | `items.delete` | Soft-delete / deactivate, existing pattern. |
+| GET | `/inventory/products/{product}/variants` | — | `items.view` | |
+| POST | `/inventory/products/{product}/variants` | `name, code, barcode?, uom_id, description?, track_lot?, track_serial?, is_active?` | `items.create` | `item_id` comes from the route, not the body — removes the global Item selector the plan doc flags. No `sale_price`/`min_stock`/`max_stock`/cost fields — this is the contract change from today's `CreateItemVariantRequest`. |
+| GET | `/inventory/products/{product}/variants/{variant}` | — | `items.view` | |
+| PATCH | `/inventory/products/{product}/variants/{variant}` | Same shape as create, partial | `items.update` | |
+| DELETE | `/inventory/products/{product}/variants/{variant}` | — | `items.delete` | |
+| GET | `/inventory/purchase-presentation-templates` | — (query: `is_active, package_type`) | `purchase_presentation_templates.view` | Global, not Product-scoped. |
+| POST | `/inventory/purchase-presentation-templates` | `code, name, package_type, base_unit_quantity, compatible_dimension_uom_id, is_active?` | `purchase_presentation_templates.manage` | Admin-managed; deliberately a coarser single `manage` permission (create+update+deactivate) since this is low-frequency catalog governance, not daily product editing. |
+| PATCH / DELETE | `/inventory/purchase-presentation-templates/{template}` | — | `purchase_presentation_templates.manage` | Deactivate, not delete, once referenced by any assignment. |
+| GET | `/inventory/products/{product}/variants/{variant}/purchase-presentations` | — | `items.view` | |
+| POST | `/inventory/products/{product}/variants/{variant}/purchase-presentations` | `template_id, package_barcode?, is_default?` | `items.update` | Assignment is scoped to a Variant the user can already edit — no new permission needed here, unlike template governance above. |
+| PATCH / DELETE | `.../purchase-presentations/{assignment}` | `package_barcode?, is_default?` | `items.update` | |
+| GET | `/inventory/brands` | — | `brands.view` | |
+| POST / PATCH / DELETE | `/inventory/brands[/{brand}]` | `name, is_active?` | `brands.create` / `brands.update` / `brands.delete` | |
+| GET | `/inventory/inventory-categories` | — | `inventory_categories.view` | |
+| POST / PATCH / DELETE | `/inventory/inventory-categories[/{category}]` | `name, position?, is_active?` | `inventory_categories.create` / `.update` / `.delete` | Distinct from `dish_categories.*` — see §3.1. |
+
+**New permissions to register** (Development/Production `PermissionSeeder`, per `#422`/`#426`):
+`brands.view/create/update/delete`, `inventory_categories.view/create/update/delete`,
+`purchase_presentation_templates.view/manage`. No new permission is needed for the assignment
+endpoints (reuse `items.*`) — see the table above for why.
+
+**Route naming decision:** `/inventory/products` is a **new** frontend route and API path prefix,
+distinct from both `/inventory/items` (today's generic Item list across all three `type` values,
+retained until `#429` removes the wizard entry point that depends on it) and `/productos` (the
+unrelated Dish/Menu catalog — see `code/webapp/src/pages/productos.tsx`). This was a genuine naming
+gap the plan doc didn't resolve explicitly; decided here to avoid the collision the audit surfaced.
+
+---
+
+## 7. Migration, compatibility, and legacy-removal sequencing
+
+This is sequencing guidance for the already-filed backlog (`#422`–`#442`); it does not change any
+issue's scope, only clarifies two points the audit surfaced (§9.3, §9.4) and confirms the dependency
+order already reflects this design.
+
+1. **`#422`** (`CAT-01`) — Add `brands`, `inventory_categories` tables and columns on `items`
+   (`brand_id` nullable FK, `inventory_category_id` FK). Additive only; no existing column removed.
+   Item `sku` becomes nullable if it isn't already (it is currently `NOT NULL unique` — this is a
+   real schema change to sequence carefully: existing rows keep their `sku`, new Product writes stop
+   populating it).
+2. **`#423`** (`CAT-02`) — New `/inventory/products` SlidePanel UI, additive, does not touch
+   `/inventory/items`.
+3. **`#424`** (`CAT-03`) — `ItemVariant` write contract stops accepting `sale_price, min_stock,
+   max_stock` from the Product/Variant path. **Compatibility:** keep the columns in the database
+   (existing rows, existing read paths in stock/reporting keep working); only the *write* surface
+   used by the new UI changes. The legacy `item-variants` global page and old `variant-form.tsx`
+   keep working against the old contract until `#429` removes them.
+4. **`#425`/`#426`/`#427`** (`CAT-04`/`CAT-05`/`CAT-06`) — Additive: new tables
+   (`purchase_presentation_templates`, `variant_purchase_presentations`), new nested UI. No
+   compatibility concern — nothing existing depends on these tables.
+5. **`#428`** (`CAT-07`) — Seed data. No schema change.
+6. **`#429`** (`CAT-08`) — First real deletion point: `ProductWizard` and its tests/exports/query
+   params, old opening-balance-in-product-creation flow, and (per §9.4 below) the dead
+   `is_manufactured` frontend field and its empty no-op migration. Only runs after `#423`–`#428` have
+   shipped and been verified to cover the wizard's functionality. The global Variant page
+   (`/inventory/item-variants`) is removed here only if, at that point, no independent workflow still
+   needs it — the plan doc already frames this as a conditional check, not a guaranteed deletion.
+7. **`#438`/`#439`/`#440`/`#441`** and Milestone B (`#431`–`#437`) proceed per the existing dependency
+   map in `plan/inventory-product-catalog-redesign.md` §15 — unchanged by this document.
+8. **`#442`** (`STK-06`, Milestone C) — Final legacy-field removal: drop `Item.sku` and the
+   now-unused `ItemVariant.last_unit_cost/avg_unit_cost/sale_price/min_stock/max_stock` columns (once
+   `#434`'s single cost source of truth and `#439`'s per-location thresholds have both landed), and
+   reconcile this document and `inventory-architecture.en.md`/`.es.md` with the as-built system.
+
+**Rollback:** every migration in steps 1 and 4 is additive (new nullable columns / new tables) — a
+rollback is a plain `migrate:rollback` with no data-loss risk before step 8. Step 8 is the only
+destructive migration in the whole sequence and is explicitly gated behind two independent
+prerequisite issues landing first, plus a reconciliation pass — not a same-PR deletion.
+
+---
+
+## 8. Decisions and open items
+
+### 8.1 Decided in this document
+
+- Brand optional, InventoryCategory required (§3.5).
+- First-class Variant attributes limited to `description` beyond the already-agreed
+  name/SKU/barcode/base UOM/lot-serial/active — no generic attribute engine in Milestone A (§3.5).
+- `/inventory/products` is a new route/path prefix, distinct from `/inventory/items` and `/productos`
+  (§6).
+- Purchase-presentation **template** management uses a coarser `purchase_presentation_templates.manage`
+  permission; **assignment** to a Variant reuses `items.update` rather than a new permission (§6).
+- Branch is the primary price-list attachment target; Operating Unit overrides (e.g. for temporary
+  events) are an explicit extension point for `#435`, not built in Milestone A — consistent with
+  `#435`'s own title ("branch or operating context").
+- Location+Variant replenishment thresholds (`#439`, `STK-03`) do not inherit a default from
+  Operating Unit level in the first slice — every Location+Variant pair is configured explicitly.
+  **Why:** the plan doc frames inheritance as conditional ("if justified") with no operational
+  evidence yet that branches share identical thresholds; the conservative reading is no inheritance
+  until real multi-location usage shows repetitive configuration is a real friction point.
+
+### 8.2 Explicit blocker — owner assigned, not resolvable from code or docs
+
+- **Exact commercial names/spellings for Buldak and Peelez product lines** (and their flavors/sizes)
+  are real-world catalog facts, not something derivable from the repository. **Blocker owner:**
+  `#428` (`CAT-07` — seed data) must confirm exact names before writing seeders; this does not block
+  any other issue in Milestone A, since `#422`–`#427` build the contract and UI generically.
+
+### 8.3 Explicitly deferred, not a blocker
+
+- A per-Variant **custom** purchase presentation that doesn't match any reusable template — the plan
+  doc's own §5 already excludes this from `#426`, framing reusable templates as the only Milestone A
+  mechanism. No new decision needed here; revisit only if a real product needs an un-reusable
+  one-off package.
+
+---
+
+## 9. Current design assessment (audit findings feeding this design)
+
+### 9.1 Backend
+
+`items`/`item_variants` already separate soft-deletable, `is_active`-flagged rows — the pattern this
+design extends rather than replaces. `CreateItemRequest` is already narrow (no cost/price); the gap
+is on the Variant write path on **both** sides — `CreateItemVariantRequest` **and**
+`UpdateItemVariantRequest` each independently accept `sale_price, min_stock, max_stock` directly
+today, so `#424` must remove the fields from both FormRequests, not just the create path.
+`ItemPolicy`/`ItemVariantPolicy` currently authorize unconditionally (`#400`, in progress in
+workspace `sushigo-a` at the time of this audit) — this design's FormRequests must call `$this->user()
+->can(...)` against the real policy once `#400` lands, per `#424`'s existing dependency note; `#421`
+itself needs no code change since it is read-only.
+
+### 9.2 Frontend
+
+No existing component implements the create→same-panel-detail transition (§5.2) — every current
+`SlidePanel` usage swaps two separate panel instances instead. `/productos` is the Dish/Menu catalog,
+not Products — a naming trap this design avoids by picking `/inventory/products` (§6).
+
+### 9.3 UOM conversions
+
+`App\Services\Inventory\Concerns\ConvertsUomQuantities` resolves a global `UomConversion` by UOM pair
+with no scoping to a specific Item/Variant — exactly the ambiguity §5 of the plan doc (and §4 above)
+replaces with Variant-scoped `VariantPurchasePresentation` for commercial packaging. The global table
+remains valid for genuine physical dimensional equivalences on Insumos.
+
+### 9.4 Pre-existing dead code (flagged for `#429`, not fixed here)
+
+`2025_11_12_092126_add_is_manufactured_to_items_table.php` is an empty no-op migration (both `up()`
+and `down()` bodies are blank) — `is_manufactured` was never actually added to the `items` table.
+The dead field reaches further than just the frontend wizard:
+
+- **Frontend component:** `product-wizard.tsx` reads/writes an `is_manufactured` field with no
+  backing column.
+- **Frontend shared type:** `types/inventory.ts` declares `is_manufactured: boolean` on the shared
+  Item type every inventory component imports — the dead field is part of the type contract, not
+  just one component's local state.
+- **Frontend tests:** `product-wizard.test.tsx`, `item-form.test.tsx`, `item-details.test.tsx`,
+  `variant-details.test.tsx`, and `types/__tests__/inventory.test.ts` all assert on
+  `is_manufactured` — any cleanup has to update five test files, not just the component and the
+  type.
+- **Backend, read path:** `ShowItemController.php` unconditionally includes
+  `'is_manufactured' => $item->is_manufactured` in every Product show response — since the column
+  doesn't exist, Eloquent's magic `__get` returns `null` for the undefined attribute, so every
+  caller of this endpoint receives a permanently-`null`, meaningless field.
+- **Backend, filter path:** `ListItemsController.php`'s Swagger annotation documents an
+  `is_manufactured` query filter, but no filtering logic for it exists anywhere in
+  `Concerns/FiltersItemListing.php` — the documented parameter is a silent no-op that misleads API
+  consumers (and Swagger UI users) into thinking it filters results.
+
+This is a pre-existing defect, unrelated to and not fixed by this design-only issue — noted here
+with its full surface area so `#429` (wizard removal) can clean up all nine locations together
+(one component, one shared type, five tests, two backend controllers) instead of discovering them
+one at a time, since most are outside the wizard component itself and easy to miss.
+
+### 9.5 Seeders
+
+No seeder currently creates `Item`/`ItemVariant` rows. `doc/conventions/testing/test-data-seeders.md`
+already reserves `InventoryTestSeeder.php` as a documented "future" slot in its Testing tier — `#428`
+fills an already-anticipated gap, not a new convention.
+
+---
+
+## 10. Dependency and delivery map
+
+Unchanged from `plan/inventory-product-catalog-redesign.md` §15, reproduced here with the actual
+GitHub issue numbers now that all 21 downstream issues are filed and confirmed to match:
+
+```text
+#421 (design, this doc) + #400 (authorization)
+  └── #422 ──→ #423 ────────────────────────────┐
+       │        │                                │
+       └── #424 ┴──→ #425 ──┐                   │
+              │              │                   │
+              └── #426 ──→ #427 ──→ #429 ──→ Usable Product Catalog
+                    │                │
+                    └── #428 ────────┘
+
+#430 + #426/#427
+  └── #431 ──→ #432 ──→ #433
+                  └──────→ #434
+
+#424 ──→ #435 ──→ #436
+#431..436 ─────────→ #437 ──→ Operational Product
+
+#430 ──→ #438
+#424 ──→ #439
+#400 + stable APIs ──→ #440
+#429 + OPS + #438/#439 ──→ #441 ──→ #442
+```
+
+No issue's scope, estimate, or dependency changes as a result of this audit — the two clarifications
+in §7 (Item `sku` nullability sequencing, `#429`'s `is_manufactured` cleanup) are implementation
+detail within already-filed issues, not a re-scope. Acceptance Criterion "the implementation backlog
+and dependency order reflect the approved design" is satisfied by this confirmation rather than by
+any issue edit.
+
+---
+
+## 11. Related decisions
+
+See [TD-03](../../decisions/td-03-product-catalog-separation.md) for the accepted architectural
+decision this design is built on (why catalog identity, packaging, cost, and price are four separate
+write surfaces instead of one wizard).
+
+---
+
+## 12. References
+
+- [Inventory Architecture & Design](../inventory-architecture.en.md)
+- `dev-lab plan/inventory-product-catalog-redesign.md` — local discovery summary this design
+  formalizes (not a repo-relative link: this file lives in the `sushigo-dev-lab` orchestration repo,
+  outside the `sushigo` monorepo, and is gitignored there — see this issue's own `## 🔗 References`)
+- [#400 — Inventory policies authorize unconditionally](https://github.com/pakodiazdev/sushigo/issues/400)
+- [#399 — Expose public_id (ULID) for Item/ItemVariant](https://github.com/pakodiazdev/sushigo/issues/399)
+- `doc/conventions/testing/test-data-seeders.md`
+- `doc/conventions/backend/media-uploads.md`
+
+---
+
+**Authorship**
+SushiGo / ComandaFlow Team · 2026-08-12

--- a/doc/architecture/product-catalog/product-catalog-architecture.es.md
+++ b/doc/architecture/product-catalog/product-catalog-architecture.es.md
@@ -1,0 +1,608 @@
+# 🍱 Inventario de Producto — Arquitectura Objetivo y Plan de Migración
+
+**Alcance**
+Diseño objetivo para la vertical de Inventario de Producto de SushiGo: Producto (`Item`,
+`type=PRODUCTO`) → Variante → Presentación de Compra, la UI progresiva en SlidePanel, los contratos
+de API, los invariantes, los identificadores públicos y el plan incremental de migración/retiro del
+`ProductWizard` actual. Producido por el
+[issue #421](https://github.com/pakodiazdev/sushigo/issues/421) como entregable de solo diseño — en
+este issue no se implementan migraciones, endpoints, UI de producción, seeders ni borrado de código
+legado.
+
+Este documento se limita a **Productos únicamente** (Hito A de la hoja de ruta abajo). Los Insumos
+requieren un flujo posterior adaptado a conversiones físicas de UOM y consumo de recetas; Activos
+Fijos permanece como un dominio separado y diferido. Complementa, y no reemplaza, a
+[Arquitectura de Inventario](../inventory-architecture.es.md), que sigue siendo dueño de
+Branch/OperatingUnit/InventoryLocation/Stock/StockMovement. Ver la §3 de ese documento (esquema
+plano de Item/ItemVariant, incluyendo los campos de costo/precio/umbral de stock que este diseño
+retira) y la §5 (Hashids vs. `public_id`) para notas sobre qué contenido queda ahora superado por
+este.
+
+---
+
+## 1. Contexto
+
+El flujo actual de creación de Producto es un `ProductWizard` de cuatro pasos
+(`code/webapp/src/components/inventory/product-wizard.tsx`) que mezcla:
+
+1. Identidad del Item (`sku, name, description, type, is_stocked, is_perishable, is_active`, más un
+   campo `is_manufactured` muerto sin columna respaldándolo — ver §9.4).
+2. Identidad de Variante **y** campos comerciales en una sola petición (`code, name, uom_id,
+   sale_price, min_stock, max_stock, is_active`).
+3. Una escritura directa a la tabla **global** `uom_conversions`, presentada como si fuera un factor
+   de empaque específico del producto.
+4. Saldo inicial por ubicación, vía un endpoint separado `/inventory/opening-balance` encadenado del
+   lado del cliente.
+
+Construir el siguiente incremento del wizard directamente arrastraría estos límites sin resolver
+hacia código nuevo. Este documento finaliza primero la forma objetivo para que el backlog de
+implementación (`#422`–`#442`, ya creados) pueda construirse sobre un contrato estable.
+`doc/conventions/tasks.md` documenta la *convención* de alias de planeación `CAT-01`…`STK-06` en sí
+(glosario de carriles, formato, un ejemplo ilustrativo de dos filas); el mapeo completo real de
+alias a issue para este roadmap vive en el `dev-lab plan/inventory-product-catalog-redesign.md` §11
+local, con `.gitignore` — no está commiteado a este repo, consistente con la propia regla de esa
+convención de que los alias nunca aparecen como una segunda copia viva dentro de un archivo del
+repo.
+
+---
+
+## 2. Principios de diseño
+
+| Principio | Descripción |
+|---|---|
+| **Identidad vs. transacción** | Producto/Variante capturan *qué es algo*. Costo, precio y stock son *eventos* registrados en otro lugar y nunca se escriben de vuelta como campos permanentes del catálogo. |
+| **Empaque explícito y reutilizable** | Los paquetes comerciales (`Box x24`, `Pack x6`) son plantillas nombradas, administradas por el admin, asignadas por Variante — nunca una fila ambigua de `UOM_CONVERSION` global reutilizada entre productos no relacionados. |
+| **Desactivar, no borrar** | Cada tabla nueva de catálogo sigue el patrón `is_active` + `SoftDeletes` ya usado por `Item`/`ItemVariant`. Las filas referenciadas por historial se desactivan, nunca se borran físicamente. |
+| **Reemplazo incremental** | El CRUD existente de Item/ItemVariant, la integración de media, los permisos y la infraestructura de pruebas se extienden, no se descartan. Los campos/rutas/UI legados se retiran solo después de que su reemplazo haya salido (ver §9). |
+| **`items` sigue siendo la tabla interna** | `Item`/`ItemVariant` siguen siendo los modelos Eloquent internos durante el reemplazo incremental. "Producto" es un vocabulario de UI/API acotado a `type = PRODUCTO`, no una tabla nueva, para evitar bifurcar el catálogo a mitad de la migración. |
+| **IDs públicos, una sola estrategia** | Cada tabla nueva expone `public_id` (ULID) vía los traits existentes `HasPublicId` + `SerializesPublicIdAsId` — la misma convención ya usada por `Dish`, `MediaGallery`, `CashAdjustment`, etc. — coordinada con, no duplicando, [#399](https://github.com/pakodiazdev/sushigo/issues/399). |
+
+---
+
+## 3. Modelo de dominio
+
+### 3.1 Entidades
+
+- **Brand** — catálogo opcional de marcas comerciales/fabricante (`Coca-Cola`, `Buldak`).
+  Normalizado, con soft-delete, independiente de las categorías de Dish.
+- **InventoryCategory** — catálogo requerido de taxonomía de inventario (`Bebidas`, `Fideos
+  Instantáneos`). Una taxonomía **nueva** y separada — no `DishCategory`, que pertenece al dominio
+  no relacionado de Menú/Platillos (`code/webapp/src/pages/productos.tsx`).
+- **Item** (`type = PRODUCTO`) — la identidad de catálogo del Producto: nombre, marca, categoría,
+  descripción, media, estado activo. Sin costo, precio, saldo inicial, ubicación ni UOM.
+- **ItemVariant** — la presentación concreta inventariada (ej. *Coca-Cola Original 600 ml*): SKU
+  (`code`), código de barras unitario, UOM base, seguimiento de lote/serie, estado activo. Sin costo,
+  precio de venta ni umbrales de stock.
+- **PurchasePresentationTemplate** — definición reutilizable de empaque comercial, administrada por
+  el admin (`Unit`, `Pack x6`, `Box x24`) con un tipo de paquete y una cantidad en unidad base.
+- **VariantPurchasePresentation** — la asignación de una plantilla a una Variante específica, con
+  código de barras de paquete opcional y bandera de default.
+
+Todo lo posterior a estas seis entidades — costo de adquisición, stock y precio por sucursal — queda
+explícitamente **fuera de alcance** de la ruta de escritura del catálogo; ver §4.
+
+### 3.2 Diagrama de dominio / ER
+
+```mermaid
+erDiagram
+  BRAND ||--o{ ITEM : brands
+  INVENTORY_CATEGORY ||--o{ ITEM : categorizes
+  ITEM ||--o{ ITEM_VARIANT : has
+  UNIT_OF_MEASURE ||--o{ ITEM_VARIANT : base_uom
+  ITEM_VARIANT ||--o{ VARIANT_PURCHASE_PRESENTATION : offered_as
+  PURCHASE_PRESENTATION_TEMPLATE ||--o{ VARIANT_PURCHASE_PRESENTATION : instantiates
+  MEDIA_ATTACHMENT }o--|| ITEM : gallery_for
+
+  BRAND {
+    bigint id PK
+    string public_id
+    string name
+    boolean is_active
+  }
+
+  INVENTORY_CATEGORY {
+    bigint id PK
+    string public_id
+    string name
+    integer position
+    boolean is_active
+  }
+
+  ITEM {
+    bigint id PK
+    string public_id
+    bigint brand_id FK "nullable"
+    bigint inventory_category_id FK "required for PRODUCTO"
+    string sku "nullable, deprecated for PRODUCTO"
+    string name
+    text description
+    enum type "INSUMO|PRODUCTO|ACTIVO"
+    boolean is_active
+  }
+
+  ITEM_VARIANT {
+    bigint id PK
+    string public_id
+    bigint item_id FK
+    bigint uom_id FK
+    string code "the SKU"
+    string barcode "nullable, app-validated unique (no DB constraint yet)"
+    string name
+    boolean track_lot
+    boolean track_serial
+    boolean is_active
+  }
+
+  PURCHASE_PRESENTATION_TEMPLATE {
+    bigint id PK
+    string public_id
+    string code
+    string name
+    enum package_type "UNIT|PACK|BOX|TRAY"
+    decimal base_unit_quantity
+    bigint compatible_dimension_uom_id FK
+    boolean is_active
+  }
+
+  VARIANT_PURCHASE_PRESENTATION {
+    bigint id PK
+    string public_id
+    bigint item_variant_id FK
+    bigint template_id FK
+    string package_barcode "nullable, unique"
+    boolean is_default
+    boolean is_active
+    json meta
+  }
+```
+
+### 3.3 Cardinalidades y reglas de ciclo de vida
+
+| Relación | Cardinalidad | Regla |
+|---|---|---|
+| Brand → Item | 1‑a‑muchos, opcional | `Item.brand_id` nullable. Desactivar una Brand no cascada; solo bloquea nuevas asignaciones (validado en el FormRequest, no un trigger de BD). |
+| InventoryCategory → Item | 1‑a‑muchos, requerido | `Item.inventory_category_id` NOT NULL para `type = PRODUCTO`. Una categoría no puede desactivarse mientras Productos activos la referencien — se aplica en el endpoint de desactivación, no como constraint de BD (el soft-delete ya preserva la integridad histórica del FK). |
+| Item → ItemVariant | 1‑a‑muchos | Sin mínimo a nivel BD. Regla de negocio (capa de aplicación, no esquema): un Producto necesita al menos una Variante **activa** para considerarse vendible/pedible por dominios posteriores (compras, precios) — el catálogo permite un Producto con cero Variantes mientras se está creando. |
+| ItemVariant → VariantPurchasePresentation | 1‑a‑muchos | Una Variante puede tener cero presentaciones inicialmente (recae en "sin empaque configurado" en las UIs de compras, un estado válido durante el despliegue de CAT-04/CAT-05). |
+| PurchasePresentationTemplate → VariantPurchasePresentation | 1‑a‑muchos, reutilizable | La misma plantilla (ej. `BOX_24`) se asigna a muchas Variantes en muchos Productos. Las plantillas usadas por cualquier asignación (pasada o presente) se desactivan, nunca se borran. |
+| VariantPurchasePresentation.is_default | exactamente un default activo por Variante | Se aplica con un índice único parcial (`item_variant_id` donde `is_default = true AND is_active = true`) más una validación a nivel de servicio en la escritura, siguiendo el mismo patrón de creación segura de primera fila que usa `Stock` con su constraint único de Location+Variant. |
+
+### 3.4 Propiedad de SKU y código de barras
+
+- **`ItemVariant.code`** es el SKU autoritativo. Ya existe, ya es único hoy, y no necesita
+  renombrarse — solo documentación más clara (descripción en Swagger, este documento) de que *es* el
+  SKU. A diferencia de `barcode` abajo, `code` ya tiene una constraint real de unicidad a nivel de
+  BD (migración `create_item_variants_table`), así que la corrupción de datos no es un riesgo — pero
+  el mismo vacío de solo-creación aplica a su *validación*: `CreateItemVariantRequest` valida
+  `unique:item_variants,code`, `UpdateItemVariantRequest` no acepta `code` en absoluto hoy, y el
+  endpoint PATCH de la §6 (que acepta "la misma forma que crear, parcial") necesitará su propia
+  regla `unique:item_variants,code,{id}` una vez que lo haga — sin ella, un `code` duplicado en PATCH
+  se manifestaría como una violación de constraint de BD sin manejar, en vez de un `422` limpio.
+  Mismo dueño que el vacío de barcode abajo: `#424` (`CAT-03`).
+- **`Item.sku`** se vuelve nullable y deprecado para `type = PRODUCTO`. El nuevo contrato de
+  creación/edición de Producto no lo lee ni lo escribe. No se elimina en esta vertical — el borrado
+  de esquema es un tema del Hito C (`#442`, "Remove legacy Inventory fields...") una vez que ningún
+  consumidor lo lea.
+- **`ItemVariant.barcode`** es el código de barras **unitario** (ya existe, nullable). Hoy solo se
+  valida como `unique:item_variants,barcode` en `CreateItemVariantRequest` — no existe una
+  constraint de unicidad a nivel de base de datos, solo un índice simple (migración
+  `add_barcode_to_item_variants_table`), y esa validación en creación es el **único** lugar donde se
+  aplica unicidad: `UpdateItemVariantRequest` no acepta `barcode` (ni `code`/`uom_id`) como campo
+  hoy, así que bajo el contrato **actual** el código de barras de una Variante solo puede
+  establecerse una vez, al crearla — no hay un vacío activo todavía porque no hay una ruta de
+  edición contra la cual competir. Eso cambia con el contrato de API de la propia §6 de este
+  documento, que agrega `barcode?` al endpoint PATCH: una vez que eso salga, la validación
+  solo-en-creación deja de ser suficiente, y se necesitan tanto una constraint de unicidad a nivel
+  de BD **como** una regla `unique:item_variants,barcode,{id}` en la ruta de edición (excluyendo la
+  propia fila) — señalado aquí para que `#424` (`CAT-03`) agregue ambas juntas, en vez de lanzar la
+  nueva capacidad de PATCH con solo la mitad de la protección de ayer.
+- **`VariantPurchasePresentation.package_barcode`** es un namespace **separado** del código de barras
+  unitario — el código impreso en una caja/paquete. Al ser una tabla nueva, debería tener una
+  constraint de unicidad real a nivel de BD desde el inicio (a diferencia del vacío heredado arriba).
+  Un código de paquete y uno unitario pueden coincidir en principio solo si pertenecen a objetos
+  físicos distintos; el diseño no necesita una constraint de unicidad cruzada entre columnas porque
+  se escanean en contextos operativos distintos (recibir una caja vs. vender una pieza).
+
+### 3.5 Requisitos de Brand/Category y primeros atributos de Variante
+
+Resuelto a partir de las hipótesis de trabajo del propio plan
+(`plan/inventory-product-catalog-redesign.md` §17, citado en la `## 🔗 References` de este issue),
+validado contra la auditoría del esquema actual y finalizado aquí:
+
+- **Brand es opcional.** No todas las líneas de producto tienen una marca distintiva por la cual
+  filtrar; hacerla obligatoria implicaría inventar marcas placeholder o bloquear el alta de catálogo.
+  Opcional con FK nullable mantiene el filtro utilizable sin volverse un impuesto de captura de
+  datos.
+- **InventoryCategory es requerida.** Todo Producto necesita un rubro para navegación/filtrado y
+  para reportes futuros; a diferencia de Brand, no existe un "sin categorizar" significativo sobre
+  el cual la UI deba renderizar.
+- **Primeros atributos de clase de Variante** (más allá de nombre/SKU/código de
+  barras/UOM base, ya acordados): `description` (texto libre nullable, nota de
+  sabor/tamaño/contenido — ej. "Original, 600 ml"), `track_lot`/`track_serial` (ya existen, se
+  conservan), `is_active`. Un motor de atributos configurables genérico (columnas separadas
+  `flavor`, `size`, `content` o una tabla EAV) explícitamente **no** se construye en el Hito A — el
+  catálogo actual de SushiGo (Coca-Cola, Buldak, Peelez, Ramune, Mochis) es totalmente representable
+  con un `description` de texto libre más el `name` propio de la Variante, y un motor genérico sin
+  demanda real de filtrado multi-atributo sería alcance especulativo. Revisar si un catálogo futuro
+  necesita filtrado de atributos estructurado (ej. "mostrar todas las variantes de 600 ml en todas
+  las marcas").
+
+---
+
+## 4. Límites de responsabilidad
+
+El defecto central del wizard actual es colapsar cinco responsabilidades distintas en una sola
+escritura. El diseño objetivo las separa explícitamente:
+
+| Responsabilidad | Dueño | Dónde vive | Hito |
+|---|---|---|---|
+| Identidad de catálogo | Producto / Variante | `items`, `item_variants` (solo columnas de identidad) | A (este documento) |
+| Empaque comercial | Presentación de Compra | `purchase_presentation_templates`, `variant_purchase_presentations` | A (`#426`/`#427`) |
+| Conversión física de UOM | `UnitOfMeasure` / `UomConversion` | Tablas globales existentes — reservadas para equivalencias dimensionales genuinas (`kg → g`), **no** empaque de producto | Sin cambios; solo Insumos en adelante |
+| Costo de adquisición | Recibo de Compra | Futuras `purchase_receipt_lines`, tomando snapshot del factor de presentación al recibir | B (`#431`/`#432`) |
+| Saldo de stock | `Stock` / `StockMovement` | Tablas existentes, actualizadas por servicios de recepción/venta/ajuste | Sin cambios (hardening en `#430`/`#438`) |
+| Precio de venta por sucursal | Lista de Precios | Futuras `price_lists` + asignación de precio por variante, vigente por rango de fechas por sucursal | B (`#435`/`#436`) |
+
+`OpeningBalanceService` (`code/api/app/Services/Inventory/OpeningBalanceService.php`) ya escribe hoy
+`last_unit_cost`/`avg_unit_cost` de forma transaccional — confirmando que el costo *ya* se trata como
+efecto secundario transaccional en la capa de servicio, aunque `CreateItemVariantController`
+actualmente también permite establecer `sale_price` directamente en la creación. El contrato
+objetivo elimina esa segunda vía: costo y precio nunca son aceptados por una petición de
+creación/edición de Producto/Variante, sin excepción.
+
+---
+
+## 5. Flujo de UX del SlidePanel de Producto
+
+### 5.1 Forma de navegación
+
+```text
+Página de Productos (/inventory/products)
+└── Nuevo Producto  ───────────────────────────┐
+    │                                          │
+    ▼                                          │
+  SlidePanel: modo creación                    │
+    ├── Nombre, Marca (opcional), Categoría*,  │
+    │   Descripción, Imágenes, Activo          │
+    └── [Guardar] ─────────────────────────────►┤
+                                                 ▼
+                                    SlidePanel: misma instancia,
+                                    ahora en modo detalle guardado
+                                        ├── Información general (edición in-place)
+                                        ├── Imágenes (patrón de galería existente)
+                                        └── Catálogo de Variantes
+                                              ├── [+ Nueva Variante] → slide anidado
+                                              │     Formulario de Variante: Nombre, SKU(code),
+                                              │     Código de barras, UOM base, Descripción,
+                                              │     track_lot/track_serial, Activo
+                                              │     [Guardar] → modo detalle anidado
+                                              └── Tarjeta de Variante → slide anidado
+                                                    Detalle de Variante
+                                                      └── Presentaciones de compra
+                                                            ├── [+ Asignar plantilla]
+                                                            │     (plantillas Unit/Pack/Box
+                                                            │     existentes; el admin también
+                                                            │     puede abrir el gestor de plantillas)
+                                                            └── lista: nombre de plantilla,
+                                                                  tipo de paquete, factor,
+                                                                  código de barras, default,
+                                                                  activo
+```
+
+`*` La Categoría es requerida al guardar; el formulario permite dejarla sin seleccionar mientras se
+está redactando solo si el SlidePanel difiere la validación hasta el envío (comportamiento estándar
+de `react-hook-form` + `zod` — no requiere casos especiales).
+
+### 5.2 Diagrama de estados
+
+```mermaid
+stateDiagram-v2
+  [*] --> Closed
+  Closed --> CreateMode: New Product
+  CreateMode --> Closed: Cancel / Esc
+  CreateMode --> DetailMode: Save succeeds (same panel instance)
+  DetailMode --> Closed: Close
+
+  state DetailMode {
+    [*] --> GeneralInfo
+    GeneralInfo --> VariantList
+    VariantList --> VariantCreate: + New Variant
+    VariantCreate --> VariantDetail: Save succeeds
+    VariantList --> VariantDetail: Select existing Variant
+    VariantDetail --> VariantList: Back
+    VariantDetail --> PresentationList: Purchase presentations
+    PresentationList --> PresentationAssign: + Assign template
+    PresentationAssign --> PresentationList: Save succeeds / Cancel
+    PresentationList --> VariantDetail: Back
+  }
+```
+
+Esta es una interacción genuinamente nueva para este código base: el `SlidePanel` actual
+(`code/webapp/src/components/ui/slide-panel.tsx`) es una primitiva de panel único genérica, y todo
+uso existente (ej. Platillos) alterna entre dos instancias de panel separadas (un panel de detalle y
+un panel de formulario) en vez de que un mismo panel transicione su propio contenido in-place.
+`CAT-02` (`#423`) es el primer consumidor de la transición creación→detalle; `CAT-04`/`CAT-06`
+(`#425`/`#427`) extienden la misma instancia de panel con niveles anidados de
+Variante/Presentación en vez de abrir nuevos paneles de nivel superior, de modo que el usuario nunca
+pierde el Producto que estaba editando.
+
+### 5.3 Estados a diseñar (por criterios de aceptación de CAT-02/CAT-04/CAT-06)
+
+Carga, vacío (sin Variantes aún / sin presentaciones aún), error de validación (inline, por campo),
+error de envío (toast + errores de campo vía `getApiValidationErrors`), teclado/foco (el foco vuelve
+a la fila que disparó el panel al cerrar, los slides anidados atrapan el foco), responsivo (móvil:
+slide de pantalla completa) y modo oscuro (convenciones `dark:` existentes — sin inventar nuevas
+primitivas Button/Label antes de que aterricen
+[[project_button_centralization]]/[[project_label_centralization]] si eso ocurre primero).
+
+---
+
+## 6. Bosquejo del contrato de API
+
+Todos los endpoints versionados bajo `/api/v1`, todos usan el patrón existente de
+`SingleActionController` (`__invoke`). El route-model-binding vía `HasPublicId` (estilo
+`{item:public_id}`) y las respuestas `SerializesPublicIdAsId` son una **convención existente en
+otra parte** del código base (`Dish`, `MediaGallery`, `CashAdjustment`) — `Item`/`ItemVariant` aún
+no la tienen, ya que `#399` ("Expose public_id (ULID) for Item/ItemVariant...") sigue abierto. Los
+endpoints de este diseño asumen que `#399` aterriza como prerrequisito, no como opción paralela:
+cada ruta abajo (`{product}`, `{variant}`, etc.) está escrita como un `public_id`, así que
+`#422`/`#424` necesitan la migración y adopción del trait de `#399` implementadas (o incluidas en
+el mismo PR) antes de que estas rutas puedan hacer binding sobre algo más que el ID numérico
+interno. Los permisos siguen la convención granular `resource.action` existente en vez del estilo
+más grueso por dominio usado por Platillos, para mantener consistencia con el mapeo `items.*` que
+`#400` ya codifica.
+
+| Método | Ruta | Petición (crear/editar) | Permiso | Notas |
+|---|---|---|---|---|
+| GET | `/inventory/products` | — (query: `search, brand_id, inventory_category_id, is_active, page`) | `items.view` | Filtra a `type = PRODUCTO` en el servidor; devuelve el conteo de variantes por fila en el listado. |
+| POST | `/inventory/products` | `name, brand_id?, inventory_category_id, description?, media_gallery_id?, owner_token?, is_active?` | `items.create` | Este contrato no acepta `sku` (se conserva nullable/legado). Sin campos de costo/precio/stock. |
+| GET | `/inventory/products/{product}` | — | `items.view` | Incluye marca, categoría, galería de media, resumen de variantes. |
+| PATCH | `/inventory/products/{product}` | Misma forma que crear, parcial | `items.update` | |
+| DELETE | `/inventory/products/{product}` | — | `items.delete` | Soft-delete / desactivación, patrón existente. |
+| GET | `/inventory/products/{product}/variants` | — | `items.view` | |
+| POST | `/inventory/products/{product}/variants` | `name, code, barcode?, uom_id, description?, track_lot?, track_serial?, is_active?` | `items.create` | `item_id` viene de la ruta, no del body — elimina el selector global de Item que señala el plan. Sin campos `sale_price`/`min_stock`/`max_stock`/costo — este es el cambio de contrato respecto al `CreateItemVariantRequest` de hoy. |
+| GET | `/inventory/products/{product}/variants/{variant}` | — | `items.view` | |
+| PATCH | `/inventory/products/{product}/variants/{variant}` | Misma forma que crear, parcial | `items.update` | |
+| DELETE | `/inventory/products/{product}/variants/{variant}` | — | `items.delete` | |
+| GET | `/inventory/purchase-presentation-templates` | — (query: `is_active, package_type`) | `purchase_presentation_templates.view` | Global, no acotado por Producto. |
+| POST | `/inventory/purchase-presentation-templates` | `code, name, package_type, base_unit_quantity, compatible_dimension_uom_id, is_active?` | `purchase_presentation_templates.manage` | Administrado por el admin; deliberadamente un único permiso `manage` más grueso (crear+editar+desactivar) por ser gobernanza de catálogo de baja frecuencia, no edición diaria de producto. |
+| PATCH / DELETE | `/inventory/purchase-presentation-templates/{template}` | — | `purchase_presentation_templates.manage` | Desactivar, no borrar, una vez referenciada por cualquier asignación. |
+| GET | `/inventory/products/{product}/variants/{variant}/purchase-presentations` | — | `items.view` | |
+| POST | `/inventory/products/{product}/variants/{variant}/purchase-presentations` | `template_id, package_barcode?, is_default?` | `items.update` | La asignación se acota a una Variante que el usuario ya puede editar — no se necesita un permiso nuevo aquí, a diferencia de la gobernanza de plantillas arriba. |
+| PATCH / DELETE | `.../purchase-presentations/{assignment}` | `package_barcode?, is_default?` | `items.update` | |
+| GET | `/inventory/brands` | — | `brands.view` | |
+| POST / PATCH / DELETE | `/inventory/brands[/{brand}]` | `name, is_active?` | `brands.create` / `brands.update` / `brands.delete` | |
+| GET | `/inventory/inventory-categories` | — | `inventory_categories.view` | |
+| POST / PATCH / DELETE | `/inventory/inventory-categories[/{category}]` | `name, position?, is_active?` | `inventory_categories.create` / `.update` / `.delete` | Distinta de `dish_categories.*` — ver §3.1. |
+
+**Permisos nuevos a registrar** (`PermissionSeeder` de Development/Production, según `#422`/`#426`):
+`brands.view/create/update/delete`, `inventory_categories.view/create/update/delete`,
+`purchase_presentation_templates.view/manage`. No se necesita un permiso nuevo para los endpoints de
+asignación (se reutiliza `items.*`) — ver la tabla arriba para el porqué.
+
+**Decisión de nomenclatura de ruta:** `/inventory/products` es una ruta frontend y un prefijo de
+ruta de API **nuevos**, distintos tanto de `/inventory/items` (el listado genérico actual de Item
+para los tres valores de `type`, conservado hasta que `#429` retire el punto de entrada del wizard
+que depende de él) como de `/productos` (el catálogo no relacionado de Platillos/Menú — ver
+`code/webapp/src/pages/productos.tsx`). Este era un vacío de nomenclatura real que el plan no
+resolvía explícitamente; decidido aquí para evitar la colisión que reveló la auditoría.
+
+---
+
+## 7. Secuencia de migración, compatibilidad y retiro de código legado
+
+Esta es una guía de secuenciación para el backlog ya creado (`#422`–`#442`); no cambia el alcance de
+ningún issue, solo aclara dos puntos que reveló la auditoría (§9.3, §9.4) y confirma que el orden de
+dependencias ya refleja este diseño.
+
+1. **`#422`** (`CAT-01`) — Agregar tablas `brands`, `inventory_categories` y columnas en `items`
+   (`brand_id` FK nullable, `inventory_category_id` FK). Solo aditivo; ninguna columna existente se
+   elimina. `Item.sku` se vuelve nullable si no lo era ya (actualmente es `NOT NULL unique` — este es
+   un cambio de esquema real que hay que secuenciar con cuidado: las filas existentes conservan su
+   `sku`, las nuevas escrituras de Producto dejan de poblarlo).
+2. **`#423`** (`CAT-02`) — Nueva UI de SlidePanel en `/inventory/products`, aditiva, no toca
+   `/inventory/items`.
+3. **`#424`** (`CAT-03`) — El contrato de escritura de `ItemVariant` deja de aceptar `sale_price,
+   min_stock, max_stock` desde la ruta de Producto/Variante. **Compatibilidad:** las columnas se
+   conservan en la base de datos (las filas existentes, las rutas de lectura existentes en
+   stock/reportes siguen funcionando); solo cambia la superficie de *escritura* que usa la nueva UI.
+   La página global legada `item-variants` y el `variant-form.tsx` viejo siguen funcionando contra el
+   contrato antiguo hasta que `#429` los retire.
+4. **`#425`/`#426`/`#427`** (`CAT-04`/`CAT-05`/`CAT-06`) — Aditivo: tablas nuevas
+   (`purchase_presentation_templates`, `variant_purchase_presentations`), UI anidada nueva. Sin
+   problema de compatibilidad — nada existente depende de estas tablas.
+5. **`#428`** (`CAT-07`) — Datos semilla. Sin cambio de esquema.
+6. **`#429`** (`CAT-08`) — Primer punto real de eliminación: `ProductWizard` y sus
+   pruebas/exports/query params, el flujo viejo de saldo inicial dentro de la creación de producto y
+   (según §9.4 abajo) el campo frontend muerto `is_manufactured` y su migración no-op vacía. Solo se
+   ejecuta después de que `#423`–`#428` hayan salido y se haya verificado que cubren la
+   funcionalidad del wizard. La página global de Variante (`/inventory/item-variants`) se elimina
+   aquí solo si, en ese punto, ningún flujo independiente sigue necesitándola — el plan ya enmarca
+   esto como una verificación condicional, no un borrado garantizado.
+7. **`#438`/`#439`/`#440`/`#441`** e Hito B (`#431`–`#437`) proceden según el mapa de dependencias
+   existente en `plan/inventory-product-catalog-redesign.md` §15 — sin cambios por este documento.
+8. **`#442`** (`STK-06`, Hito C) — Eliminación final de campos legados: eliminar `Item.sku` y las
+   columnas ahora no usadas `ItemVariant.last_unit_cost/avg_unit_cost/sale_price/min_stock/max_stock`
+   (una vez que la fuente única de verdad de costo de `#434` y los umbrales por ubicación de `#439`
+   hayan aterrizado ambos), y reconciliar este documento e
+   `inventory-architecture.en.md`/`.es.md` con el sistema tal como quedó construido.
+
+**Rollback:** cada migración en los pasos 1 y 4 es aditiva (columnas nuevas nullable / tablas
+nuevas) — un rollback es un simple `migrate:rollback` sin riesgo de pérdida de datos antes del paso
+8. El paso 8 es la única migración destructiva de toda la secuencia y está explícitamente
+condicionada a que dos issues prerrequisito independientes aterricen primero, más un pase de
+reconciliación — no un borrado en el mismo PR.
+
+---
+
+## 8. Decisiones y puntos abiertos
+
+### 8.1 Decidido en este documento
+
+- Brand opcional, InventoryCategory requerida (§3.5).
+- Atributos de clase de Variante limitados a `description` más allá de lo ya acordado
+  nombre/SKU/código de barras/UOM base/lote-serie/activo — sin motor de atributos genérico en el
+  Hito A (§3.5).
+- `/inventory/products` es una ruta/prefijo nuevo, distinto de `/inventory/items` y `/productos`
+  (§6).
+- La gestión de **plantillas** de presentación de compra usa un permiso más grueso
+  `purchase_presentation_templates.manage`; la **asignación** a una Variante reutiliza `items.update`
+  en vez de un permiso nuevo (§6).
+- La sucursal (Branch) es el objetivo de asignación primario de listas de precios; los overrides por
+  Operating Unit (ej. para eventos temporales) son un punto de extensión explícito para `#435`, no
+  construido en el Hito A — consistente con el propio título de `#435` ("branch or operating
+  context").
+- Los umbrales de reabastecimiento por Ubicación+Variante (`#439`, `STK-03`) no heredan un default
+  desde el nivel de Operating Unit en la primera entrega — cada par Ubicación+Variante se configura
+  explícitamente. **Por qué:** el plan enmarca la herencia como condicional ("si se justifica") sin
+  evidencia operativa aún de que las sucursales comparten umbrales idénticos; la lectura conservadora
+  es sin herencia hasta que el uso real multi-ubicación muestre que la configuración repetitiva es
+  una fricción real.
+
+### 8.2 Bloqueo explícito — dueño asignado, no resoluble desde código o documentación
+
+- **Los nombres/ortografías comerciales exactos de las líneas de producto Buldak y Peelez** (y sus
+  sabores/tamaños) son hechos del mundo real, no algo derivable del repositorio. **Dueño del
+  bloqueo:** `#428` (`CAT-07` — datos semilla) debe confirmar los nombres exactos antes de escribir
+  los seeders; esto no bloquea ningún otro issue del Hito A, ya que `#422`–`#427` construyen el
+  contrato y la UI de forma genérica.
+
+### 8.3 Explícitamente diferido, no un bloqueo
+
+- Una presentación de compra **personalizada** por Variante que no coincida con ninguna plantilla
+  reutilizable — la propia §5 del plan ya excluye esto de `#426`, enmarcando las plantillas
+  reutilizables como el único mecanismo del Hito A. No se necesita una decisión nueva aquí; revisar
+  solo si un producto real necesita un paquete único no reutilizable.
+
+---
+
+## 9. Evaluación del diseño actual (hallazgos de la auditoría que alimentan este diseño)
+
+### 9.1 Backend
+
+`items`/`item_variants` ya separan filas con soft-delete y bandera `is_active` — el patrón que este
+diseño extiende en vez de reemplazar. `CreateItemRequest` ya es acotado (sin costo/precio); el vacío
+está en la ruta de escritura de Variante en **ambos** lados — `CreateItemVariantRequest` **y**
+`UpdateItemVariantRequest` aceptan cada uno, de forma independiente, `sale_price, min_stock,
+max_stock` directamente hoy, así que `#424` debe remover los campos de ambos FormRequests, no solo
+de la ruta de creación. `ItemPolicy`/`ItemVariantPolicy` actualmente autorizan sin condición (`#400`, en
+progreso en el workspace `sushigo-a` al momento de esta auditoría) — los FormRequests de este diseño
+deben llamar a `$this->user()->can(...)` contra la política real una vez que `#400` aterrice, según
+la nota de dependencia ya existente en `#424`; `#421` en sí no necesita ningún cambio de código
+porque es de solo lectura.
+
+### 9.2 Frontend
+
+Ningún componente existente implementa la transición creación→detalle en el mismo panel (§5.2) —
+todo uso actual de `SlidePanel` alterna dos instancias de panel separadas en su lugar. `/productos`
+es el catálogo de Platillos/Menú, no Productos — una trampa de nomenclatura que este diseño evita
+eligiendo `/inventory/products` (§6).
+
+### 9.3 Conversiones de UOM
+
+`App\Services\Inventory\Concerns\ConvertsUomQuantities` resuelve una `UomConversion` global por par
+de UOM sin acotarla a un Item/Variante específico — exactamente la ambigüedad que la §5 del plan (y
+la §4 arriba) reemplazan con `VariantPurchasePresentation` acotada por Variante para el empaque
+comercial. La tabla global sigue siendo válida para equivalencias dimensionales físicas genuinas en
+Insumos.
+
+### 9.4 Código muerto preexistente (señalado para `#429`, no corregido aquí)
+
+`2025_11_12_092126_add_is_manufactured_to_items_table.php` es una migración no-op vacía (los cuerpos
+de `up()` y `down()` están vacíos) — `is_manufactured` nunca se agregó realmente a la tabla `items`.
+El campo muerto alcanza más allá del wizard frontend:
+
+- **Componente frontend:** `product-wizard.tsx` lee/escribe un campo `is_manufactured` sin columna
+  respaldándolo.
+- **Tipo compartido frontend:** `types/inventory.ts` declara `is_manufactured: boolean` en el tipo
+  Item compartido que importa cada componente de inventario — el campo muerto es parte del contrato
+  de tipos, no solo el estado local de un componente.
+- **Pruebas frontend:** `product-wizard.test.tsx`, `item-form.test.tsx`, `item-details.test.tsx`,
+  `variant-details.test.tsx` y `types/__tests__/inventory.test.ts` todas aseveran sobre
+  `is_manufactured` — cualquier limpieza tiene que actualizar cinco archivos de prueba, no solo el
+  componente y el tipo.
+- **Backend, ruta de lectura:** `ShowItemController.php` incluye incondicionalmente
+  `'is_manufactured' => $item->is_manufactured` en cada respuesta de detalle de Producto — como la
+  columna no existe, el `__get` mágico de Eloquent retorna `null` para el atributo indefinido, así
+  que cualquier consumidor de este endpoint recibe un campo permanentemente `null` y sin sentido.
+- **Backend, ruta de filtro:** la anotación Swagger de `ListItemsController.php` documenta un
+  filtro de query `is_manufactured`, pero no existe lógica de filtrado para él en ninguna parte de
+  `Concerns/FiltersItemListing.php` — el parámetro documentado es un no-op silencioso que engaña a
+  los consumidores de la API (y a quienes usan Swagger UI) haciéndoles creer que filtra resultados.
+
+Es un defecto preexistente, no relacionado con este issue de solo diseño y no corregido por él —
+señalado aquí con su superficie completa para que `#429` (retiro del wizard) limpie las nueve
+ubicaciones juntas (un componente, un tipo compartido, cinco pruebas, dos controladores backend) en
+vez de descubrirlas una por una, ya que la mayoría están fuera del propio componente del wizard y son
+fáciles de pasar por alto.
+
+### 9.5 Seeders
+
+Ningún seeder crea actualmente filas de `Item`/`ItemVariant`.
+`doc/conventions/testing/test-data-seeders.md` ya reserva `InventoryTestSeeder.php` como un slot
+"futuro" documentado en su nivel Testing — `#428` llena un vacío ya anticipado, no una convención
+nueva.
+
+---
+
+## 10. Mapa de dependencias y entrega
+
+Sin cambios respecto a `plan/inventory-product-catalog-redesign.md` §15, reproducido aquí con los
+números reales de issue de GitHub ahora que los 21 issues posteriores están creados y confirmados
+como coincidentes:
+
+```text
+#421 (diseño, este documento) + #400 (autorización)
+  └── #422 ──→ #423 ────────────────────────────┐
+       │        │                                │
+       └── #424 ┴──→ #425 ──┐                   │
+              │              │                   │
+              └── #426 ──→ #427 ──→ #429 ──→ Catálogo de Producto Usable
+                    │                │
+                    └── #428 ────────┘
+
+#430 + #426/#427
+  └── #431 ──→ #432 ──→ #433
+                  └──────→ #434
+
+#424 ──→ #435 ──→ #436
+#431..436 ─────────→ #437 ──→ Producto Operacional
+
+#430 ──→ #438
+#424 ──→ #439
+#400 + APIs estables ──→ #440
+#429 + OPS + #438/#439 ──→ #441 ──→ #442
+```
+
+Ningún alcance, estimación o dependencia de issue cambia como resultado de esta auditoría — las dos
+aclaraciones de la §7 (secuenciación de nullability de `sku` en Item, limpieza de `is_manufactured`
+en `#429`) son detalle de implementación dentro de issues ya creados, no un re-scope. El criterio de
+aceptación "el backlog de implementación y el orden de dependencias reflejan el diseño aprobado" se
+satisface con esta confirmación en vez de con alguna edición de issue.
+
+---
+
+## 11. Decisiones relacionadas
+
+Ver [TD-03](../../decisions/td-03-product-catalog-separation.md) para la decisión arquitectónica
+aceptada sobre la que se construye este diseño (por qué identidad de catálogo, empaque, costo y
+precio son cuatro superficies de escritura separadas en vez de un solo wizard).
+
+---
+
+## 12. Referencias
+
+- [Arquitectura de Inventario](../inventory-architecture.es.md)
+- `dev-lab plan/inventory-product-catalog-redesign.md` — resumen de descubrimiento local que este
+  diseño formaliza (no es un link relativo al repo: este archivo vive en el repositorio de
+  orquestación `sushigo-dev-lab`, fuera del monorepo `sushigo`, y está en su `.gitignore` — ver la
+  `## 🔗 References` de este mismo issue)
+- [#400 — Inventory policies authorize unconditionally](https://github.com/pakodiazdev/sushigo/issues/400)
+- [#399 — Expose public_id (ULID) for Item/ItemVariant](https://github.com/pakodiazdev/sushigo/issues/399)
+- `doc/conventions/testing/test-data-seeders.md`
+- `doc/conventions/backend/media-uploads.md`
+
+---
+
+**Autoría**
+SushiGo / ComandaFlow Team · 2026-08-12

--- a/doc/decisions.md
+++ b/doc/decisions.md
@@ -15,3 +15,4 @@ Format modeled on the same convention used in
 |----|----------|------|
 | [TD-01](decisions/td-01-single-source-issue-tracking.md) | GitHub Issue as single source of truth during work; local task file archived only at close | Process |
 | [TD-02](decisions/td-02-media-cleanup-strategy.md) | Orphaned media cleanup runs at container startup, not on a recurring schedule | Infrastructure |
+| [TD-03](decisions/td-03-product-catalog-separation.md) | Product catalog splits identity from packaging, cost, and price into four write surfaces | Inventory |

--- a/doc/decisions/td-03-product-catalog-separation.md
+++ b/doc/decisions/td-03-product-catalog-separation.md
@@ -1,0 +1,67 @@
+# TD-03 · Product catalog splits identity from packaging, cost, and price
+
+## Decision
+
+The Product inventory vertical (`Item`/`ItemVariant` scoped to `type = PRODUCTO`) is redesigned
+around four separate write surfaces instead of the current single `ProductWizard`:
+
+1. **Catalog identity** — Product (`Item`) and Variant (`ItemVariant`), holding only what
+   identifies a thing: name, brand, category, SKU, barcode, base unit of measure.
+2. **Commercial packaging** — a new `PurchasePresentationTemplate` /
+   `VariantPurchasePresentation` pair, replacing ad-hoc writes to the global `uom_conversions`
+   table for product packaging.
+3. **Acquisition cost** — produced transactionally by purchase receipts (Milestone B), never a
+   permanent field on Variant.
+4. **Branch sale price** — produced by effective-dated price lists (Milestone B), never a
+   permanent field on Variant.
+
+Catalog create/update requests never accept cost, sale price, opening stock, location, or UOM
+conversion factors. Full design, ERD, API contract, and migration sequencing:
+[Product Catalog — Target Architecture](../architecture/product-catalog/product-catalog-architecture.en.md).
+
+## Justification
+
+**Why split now instead of extending the wizard?** The current wizard's four steps already write
+to `Item`, `ItemVariant` (including `sale_price`/`min_stock`/`max_stock`), the global
+`uom_conversions` table, and `/inventory/opening-balance` — four different domains in one form.
+Every new field request (a package barcode, a supplier cost) would have nowhere principled to go
+without this split, and would keep getting bolted onto `ItemVariant` by default, growing the same
+problem it's meant to fix.
+
+**Why not reuse the global `UomConversion` table for product packaging?**
+`App\Services\Inventory\Concerns\ConvertsUomQuantities` resolves conversions by UOM pair only, with
+no scoping to a specific Item or Variant — a `Box → Piece` row would silently apply to *every*
+Variant using those two units, even though a Coca-Cola box and a napkin box hold different
+quantities. `VariantPurchasePresentation` scopes the factor to one Variant; `UomConversion` remains
+reserved for genuine physical dimensional equivalences (`kg → g`) on Insumos.
+
+**Why keep `items`/`item_variants` as the internal tables instead of a new `products` table?** A
+parallel table would fork the catalog mid-migration and duplicate media integration, permissions,
+and test infrastructure that already work. "Product" stays a UI/API vocabulary scoped to
+`type = PRODUCTO`; the internal model name doesn't change.
+
+**Why deprecate `Item.sku` instead of dropping it immediately?** Existing rows and read paths still
+reference it. Dropping it is the last step of the migration sequence (Milestone C, `#442`), gated
+behind every replacement write path landing first — not a same-PR deletion. `ItemVariant.code`
+becomes the documented, authoritative SKU going forward.
+
+**Why is Brand optional but InventoryCategory required?** Not every product line has a distinct
+brand worth filtering by, so a mandatory Brand would force placeholder data. Every product needs a
+category for navigation and reporting, and there is no meaningful "uncategorized" state the UI
+should render around.
+
+**Known, accepted limitation:** cost and stock columns (`last_unit_cost`, `avg_unit_cost`,
+`sale_price`, `min_stock`, `max_stock`) remain on `item_variants` through Milestone A and most of
+Milestone B — only the *write path used by the new Product UI* stops touching them. They are not
+dropped until `#442`, after `#434` (single cost source of truth) and `#439` (per-location
+thresholds) land.
+
+## When to revisit
+
+If a future catalog needs structured, filterable Variant attributes (e.g. querying "all 600 ml
+variants across every brand"), revisit the decision to keep Variant attributes as a single free-text
+`description` field rather than a generic attribute engine — see
+[Product Catalog — Target Architecture](../architecture/product-catalog/product-catalog-architecture.en.md)
+§3.5. If a real product needs a one-off commercial package that doesn't fit any reusable
+`PurchasePresentationTemplate`, revisit the "reusable templates only" constraint from that
+document's §8.3.

--- a/doc/sprints/sprint-003-development-platform-and-product-reliability.md
+++ b/doc/sprints/sprint-003-development-platform-and-product-reliability.md
@@ -181,7 +181,7 @@ change and must update estimates, dependencies, conflicts, and the scope-change 
 | ⏳ | #401 | `sushigo` | Add administrator-managed employee avatars with reusable initials fallback | High | 4h | 7h | — | — | Foundation required by #420 |
 | ✅ | #400 | `sushigo` | Enforce permissions in Item, ItemVariant, and InventoryLocation policies | High | 2h | 4h | 3.2h | PR #445 | PR ready, merge pending |
 | ⏳ | #430 | `sushigo` | Prevent concurrent stock overselling and enforce balance invariants | Critical | 4h | 8h | — | — | Land early; required before future purchase receiving (#432) |
-| ⏳ | #421 | `sushigo` | Design the Product Inventory target architecture and migration plan | Medium | 3h | 6h | — | — | Design-only gate; #422/#423 remain outside Sprint 3 |
+| ✅ | #421 | `sushigo` | Design the Product Inventory target architecture and migration plan | Medium | 3h | 6h | 3.75h | PR #446 | Domain model, ERD, SlidePanel flow, API outline, TD-03; PR ready, merge pending |
 |  |  |  | **Round total** |  | **18h** | **35h** | **—** |  |  |
 
 ### Round 2 — Add On-Demand Database Inspection
@@ -349,7 +349,7 @@ Sessions arrays. Estimates remain planning ranges until execution evidence is re
 | ⏳ | #420 | `sushigo` | Pending | — | — | — | Self-service editing and remaining identity-surface rollout |
 | ✅ | #400 | `sushigo` | Replaced unconditional `return true` stubs in ItemPolicy/ItemVariantPolicy/InventoryLocationPolicy with real Spatie permission checks; 72 new unit assertions | PR #445 | — | 3.2h | 72 policy unit tests + 44 regression tests passing; Pint clean; SonarCloud quality gate passing (100% new coverage); Copilot review clean; Devin/DeepWiki 0 bugs, 2 flags fixed (stale comment, nullable-param footgun), 4 evaluated as false positive/informational |
 | ⏳ | #430 | `sushigo` | Pending | — | — | — | Atomic Stock mutation and balance-invariant enforcement |
-| ⏳ | #421 | `sushigo` | Pending | — | — | — | Design/ERD/UI/API/migration gate only; no production implementation |
+| ✅ | #421 | `sushigo` | Finalized the Product → Variant → Purchase Presentation domain model, ERD, SlidePanel UX flow, API contract outline, and additive-first migration sequencing for #422-#442; recorded TD-03 | PR #446 | — | 3.75h | Design/ERD/UI/API/migration gate only, no production implementation; 4 Copilot threads + 5 Devin review cycles resolved, all real findings |
 | 🚧 | #443 | `sushigo` | Sprint lifecycle and planning documentation | — | — | In progress | Opportunistic startup work; branch and PR carry the session-created documentation |
 
 ## 14. Quality Results

--- a/doc/tasks/2026-08/421-design-product-inventory-target-architecture.md
+++ b/doc/tasks/2026-08/421-design-product-inventory-target-architecture.md
@@ -1,0 +1,83 @@
+# 📐 Design the Product Inventory target architecture and migration plan
+
+## Description
+
+Audit and finalize the target architecture for the Product inventory vertical before any replacement implementation begins. This is a design-only issue.
+
+## Reason
+
+The current module mixes Product identity, Variants, physical UOM conversions, opening balances, costs and sale prices inside one wizard. Implementing directly would bake unresolved boundaries into new code and make the cleanup unsafe.
+
+## Objective
+
+Produce one reviewed design covering Product → Variant → Purchase Presentation, the progressive SlidePanel flow, API contracts, invariants, public identifiers, and an incremental migration/removal plan.
+
+## ✅ Technical Tasks
+
+- [x] Audit the affected backend schema, APIs, frontend routes/components, seeders, permissions, tests and architecture docs.
+- [x] Finalize the domain model, cardinalities, lifecycle rules, SKU/barcode ownership, Brand/Category requirements and first Variant attributes.
+- [x] Create the ERD/domain diagram, Product SlidePanel state/wireframe, API contract outline and dependency map.
+- [x] Separate catalog, physical UOM conversion, purchases/acquisition cost, stock and branch pricing responsibilities.
+- [x] Define migration, compatibility, rollback and legacy-removal sequencing.
+- [x] Record accepted decisions in the repository architecture/ADR format and re-scope downstream issues when evidence requires it.
+
+## 🎯 Acceptance Criteria
+
+- [x] Reviewed design, ERD, UI flow, API outline and migration plan exist.
+- [x] Every unresolved product decision is either decided or recorded with an explicit blocker/owner.
+- [x] No migrations, endpoints, production UI, seeders or legacy deletion are implemented in this issue.
+- [x] The implementation backlog and dependency order reflect the approved design.
+
+## 🔗 References
+
+- Existing authorization correction: #400
+- Local discovery summary: dev-lab plan/inventory-product-catalog-redesign.md
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `3h` · **Pessimistic:** `6h` · **Tracked:** `3h45m`
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-08-12", "start": "20:23", "end": "00:08" }
+]
+```
+
+## 📊 Retrospective
+- **Actual total:** 3h 45m (225m), spanning 2026-08-12 20:23 through 2026-08-13 00:08
+- **vs optimistic:** +45m
+- **vs pessimistic:** −2h 15m
+
+**Justification:**
+The work itself (codebase audit, finalizing the domain model, writing the bilingual
+architecture doc, the ADR, and the migration/dependency-map sections) tracked close to the
+optimistic estimate. The overrun past optimistic — and most of the wall-clock time — came from
+the automated review loop, not the design work itself: Copilot's review caught four real
+inaccuracies (a wrong-language cross-doc link, an overstated DB-uniqueness claim, and a wrong
+section reference), and Devin's DeepWiki scan ran five full cycles, each surfacing genuine,
+verifiable defects rather than false positives — remaining stale Hashids references left behind
+by an earlier partial fix, a pre-existing `doc/README.md` duplication with dead `en/`/`es/`
+links, and, most substantively, a dead `is_manufactured` field whose footprint turned out to
+reach far past the frontend wizard (a shared TypeScript type, five test files, and two backend
+controllers, one of which silently returns a permanently-`null` field and the other a no-op
+Swagger-documented filter). `/finish-pr`'s own close-out re-validation (post-squash Devin re-scan)
+caught three more real inaccuracies the earlier cycles missed (the sale_price/min_stock/max_stock
+write gap applies to both Create and Update FormRequests, not create-only; the SKU `code` field
+needs the same update-path uniqueness hardening as barcode; and `public_id` route-model-binding was
+described as already existing on Item/ItemVariant when it depends on `#399` landing first) plus two
+pre-existing broken root-`README.md` links unrelated to this issue but caught while the file was
+already open for the sprint-progress update. Two further Devin "Bug" findings on the housekeeping
+commit were evaluated and kept as-is — they're explicitly correct per `finish-pr.md`'s own
+Completed-cell convention and `doc/conventions/sprints.md` §9's aggregate-totals rule, not defects.
+Every review cycle found something real (or correctly deferred to documented convention), so none
+of the time was spent chasing false positives — the design's second- and third-order accuracy
+simply took more verification passes than the first draft anticipated, well within the pessimistic
+estimate.
+
+
+
+
+
+


### PR DESCRIPTION
## Summary
Closes #421
Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/446

- 📐 Finalized the Product → Variant → Purchase Presentation domain model, cardinalities, lifecycle rules, SKU/barcode ownership, and Brand/Category rules
- 🗺️ Added ERD, Product SlidePanel state diagram/wireframe, API contract outline and dependency map in `doc/architecture/product-catalog/` (EN + ES)
- 🧩 Separated catalog identity, physical UOM conversion, acquisition cost, stock, and branch pricing into four distinct responsibility owners
- 🔀 Defined the additive-first migration, compatibility and legacy-removal sequence across the already-filed `#422`-`#442` backlog — confirmed dependency order still matches, no re-scope needed
- 📝 Recorded TD-03 in `doc/decisions/` and fixed stale Hashids/public_id references in `inventory-architecture.en.md`/`.es.md`

This is a **design-only** deliverable per the issue's own scope: no migrations, endpoints, production UI, seeders, or legacy deletion are part of this PR — only architecture/ADR documentation.

## Manual Testing
This PR only changes Markdown files under `doc/`. To review:
1. Read `doc/architecture/product-catalog/product-catalog-architecture.en.md` — confirm the domain model (§3), responsibility boundaries (§4), SlidePanel flow (§5), API contract outline (§6), and migration sequencing (§7) are internally consistent and actionable for the downstream `#422`-`#429` issues.
2. Read `doc/decisions/td-03-product-catalog-separation.md` — confirm the ADR's Decision/Justification/When to revisit format matches `doc/decisions/td-02-media-cleanup-strategy.md`'s existing convention.
3. Open `doc/architecture/inventory-architecture.en.md` §3 and §5 — confirm the added "stale" callouts correctly point to the new document instead of silently leaving outdated Hashids/flat-schema claims.
4. Render the two Mermaid diagrams (ERD in §3.2, state diagram in §5.2 of the new doc) in a Markdown previewer (e.g. GitHub's own PR file view) to confirm they render without syntax errors.
5. Cross-check `doc/architecture/product-catalog/product-catalog-architecture.en.md` §10's dependency map against `gh issue list --repo pakodiazdev/sushigo` for issues `#422`-`#442` — all 21 already exist and are open, matching the map.

## 🤔 Assumptions

Judgment calls resolved through research (issue body, referenced `plan/inventory-product-catalog-redesign.md`, and the current codebase) rather than stated outright by the issue text — see `product-catalog-architecture.en.md` §8.1 for the full reasoning behind each:

- Brand is optional, InventoryCategory is required — carried over from the referenced plan doc's own stated working assumption (§17 of that doc), finalized here rather than re-opened.
- `/inventory/products` is a new frontend route/API path prefix, distinct from both `/inventory/items` (today's generic Item list) and `/productos` (the unrelated Dish/Menu catalog) — a naming gap the plan doc didn't resolve explicitly; decided to avoid the collision the audit surfaced.
- Purchase-presentation **template** management uses a coarser `purchase_presentation_templates.manage` permission; **assignment** to a Variant reuses `items.update` instead of a new permission.
- Branch is the primary price-list attachment target for `#435`; Operating Unit overrides are an explicit future extension point, not built in Milestone A.
- Location+Variant replenishment thresholds (`#439`) do not inherit a default from Operating Unit level in the first slice — conservative reading chosen because the plan doc frames inheritance as conditional ("if justified") with no operational evidence yet.
- First-class Variant attributes are limited to a free-text `description` beyond the already-agreed name/SKU/barcode/base UOM — no generic attribute engine in Milestone A, since the current catalog is fully representable without one.

## ⚠️ Needs Human Judgment

Two Devin/DeepWiki "Bug" findings on the `/finish-pr` housekeeping commit (README Sprints table, Sprint 003 doc) were kept as-is rather than "fixed", because each one is explicitly correct per a documented rule that overrides Devin's stylistic expectation:

- **"Sprint summary table shows a progress percentage where every other row shows a completion date"** (`README.md:262`) — `.claude/commands/finish-pr.md` Phase 7 explicitly instructs: *"Since the sprint is not yet closed, its Completed cell shows the running progress percentage... instead of a date — that cell only becomes the actual completion date once the sprint formally closes."* The percentage is correct for an in-progress sprint by this repo's own closing procedure; reverting to a date would be factually wrong (the sprint hasn't closed).
- **"Sprint document marks a work item as done while its own totals still report nothing completed"** (`sprint-003-....md:184`) — `doc/conventions/sprints.md` §9 "Multi-Agent Editing Rules" explicitly states aggregate totals (round-total footer rows) are owned by "the project owner or a designated coordination agent" and "should be recalculated by the coordination agent at round boundaries and sprint closure" — an implementation agent finishing one issue's PR must not touch them. Devin correctly observed the numbers don't reconcile yet; that's the documented, intended state until the coordination agent's own pass, not a defect in this PR.

Every other Devin/Copilot finding across 5 review cycles (Copilot: 4 threads; Devin: multiple rounds culminating in this final validation) was a real, verified defect and has been fixed — see the commit history on this branch before the final squash for the full list (barcode/SKU uniqueness scope, `public_id` route-binding assumption, the `is_manufactured` dead-code surface, stale Hashids references, broken doc links, an arithmetic error, and a mismatched cross-reference).

## Test plan
- [x] N/A — documentation-only change, no migrations/endpoints/UI/seeders/tests to run
- [x] Markdown/Mermaid diagrams reviewed for internal consistency and valid syntax

## Workspace
`sushigo-c` — `docs/421-product-inventory-architecture`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

