### PR TITLE
🔨 [#448][a] - Isolate automated review loops 🤖

### DIFF
--- a/.claude/commands/finish-pr.md
+++ b/.claude/commands/finish-pr.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(gh pr view:*), Bash(gh pr checks:*), Bash(gh pr edit:*), Bash(gh pr diff:*), Bash(gh issue view:*), Bash(gh issue edit:*), Bash(gh api:*), Bash(gh project:*), Bash(gh repo view:*), Bash(git fetch:*), Bash(git log:*), Bash(git diff:*), Bash(git status:*), Bash(git branch:*), Bash(git merge-base:*), Bash(git reset:*), Bash(git rebase:*), Bash(git commit:*), Bash(git push:*), Bash(git rev-parse:*), Bash(date:*), Bash(find:*), Bash(ls:*), Bash(grep:*), Bash(mkdir:*), Read, Edit, Write, WebFetch
+allowed-tools: Bash(gh pr view:*), Bash(gh pr checks:*), Bash(gh pr edit:*), Bash(gh pr diff:*), Bash(gh issue view:*), Bash(gh issue edit:*), Bash(gh api:*), Bash(gh project:*), Bash(gh repo view:*), Bash(git fetch:*), Bash(git log:*), Bash(git diff:*), Bash(git add:*), Bash(git status:*), Bash(git branch:*), Bash(git merge-base:*), Bash(git reset:*), Bash(git rebase:*), Bash(git commit:*), Bash(git push:*), Bash(git rev-parse:*), Bash(date:*), Bash(find:*), Bash(ls:*), Bash(grep:*), Bash(mkdir:*), Bash(cd:*), Bash(sort:*), Bash(diff:*), Bash(cp:*), Bash(tail:*), Bash(wc:*), Read, Edit, Write, WebFetch
 description: Validate a PR is ready to merge and perform the final housekeeping (squash commits, finalize the issue in place, archive it locally, sync sprint/README, move the issue to Done) — never merges automatically
 argument-hint: [pr-number]
 ---
@@ -27,6 +27,38 @@ Per [TD-01](../../doc/decisions/td-01-single-source-issue-tracking.md), the GitH
 only live document for this work up to this point — nothing under `doc/tasks/` exists yet for it.
 This command is the **only** place that creates the local archive, and it does so exactly once,
 after the issue itself is fully finalized.
+
+### Safe working-directory rule for file-list captures
+
+Every `git diff ... | sort > /tmp/finish-pr-...` capture below must run from the correct
+`workspaces/sushigo-<x>` clone. Resolve the expected clone from the active `/finish-pr` session and
+the PR's `headRefName`, then change to that known path in a **standalone Bash tool call with no pipe
+or redirection**. Do not use `git rev-parse --show-toplevel` to discover the clone before entering
+it: from the dev-lab root or another repository, that would resolve the wrong toplevel.
+
+```bash
+cd <expected-workspace-root>
+```
+
+In another standalone call, verify that the directory is the expected clone and has the PR branch
+checked out before capturing anything:
+
+```bash
+git rev-parse --show-toplevel
+git branch --show-current
+```
+
+Only after that call succeeds, run the capture in a second Bash tool call. Never construct
+`cd <dir> && git diff ... > /tmp/...` (and never hide the same combination behind `git -C` in the
+redirecting call): Claude Code's safety classifier correctly requires manual approval for that
+compound shape. Keeping directory selection and output redirection in separate tool calls preserves
+the zero-interruption contract without weakening permissions.
+
+Every file-list capture uses the three-dot form
+`git diff origin/<baseRefName>...HEAD --name-only`. Three dots compare `HEAD` with the merge base,
+so files changed only on an advancing base branch never pollute the PR's file list. Do not replace
+it with the two-endpoint form `git diff origin/<baseRefName> HEAD`: Phase 1b and Phase 7.6c can
+rebase onto a newer base between captures, and two-endpoint lists are not stable across that move.
 
 ---
 
@@ -71,6 +103,20 @@ push force-restarts both CI and the Devin scan. A result captured now would just
 that's about to be replaced, and Phase 8 would end up reporting stale status. They're checked
 authoritatively in **Phase 7.6**, right after that single final push — that is the real gate before
 Phase 8 declares the PR ready to merge.
+
+Before the checks below (and therefore before any Phase 1b auto-rebase), follow the safe
+working-directory rule above. Refresh the base ref first in its own Bash call so a stale local
+`origin/<baseRefName>` cannot make base commits already contained in `HEAD` look like PR changes:
+
+```bash
+git fetch origin <baseRefName>
+```
+
+Only after that fetch succeeds, capture the branch's current file list in a separate Bash call:
+
+```bash
+git diff origin/<baseRefName>...HEAD --name-only | sort > /tmp/finish-pr-<N>-files-before.txt
+```
 
 ### 1a. Review threads
 
@@ -146,8 +192,15 @@ origin/<base>..HEAD | wc -l` is already `1`.
 
 ```bash
 git fetch origin <baseRefName>
-git log --format='%B' --reverse origin/<baseRefName>..HEAD
+git log --format='%B' --reverse $(git merge-base origin/<baseRefName> HEAD)..HEAD
 ```
+
+Use `$(git merge-base origin/<baseRefName> HEAD)` — real shell command substitution, not a
+placeholder to fill in by hand — everywhere this phase needs the branch's starting point. Recompute
+it fresh in each command rather than carrying a value across separate Bash tool calls: shell state
+(including variables) does not persist between calls, only the working directory does. Recomputing
+is safe here because nothing re-fetches `origin/<baseRefName>` again until Phase 7.5, so every
+command in this phase resolves to the same commit regardless of when it runs.
 
 Read every commit message in the branch. Synthesize **one** new commit message that follows this
 repo's mandatory convention (`doc/conventions/git/commits.md` / root `CLAUDE.md`):
@@ -175,7 +228,7 @@ Rules for the synthesis:
 Apply it:
 
 ```bash
-git reset --soft origin/<baseRefName>
+git reset --soft $(git merge-base origin/<baseRefName> HEAD)
 git commit -m "<synthesized message>"
 ```
 
@@ -183,11 +236,18 @@ Verify nothing was lost — the squashed single-commit diff must be identical to
 diff:
 
 ```bash
-git diff origin/<baseRefName> HEAD --stat
+git diff origin/<baseRefName>...HEAD --stat
 ```
 
-Compare against the file list you already have from `gh pr diff <N> --name-only` (Phase 0/1). If
-they don't match, stop and report — do not push a divergent diff.
+Follow the safe working-directory rule above, then capture the post-squash list in its own Bash
+call and compare it with Phase 1's pre-rebase/pre-squash capture:
+
+```bash
+git diff origin/<baseRefName>...HEAD --name-only | sort > /tmp/finish-pr-<N>-files-after.txt
+diff /tmp/finish-pr-<N>-files-before.txt /tmp/finish-pr-<N>-files-after.txt && echo "MATCH"
+```
+
+If they don't match, stop and report — do not push a divergent diff.
 
 Do **not** push yet — this commit is local-only scaffolding for Phase 7.5's final squash+push, the
 single push point in this command.
@@ -395,24 +455,40 @@ everything into one commit here, instead of after every phase, means CI and the 
 scan restart at most once between here and Phase 7.6's check, instead of on every intermediate
 housekeeping commit:
 
+Follow the safe working-directory rule above. Run its `cd` as a standalone Bash call first; only
+then run this separate capture/reset call:
+
 ```bash
 git fetch origin <baseRefName>
-git diff origin/<baseRefName> HEAD --name-only | sort > /tmp/finish-pr-<N>-files-before.txt
-git reset --soft origin/<baseRefName>
+SQUASH_BASE=$(git merge-base origin/<baseRefName> HEAD)
+git diff origin/<baseRefName>...HEAD --name-only | sort > /tmp/finish-pr-<N>-files-before.txt
+git reset --soft "$SQUASH_BASE"
 ```
+
+Do not reset to the freshly fetched `origin/<baseRefName>` tip. If the base advanced during
+Phases 2–7, that would create a commit whose tree reverses the newly merged base work. Keeping the
+pre-squash merge base as the new commit's parent also keeps both three-dot captures anchored to the
+same starting point; Phase 7.6c handles any resulting `BEHIND` state with its validated rebase path.
 
 Write one final commit message that is the Phase 2 message with any genuinely new substance from
 Phases 4/6/7 folded in as trailing bullets (issue archived, sprint/README progress updated) — do
 not just concatenate every intermediate commit message verbatim.
 
+After committing, confirm the shell is still at the resolved workspace root, then run the
+post-squash capture as a separate Bash call — never prefix it with `cd ... &&`:
+
 ```bash
 git commit -m "<final consolidated message>"
-git diff origin/<baseRefName> HEAD --name-only | sort > /tmp/finish-pr-<N>-files-after.txt
+git diff origin/<baseRefName>...HEAD --name-only | sort > /tmp/finish-pr-<N>-files-after.txt
 diff /tmp/finish-pr-<N>-files-before.txt /tmp/finish-pr-<N>-files-after.txt && echo "MATCH"
-git push --force-with-lease origin HEAD
 ```
 
-If the diff doesn't match, stop and report — do not push a divergent diff.
+If the diff doesn't match, stop and report — do not push a divergent diff. Only after the
+comparison succeeds, push in a separate Bash call:
+
+```bash
+git push --force-with-lease origin HEAD
+```
 
 If Phase 7.6 (next) finds a real bug that needs a code fix, fix it, commit it, then repeat Phase
 7.5 (and then 7.6 again) so the branch still ends at exactly one commit and the final CI/Devin
@@ -485,10 +561,12 @@ git rebase origin/<baseRefName>
 - If it **succeeds**, the branch is already a single commit from Phase 7.5, so the rebase replays
   cleanly as one commit. Re-validate against the file list Phase 7.5 already proved correct
   (`finish-pr-<N>-files-after.txt`, captured post-squash against the *old* base) — preserve it under
-  its own name first, since the next command overwrites `finish-pr-<N>-files-after.txt` in place:
+  its own name first. Follow the safe working-directory rule again: make the workspace root current
+  in a standalone Bash call, then run the copy/re-diff below in a separate call. Never combine its
+  output redirection with `cd` or `git -C`:
   ```bash
   cp /tmp/finish-pr-<N>-files-after.txt /tmp/finish-pr-<N>-files-preverify.txt
-  git diff origin/<baseRefName> HEAD --name-only | sort > /tmp/finish-pr-<N>-files-after.txt
+  git diff origin/<baseRefName>...HEAD --name-only | sort > /tmp/finish-pr-<N>-files-after.txt
   diff /tmp/finish-pr-<N>-files-preverify.txt /tmp/finish-pr-<N>-files-after.txt && echo "MATCH"
   ```
   A clean rebase replays the same patch onto a new parent, so this must still match — a mismatch

--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(gh issue view:*), Bash(gh issue edit:*), Bash(gh pr view:*), Bash(gh pr create:*), Bash(gh pr edit:*), Bash(gh pr checks:*), Bash(gh pr diff:*), Bash(gh run view:*), Bash(gh run watch:*), Bash(gh api:*), Bash(gh repo view:*), Bash(gh project item-list:*), Bash(gh project item-add:*), Bash(gh project:*), Bash(git checkout:*), Bash(git switch:*), Bash(git branch:*), Bash(git fetch:*), Bash(git push:*), Bash(git log:*), Bash(git diff:*), Bash(git add:*), Bash(git commit:*), Bash(git status:*), Bash(git rebase:*), Bash(git reset:*), Bash(git merge-base:*), Bash(git rev-parse:*), Bash(find:*), Bash(ls:*), Bash(grep:*), Bash(mkdir:*), Bash(tail:*), Bash(date:*), Bash(sleep:*), Bash(cd:*), Bash(basename:*), Bash(docker exec:*), Bash(php artisan:*), Bash(./vendor/bin/pint:*), Bash(npm:*), Bash(npx:*), Bash(make:*), Bash(curl:*), Read, Edit, Write, WebFetch, ToolSearch, mcp__claude-in-chrome__get_page_text, mcp__claude-in-chrome__tabs_context_mcp, mcp__claude-in-chrome__find, mcp__claude-in-chrome__navigate, mcp__claude-in-chrome__browser_batch, mcp__claude-in-chrome__read_page
+allowed-tools: Bash(gh issue view:*), Bash(gh issue edit:*), Bash(gh pr view:*), Bash(gh pr create:*), Bash(gh pr edit:*), Bash(gh pr checks:*), Bash(gh pr diff:*), Bash(gh run view:*), Bash(gh run watch:*), Bash(gh api:*), Bash(gh repo view:*), Bash(gh project item-list:*), Bash(gh project item-add:*), Bash(gh project:*), Bash(git checkout:*), Bash(git switch:*), Bash(git branch:*), Bash(git fetch:*), Bash(git push:*), Bash(git log:*), Bash(git diff:*), Bash(git add:*), Bash(git commit:*), Bash(git status:*), Bash(git rebase:*), Bash(git reset:*), Bash(git merge-base:*), Bash(git rev-parse:*), Bash(find:*), Bash(ls:*), Bash(grep:*), Bash(mkdir:*), Bash(tail:*), Bash(wc:*), Bash(date:*), Bash(sleep:*), Bash(cd:*), Bash(sort:*), Bash(diff:*), Bash(cp:*), Bash(basename:*), Bash(docker exec:*), Bash(php artisan:*), Bash(./vendor/bin/pint:*), Bash(npm:*), Bash(npx:*), Bash(make:*), Bash(curl:*), Read, Edit, Write, WebFetch, ToolSearch, Agent, mcp__claude-in-chrome__get_page_text, mcp__claude-in-chrome__tabs_context_mcp, mcp__claude-in-chrome__find, mcp__claude-in-chrome__navigate, mcp__claude-in-chrome__browser_batch, mcp__claude-in-chrome__read_page
 description: End-to-end autonomous delivery for a single GitHub issue — validate it exists, gather context, implement via TDD, open the PR, then loop through CI, Copilot review, and Devin/DeepWiki review until everything is green. Runs fully unattended: never pauses for human input, even on a business-rule dispute — the issue's literal text wins and every override is logged on the PR for later review. Never merges.
 argument-hint: <issue-number>
 ---
@@ -82,6 +82,29 @@ this pipeline overrode. Phase 8's Chrome-extension check (also reached via Phase
 7.6b) auto-skips instead of asking whether to wait — see that phase for the exact fallback. Phase 10
 does not ask for `/usage` output — cost logging is skipped entirely in this mode, noted as such in
 the final report instead of blocking on it.
+
+### Automated-review subagent boundary
+
+Phases 6, 7, and 8 deliberately dispatch their automated-review work through the `Agent` tool.
+Use **one foreground, general-purpose subagent for each whole loop**, not one subagent per poll or
+per review cycle. A whole-loop dispatch keeps every poll response, diff/context read, test log,
+CI-watch update, and Chrome page read in one disposable context and gives the parent a single
+summary. Dispatching per cycle would create repeated handoffs, force each worker to rebuild the
+same PR context, and make ownership of the shared checkout ambiguous. Foreground execution is
+required because every loop can edit, commit, and push the same branch; never run these review
+subagents concurrently with the parent or with each other.
+
+Subagents cannot spawn other subagents. Therefore Phase 8's single Devin worker also performs the
+Copilot re-poll required after each Devin-driven push. That nested Copilot work is still isolated
+from the parent `/issue` session, which is the boundary this command requires.
+
+For every dispatch, give the subagent the repository, issue number, PR number, branch name, the
+applicable safety cap/window, and the exact command sections it must follow. Require it to do the
+complete loop — polling, analysis, fixes, relevant tests, commits, pushes, review replies/thread
+resolution, and CI re-validation — and to return **only** the compact contract specified by that
+phase. The parent must not repeat or request the worker's raw polling responses, file reads,
+browser output, or CI-watch log. It may act only on the returned summary and on its own single CI
+gate required below.
 
 ---
 
@@ -302,29 +325,42 @@ this text.
 
 ## PHASE 6 — Copilot review loop
 
-Poll for Copilot's automated review (it posts asynchronously, usually within a few minutes):
+Dispatch one foreground, general-purpose subagent for the entire Copilot poll-and-response loop.
+Pass it the repository, issue, PR, and branch identifiers and instruct it to:
 
-```bash
-gh api --paginate repos/pakodiazdev/sushigo/pulls/<N>/reviews --jq '.[].user.login'
+1. Poll every ~30s for up to ~10 minutes for a review whose author login contains `copilot`
+   case-insensitively. If none arrives, finish as `no-review`; do not block indefinitely.
+2. Once a review exists, read and follow `.claude/commands/pr-comments.md` Steps 1–7 in full.
+3. Add this third outcome to Step 4a alongside Address / Skip:
+   - **Business-rule dispute** — keep the issue's literal behavior, reply with the relevant
+     Description/Objective/Acceptance Criteria, resolve the thread, and append the verbatim
+     comment plus that reasoning to the PR's `## ⚠️ Needs Human Judgment` section.
+4. Run the locally relevant tests and linters for every fix, commit and push as the referenced
+   command requires, then run the Phase 5 CI gate if it pushed commits. If that gate reaches its
+   six-identical-failures safety cap, return `status: failed` with `ci: failed`; never pair
+   `ci: failed` with `status: completed` or `status: no-review`.
+
+Require the subagent to return only:
+
+```text
+COPILOT_LOOP
+status: completed | no-review | failed
+threads: found=<N> addressed=<N> skipped=<N> business_rule_disputes=<N>
+commits: pushed=<yes|no> shas=<comma-separated short SHAs or none>
+ci: success | failed | not-rerun
+notes: <one compact line; no raw comments, diffs, polls, or CI log>
 ```
 
-Poll every ~30s for up to ~10 minutes. If nothing from a login containing `copilot` (case-
-insensitive — GitHub's bot login is `copilot-pull-request-reviewer`, but don't rely on exact casing)
-shows up in that window, treat it as "no review to attend" and continue to Phase 7 — don't block
-forever on a review that may not fire for this diff.
-
-Once a Copilot review is present, **read and follow `.claude/commands/pr-comments.md`'s Steps 1–7
-in full**, with one addition inserted into Step 4a's analysis:
-
-> **Business-rule dispute** — the comment isn't proposing a code fix, it's disputing what the
-> feature should *do* (see "The zero-interruption rule"). Keep the issue's literal reading, reply on
-> the thread explaining why (citing the issue's Description/Objective/Acceptance Criteria), resolve
-> the thread, and add a bullet to the PR's `## ⚠️ Needs Human Judgment` section with the comment
-> verbatim and that same reasoning. Every other comment still follows `pr-comments.md`'s existing
-> Address / Skip logic exactly.
-
-If this loop pushed any new commits, **re-run the CI gate (Phase 5)** before moving on — don't act
-on a stale CI result.
+If `status: failed`, the parent must fetch the issue body and fill the current Sessions entry's
+`end` **only if it is still `"?"`**, then write it back and stop with the compact reason. This makes
+cleanup idempotent when the worker already closed the session through Phase 5's safety-cap path.
+Also stop through this same idempotent cleanup path if the contract is malformed as `ci: failed`
+with any non-failed status; never restart a CI gate whose safety cap the worker already exhausted.
+Only when `pushed=yes` and `ci` is `success` or `not-rerun`, the parent must **invoke the complete CI
+gate (Phase 5) once** before Phase 7. That invocation follows Phase 5's normal failure handling:
+diagnose, fix, commit, push, and re-run checks until green or the six-identical-failures safety cap;
+"once" means one invocation of that whole gate, not one `gh pr checks` attempt. Do not perform any
+Copilot polling in the parent session, and do not continue to Phase 7 unless the gate passes.
 
 ---
 
@@ -356,77 +392,98 @@ git push --force-with-lease origin HEAD
 ```
 
 This push restarts CI, the Devin/DeepWiki scan, **and** Copilot's automated review (any push does,
-force or not) — it can post a fresh review with new threads on the squashed commit. **Re-run the CI
-gate (Phase 5)** once before entering Phase 8.
+force or not) — it can post a fresh review with new threads on the squashed commit. **Invoke the
+complete CI gate (Phase 5)** before entering Phase 8, including its normal diagnose/fix/retry loop
+until green or its safety cap.
 
-Also re-poll for Copilot, but not with Phase 6's plain existence check — a Copilot review from
-*before* this push already exists in the list by now, so "does any `copilot` login show up" would
-trivially pass immediately without waiting for anything new, letting a fresh comment from *this*
-push slip past unnoticed. Instead, record the latest existing review's `submitted_at` (or the
-review count) right before pushing, then poll (same ~30s / ~10min cadence as Phase 6) until either
-a *newer* `submitted_at` appears or the count increases:
+After the squash push and its parent-owned CI gate pass, dispatch a new foreground,
+general-purpose subagent for the post-squash Copilot loop. The parent does not fetch Copilot review
+state itself. Instruct the worker to resolve the exact pushed SHA with `git rev-parse HEAD`, then
+poll the PR reviews at the same ~30s / ~10min cadence until a Copilot review whose `commit_id`
+equals that SHA appears. Compare full SHAs, not timestamps, review counts, or local/server clock
+values. A review submitted after the push can still belong to the previous SHA, so recency alone is
+not proof that it reviewed the squashed commit. Exact `commit_id` matching prevents a late review
+of the pre-squash head from ending the poll before feedback for the pushed commit arrives, without
+leaking any poll responses into the parent context.
 
-```bash
-gh api --paginate repos/pakodiazdev/sushigo/pulls/<N>/reviews --jq '.[] | select(.user.login | test("copilot"; "i")) | .submitted_at' | tail -1
-```
+If a new review arrives, the worker follows `pr-comments.md` Steps 1–7 with Phase 6's exact
+business-rule-dispute behavior, runs relevant tests/linters, commits and pushes fixes, and runs the
+Phase 5 CI gate after any push. If that gate reaches its safety cap, it must return `status: failed`
+with `ci: failed`. If no qualifying review arrives, it returns `no-review`.
 
-If a genuinely new Copilot review shows up, follow `pr-comments.md`'s Steps 1–7 in full (same
-business-rule-dispute addition as Phase 6). If nothing newer appears within the window, treat it
-like Phase 6 — no review to attend — and continue to Phase 8.
+Require the same `COPILOT_LOOP` return contract as Phase 6. If it returns `status: failed`, the
+parent must fetch the issue body and fill the current Sessions entry's `end` **only if it is still
+`"?"`**, then write it back and stop. This preserves an end time the worker may already have written
+through Phase 5's safety-cap path. If it returns `pushed=yes`, the parent must **invoke the complete
+CI gate (Phase 5) once** before Phase 8 only when `ci` is `success` or `not-rerun`, following its
+normal diagnose/fix/retry loop until green or its safety cap; do not continue on a failed gate. If
+the worker ever returns the invalid combination `ci: failed` with a non-failed status, use the same
+idempotent session cleanup and stop instead of restarting CI. Do not copy raw findings into the
+parent report; retain only the contract counts, commit SHAs, CI state, and compact note.
 
 ---
 
 ## PHASE 8 — Devin / DeepWiki review loop
 
-This project is on Devin's free tier — the review surface is the public DeepWiki-mirrored page, not
-a private API. Use the Chrome browser tools (load via `ToolSearch` if deferred):
+Dispatch one foreground, general-purpose subagent for the **entire** Devin/DeepWiki loop, including
+all Copilot re-polls caused by Devin-driven pushes. Pass it the repository, issue, PR, branch, and
+the same **5-cycle safety cap**. The worker owns the following workflow without returning any
+intermediate browser, diff, test, poll, or CI output to the parent:
 
+1. Load the `mcp__claude-in-chrome__*` tools with `ToolSearch` first if they are deferred in the
+   worker's fresh context, then open `https://app.devin.ai/review/pakodiazdev/sushigo/pull/<N>`.
+   The page is a client-rendered SPA, so `WebFetch` is insufficient; use page text/find and a
+   screenshot only when needed. If scanning is in progress, wait and re-check. Do not treat tools
+   that merely need deferred loading as unavailable.
+2. Only if the Chrome tools still cannot be invoked after that `ToolSearch` loading attempt, try
+   `tabs_context_mcp` once. If it succeeds, the connection recovered: continue the review from
+   step 1 with the now-connected Chrome tools. Only if it still fails, return `skipped` with
+   `chrome: unavailable`; this supplementary check must not prompt the user.
+3. Verify every reported bug against the code. Fix real bugs; record false positives as
+   not-applicable with a compact reason.
+4. Evaluate every flag as fixed, not-applicable, or a business-rule dispute. For a dispute, keep
+   the issue's literal behavior and append the verbatim flag plus reasoning to the PR's
+   `## ⚠️ Needs Human Judgment` section. Every flag must receive an outcome, but the page itself
+   does not need to show zero flags.
+5. After Devin-driven changes, run the locally relevant tests/linters, commit, and push. Run the
+   Phase 5 CI gate **before** polling Copilot so any fixes that gate commits and pushes are included
+   in the reviewed head. If the gate reaches its safety cap, return `status: failed` with
+   `ci: failed` immediately. Once CI is green, resolve the resulting final pushed SHA, then perform
+   Phase 7's exact-`commit_id` Copilot poll for that SHA with the shorter few-minute window and
+   process any new threads through `pr-comments.md` Steps 1–7 plus the business-rule-dispute rule.
+   If Copilot handling pushes further commits, run the complete Phase 5 CI gate again against that
+   new head before reloading Devin for the next cycle. The same safety-cap-to-failed mapping applies
+   to this second gate. Never report a completed, skipped, or safety-cap Devin outcome with
+   `ci: failed`.
+6. Finish when Devin shows 0 bugs and every flag has been evaluated, or stop after 5 cycles. Before
+   returning either `safety-cap` or `failed`, attempt to close the issue's open Sessions entry with
+   the current time. The parent still verifies this independently, because a worker can fail before
+   it reaches its own cleanup path.
+
+Require the subagent to return only:
+
+```text
+DEVIN_LOOP
+status: completed | skipped | safety-cap | failed
+cycles: <N>/5
+bugs: found=<N> fixed=<N> not_applicable=<N> remaining=<N>
+flags: evaluated=<N> fixed=<N> not_applicable=<N> business_rule_disputes=<N>
+copilot: threads_addressed=<N> skipped=<N> business_rule_disputes=<N>
+commits: pushed=<yes|no> shas=<comma-separated short SHAs or none>
+ci: success | failed | not-rerun
+chrome: connected | unavailable
+notes: <one compact line; no raw findings, diffs, polls, browser text, or CI log>
 ```
-navigate → https://app.devin.ai/review/pakodiazdev/sushigo/pull/<N>
-```
 
-The page is a client-rendered SPA — `WebFetch` returns an empty shell and is not sufficient here;
-use `get_page_text` / `find` (and a screenshot if the text extraction is ambiguous).
-
-- **If the scan is still running** ("in progress"/"scanning"), wait and re-check — a short poll
-  loop, or `ScheduleWakeup` if this is running as a background/dispatched session — rather than
-  reporting an incomplete result.
-- **If the Chrome extension isn't connected**, try `tabs_context_mcp` once; if it still fails, skip
-  this phase automatically — this sub-check is supplementary to CI and Copilot, not a hard blocker
-  on its own. Note the skip plainly in the final report (Phase 10) as "Devin/DeepWiki: skipped,
-  Chrome extension unavailable" rather than silently omitting it.
-
-Once loaded, read the **Bugs** count and the **Flags** panel. Then, in a loop:
-
-1. **For every reported bug** — read the referenced code and verify it's real. If real, fix it
-   (same discipline as Phase 3). If it's a false positive, note why in your final report and don't
-   silently dismiss it without checking.
-2. **For every flag** — evaluate whether it's valid and impactful, using the same business-rule bar
-   as everywhere else in this command: if a flag amounts to disputing intended behavior, keep the
-   issue's literal reading and add it to the PR's `## ⚠️ Needs Human Judgment` section instead of
-   fixing it; otherwise decide yourself. If not valid, record why in your own report — the DeepWiki page
-   is a public, unauthenticated mirror (no GitHub connection in this pipeline), so its own
-   "Resolve"/"Mark as read" controls may not actually persist anything; try them if available, but
-   the written record in your report is what actually matters, not the page's state. If valid,
-   treat it like a bug and fix it. **You don't need to reach zero flags** — but every flag
-   must be explicitly evaluated and the reasoning recorded, even if the conclusion is "not
-   applicable."
-3. **If anything changed as a result:**
-   - Run the locally-relevant tests again (Phase 3's scope + discipline).
-   - Commit and push.
-   - Re-check Copilot the same way Phase 7 does — a plain "does a `copilot` login exist" check
-     would trivially pass on a review already sitting there from before this push; record the
-     latest existing review's `submitted_at` (or count) right before pushing, then poll (shorter
-     window — a few minutes is enough since this is a smaller diff) until a *newer* one appears.
-   - **Re-run the CI gate (Phase 5).**
-   - Reload the Devin page and re-check for new bugs/flags introduced by this round's fix.
-4. Repeat from step 1 until Devin shows **0 bugs** and every flag has been evaluated (resolved,
-   fixed, or explicitly noted as not applicable).
-
-**Safety cap:** stop after **5 cycles** through this loop and report the remaining state to the
-user rather than continuing indefinitely. Close the Sessions entry (Phase 2's rule) before
-reporting — do not attempt cost logging (Phase 10 skips it entirely per the zero-interruption
-rule; there's nothing to do here on that front).
+If `status: safety-cap` or `status: failed`, the parent must fetch the issue body, fill the current
+Sessions entry's `end` if it is still `"?"`, write it back, and only then stop with the compact
+remaining state. This verification is mandatory even if the worker reports that it already closed
+the entry. If `status: skipped`, continue and preserve the skip for Phase 10. If the summary says
+`pushed=yes` and `ci` is `success` or `not-rerun`, the parent must **invoke the complete CI gate
+(Phase 5) once** before Phase 9, following its normal diagnose/fix/retry loop until green or its
+safety cap; do not continue on a failed gate. If the contract is malformed as `ci: failed` with any
+non-failed status, perform the same idempotent session cleanup and stop instead of restarting CI.
+The parent must never open the Devin page or poll Copilot during this phase.
 
 ---
 
@@ -522,6 +579,18 @@ issue — if one already exists from a prior manual run, leave it exactly as-is.
 run's cost logged, run `/usage` yourself afterward; this command will not ask for it.
 
 ### 10b. Print the final report
+
+Before printing, fetch the current PR body and read its canonical `## ⚠️ Needs Human Judgment`
+section:
+
+```bash
+gh pr view <N> --repo pakodiazdev/sushigo --json body --jq .body
+```
+
+Copy every bullet from that section into the matching final-report section below. This read does
+not violate the subagent boundary: the PR body is the durable decision record written by the
+workers, not raw polling, browser, diff, or CI output. If the section is empty, omit the report
+subsection instead of leaving placeholder bullets.
 
 ````
 ## Issue #<NNN> — Ready for your review

--- a/doc/sprints/sprint-003-development-platform-and-product-reliability.md
+++ b/doc/sprints/sprint-003-development-platform-and-product-reliability.md
@@ -6,7 +6,7 @@ status: In Progress
 created: 2026-08-12
 started: 2026-08-12
 completed:
-last_updated: 2026-08-12
+last_updated: 2026-08-13
 
 base_branch: main
 base_commit: cfd6cfb
@@ -147,6 +147,7 @@ scope. Changes made after promotion must be recorded here without deleting histo
 | Date | Issue | Title | Trigger | Result |
 |---|---:|---|---|---|
 | 2026-08-12 | #443 | Formally close Sprint 002, promote Sprint 003, and record Sprint 004 planning | Sprint lifecycle transition and planning documents were ready for permanent review | Sprint 002 closed; Sprint 003 promoted; Sprint 004 and roadmap convention submitted together |
+| 2026-08-13 | #448 | Move `/issue` automated-review loops to isolated subagents | Review-loop context growth and `finish-pr` approval interruptions required an unplanned reliability pass | Copilot/Devin loops isolated, CI/session safeguards hardened, and file-list captures stabilized; 9.3h tracked; PR #451, merge pending |
 
 ## 6. Value Ranking
 
@@ -351,6 +352,7 @@ Sessions arrays. Estimates remain planning ranges until execution evidence is re
 | ⏳ | #430 | `sushigo` | Pending | — | — | — | Atomic Stock mutation and balance-invariant enforcement |
 | ✅ | #421 | `sushigo` | Finalized the Product → Variant → Purchase Presentation domain model, ERD, SlidePanel UX flow, API contract outline, and additive-first migration sequencing for #422-#442; recorded TD-03 | PR #446 | — | 3.75h | Design/ERD/UI/API/migration gate only, no production implementation; 4 Copilot threads + 5 Devin review cycles resolved, all real findings |
 | 🚧 | #443 | `sushigo` | Sprint lifecycle and planning documentation | — | — | In progress | Opportunistic startup work; branch and PR carry the session-created documentation |
+| ✅ | #448 | `sushigo` | Isolated Copilot and Devin review loops into foreground workers and hardened unattended close-out safeguards | PR #451 | — | 9.3h | Docs/command-file change, no test suite: `git diff --check`, frontmatter/allow-list, and compact-contract/safe-capture structural assertions all passing; 6 Copilot review threads resolved (SHA-anchored re-checks, idempotent session cleanup, squash-verification stabilization, allow-list completion, canonical-body dispute sourcing); PR ready, merge pending |
 
 ## 14. Quality Results
 
@@ -378,11 +380,12 @@ Inventory authorization and Stock mutation, and an implementation-ready Product 
 
 - **Confirmed planned Issues:** 5 dev-lab Issues and 5 SushiGo Issues.
 - **Pending planned Issues:** 0; scope selection is complete.
-- **Opportunistic startup Issues:** 1 (`#443`), tracked outside the ten-Issue implementation total.
+- **Opportunistic Issues:** 2 (`#443`, `#448`), tracked outside the ten-Issue implementation total;
+  `#443` covers sprint startup and `#448` covers in-progress pipeline reliability work.
 - **Confirmed estimate:** 27h optimistic / 53h pessimistic.
 - **Completed:** 0.
 - **Deprecated or cancelled:** 0.
-- **Tracked:** no sessions yet.
+- **Tracked:** 9.3h for opportunistic #448; planned-scope totals remain separate.
 
 ### 15.3 Known Limitations
 

--- a/doc/tasks/2026-08/448-isolate-review-loops-in-subagents.md
+++ b/doc/tasks/2026-08/448-isolate-review-loops-in-subagents.md
@@ -1,0 +1,160 @@
+# 🔨 Move /issue's Devin/DeepWiki and Copilot review loops to isolated subagents
+
+## Description
+
+Extract `.claude/commands/issue.md`'s automated-review loops — **Phase 8** (Devin/DeepWiki) and
+**Phase 6/7's Copilot polling-and-response loop**, including the Copilot re-poll nested inside every
+Phase 8 cycle — so each runs inside an isolated subagent instead of the main `/issue` session. Each
+subagent performs the same work it does today (poll, read findings, fix, test, commit, push,
+re-validate) and returns only a compact summary to the parent session.
+
+## Reason
+
+Both loops currently run inside the same continuous, never-forked `/issue` session as every other
+phase, and both share the same expensive shape: **poll → read findings → fix → commit → push →
+re-poll → re-run CI**, none of which is ever discarded from context since the whole pipeline is one
+session from Phase 0 through Phase 10.
+
+Devin's cost is the more visible half (Chrome page reads), documented on the original scope of this
+issue:
+- #378: estimated 3–6h, tracked **29h55m** — retrospective attributes this explicitly to "the
+  unattended /issue pipeline's own design: it runs the Devin/DeepWiki automated review to its full
+  5-cycle safety cap."
+- #377: estimated 4h, tracked 9h29m (+137%) — 4 Devin cycles, 6 genuine defects.
+- #384 (a small config fix): the loop still ran a full pass and found 0 bugs — same overhead paid
+  for zero value.
+
+But Copilot's polling loop compounds **more often** than Devin's, just less visibly (no browser
+involved, so it's easy to overlook when reasoning about cost):
+- Phase 6: initial poll (~30s cadence, up to ~10min) + full `pr-comments.md` Steps 1–7 per comment.
+- Phase 7: re-polled again after the post-review squash, with its own wait window.
+- Phase 8: re-polled again **inside every one of the up to 5 Devin cycles**, each time a fix is
+  pushed.
+
+So a full run can re-poll and re-process Copilot review threads far more than 3 times, each time
+carrying its own polling responses and `pr-comments.md` diff/context reads into the same
+ever-growing session. Isolating both loops in subagents is a lower-risk experiment before deciding
+whether to cut either phase down to a single best-effort check (matching `finish-pr.md`'s existing
+non-looping Phase 7.6b model) or remove it outright — both loops do catch real, worth-fixing defects
+today, so the goal here is to keep that value while stopping their internal back-and-forth from
+polluting the parent session's context.
+
+**A third, unrelated friction source also breaks the "zero-interruption" promise and belongs in the
+same cleanup pass.** `finish-pr.md`'s file-list-capture steps (the before-diff ahead of Phase 1b's
+auto-rebase, the after-diff following Phase 2's squash, and the re-diff in Phase 7.6c after a late
+rebase) need to run `git diff`/`sort` from inside the correct `workspaces/sushigo-<x>` clone and
+redirect the result to a `/tmp/finish-pr-<N>-files-*.txt` file. When executed as a single compound
+Bash command — `cd workspaces/sushigo-<x> && git diff ... > /tmp/...` — Claude Code's own safety
+classifier flags it ("Compound command contains cd with output redirection - manual approval
+required to prevent path resolution bypass") and stops for manual approval, exactly the kind of
+human-in-the-loop interruption `/issue`'s zero-interruption rule is designed to avoid. This is not a
+permission-configuration gap — the classifier exists specifically to stop `cd`+redirect compound
+commands from bypassing path-scoped permissions, so it should not be allowlisted away. The real fix
+is to stop constructing the compound form at all: run the `cd` (or `git -C <dir> ...`) and the
+redirecting command as separate steps so no single Bash invocation combines both.
+
+## Objective
+
+Phase 6/7's Copilot loop and Phase 8's Devin loop produce the same review outcome (comments/bugs
+addressed, flags evaluated, same safety caps) but none of their polling responses, diff/context
+reads, CI-watch output, or Chrome page reads land in the parent `/issue` session's context — only a
+final structured summary per loop does. The parent session can act on each summary (re-run its own
+CI gate once, continue to the next phase) without ever having carried the loop's internal
+back-and-forth itself. Separately, none of `finish-pr.md`'s file-list-capture steps trigger a
+manual-approval prompt anymore — `/issue` runs from Phase 0 to Phase 10 without a single
+human-in-the-loop interruption on a clean run.
+
+## ✅ Technical Tasks
+
+- [x] 🔍 Decide the subagent invocation shape for each loop (dispatch once for the whole loop vs.
+      once per cycle/poll-round) and document the tradeoff directly in the command file
+- [x] 📝 Rewrite `.claude/commands/issue.md` Phase 8 to dispatch the Devin/DeepWiki loop to a
+      subagent, passing the PR number and the same 5-cycle safety cap
+- [x] 📝 Rewrite Phase 6 to dispatch the Copilot poll-and-respond loop (`pr-comments.md` Steps 1–7)
+      to a subagent
+- [x] 📝 Apply the same treatment to Phase 7's post-squash Copilot re-poll and to the Copilot re-poll
+      nested inside each Phase 8 cycle, so no Copilot polling ever runs directly in the parent
+      session
+- [x] 📤 Define each subagent's return contract: for Copilot — threads addressed/skipped/business-
+      rule-disputed; for Devin — bug count, flags evaluated (fixed / not-applicable / business-rule-
+      dispute); both — commits made, final CI state
+- [x] 🔁 Ensure the parent session still re-runs its own CI gate (Phase 5) once after any subagent
+      reports pushed commits, per the existing rule
+- [x] 🧾 Preserve the `## ⚠️ Needs Human Judgment` business-rule-dispute behavior for both loops —
+      each subagent must still be able to write that section to the PR body, not just report back to
+      the parent
+- [ ] 📊 Manually compare token/wall-clock cost on at least one real issue run through the new
+      Phase 6/7/8 vs. a comparable prior issue, to validate the hypothesis before deciding on full
+      removal of either loop
+- [x] 🔀 Rewrite `finish-pr.md`'s three file-list-capture snippets (pre-Phase-1b before-diff,
+      post-Phase-2 after-diff, Phase 7.6c re-diff) so the workspace `cd`/`git -C` and the
+      redirecting `git diff ... | sort > /tmp/...` never appear in the same compound Bash command —
+      document the split explicitly in the command file so any future agent follows it too, not just
+      this run
+
+## 🎯 Acceptance Criteria
+
+- [ ] Running `/issue` on an issue that triggers real Copilot comments and real Devin findings still
+      results in both being addressed/fixed, tested, committed, and pushed, exactly as today
+- [ ] The parent `/issue` session's transcript does not contain the subagents' individual polling
+      responses, `pr-comments.md` diff/context reads, Chrome navigations, or CI-watch polling output
+      — only each loop's final summary
+- [ ] The `## ⚠️ Needs Human Judgment` section and the Sessions-closing rule still work correctly
+      when either loop stops early (its safety cap reached) inside a subagent
+- [ ] A before/after comparison (even informal) is recorded on this issue showing whether
+      context/token growth actually improved for both loops
+- [ ] A full `/issue` run against a dev-lab workspace completes Phase 0 through Phase 10 without a
+      single manual-approval prompt on a clean pass (no CI failures, no business-rule disputes)
+
+## 🔗 References
+
+- `.claude/commands/issue.md` Phase 6 (Copilot), Phase 7 (post-squash re-poll), Phase 8
+  (Devin/DeepWiki) — current loop implementations
+- `.claude/commands/pr-comments.md` Steps 1–7 — reused by Phase 6/7/8's Copilot handling
+- `.claude/commands/finish-pr.md` Phase 7.6b — existing single-check, non-looping model used for
+  comparison
+- `.claude/commands/finish-pr.md` — file-list-capture snippets around the before-diff (pre-1b),
+  after-diff (post-2), and Phase 7.6c re-diff, source of the `cd`+redirect manual-approval prompt
+- Retrospectives citing the cost: `doc/tasks/2026-08/378-media-gallery-uploader-component.md`,
+  `doc/tasks/2026-08/377-media-upload-system.md`,
+  `doc/tasks/2026-08/384-remove-hardcoded-app-key.md`
+
+## ⏱️ Time
+
+### 📊 Estimates
+- **Optimistic:** `3h30m` · **Pessimistic:** `6h30m` · **Tracked:** `9h20m`
+
+### 📅 Sessions
+```json
+[
+  { "date": "2026-08-13", "start": "07:48", "end": "17:08" }
+]
+```
+
+## 📊 Retrospective
+- **Actual total:** 9h20m (560m)
+- **vs optimistic:** +5h50m
+- **vs pessimistic:** +2h50m
+
+**Justification:**
+The estimate assumed a mostly mechanical extraction of two existing loops (Devin/DeepWiki and
+Copilot) into subagent dispatches. The actual scope grew in three ways not contemplated in the
+original 3h30m–6h30m band. First, defining a compact, lossless return contract for each subagent
+(Copilot: threads addressed/skipped/business-rule-disputed; Devin: bug count, flags, commits, CI
+state) required more careful design than a simple dispatch — the whole point of the issue is that
+the parent session never sees the loop's internals, so the contract has to be complete enough that
+nothing gets silently dropped. Second, the file-list-capture safety-classifier fix (Reason's third,
+originally "unrelated" friction source) turned out to be more delicate than expected: getting `cd`
+and redirection fully separated across all three `finish-pr.md` snippets (pre-1b, post-2, 7.6c)
+while still keeping the diffs anchored to a stable merge base took several passes. Third, review
+response consumed real time — 6 review threads were opened and resolved across `issue.md` and
+`finish-pr.md`, covering anchoring re-checks to exact commit SHAs, idempotent session cleanup on
+review failure, stabilizing squash verification against merge-base file lists, completing
+unattended command allow-lists, and sourcing overridden reviewer disagreements from the canonical
+PR body — each a genuine correctness or safety fix, not rubber-stamp feedback. The one technical
+task left unticked (a live token/wall-clock comparison run) and all acceptance criteria requiring a
+real `/issue` execution remain open by design; they need a subsequent real issue to validate against
+and are explicitly called out as pending in both the issue and the PR's manual testing steps.
+
+
+


### PR DESCRIPTION
## Summary

Closes #448
Devin Review: https://deepwiki.com/pakodiazdev/sushigo/pull/451

- Move the Phase 6 and post-squash Phase 7 Copilot loops behind foreground `Agent` dispatches
- Move the complete five-cycle Devin loop, including nested Copilot re-polls, into one isolated worker
- Define compact return contracts and keep one parent-owned CI revalidation after worker pushes
- Split `finish-pr` workspace selection from redirected file-list captures to preserve zero-interruption execution

## Manual Testing

1. Open this branch in Claude Code and run `rg -n "Automated-review subagent boundary|COPILOT_LOOP|DEVIN_LOOP" .claude/commands/issue.md`.
2. Confirm the output contains one shared dispatch policy, the Copilot contract, and the Devin contract.
3. Run `rg -n "Safe working-directory rule|files-before|files-after|files-preverify" .claude/commands/finish-pr.md`.
4. Confirm every redirected file-list capture is preceded by instructions to select the workspace in a separate Bash call, and no executable snippet combines `cd`/`git -C` with redirection.
5. On a subsequent real issue, run `/issue <issue-number>` and verify Phases 6/7/8 return only the documented compact summaries to the parent transcript. This live cost/context comparison remains intentionally pending until such a run exists.

## 🤔 Assumptions

- A single foreground worker owns each full loop because Claude Code subagents isolate context but share sequential branch state; Phase 8 keeps its nested Copilot polling in the Devin worker because subagents cannot spawn subagents.
- The built-in general-purpose subagent is used instead of adding project-specific agent files; the loop instructions and return schemas stay versioned beside `/issue`.

## ⚠️ Needs Human Judgment

None at implementation time.

## Test plan

- [x] `git diff --check`
- [x] Frontmatter delimiters and `Agent` allowlist presence verified
- [x] Compact contract and safe-capture structural assertions verified
- [ ] Real `/issue` run token/wall-clock comparison (requires a subsequent eligible issue)

## Workspace

`sushigo-a` — `refactor/448-isolate-review-loops`

🤖 Generated with Codex
